### PR TITLE
Fixes and example enhancement

### DIFF
--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -389,10 +389,10 @@ func runToolCalls(ctx context.Context, options *RunOptions, contents ...Content)
 }
 
 // funcCall executes a function tool call.
-func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallContent) (ct Content) {
+func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallContent) Content {
 	if toolCall.Error != nil {
 		// If there was an error parsing the tool call, return the error.
-		return &FunctionCallContent{
+		return &FunctionResultContent{
 			CallID: toolCall.CallID,
 			Error:  toolCall.Error,
 		}
@@ -411,7 +411,7 @@ func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallCont
 	}
 
 	if found == nil {
-		return &FunctionCallContent{
+		return &FunctionResultContent{
 			CallID: toolCall.CallID,
 			Error:  fmt.Errorf("tool not found: %s", toolCall.Name),
 		}
@@ -420,30 +420,35 @@ func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallCont
 	var args map[string]any
 	if toolCall.Arguments != "" {
 		if err := json.Unmarshal([]byte(toolCall.Arguments), &args); err != nil {
-			return &FunctionCallContent{
+			return &FunctionResultContent{
 				CallID: toolCall.CallID,
 				Error:  fmt.Errorf("failed to parse arguments: %w", err),
 			}
 		}
 	}
 
+	// Handle panics during tool execution
+	var panicErr error
 	defer func() {
 		if r := recover(); r != nil {
-			var err error
 			if e, ok := r.(error); ok {
-				err = e
+				panicErr = e
 			} else {
-				err = fmt.Errorf("%v", r)
-			}
-			ct = &FunctionResultContent{
-				CallID: toolCall.CallID,
-				Error:  fmt.Errorf("tool execution panic: %v", err),
+				panicErr = fmt.Errorf("%v", r)
 			}
 		}
 	}()
 
 	// Execute the tool
 	result, err := found.Call(ctx, args)
+
+	if panicErr != nil {
+		return &FunctionResultContent{
+			CallID: toolCall.CallID,
+			Error:  fmt.Errorf("tool execution panic: %v", panicErr),
+		}
+	}
+
 	return &FunctionResultContent{
 		CallID: toolCall.CallID,
 		Error:  err,

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -428,26 +428,20 @@ func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallCont
 	}
 
 	// Handle panics during tool execution
-	var panicErr error
-	defer func() {
-		if r := recover(); r != nil {
-			if e, ok := r.(error); ok {
-				panicErr = e
-			} else {
-				panicErr = fmt.Errorf("%v", r)
+	var result any
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if e, ok := r.(error); ok {
+					err = fmt.Errorf("tool execution panic: %w", e)
+				} else {
+					err = fmt.Errorf("tool execution panic: %v", r)
+				}
 			}
-		}
+		}()
+		result, err = found.Call(ctx, args)
 	}()
-
-	// Execute the tool
-	result, err := found.Call(ctx, args)
-
-	if panicErr != nil {
-		return &FunctionResultContent{
-			CallID: toolCall.CallID,
-			Error:  fmt.Errorf("tool execution panic: %v", panicErr),
-		}
-	}
 
 	return &FunctionResultContent{
 		CallID: toolCall.CallID,

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -391,11 +391,9 @@ func runToolCalls(ctx context.Context, options *RunOptions, contents ...Content)
 // funcCall executes a function tool call.
 func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallContent) Content {
 	if toolCall.Error != nil {
-		// If there was an error parsing the tool call, return the error.
-		return &FunctionResultContent{
-			CallID: toolCall.CallID,
-			Error:  toolCall.Error,
-		}
+		// If there was an error parsing the tool call, return it as-is.
+		// This error occurred during mapping from the AI model to FunctionCallContent.
+		return toolCall
 	}
 
 	// Find the tool in the options

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -160,23 +160,7 @@ func (a *client) buildCompletionParams(options *agent.RunOptions, messages ...*a
 		Messages: make([]openai.ChatCompletionMessageParamUnion, 0, len(messages)+1),
 	}
 	for _, msg := range messages {
-		// Special handling for tool messages: each tool result needs its own message
-		if msg.Role == agent.RoleTool {
-			for _, content := range msg.Contents {
-				if funcResult, ok := content.(*agent.FunctionResultContent); ok {
-					txt := funcResult.Result
-					if funcResult.Error != nil {
-						txt = funcResult.Error
-					}
-					params.Messages = append(params.Messages, openai.ToolMessage(
-						[]openai.ChatCompletionContentPartTextParam{{Text: fmt.Sprintf("%v", txt)}},
-						funcResult.CallID,
-					))
-				}
-			}
-		} else {
-			params.Messages = append(params.Messages, buildMessageParam(msg))
-		}
+		params.Messages = append(params.Messages, buildMessageParam(msg)...)
 	}
 
 	if options != nil {
@@ -244,8 +228,9 @@ func (a *client) buildCompletionParams(options *agent.RunOptions, messages ...*a
 	return params
 }
 
-// buildMessageParam converts an agent.Message to an OpenAI message parameter.
-func buildMessageParam(msg *agent.Message) openai.ChatCompletionMessageParamUnion {
+// buildMessageParam converts an agent.Message to one or more OpenAI message parameters.
+// Returns a slice because some agent messages (like RoleTool) need to be split into multiple OpenAI messages.
+func buildMessageParam(msg *agent.Message) []openai.ChatCompletionMessageParamUnion {
 	switch msg.Role {
 	case agent.RoleSystem:
 		var contents []openai.ChatCompletionContentPartTextParam
@@ -256,7 +241,8 @@ func buildMessageParam(msg *agent.Message) openai.ChatCompletionMessageParamUnio
 				})
 			}
 		}
-		return openai.SystemMessage(contents)
+		return []openai.ChatCompletionMessageParamUnion{openai.SystemMessage(contents)}
+
 	case agent.RoleUser:
 		var contents []openai.ChatCompletionContentPartUnionParam
 		for _, content := range msg.Contents {
@@ -305,7 +291,7 @@ func buildMessageParam(msg *agent.Message) openai.ChatCompletionMessageParamUnio
 				}))
 			}
 		}
-		return openai.UserMessage(contents)
+		return []openai.ChatCompletionMessageParamUnion{openai.UserMessage(contents)}
 
 	case agent.RoleAssistant:
 		var contents []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
@@ -336,12 +322,29 @@ func buildMessageParam(msg *agent.Message) openai.ChatCompletionMessageParamUnio
 				})
 			}
 		}
-		return openai.ChatCompletionMessageParamUnion{
+		return []openai.ChatCompletionMessageParamUnion{{
 			OfAssistant: &openai.ChatCompletionAssistantMessageParam{
 				Content:   openai.ChatCompletionAssistantMessageParamContentUnion{OfArrayOfContentParts: contents},
 				ToolCalls: toolCalls,
 			},
+		}}
+
+	case agent.RoleTool:
+		// Each tool result needs its own separate message for OpenAI API compliance
+		var messages []openai.ChatCompletionMessageParamUnion
+		for _, content := range msg.Contents {
+			if funcResult, ok := content.(*agent.FunctionResultContent); ok {
+				txt := funcResult.Result
+				if funcResult.Error != nil {
+					txt = funcResult.Error
+				}
+				messages = append(messages, openai.ToolMessage(
+					[]openai.ChatCompletionContentPartTextParam{{Text: fmt.Sprintf("%v", txt)}},
+					funcResult.CallID,
+				))
+			}
 		}
+		return messages
 
 	default:
 		panic("unknown message role: " + string(msg.Role))

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -160,7 +160,23 @@ func (a *client) buildCompletionParams(options *agent.RunOptions, messages ...*a
 		Messages: make([]openai.ChatCompletionMessageParamUnion, 0, len(messages)+1),
 	}
 	for _, msg := range messages {
-		params.Messages = append(params.Messages, buildMessageParam(msg))
+		// Special handling for tool messages: each tool result needs its own message
+		if msg.Role == agent.RoleTool {
+			for _, content := range msg.Contents {
+				if funcResult, ok := content.(*agent.FunctionResultContent); ok {
+					txt := funcResult.Result
+					if funcResult.Error != nil {
+						txt = funcResult.Error
+					}
+					params.Messages = append(params.Messages, openai.ToolMessage(
+						[]openai.ChatCompletionContentPartTextParam{{Text: fmt.Sprintf("%v", txt)}},
+						funcResult.CallID,
+					))
+				}
+			}
+		} else {
+			params.Messages = append(params.Messages, buildMessageParam(msg))
+		}
 	}
 
 	if options != nil {
@@ -326,24 +342,6 @@ func buildMessageParam(msg *agent.Message) openai.ChatCompletionMessageParamUnio
 				ToolCalls: toolCalls,
 			},
 		}
-
-	case agent.RoleTool:
-		var contents []openai.ChatCompletionContentPartTextParam
-		var callID string
-		for _, content := range msg.Contents {
-			switch content := content.(type) {
-			case *agent.FunctionResultContent:
-				txt := content.Result
-				if content.Error != nil {
-					txt = content.Error
-				}
-				contents = append(contents, openai.ChatCompletionContentPartTextParam{
-					Text: fmt.Sprintf("%v", txt),
-				})
-				callID = content.CallID
-			}
-		}
-		return openai.ToolMessage(contents, callID)
 
 	default:
 		panic("unknown message role: " + string(msg.Role))

--- a/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
+++ b/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
@@ -32,6 +32,7 @@ var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
 }, func(_ context.Context, req weatherRequest) (weatherResponse, error) {
+	fmt.Printf("🔧 Weather tool called for location: %s\n", req.Location)
 	return weatherResponse{
 		Conditions: []string{"sunny", "cloudy", "rainy", "stormy"}[rand.Intn(4)],
 		HighTemp:   rand.Intn(21) + 10,
@@ -55,27 +56,50 @@ func main() {
 		},
 	})
 
+	// Add this debug code:
+	if ag.Config.Opts != nil && len(ag.Config.Opts.Tools) > 0 {
+		fmt.Println("📋 Registered tools:")
+		for _, t := range ag.Config.Opts.Tools {
+			name, desc := t.ToolInfo()
+			fmt.Printf("  - %s: %s\n", name, desc)
+		}
+		fmt.Println()
+	}
+
+	// Example 1: Tool WILL be called (weather-related query)
 	nonStreamingExample(ag, "What's the weather like in Seattle?")
+
+	// Example 2: Tool WILL be called (streaming)
 	streamingExample(ag, "What's the weather like in Portland?")
+
+	// Example 3: Tool will NOT be called (general conversation)
+	nonStreamingExample(ag, "Hello! How are you today?")
+
+	// Example 4: Tool will NOT be called (unrelated question)
+	nonStreamingExample(ag, "What is the capital of France?")
+
+	// Example 5: Tool WILL be called (implicit weather request)
+	nonStreamingExample(ag, "Should I bring an umbrella in Boston today?")
 
 }
 
 func nonStreamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("=== Non-streaming Response Example ===\n")
+	fmt.Printf("\n=== Non-streaming Response Example ===\n")
 	fmt.Printf("User: %s\n", query)
 	resp, err := ag.RunText(ctx, query)
 	if err != nil {
 		fmt.Print(err)
 		return
 	}
-	fmt.Printf("Result: %s\n", resp.Text())
+	fmt.Printf("Assistant: %s\n", resp.Text())
 }
 
 func streamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("=== Streaming Response Example ===\n")
+	fmt.Printf("\n=== Streaming Response Example ===\n")
 	fmt.Printf("User: %s\n", query)
+	fmt.Print("Assistant: ")
 	stream := ag.RunStream(ctx, nil, nil, agent.NewTextMessage(query))
 	for update, err := range stream {
 		if err != nil {


### PR DESCRIPTION
Enhanced basic chat example to illustrate tool calling

Fix multiple tool call handling in OpenAI adapter

- Fix funcCall to return FunctionResultContent for all error cases
- Split tool result messages to send one message per tool call ID
- Ensure each tool_call_id gets its own response message per Azure OpenAI API requirements

This resolves 400 Bad Request errors when LLM makes multiple tool calls simultaneously.
The OpenAI adapter now correctly creates separate tool messages for each FunctionResultContent instead of bundling them into a single message with only the last call ID.