### PR TITLE
Support structured output

### DIFF
--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -5,11 +5,13 @@ package agent
 import (
 	"cmp"
 	"context"
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"iter"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/microsoft/agent-framework/go/format"
 	"github.com/microsoft/agent-framework/go/tool"
@@ -90,22 +92,28 @@ func (a *Agent) Run(ctx context.Context, thread Thread, opts *RunOptions, messag
 		message := finalResponse.Messages[0]
 		threadMessages = append(threadMessages, message)
 	}
+	outMessages := threadMessages[startLength:]
 	if thread != nil {
-		if err := thread.AddMessage(ctx, threadMessages[startLength:]...); err != nil {
+		if err := thread.AddMessage(ctx, outMessages...); err != nil {
 			return nil, err
 		}
 	}
 	if ctxprovider := a.contextProvider(thread); ctxprovider != nil {
-		if err := ctxprovider.Invoked(ctx, messages, threadMessages[startLength:], nil); err != nil {
+		if err := ctxprovider.Invoked(ctx, messages, outMessages, nil); err != nil {
 			return nil, err
 		}
 	}
-
-	return &RunResponse{
+	response := &RunResponse{
 		Messages:   threadMessages[startLength:],
 		ResponseID: finalResponse.ResponseID,
 		AgentID:    id,
-	}, nil
+	}
+	if opts.Response != nil {
+		if err := opts.Response.UnmarshalBinary([]byte(response.Text())); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+	}
+	return response, nil
 }
 
 func (a *Agent) RunText(ctx context.Context, msg string) (*RunResponse, error) {
@@ -198,6 +206,20 @@ func (a *Agent) RunStream(ctx context.Context, thread Thread, opts *RunOptions, 
 				return
 			}
 		}
+		if opts.Response != nil {
+			var finalText strings.Builder
+			for _, msg := range threadMessages[startLength:] {
+				for _, content := range msg.Contents {
+					if textContent, ok := content.(*TextContent); ok {
+						finalText.WriteString(textContent.Text)
+					}
+				}
+			}
+			if err := opts.Response.UnmarshalBinary([]byte(finalText.String())); err != nil {
+				yield(nil, fmt.Errorf("failed to unmarshal response: %w", err))
+				return
+			}
+		}
 	}
 }
 
@@ -226,9 +248,16 @@ func (a *Agent) runStreamFallback(ctx context.Context, thread Thread, options *R
 
 // RunOptions contains options for agent execution.
 type RunOptions struct {
+	// Response is an object to unmarshal the response into.
+	// For streaming responses, this will be called once with the full response.
+	// Ignored if nil.
+	Response encoding.BinaryUnmarshaler
+
 	// ResponseFormat represents the desired response format for agent execution.
 	// It is up to the client implementation if or how to honor the request.
 	// If the client implementation doesn't recognize the specific kind, it can be ignored.
+	// If nil and Response implemented [format.FormatProvider], it is obtained from there.
+	// Otherwise, the client default is used.
 	ResponseFormat format.Format
 
 	// Tools to make available to the agent.
@@ -272,6 +301,8 @@ func (o *RunOptions) Merge(other *RunOptions) *RunOptions {
 	o.Temperature = cmp.Or(other.Temperature, o.Temperature)
 	o.TopP = cmp.Or(other.TopP, o.TopP)
 	o.MaxTokens = cmp.Or(other.MaxTokens, o.MaxTokens)
+	o.ResponseFormat = cmp.Or(other.ResponseFormat, o.ResponseFormat)
+	o.Response = cmp.Or(other.Response, o.Response)
 	if other.AdditionalMetadata != nil {
 		if o.AdditionalMetadata == nil {
 			o.AdditionalMetadata = make(map[string]any)
@@ -313,13 +344,13 @@ type RunResponseUpdate struct {
 
 // Text returns the concatenated text contents of the response messages.
 func (r *RunResponseUpdate) Text() string {
-	var text string
+	var sb strings.Builder
 	for _, content := range r.Contents {
 		if textContent, ok := content.(*TextContent); ok {
-			text += textContent.Text
+			sb.WriteString(textContent.Text)
 		}
 	}
-	return text
+	return sb.String()
 }
 
 func (a *Agent) contextProvider(thread Thread) ContextProvider {
@@ -336,6 +367,16 @@ func (a *Agent) contextProvider(thread Thread) ContextProvider {
 
 func (a *Agent) prepareRun(ctx context.Context, thread Thread, opts *RunOptions, messages []*Message) (*RunOptions, []*Message, error) {
 	opts = a.Config.Opts.Merge(opts)
+	if opts.ResponseFormat == nil && opts.Response != nil {
+		// Try to get the format from the response object.
+		if rf, ok := opts.Response.(format.FormatProvider); ok {
+			var err error
+			opts.ResponseFormat, err = rf.Format()
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
 	messages = slices.Clone(messages)
 	if a.Config.SystemInstructions != "" {
 		messages = append([]*Message{NewMessage(RoleSystem, &TextContent{Text: a.Config.SystemInstructions})}, messages...)

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -11,13 +11,9 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/microsoft/agent-framework/go/format"
 	"github.com/microsoft/agent-framework/go/tool"
 )
-
-// Agent represents an AI agent that can execute tasks using a client and tools.
-type Agent struct {
-	Config Config
-}
 
 // Config contains configuration for an [Agent].
 type Config struct {
@@ -34,6 +30,11 @@ type Config struct {
 	Run func(ctx context.Context, thread Thread, opts *RunOptions, messages ...*Message) (*RunResponse, error)
 
 	RunStream func(ctx context.Context, thread Thread, opts *RunOptions, messages ...*Message) iter.Seq2[*RunResponseUpdate, error]
+}
+
+// Agent represents an AI agent that can execute tasks using a client and tools.
+type Agent struct {
+	Config Config
 }
 
 func (a *Agent) ID() string {
@@ -225,6 +226,11 @@ func (a *Agent) runStreamFallback(ctx context.Context, thread Thread, options *R
 
 // RunOptions contains options for agent execution.
 type RunOptions struct {
+	// ResponseFormat represents the desired response format for agent execution.
+	// It is up to the client implementation if or how to honor the request.
+	// If the client implementation doesn't recognize the specific kind, it can be ignored.
+	ResponseFormat format.Format
+
 	// Tools to make available to the agent.
 	Tools []tool.Tool
 

--- a/go/agent/func_test.go
+++ b/go/agent/func_test.go
@@ -23,10 +23,6 @@ func TestAgentCallTool(t *testing.T) {
 	funcDef := &functool.Func{
 		Name:        "get_weather",
 		Description: "Get weather for a location",
-		InputSchema: map[string]any{
-			"type":       "object",
-			"properties": map[string]any{"location": map[string]any{"type": "string"}},
-		},
 	}
 
 	tl := functool.MustNew(funcDef, handler)

--- a/go/format/format.go
+++ b/go/format/format.go
@@ -9,6 +9,11 @@ type Format interface {
 	Kind() string
 }
 
+// FormatProvider is an interface for types that can provide a Format.
+type FormatProvider interface {
+	Format() (Format, error)
+}
+
 type simple struct {
 	kind string
 }

--- a/go/format/format.go
+++ b/go/format/format.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package format
+
+// Format represents the desired format, e.g., for agent responses or tool input/output.
+type Format interface {
+	// Kind if the format type.
+	// For example, "text" or "json".
+	Kind() string
+}
+
+type simple struct {
+	kind string
+}
+
+func (s simple) Kind() string {
+	return s.kind
+}
+
+// JSON represents the JSON format.
+// Use [format/jsonformat] for more advanced JSON schema-based formatting.
+func JSON() Format {
+	return simple{kind: "json"}
+}
+
+// Text represents the plain text format.
+func Text() Format {
+	return simple{kind: "text"}
+}

--- a/go/format/jsonformat/example_test.go
+++ b/go/format/jsonformat/example_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package jsonformat_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/microsoft/agent-framework/go/format/jsonformat"
+)
+
+func ExampleValue_string() {
+	// Create a Value with a string
+	value := jsonformat.MustNewValue("hello world", nil)
+
+	// Marshal to JSON
+	data, _ := json.Marshal(value)
+	fmt.Printf("JSON: %s\n", string(data))
+
+	// Unmarshal from JSON
+	newValue := new(jsonformat.Value[string])
+	_ = json.Unmarshal(data, newValue)
+	fmt.Printf("Value: %s\n", newValue.Unwrap())
+
+	// Output:
+	// JSON: "hello world"
+	// Value: hello world
+}
+
+func ExampleValue_int() {
+	// Create a Value with an int
+	value := jsonformat.MustNewValue(42, nil)
+
+	// Marshal to JSON
+	data, _ := json.Marshal(value)
+	fmt.Printf("JSON: %s\n", string(data))
+
+	// Unmarshal from JSON
+	newValue := new(jsonformat.Value[int])
+	_ = json.Unmarshal(data, newValue)
+	fmt.Printf("Value: %d\n", newValue.Unwrap())
+
+	// Output:
+	// JSON: 42
+	// Value: 42
+}
+
+func ExampleValue_slice() {
+	// Create a Value with a slice
+	value := jsonformat.MustNewValue([]string{"one", "two", "three"}, nil)
+
+	// Marshal to JSON
+	data, _ := json.Marshal(value)
+	fmt.Printf("JSON: %s\n", string(data))
+
+	// Unmarshal from JSON
+	newValue := new(jsonformat.Value[[]string])
+	_ = json.Unmarshal(data, newValue)
+	fmt.Printf("Value: %v\n", newValue.Unwrap())
+
+	// Output:
+	// JSON: ["one","two","three"]
+	// Value: [one two three]
+}
+
+func ExampleValue_map() {
+	// Create a Value with a map
+	value := jsonformat.MustNewValue(map[string]int{"count": 42, "total": 100}, nil)
+
+	// Marshal to JSON
+	data, _ := json.Marshal(value)
+
+	// Note: Map order is not guaranteed in Go, so we just check it unmarshals correctly
+	newValue := new(jsonformat.Value[map[string]int])
+	_ = json.Unmarshal(data, newValue)
+	result := newValue.Unwrap()
+
+	fmt.Printf("count: %d, total: %d\n", result["count"], result["total"])
+
+	// Output:
+	// count: 42, total: 100
+}

--- a/go/format/jsonformat/jsonformat.go
+++ b/go/format/jsonformat/jsonformat.go
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package jsonformat
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/microsoft/agent-framework/go/format"
+)
+
+// The jsonschema handling is loosely based on https://github.com/modelcontextprotocol/go-sdk
+
+var _ format.Format = (*Format)(nil)
+
+// Format implements the [format.Format] interface for JSON schema-based formats.
+type Format struct {
+	Name        string
+	Description string
+	Strict      bool
+	Schema      *jsonschema.Schema
+
+	resolvedSchema *jsonschema.Resolved
+	zero           any
+}
+
+func (f *Format) Kind() string {
+	return "json"
+}
+
+// Options for creating a [Format] or a [Value] for a type T.
+type Options struct {
+	jsonschema.ForOptions
+
+	// Name is the name of the schema.
+	//
+	// If empty, the name of the type T is used.
+	Name string
+
+	// Description is the description of the schema.
+	Description string
+
+	// Strict indicates whether to enable strict validation
+	// of the JSON schema and the strict adherence to the schema during
+	// marshaling and unmarshaling.
+	Strict bool
+}
+
+// MustFor calls [For] and panics on error.
+func MustFor[T any](opts *Options) *Format {
+	f, err := For[T](opts)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// For creates a Schema for the type T.
+// If opts is nil, default options are used.
+// The any type is treated as an empty object.
+func For[T any](opts *Options) (*Format, error) {
+	if opts == nil {
+		opts = &Options{}
+	}
+	rt := reflect.TypeFor[T]()
+	name := opts.Name
+	if name == "" {
+		name = rt.Name()
+	}
+	var schema *jsonschema.Schema
+	var zero any
+	if rt == reflect.TypeFor[any]() {
+		// Special handling for an "any" input: treat as an empty object.
+		schema = &jsonschema.Schema{Type: "object"}
+	} else {
+		if rt.Kind() == reflect.Pointer {
+			// Pointers are treated equivalently to non-pointers when deriving the schema.
+			// If an indirection occurred to derive the schema, a non-nil zero value is
+			// returned to be used in place of the typed nil zero value.
+			rt = rt.Elem()
+			zero = reflect.Zero(rt).Interface()
+		}
+		var err error
+		schema, err = jsonschema.ForType(rt, &opts.ForOptions)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Always set ValidateDefaults to true when resolving the schema,
+	// even when opts.Strict is false. The JSON Schema spec says it should
+	// only be false for tools that generate schema visualizations.
+	resolved, err := schema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
+	if err != nil {
+		return nil, fmt.Errorf("resolving schema: %w", err)
+	}
+	return &Format{
+		Name:           name,
+		Description:    opts.Description,
+		Schema:         schema,
+		Strict:         opts.Strict,
+		resolvedSchema: resolved,
+		zero:           zero,
+	}, nil
+}
+
+// applySchema validates whether data is valid JSON according to the provided
+// schema, after applying schema defaults.
+//
+// Returns the JSON value augmented with defaults.
+func applySchema(data json.RawMessage, resolved *jsonschema.Resolved, strict bool) (json.RawMessage, error) {
+	var v any
+
+	// For primitive types (non-object, non-array), unmarshal directly into the appropriate type
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, fmt.Errorf("unmarshaling arguments: %w", err)
+		}
+	}
+
+	// ApplyDefaults and Validate work on the unmarshaled value
+	if err := resolved.ApplyDefaults(&v); err != nil {
+		return nil, fmt.Errorf("applying schema defaults:\n%w", err)
+	}
+
+	if strict {
+		if err := resolved.Validate(&v); err != nil {
+			return nil, err
+		}
+	}
+
+	// We must re-marshal with the default values applied.
+	var err error
+	data, err = json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling with defaults: %v", err)
+	}
+	return data, nil
+}

--- a/go/format/jsonformat/jsonformat_test.go
+++ b/go/format/jsonformat/jsonformat_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package jsonformat_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/agent-framework/go/format/jsonformat"
+)
+
+type SimpleStruct struct {
+	Name  string `json:"name"`
+	Age   int    `json:"age"`
+	Email string `json:"email,omitempty"`
+}
+
+type NestedStruct struct {
+	ID     string       `json:"id"`
+	Person SimpleStruct `json:"person"`
+	Active bool         `json:"active"`
+}
+
+type PointerStruct struct {
+	Value *string `json:"value,omitempty"`
+	Count *int    `json:"count,omitempty"`
+}
+
+func TestFor(t *testing.T) {
+	t.Run("SimpleStruct", func(t *testing.T) {
+		format, err := jsonformat.For[SimpleStruct](nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if format.Name != "SimpleStruct" {
+			t.Fatalf("expected: %v, got: %v", "SimpleStruct", format.Name)
+		}
+		if format.Kind() != "json" {
+			t.Fatalf("expected: %v, got: %v", "json", format.Kind())
+		}
+	})
+
+	t.Run("WithCustomName", func(t *testing.T) {
+		opts := &jsonformat.Options{
+			Name:        "CustomName",
+			Description: "A custom description",
+		}
+		format, err := jsonformat.For[SimpleStruct](opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if format.Name != "CustomName" {
+			t.Fatalf("expected: %v, got: %v", "CustomName", format.Name)
+		}
+		if format.Description != "A custom description" {
+			t.Fatalf("expected: %v, got: %v", "A custom description", format.Description)
+		}
+	})
+
+	t.Run("WithStrict", func(t *testing.T) {
+		opts := &jsonformat.Options{
+			Strict: true,
+		}
+		format, err := jsonformat.For[SimpleStruct](opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !format.Strict {
+			t.Fatal("expected Strict to be true")
+		}
+	})
+
+	t.Run("AnyType", func(t *testing.T) {
+		format, err := jsonformat.For[any](nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if format.Schema.Type != "object" {
+			t.Fatalf("expected: %v, got: %v", "object", format.Schema.Type)
+		}
+	})
+
+	t.Run("PointerType", func(t *testing.T) {
+		format, err := jsonformat.For[*SimpleStruct](nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Pointer types don't have a name by default
+		if format.Name != "" {
+			t.Fatalf("expected: %v, got: %v", "", format.Name)
+		}
+	})
+
+	t.Run("PrimitiveTypes", func(t *testing.T) {
+		t.Run("String", func(t *testing.T) {
+			_, err := jsonformat.For[string](nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("Int", func(t *testing.T) {
+			_, err := jsonformat.For[int](nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("Bool", func(t *testing.T) {
+			_, err := jsonformat.For[bool](nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+
+	t.Run("NestedStruct", func(t *testing.T) {
+		format, err := jsonformat.For[NestedStruct](nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if format.Name != "NestedStruct" {
+			t.Fatalf("expected: %v, got: %v", "NestedStruct", format.Name)
+		}
+	})
+}
+
+func TestMustFor(t *testing.T) {
+	assertNotPanics(t, func() {
+		jsonformat.MustFor[SimpleStruct](nil)
+	})
+}
+
+func TestFormatKind(t *testing.T) {
+	format := jsonformat.MustFor[SimpleStruct](nil)
+	if format.Kind() != "json" {
+		t.Fatalf("expected: %v, got: %v", "json", format.Kind())
+	}
+}
+
+func assertPanics(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic, but function did not panic")
+		}
+	}()
+	fn()
+}
+
+func assertNotPanics(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("expected no panic, but got panic: %v", r)
+		}
+	}()
+	fn()
+}

--- a/go/format/jsonformat/value.go
+++ b/go/format/jsonformat/value.go
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package jsonformat
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// A Value represents a value of type T along with its JSON Schema.
+// It can marshal and unmarshal itself to and from JSON, validating against the schema.
+// The zero Value corresponds to the zero value of type T.
+type Value[T any] struct {
+	value  T
+	format *Format
+
+	opts     *Options
+	initOnce sync.Once
+	initErr  error
+}
+
+// MustNewValue calls [NewValue] and panics on error.
+func MustNewValue[T any](v T, opts *Options) *Value[T] {
+	val, err := NewValue(v, opts)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+// NewValue creates a new Value for type T.
+// If opts is nil, default options are used.
+// The any type is treated as an empty object.
+func NewValue[T any](v T, opts *Options) (*Value[T], error) {
+	val := &Value[T]{value: v, opts: opts}
+	if err := val.init(opts); err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+func (v *Value[T]) init(opts *Options) error {
+	v.initOnce.Do(func() {
+		if reflect.TypeFor[T]() == reflect.TypeFor[any]() && any(v.value) != nil {
+			v.initErr = errors.New("cannot create Value[any] with non-nil value")
+			return
+		}
+		v.format, v.initErr = For[T](opts)
+	})
+	return v.initErr
+}
+
+func (v *Value[T]) UnmarshalJSON(data []byte) error {
+	if err := v.init(v.opts); err != nil {
+		return err
+	}
+	var err error
+	data, err = applySchema(data, v.format.resolvedSchema, v.format.Strict)
+	if err != nil {
+		return fmt.Errorf("validating: %v", err)
+	}
+	// Unmarshal and validate args.
+	if data != nil {
+		if err := json.Unmarshal(data, &v.value); err != nil {
+			return fmt.Errorf("unmarshaling: %w", err)
+		}
+	}
+	return nil
+}
+
+func (v *Value[T]) MarshalJSON() ([]byte, error) {
+	if err := v.init(v.opts); err != nil {
+		return nil, err
+	}
+	// Marshal the output and put the RawMessage in the StructuredContent field.
+	var outval any = v.value
+	if v.format.zero != nil {
+		// Avoid typed nil, which will serialize as JSON null.
+		// Instead, use the zero value of the unpointered type.
+		var z T
+		if any(v.value) == any(z) { // zero is only non-nil if Out is a pointer type
+			outval = v.format.zero
+		}
+	}
+	if outval == nil {
+		return nil, nil
+	}
+	outbytes, err := json.Marshal(outval)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling: %w", err)
+	}
+	// Validate the output JSON, and apply defaults.
+	//
+	// We validate against the JSON, rather than the output value, as
+	// some types may have custom JSON marshalling.
+	outJSON, err := applySchema(json.RawMessage(outbytes), v.format.resolvedSchema, v.format.Strict)
+	if err != nil {
+		return nil, fmt.Errorf("validating: %w", err)
+	}
+	return outJSON, nil
+}
+
+// Wrap replaces the underlying value with val.
+func (v *Value[T]) Wrap(val T) {
+	v.value = val
+}
+
+// Unwrap returns the underlying value.
+func (v *Value[T]) Unwrap() T {
+	return v.value
+}
+
+// Format returns the [Format] associated with this value.
+func (v *Value[T]) Format() (*Format, error) {
+	if err := v.init(v.opts); err != nil {
+		return nil, err
+	}
+	return v.format, nil
+}
+
+// MustFormat calls [Format] and panics on error.
+func (v *Value[T]) MustFormat() *Format {
+	f, err := v.Format()
+	if err != nil {
+		panic(err)
+	}
+	return f
+}

--- a/go/format/jsonformat/value.go
+++ b/go/format/jsonformat/value.go
@@ -3,12 +3,17 @@
 package jsonformat
 
 import (
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
+
+	"github.com/microsoft/agent-framework/go/format"
 )
+
+var _ encoding.BinaryUnmarshaler = (*Value[any])(nil)
+var _ format.FormatProvider = (*Value[any])(nil)
 
 // A Value represents a value of type T along with its JSON Schema.
 // It can marshal and unmarshal itself to and from JSON, validating against the schema.
@@ -17,9 +22,8 @@ type Value[T any] struct {
 	value  T
 	format *Format
 
-	opts     *Options
-	initOnce sync.Once
-	initErr  error
+	opts    *Options
+	initErr error
 }
 
 // MustNewValue calls [NewValue] and panics on error.
@@ -43,14 +47,18 @@ func NewValue[T any](v T, opts *Options) (*Value[T], error) {
 }
 
 func (v *Value[T]) init(opts *Options) error {
-	v.initOnce.Do(func() {
+	if v.format == nil && v.initErr == nil {
 		if reflect.TypeFor[T]() == reflect.TypeFor[any]() && any(v.value) != nil {
 			v.initErr = errors.New("cannot create Value[any] with non-nil value")
-			return
+			return v.initErr
 		}
 		v.format, v.initErr = For[T](opts)
-	})
+	}
 	return v.initErr
+}
+
+func (v *Value[T]) UnmarshalBinary(data []byte) error {
+	return v.UnmarshalJSON(data)
 }
 
 func (v *Value[T]) UnmarshalJSON(data []byte) error {
@@ -114,7 +122,12 @@ func (v *Value[T]) Unwrap() T {
 }
 
 // Format returns the [Format] associated with this value.
-func (v *Value[T]) Format() (*Format, error) {
+func (v *Value[T]) Format() (format.Format, error) {
+	return v.FormatJSON()
+}
+
+// FormatJSON returns the [Format] associated with this value.
+func (v *Value[T]) FormatJSON() (*Format, error) {
 	if err := v.init(v.opts); err != nil {
 		return nil, err
 	}
@@ -122,7 +135,7 @@ func (v *Value[T]) Format() (*Format, error) {
 }
 
 // MustFormat calls [Format] and panics on error.
-func (v *Value[T]) MustFormat() *Format {
+func (v *Value[T]) MustFormat() format.Format {
 	f, err := v.Format()
 	if err != nil {
 		panic(err)

--- a/go/format/jsonformat/value_test.go
+++ b/go/format/jsonformat/value_test.go
@@ -1,0 +1,643 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package jsonformat_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/agent-framework/go/format/jsonformat"
+)
+
+func TestNewValue(t *testing.T) {
+	t.Run("SimpleStruct", func(t *testing.T) {
+		initial := SimpleStruct{Name: "John", Age: 30, Email: "john@example.com"}
+		value, err := jsonformat.NewValue(initial, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(initial, value.Unwrap()) {
+			t.Fatalf("expected: %v, got: %v", initial, value.Unwrap())
+		}
+	})
+
+	t.Run("ZeroValue", func(t *testing.T) {
+		value, err := jsonformat.NewValue(SimpleStruct{}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(SimpleStruct{}, value.Unwrap()) {
+			t.Fatalf("expected: %v, got: %v", SimpleStruct{}, value.Unwrap())
+		}
+	})
+
+	t.Run("WithOptions", func(t *testing.T) {
+		opts := &jsonformat.Options{
+			Name:        "TestValue",
+			Description: "Test description",
+		}
+		value, err := jsonformat.NewValue(SimpleStruct{Name: "Test"}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		format, err := value.Format()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if format.Name != "TestValue" {
+			t.Fatalf("expected: %v, got: %v", "TestValue", format.Name)
+		}
+		if format.Description != "Test description" {
+			t.Fatalf("expected: %v, got: %v", "Test description", format.Description)
+		}
+	})
+
+	t.Run("AnyTypeWithNilValue", func(t *testing.T) {
+		value, err := jsonformat.NewValue[any](nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if value == nil {
+			t.Fatal("expected non-nil value, got nil")
+		}
+	})
+
+	t.Run("AnyTypeWithNonNilValue", func(t *testing.T) {
+		value, err := jsonformat.NewValue[any]("something", nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if value != nil {
+			t.Fatalf("expected nil, got: %v", value)
+		}
+		want := "cannot create Value[any] with non-nil value"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got: %q", want, err.Error())
+		}
+	})
+
+	t.Run("PointerType", func(t *testing.T) {
+		name := "test"
+		ps := &PointerStruct{Value: &name}
+		value, err := jsonformat.NewValue(ps, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ps, value.Unwrap()) {
+			t.Fatalf("expected: %v, got: %v", ps, value.Unwrap())
+		}
+	})
+}
+
+func TestMustNewValue(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		assertNotPanics(t, func() {
+			jsonformat.MustNewValue(SimpleStruct{Name: "Test"}, nil)
+		})
+	})
+
+	t.Run("Panic", func(t *testing.T) {
+		assertPanics(t, func() {
+			_ = jsonformat.MustNewValue[any]("invalid", nil)
+		})
+	})
+}
+
+func TestValueWrapUnwrap(t *testing.T) {
+	value := jsonformat.MustNewValue(SimpleStruct{Name: "Initial"}, nil)
+
+	t.Run("InitialValue", func(t *testing.T) {
+		got := value.Unwrap()
+		if got.Name != "Initial" {
+			t.Fatalf("expected: %v, got: %v", "Initial", got.Name)
+		}
+	})
+
+	t.Run("WrapNewValue", func(t *testing.T) {
+		newVal := SimpleStruct{Name: "Updated", Age: 25}
+		value.Wrap(newVal)
+		got := value.Unwrap()
+		if !reflect.DeepEqual(newVal, got) {
+			t.Fatalf("expected: %v, got: %v", newVal, got)
+		}
+	})
+}
+
+func TestValueFormat(t *testing.T) {
+	value := jsonformat.MustNewValue(SimpleStruct{}, nil)
+	format, err := value.Format()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if format.Name != "SimpleStruct" {
+		t.Fatalf("expected: %v, got: %v", "SimpleStruct", format.Name)
+	}
+}
+
+func TestValueMustFormat(t *testing.T) {
+	value := jsonformat.MustNewValue(SimpleStruct{}, nil)
+	assertNotPanics(t, func() {
+		value.MustFormat()
+	})
+}
+
+func TestValueMarshalJSON(t *testing.T) {
+	t.Run("SimpleStruct", func(t *testing.T) {
+		testRoundtrip(t, SimpleStruct{Name: "John", Age: 30, Email: "john@example.com"})
+	})
+
+	t.Run("ZeroValue", func(t *testing.T) {
+		testRoundtrip(t, SimpleStruct{})
+	})
+
+	t.Run("NestedStruct", func(t *testing.T) {
+		testRoundtrip(t, NestedStruct{
+			ID: "123",
+			Person: SimpleStruct{
+				Name: "Jane",
+				Age:  25,
+			},
+			Active: true,
+		})
+	})
+
+	t.Run("PointerTypeWithNil", func(t *testing.T) {
+		// Note: marshaling nil pointer and unmarshaling creates zero value, not nil
+		var ps *PointerStruct
+		value, err := jsonformat.NewValue(ps, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = json.Marshal(value); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("PointerTypeWithValue", func(t *testing.T) {
+		name := "test"
+		ps := &PointerStruct{Value: &name}
+		testRoundtrip(t, ps)
+	})
+}
+
+func TestValueUnmarshalJSON(t *testing.T) {
+	t.Run("SimpleStruct", func(t *testing.T) {
+		input := `{"name":"Alice","age":28,"email":"alice@example.com"}`
+		value := &jsonformat.Value[SimpleStruct]{}
+
+		err := json.Unmarshal([]byte(input), value)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := SimpleStruct{Name: "Alice", Age: 28, Email: "alice@example.com"}
+		if !reflect.DeepEqual(expected, value.Unwrap()) {
+			t.Fatalf("expected: %v, got: %v", expected, value.Unwrap())
+		}
+	})
+
+	t.Run("PartialData", func(t *testing.T) {
+		input := `{"name":"Bob","age":35}`
+		value := &jsonformat.Value[SimpleStruct]{}
+
+		err := json.Unmarshal([]byte(input), value)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := SimpleStruct{Name: "Bob", Age: 35, Email: ""}
+		if !reflect.DeepEqual(expected, value.Unwrap()) {
+			t.Fatalf("expected: %v, got: %v", expected, value.Unwrap())
+		}
+	})
+
+	t.Run("NestedStruct", func(t *testing.T) {
+		input := `{"id":"456","person":{"name":"Charlie","age":40},"active":false}`
+		value := &jsonformat.Value[NestedStruct]{}
+
+		err := json.Unmarshal([]byte(input), value)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := NestedStruct{
+			ID:     "456",
+			Person: SimpleStruct{Name: "Charlie", Age: 40},
+			Active: false,
+		}
+		if !reflect.DeepEqual(expected, value.Unwrap()) {
+			t.Fatalf("expected: %v, got: %v", expected, value.Unwrap())
+		}
+	})
+
+	t.Run("ZeroValueStruct", func(t *testing.T) {
+		input := `{"name":"","age":0}`
+		value := &jsonformat.Value[SimpleStruct]{}
+
+		err := json.Unmarshal([]byte(input), value)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := SimpleStruct{Name: "", Age: 0}
+		if !reflect.DeepEqual(expected, value.Unwrap()) {
+			t.Fatalf("expected: %v, got: %v", expected, value.Unwrap())
+		}
+	})
+}
+
+func TestValueRoundtrip(t *testing.T) {
+	t.Run("SimpleStruct", func(t *testing.T) {
+		testRoundtrip(t, SimpleStruct{Name: "David", Age: 45, Email: "david@example.com"})
+	})
+
+	t.Run("NestedStruct", func(t *testing.T) {
+		testRoundtrip(t, NestedStruct{
+			ID: "789",
+			Person: SimpleStruct{
+				Name:  "Eve",
+				Age:   32,
+				Email: "eve@example.com",
+			},
+			Active: true,
+		})
+	})
+
+	t.Run("PointerStruct", func(t *testing.T) {
+		count := 5
+		name := "pointer test"
+		testRoundtrip(t, PointerStruct{
+			Value: &name,
+			Count: &count,
+		})
+	})
+}
+
+func testRoundtrip[T any](t *testing.T, original T) {
+	t.Helper()
+
+	// Create a Value with the original data
+	value, err := jsonformat.NewValue(original, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the value matches
+	if !reflect.DeepEqual(original, value.Unwrap()) {
+		t.Fatalf("expected: %v, got: %v", original, value.Unwrap())
+	}
+
+	// Marshal to JSON
+	data, err := value.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unmarshal back
+	newValue := new(jsonformat.Value[T])
+	err = newValue.UnmarshalJSON(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare using reflect.DeepEqual
+	result := newValue.Unwrap()
+	if !reflect.DeepEqual(original, result) {
+		t.Fatalf("expected: %v, got: %v", original, result)
+	}
+}
+
+func TestValueWithOptions(t *testing.T) {
+	t.Run("CustomNameAndDescription", func(t *testing.T) {
+		opts := &jsonformat.Options{
+			Name:        "CustomStruct",
+			Description: "This is a custom struct",
+		}
+		value := jsonformat.MustNewValue(SimpleStruct{Name: "Test"}, opts)
+
+		format := value.MustFormat()
+		if format.Name != "CustomStruct" {
+			t.Fatalf("expected: %v, got: %v", "CustomStruct", format.Name)
+		}
+		if format.Description != "This is a custom struct" {
+			t.Fatalf("expected: %v, got: %v", "This is a custom struct", format.Description)
+		}
+	})
+
+	t.Run("StrictMode", func(t *testing.T) {
+		opts := &jsonformat.Options{
+			Strict: true,
+		}
+		value := jsonformat.MustNewValue(SimpleStruct{Name: "Test"}, opts)
+
+		format := value.MustFormat()
+		if !format.Strict {
+			t.Fatal("expected Strict to be true")
+		}
+	})
+}
+
+func TestValueMarshalNilPointer(t *testing.T) {
+	// Test marshaling a nil pointer value
+	var ps *PointerStruct
+	value, err := jsonformat.NewValue(ps, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := json.Marshal(value); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValueLazyInit(t *testing.T) {
+	// Test that Format is lazily initialized
+	value := &jsonformat.Value[SimpleStruct]{}
+
+	// Before any operation, format should not be initialized
+	// First call to Format should initialize it
+	format1, err := value.Format()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call should return the same format
+	format2, err := value.Format()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(format1, format2) {
+		t.Fatalf("expected: %v, got: %v", format1, format2)
+	}
+}
+
+func TestValueUnmarshalInvalidJSON(t *testing.T) {
+	t.Run("InvalidJSON", func(t *testing.T) {
+		input := `{"name":"test","age":"not a number"}`
+		value := &jsonformat.Value[SimpleStruct]{}
+
+		err := json.Unmarshal([]byte(input), value)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("MalformedJSON", func(t *testing.T) {
+		input := `{invalid json}`
+		value := &jsonformat.Value[SimpleStruct]{}
+
+		err := json.Unmarshal([]byte(input), value)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestValueMarshalAfterWrap(t *testing.T) {
+	value := jsonformat.MustNewValue(SimpleStruct{Name: "Initial", Age: 20}, nil)
+
+	// Marshal initial value
+	data1, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap with new value
+	value.Wrap(SimpleStruct{Name: "Updated", Age: 30})
+
+	// Marshal wrapped value
+	data2, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unmarshal both and compare
+	var result1, result2 SimpleStruct
+	if err := json.Unmarshal(data1, &result1); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data2, &result2); err != nil {
+		t.Fatal(err)
+	}
+
+	expected1 := SimpleStruct{Name: "Initial", Age: 20}
+	expected2 := SimpleStruct{Name: "Updated", Age: 30}
+	if !reflect.DeepEqual(expected1, result1) {
+		t.Fatalf("expected: %v, got: %v", expected1, result1)
+	}
+	if !reflect.DeepEqual(expected2, result2) {
+		t.Fatalf("expected: %v, got: %v", expected2, result2)
+	}
+}
+
+func TestComplexNestedStructure(t *testing.T) {
+	type Address struct {
+		Street  string `json:"street"`
+		City    string `json:"city"`
+		ZipCode string `json:"zipCode"`
+	}
+
+	type Contact struct {
+		Email   string  `json:"email"`
+		Phone   string  `json:"phone"`
+		Address Address `json:"address"`
+	}
+
+	type Employee struct {
+		ID      string  `json:"id"`
+		Name    string  `json:"name"`
+		Contact Contact `json:"contact"`
+		Active  bool    `json:"active"`
+	}
+
+	testRoundtrip(t, Employee{
+		ID:   "emp123",
+		Name: "John Doe",
+		Contact: Contact{
+			Email: "john@example.com",
+			Phone: "+1234567890",
+			Address: Address{
+				Street:  "123 Main St",
+				City:    "Springfield",
+				ZipCode: "12345",
+			},
+		},
+		Active: true,
+	})
+}
+
+func TestSliceAndMapTypes(t *testing.T) {
+	type DataStruct struct {
+		Tags     []string          `json:"tags"`
+		Metadata map[string]string `json:"metadata"`
+	}
+
+	testRoundtrip(t, DataStruct{
+		Tags: []string{"tag1", "tag2", "tag3"},
+		Metadata: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	})
+}
+
+func TestBuiltinTypes(t *testing.T) {
+	t.Run("String", func(t *testing.T) {
+		testRoundtrip(t, "hello world")
+		testRoundtrip(t, "")
+		testRoundtrip(t, "special chars: !@#$%^&*()")
+	})
+
+	t.Run("Int", func(t *testing.T) {
+		testRoundtrip(t, 0)
+		testRoundtrip(t, 42)
+		testRoundtrip(t, -100)
+		testRoundtrip(t, 999999)
+	})
+
+	t.Run("Int64", func(t *testing.T) {
+		testRoundtrip(t, int64(0))
+		testRoundtrip(t, int64(123456789012345))
+		testRoundtrip(t, int64(-123456789012345))
+	})
+
+	t.Run("Float64", func(t *testing.T) {
+		testRoundtrip(t, 0.0)
+		testRoundtrip(t, 3.14159)
+		testRoundtrip(t, -273.15)
+		testRoundtrip(t, 1.23e10)
+	})
+
+	t.Run("Bool", func(t *testing.T) {
+		testRoundtrip(t, true)
+		testRoundtrip(t, false)
+	})
+
+	t.Run("Uint", func(t *testing.T) {
+		testRoundtrip(t, uint(0))
+		testRoundtrip(t, uint(42))
+		testRoundtrip(t, uint(4294967295))
+	})
+}
+
+func TestBuiltinValueOperations(t *testing.T) {
+	t.Run("WrapUnwrapString", func(t *testing.T) {
+		value := jsonformat.MustNewValue("initial", nil)
+		if value.Unwrap() != "initial" {
+			t.Fatalf("expected: %v, got: %v", "initial", value.Unwrap())
+		}
+
+		value.Wrap("updated")
+		if value.Unwrap() != "updated" {
+			t.Fatalf("expected: %v, got: %v", "updated", value.Unwrap())
+		}
+	})
+
+	t.Run("WrapUnwrapInt", func(t *testing.T) {
+		value := jsonformat.MustNewValue(10, nil)
+		if value.Unwrap() != 10 {
+			t.Fatalf("expected: %v, got: %v", 10, value.Unwrap())
+		}
+
+		value.Wrap(20)
+		if value.Unwrap() != 20 {
+			t.Fatalf("expected: %v, got: %v", 20, value.Unwrap())
+		}
+	})
+
+	t.Run("FormatString", func(t *testing.T) {
+		value := jsonformat.MustNewValue("test", nil)
+		format := value.MustFormat()
+		if format.Kind() != "json" {
+			t.Fatalf("expected: %v, got: %v", "json", format.Kind())
+		}
+	})
+
+	t.Run("FormatInt", func(t *testing.T) {
+		value := jsonformat.MustNewValue(42, nil)
+		format := value.MustFormat()
+		if format.Kind() != "json" {
+			t.Fatalf("expected: %v, got: %v", "json", format.Kind())
+		}
+	})
+}
+
+func TestBuiltinSliceTypes(t *testing.T) {
+	t.Run("StringSlice", func(t *testing.T) {
+		original := []string{"one", "two", "three"}
+		testRoundtrip(t, original)
+	})
+
+	t.Run("IntSlice", func(t *testing.T) {
+		original := []int{1, 2, 3, 4, 5}
+		testRoundtrip(t, original)
+	})
+
+	t.Run("BoolSlice", func(t *testing.T) {
+		original := []bool{true, false, true}
+		testRoundtrip(t, original)
+	})
+
+	t.Run("EmptySlice", func(t *testing.T) {
+		original := []string{}
+		testRoundtrip(t, original)
+	})
+}
+
+func TestBuiltinMapTypes(t *testing.T) {
+	t.Run("StringMap", func(t *testing.T) {
+		original := map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		}
+		testRoundtrip(t, original)
+	})
+
+	t.Run("IntMap", func(t *testing.T) {
+		original := map[string]int{
+			"count": 42,
+			"total": 100,
+		}
+		testRoundtrip(t, original)
+	})
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		original := map[string]string{}
+		testRoundtrip(t, original)
+	})
+}
+
+func TestBuiltinPointerTypes(t *testing.T) {
+	t.Run("StringPointer", func(t *testing.T) {
+		str := "test"
+		value := jsonformat.MustNewValue(&str, nil)
+		result := value.Unwrap()
+		if *result != "test" {
+			t.Fatalf("expected: %v, got: %v", "test", *result)
+		}
+	})
+
+	t.Run("IntPointer", func(t *testing.T) {
+		num := 42
+		value := jsonformat.MustNewValue(&num, nil)
+		result := value.Unwrap()
+		if *result != 42 {
+			t.Fatalf("expected: %v, got: %v", 42, *result)
+		}
+	})
+
+	t.Run("NilPointer", func(t *testing.T) {
+		var str *string
+		value, err := jsonformat.NewValue(str, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := value.Unwrap()
+		if result != nil {
+			t.Fatalf("expected nil, got: %v", result)
+		}
+	})
+}

--- a/go/format/jsonformat/value_test.go
+++ b/go/format/jsonformat/value_test.go
@@ -43,7 +43,7 @@ func TestNewValue(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		format, err := value.Format()
+		format, err := value.FormatJSON()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -128,7 +128,7 @@ func TestValueWrapUnwrap(t *testing.T) {
 
 func TestValueFormat(t *testing.T) {
 	value := jsonformat.MustNewValue(SimpleStruct{}, nil)
-	format, err := value.Format()
+	format, err := value.FormatJSON()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,10 @@ func TestValueWithOptions(t *testing.T) {
 		}
 		value := jsonformat.MustNewValue(SimpleStruct{Name: "Test"}, opts)
 
-		format := value.MustFormat()
+		format, err := value.FormatJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
 		if format.Name != "CustomStruct" {
 			t.Fatalf("expected: %v, got: %v", "CustomStruct", format.Name)
 		}
@@ -333,7 +336,10 @@ func TestValueWithOptions(t *testing.T) {
 		}
 		value := jsonformat.MustNewValue(SimpleStruct{Name: "Test"}, opts)
 
-		format := value.MustFormat()
+		format, err := value.FormatJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
 		if !format.Strict {
 			t.Fatal("expected Strict to be true")
 		}

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/format/jsonformat"
 	"github.com/microsoft/agent-framework/go/tool"
 	"github.com/microsoft/agent-framework/go/tool/websearchtool"
 	"github.com/openai/openai-go/v3"
@@ -175,6 +176,29 @@ func (a *client) buildCompletionParams(options *agent.RunOptions, messages ...*a
 		}
 		if options.MaxTokens != nil {
 			params.MaxTokens = openai.Int(int64(*options.MaxTokens))
+		}
+		if options.ResponseFormat != nil {
+			switch options.ResponseFormat.Kind() {
+			case "json":
+				if schema, ok := options.ResponseFormat.(*jsonformat.Format); ok {
+					params.ResponseFormat.OfJSONSchema = &shared.ResponseFormatJSONSchemaParam{
+						JSONSchema: shared.ResponseFormatJSONSchemaJSONSchemaParam{
+							Name:   schema.Name,
+							Schema: schema.Schema,
+						},
+					}
+					if schema.Description != "" {
+						params.ResponseFormat.OfJSONSchema.JSONSchema.Description = openai.String(schema.Description)
+					}
+					if schema.Strict {
+						params.ResponseFormat.OfJSONSchema.JSONSchema.Strict = openai.Bool(true)
+					}
+				} else {
+					// Fallback to generic JSON object format
+					param := shared.NewResponseFormatJSONObjectParam()
+					params.ResponseFormat.OfJSONObject = &param
+				}
+			}
 		}
 		for _, tl := range options.Tools {
 			switch tl := tl.(type) {

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -16,8 +16,8 @@ This sample demonstrates using structured output capabilities with OpenAI Chat C
 showing jsonschema model integration for type-safe response parsing and data extraction.
 */
 
-type Output struct {
-	City       string `json:"city"`
+type CityInfo struct {
+	Name       string `json:"name"`
 	Population int
 	Area       float64 `jsonschema:"area in square kilometers"`
 }
@@ -33,7 +33,7 @@ func main() {
 	const query = "Tell me about Paris, France"
 	fmt.Println("User: " + query)
 
-	var out jsonformat.Value[Output]
+	var out jsonformat.Value[CityInfo]
 	resp, err := ag.Run(ctx, nil, &agent.RunOptions{Response: &out}, agent.NewTextMessage(query))
 	if err != nil {
 		fmt.Print(err)
@@ -42,7 +42,8 @@ func main() {
 
 	fmt.Printf("Agent raw response: %s\n", resp.Text())
 
-	fmt.Printf("City: %v\n", out.Unwrap().City)
-	fmt.Printf("Population: %v\n", out.Unwrap().Population)
-	fmt.Printf("Area: %v\n", out.Unwrap().Area)
+	city := out.Unwrap()
+	fmt.Printf("City Name: %v\n", city.Name)
+	fmt.Printf("Population: %v\n", city.Population)
+	fmt.Printf("Area: %v\n", city.Area)
 }

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -34,17 +34,15 @@ func main() {
 	fmt.Println("User: " + query)
 
 	var out jsonformat.Value[Output]
-	resp, err := ag.Run(ctx, nil, &agent.RunOptions{ResponseFormat: out.MustFormat()}, agent.NewTextMessage(query))
+	resp, err := ag.Run(ctx, nil, &agent.RunOptions{Response: &out}, agent.NewTextMessage(query))
 	if err != nil {
 		fmt.Print(err)
 		return
 	}
 
-	if err := out.UnmarshalJSON([]byte(resp.Text())); err != nil {
-		fmt.Print(err)
-		return
-	}
+	fmt.Printf("Agent raw response: %s\n", resp.Text())
 
 	fmt.Printf("City: %v\n", out.Unwrap().City)
 	fmt.Printf("Population: %v\n", out.Unwrap().Population)
+	fmt.Printf("Area: %v\n", out.Unwrap().Area)
 }

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/format/jsonformat"
+	"github.com/microsoft/agent-framework/go/openai"
+)
+
+/*
+OpenAI Chat Client with Structured Output Example
+
+This sample demonstrates using structured output capabilities with OpenAI Chat Client,
+showing jsonschema model integration for type-safe response parsing and data extraction.
+*/
+
+type Output struct {
+	City       string `json:"city"`
+	Population int
+	Area       float64 `jsonschema:"area in square kilometers"`
+}
+
+func main() {
+	ctx := context.Background()
+	ag := openai.NewChatAgent(openai.AgentConfig{
+		Model:              "gpt-5-nano",
+		Name:               "CityAgent",
+		SystemInstructions: "You are a helpful agent that describes cities in a structured format.",
+	})
+
+	const query = "Tell me about Paris, France"
+	fmt.Println("User: " + query)
+
+	var out jsonformat.Value[Output]
+	resp, err := ag.Run(ctx, nil, &agent.RunOptions{ResponseFormat: out.MustFormat()}, agent.NewTextMessage(query))
+	if err != nil {
+		fmt.Print(err)
+		return
+	}
+
+	if err := out.UnmarshalJSON([]byte(resp.Text())); err != nil {
+		fmt.Print(err)
+		return
+	}
+
+	fmt.Printf("City: %v\n", out.Unwrap().City)
+	fmt.Printf("Population: %v\n", out.Unwrap().Population)
+}

--- a/go/tool/functool/func.go
+++ b/go/tool/functool/func.go
@@ -6,9 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/microsoft/agent-framework/go/format/jsonformat"
 	"github.com/microsoft/agent-framework/go/tool"
 )
 
@@ -46,17 +45,17 @@ func (t *Tool) ToolInfo() (name string, description string) {
 }
 
 func (t *Tool) Schema() any {
-	if t.Func.InputSchema == nil {
+	if t.Func.inputFormat == nil {
 		// This prevents the tool author from forgetting to write a schema where
 		// one should be provided. If we papered over this by supplying the empty
 		// schema, then every input would be validated and the problem wouldn't be
 		// discovered until runtime, when the LLM sent bad data.
-		panic("FuncTool.Schema: InputSchema is nil")
+		panic("InputSchema is nil")
 	}
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"arg0": t.Func.InputSchema,
+			"arg0": t.Func.inputFormat.Schema,
 		},
 		"required": []string{"arg0"},
 	}
@@ -85,187 +84,46 @@ func New[In, Out any](fnp *Func, h HandlerFor[In, Out]) (*Tool, error) {
 	t := Tool{
 		Func: *fnp,
 	}
-	// Special handling for an "any" input: treat as an empty object.
-	if reflect.TypeFor[In]() == reflect.TypeFor[any]() && t.Func.InputSchema == nil {
-		t.Func.InputSchema = &jsonschema.Schema{Type: "object"}
-	}
-	var inputResolved *jsonschema.Resolved
-	if _, err := setSchema[In](&t.Func.InputSchema, &inputResolved); err != nil {
+
+	var inzero In
+	in, err := jsonformat.NewValue(inzero, nil)
+	if err != nil {
 		return nil, fmt.Errorf("input schema: %w", err)
 	}
+	t.Func.inputFormat, _ = in.Format()
 
-	// Handling for zero values:
-	//
-	// If Out is a pointer type and we've derived the output schema from its
-	// element type, use the zero value of its element type in place of a typed
-	// nil.
-	var (
-		elemZero       any // only non-nil if Out is a pointer type
-		outputResolved *jsonschema.Resolved
-	)
-	if t.Func.OutputSchema != nil || reflect.TypeFor[Out]() != reflect.TypeFor[any]() {
-		var err error
-		elemZero, err = setSchema[Out](&t.Func.OutputSchema, &outputResolved)
-		if err != nil {
-			return nil, fmt.Errorf("output schema: %v", err)
-		}
+	var out jsonformat.Value[Out]
+	t.Func.outputFormat, err = out.Format()
+	if err != nil {
+		return nil, fmt.Errorf("output schema: %w", err)
 	}
 
 	t.Handler = func(ctx context.Context, args string) (any, error) {
-		var input json.RawMessage
-		if args != "" {
-			input = json.RawMessage(args)
+		if err := in.UnmarshalJSON([]byte(args)); err != nil {
+			return nil, err
 		}
-		// Validate input and apply defaults.
-		var err error
-		input, err = applySchema(input, inputResolved)
-		if err != nil {
-			return nil, fmt.Errorf("validating \"arguments\": %v", err)
-		}
-
-		// Unmarshal and validate args.
-		var in In
-		if input != nil {
-			if err := json.Unmarshal(input, &in); err != nil {
-				return nil, err
-			}
-		}
-
 		// Call typed handler.
-		out, err := h(ctx, in)
-		// Handle server errors appropriately:
-		// - If the handler returns a structured error (like jsonrpc2.WireError), return it directly
-		// - If the handler returns a regular error, wrap it in a CallToolResult with IsError=true
-		// - This allows tools to distinguish between protocol errors and tool execution errors
+		outval, err := h(ctx, in.Unwrap())
 		if err != nil {
 			return nil, err
 		}
+		out.Wrap(outval)
+		outjson, err := out.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		return json.RawMessage(outjson), nil
 
-		// Marshal the output and put the RawMessage in the StructuredContent field.
-		var outval any = out
-		if elemZero != nil {
-			// Avoid typed nil, which will serialize as JSON null.
-			// Instead, use the zero value of the unpointered type.
-			var z Out
-			if any(out) == any(z) { // zero is only non-nil if Out is a pointer type
-				outval = elemZero
-			}
-		}
-		if outval != nil {
-			outbytes, err := json.Marshal(outval)
-			if err != nil {
-				return nil, fmt.Errorf("marshaling output: %w", err)
-			}
-			outJSON := json.RawMessage(outbytes)
-			// Validate the output JSON, and apply defaults.
-			//
-			// We validate against the JSON, rather than the output value, as
-			// some types may have custom JSON marshalling (issue #447).
-			outJSON, err = applySchema(outJSON, outputResolved)
-			if err != nil {
-				return nil, fmt.Errorf("validating tool output: %w", err)
-			}
-			return outJSON, nil
-		}
-		return nil, nil
 	} // end of handler
 
 	return &t, nil
 }
 
-// setSchema sets the schema and resolved schema corresponding to the type T.
-//
-// If sfield is nil, the schema is derived from T.
-//
-// Pointers are treated equivalently to non-pointers when deriving the schema.
-// If an indirection occurred to derive the schema, a non-nil zero value is
-// returned to be used in place of the typed nil zero value.
-//
-// Note that if sfield already holds a schema, zero will be nil even if T is a
-// pointer: if the user provided the schema, they may have intentionally
-// derived it from the pointer type, and handling of zero values is up to them.
-func setSchema[T any](sfield *any, rfield **jsonschema.Resolved) (zero any, err error) {
-	var internalSchema *jsonschema.Schema
-	if *sfield == nil {
-		rt := reflect.TypeFor[T]()
-		if rt.Kind() == reflect.Pointer {
-			rt = rt.Elem()
-			zero = reflect.Zero(rt).Interface()
-		}
-		internalSchema, err = jsonschema.ForType(rt, &jsonschema.ForOptions{})
-		if err == nil {
-			*sfield = internalSchema
-		}
-	} else if err := remarshal(*sfield, &internalSchema); err != nil {
-		return zero, err
-	}
-	if err != nil {
-		return zero, err
-	}
-	*rfield, err = internalSchema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
-	return zero, err
-}
-
-// applySchema validates whether data is valid JSON according to the provided
-// schema, after applying schema defaults.
-//
-// Returns the JSON value augmented with defaults.
-func applySchema(data json.RawMessage, resolved *jsonschema.Resolved) (json.RawMessage, error) {
-	// TODO: use reflection to create the struct type to unmarshal into.
-	// Separate validation from assignment.
-
-	// Use default JSON marshalling for validation.
-	//
-	// This avoids inconsistent representation due to custom marshallers, such as
-	// time.Time (issue #449).
-	//
-	// Additionally, unmarshalling into a map ensures that the resulting JSON is
-	// at least {}, even if data is empty. For example, arguments is technically
-	// an optional property of callToolParams, and we still want to apply the
-	// defaults in this case.
-	//
-	// TODO(rfindley): in which cases can resolved be nil?
-	if resolved != nil {
-		v := make(map[string]any)
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &v); err != nil {
-				return nil, fmt.Errorf("unmarshaling arguments: %w", err)
-			}
-		}
-		if err := resolved.ApplyDefaults(&v); err != nil {
-			return nil, fmt.Errorf("applying schema defaults:\n%w", err)
-		}
-		if err := resolved.Validate(&v); err != nil {
-			return nil, err
-		}
-		// We must re-marshal with the default values applied.
-		var err error
-		data, err = json.Marshal(v)
-		if err != nil {
-			return nil, fmt.Errorf("marshalling with defaults: %v", err)
-		}
-	}
-	return data, nil
-}
-
-// remarshal marshals from to JSON, and then unmarshals into to, which must be
-// a pointer type.
-func remarshal(from, to any) error {
-	data, err := json.Marshal(from)
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(data, to); err != nil {
-		return err
-	}
-	return nil
-}
-
 // Func represents a tool that wraps a Go function to make it callable by AI models.
 type Func struct {
-	Name                 string
-	Description          string
-	AdditionalProperties map[string]any
-	InputSchema          any
-	OutputSchema         any
+	Name        string
+	Description string
+
+	inputFormat  *jsonformat.Format
+	outputFormat *jsonformat.Format
 }

--- a/go/tool/functool/func.go
+++ b/go/tool/functool/func.go
@@ -90,10 +90,13 @@ func New[In, Out any](fnp *Func, h HandlerFor[In, Out]) (*Tool, error) {
 	if err != nil {
 		return nil, fmt.Errorf("input schema: %w", err)
 	}
-	t.Func.inputFormat, _ = in.Format()
+	t.Func.inputFormat, err = in.FormatJSON()
+	if err != nil {
+		return nil, fmt.Errorf("input schema: %w", err)
+	}
 
 	var out jsonformat.Value[Out]
-	t.Func.outputFormat, err = out.Format()
+	t.Func.outputFormat, err = out.FormatJSON()
 	if err != nil {
 		return nil, fmt.Errorf("output schema: %w", err)
 	}


### PR DESCRIPTION
Structured output allows you do instruct the AI provider to generate a response following a specific schema so that it can then be easily unmarshalled into a Go type.

This PR provides some built-in formats. The most interesting is `format/jsonformat`, which automatically generates JSON Schema definitions for Go types (which OpenAI understand) and also deal with marshalling and unmarshalling. Part of the json schema code already existed in `tool/functool` (which supports similar things). That code has been refactored and generalized. `tool/functool` now uses `format/jsonformat`.

Example of what you can do now:

```go
// Define the desired output type
type CityInfo struct {
	Name       string `json:"name"`
	Population int
	Area       float64 `jsonschema:"area in square kilometers"`
}

// Run the model
var out jsonformat.Value[CityInfo]
ag.Run(ctx, nil, &agent.RunOptions{Response: &out}, agent.NewTextMessage(query))

// Implement the business logic
city := out.Unwrap()
fmt.Printf("City Name: %v\n", city.Name)
fmt.Printf("Population: %v\n", city.Population)
fmt.Printf("Area: %v\n", city.Area)
```