### PR TITLE
Move all content symbols to the content package

### DIFF
--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/format"
 	"github.com/microsoft/agent-framework/go/tool"
 )
@@ -136,7 +137,7 @@ func (a *Agent) RunStream(ctx context.Context, thread Thread, opts *RunOptions, 
 		var success bool
 
 		for range maxRetries {
-			var contents []Content
+			var contents []content.Content
 			for update, err := range a.Config.RunStream(ctx, thread, opts, threadMessages...) {
 				if err != nil {
 					yield(nil, err)
@@ -150,8 +151,8 @@ func (a *Agent) RunStream(ctx context.Context, thread Thread, opts *RunOptions, 
 			threadMessages = append(threadMessages, NewMessage(RoleAssistant, contents...))
 
 			// Check if this response contains tool calls
-			hasToolCalls := slices.ContainsFunc(contents, func(content Content) bool {
-				_, ok := content.(*FunctionCallContent)
+			hasToolCalls := slices.ContainsFunc(contents, func(c content.Content) bool {
+				_, ok := c.(*content.FunctionCall)
 				return ok
 			})
 
@@ -209,8 +210,8 @@ func (a *Agent) RunStream(ctx context.Context, thread Thread, opts *RunOptions, 
 		if opts.Response != nil {
 			var finalText strings.Builder
 			for _, msg := range threadMessages[startLength:] {
-				for _, content := range msg.Contents {
-					if textContent, ok := content.(*TextContent); ok {
+				for _, c := range msg.Contents {
+					if textContent, ok := c.(*content.Text); ok {
 						finalText.WriteString(textContent.Text)
 					}
 				}
@@ -317,15 +318,14 @@ type RunResponse struct {
 	AgentID    string
 	ResponseID string
 	Messages   []*Message
-	Usage      *UsageDetails
 }
 
 // Text returns the concatenated text contents of the response messages.
 func (r *RunResponse) Text() string {
 	var text string
 	for _, msg := range r.Messages {
-		for _, content := range msg.Contents {
-			if textContent, ok := content.(*TextContent); ok {
+		for _, c := range msg.Contents {
+			if textContent, ok := c.(*content.Text); ok {
 				text += textContent.Text
 			}
 		}
@@ -339,14 +339,14 @@ type RunResponseUpdate struct {
 	MessageID  string
 	ResponseID string
 	Role       Role
-	Contents   []Content
+	Contents   []content.Content
 }
 
 // Text returns the concatenated text contents of the response messages.
 func (r *RunResponseUpdate) Text() string {
 	var sb strings.Builder
-	for _, content := range r.Contents {
-		if textContent, ok := content.(*TextContent); ok {
+	for _, c := range r.Contents {
+		if textContent, ok := c.(*content.Text); ok {
 			sb.WriteString(textContent.Text)
 		}
 	}
@@ -379,7 +379,7 @@ func (a *Agent) prepareRun(ctx context.Context, thread Thread, opts *RunOptions,
 	}
 	messages = slices.Clone(messages)
 	if a.Config.SystemInstructions != "" {
-		messages = append([]*Message{NewMessage(RoleSystem, &TextContent{Text: a.Config.SystemInstructions})}, messages...)
+		messages = append([]*Message{NewMessage(RoleSystem, &content.Text{Text: a.Config.SystemInstructions})}, messages...)
 	}
 	if opts != nil {
 		if err := initTools(ctx, opts.Tools); err != nil {
@@ -400,7 +400,7 @@ func (a *Agent) prepareRun(ctx context.Context, thread Thread, opts *RunOptions,
 		if ctxData != nil {
 			opts.Tools = append(opts.Tools, ctxData.Tools...)
 			if ctxData.Instructions != "" {
-				messages = append([]*Message{NewMessage(RoleSystem, &TextContent{Text: ctxData.Instructions})}, messages...)
+				messages = append([]*Message{NewMessage(RoleSystem, &content.Text{Text: ctxData.Instructions})}, messages...)
 			}
 			messages = append(messages, ctxData.Messages...)
 		}
@@ -436,26 +436,26 @@ func initTools(ctx context.Context, tools []tool.Tool) error {
 	return nil
 }
 
-func runToolCalls(ctx context.Context, options *RunOptions, contents ...Content) []Content {
+func runToolCalls(ctx context.Context, options *RunOptions, contents ...content.Content) []content.Content {
 	if len(options.Tools) == 0 {
 		return nil
 	}
 	funcResults := make(map[string]struct{})
-	for _, contents := range contents {
-		if funcResult, ok := contents.(*FunctionResultContent); ok {
+	for _, c := range contents {
+		if funcResult, ok := c.(*content.FunctionResult); ok {
 			funcResults[funcResult.CallID] = struct{}{}
 		}
 	}
-	funcCalls := make([]*FunctionCallContent, 0, len(contents)-len(funcResults))
-	for _, contents := range contents {
-		if fc, ok := contents.(*FunctionCallContent); ok {
+	funcCalls := make([]*content.FunctionCall, 0, len(contents)-len(funcResults))
+	for _, c := range contents {
+		if fc, ok := c.(*content.FunctionCall); ok {
 			if _, executed := funcResults[fc.CallID]; executed {
 				continue
 			}
 			funcCalls = append(funcCalls, fc)
 		}
 	}
-	toolContent := make([]Content, 0, len(funcCalls))
+	toolContent := make([]content.Content, 0, len(funcCalls))
 	for _, fc := range funcCalls {
 		toolContent = append(toolContent, funcCall(ctx, options.Tools, fc))
 	}
@@ -463,7 +463,7 @@ func runToolCalls(ctx context.Context, options *RunOptions, contents ...Content)
 }
 
 // funcCall executes a function tool call.
-func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallContent) Content {
+func funcCall(ctx context.Context, tools []tool.Tool, toolCall *content.FunctionCall) content.Content {
 	if toolCall.Error != nil {
 		// If there was an error parsing the tool call, return it as-is.
 		// This error occurred during mapping from the AI model to FunctionCallContent.
@@ -483,7 +483,7 @@ func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallCont
 	}
 
 	if found == nil {
-		return &FunctionResultContent{
+		return &content.FunctionResult{
 			CallID: toolCall.CallID,
 			Error:  fmt.Errorf("tool not found: %s", toolCall.Name),
 		}
@@ -492,7 +492,7 @@ func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallCont
 	var args map[string]any
 	if toolCall.Arguments != "" {
 		if err := json.Unmarshal([]byte(toolCall.Arguments), &args); err != nil {
-			return &FunctionResultContent{
+			return &content.FunctionResult{
 				CallID: toolCall.CallID,
 				Error:  fmt.Errorf("failed to parse arguments: %w", err),
 			}
@@ -515,7 +515,7 @@ func funcCall(ctx context.Context, tools []tool.Tool, toolCall *FunctionCallCont
 		result, err = found.Call(ctx, args)
 	}()
 
-	return &FunctionResultContent{
+	return &content.FunctionResult{
 		CallID: toolCall.CallID,
 		Error:  err,
 		Result: result,

--- a/go/agent/agent_test.go
+++ b/go/agent/agent_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/internal/agenttest"
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/tool"
 )
 
@@ -43,7 +44,7 @@ func TestAgent_CustomResponse(t *testing.T) {
 		AgentID:    "custom-agent",
 		ResponseID: "custom-response",
 		Messages: []*agent.Message{
-			agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: respTest}),
+			agent.NewMessage(agent.RoleAssistant, &content.Text{Text: respTest}),
 		},
 	}
 	client.SetResponse(customResponse)
@@ -79,11 +80,11 @@ func TestAgent_RunStream(t *testing.T) {
 	client.SetStreamUpdates([]*agent.RunResponseUpdate{
 		{
 			Role:     agent.RoleAssistant,
-			Contents: []agent.Content{&agent.TextContent{Text: "Hello "}},
+			Contents: []content.Content{&content.Text{Text: "Hello "}},
 		},
 		{
 			Role:     agent.RoleAssistant,
-			Contents: []agent.Content{&agent.TextContent{Text: "world!"}},
+			Contents: []content.Content{&content.Text{Text: "world!"}},
 		},
 	})
 
@@ -112,10 +113,10 @@ func TestAgent_ResponseSequence(t *testing.T) {
 
 	responses := []*agent.RunResponse{
 		{
-			Messages: []*agent.Message{agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: respText1})},
+			Messages: []*agent.Message{agent.NewMessage(agent.RoleAssistant, &content.Text{Text: respText1})},
 		},
 		{
-			Messages: []*agent.Message{agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: respText2})},
+			Messages: []*agent.Message{agent.NewMessage(agent.RoleAssistant, &content.Text{Text: respText2})},
 		},
 	}
 	client.WithResponseSequence(responses...)
@@ -142,7 +143,7 @@ func TestAgent_WithToolCalls(t *testing.T) {
 
 	const respText = "The weather in Seattle is sunny"
 
-	toolCalls := []*agent.FunctionCallContent{
+	toolCalls := []*content.FunctionCall{
 		{
 			Name:      "get_weather",
 			Arguments: `{"location": "Seattle"}`,
@@ -191,13 +192,13 @@ func TestAgent_CustomFunction(t *testing.T) {
 			return &agent.RunResponse{
 				AgentID:    client.ID(),
 				ResponseID: "resp-1",
-				Messages:   []*agent.Message{agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: respText1})},
+				Messages:   []*agent.Message{agent.NewMessage(agent.RoleAssistant, &content.Text{Text: respText1})},
 			}, nil
 		}
 		return &agent.RunResponse{
 			AgentID:    client.ID(),
 			ResponseID: "resp-2",
-			Messages:   []*agent.Message{agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: respText2})},
+			Messages:   []*agent.Message{agent.NewMessage(agent.RoleAssistant, &content.Text{Text: respText2})},
 		}, nil
 	}
 
@@ -229,7 +230,7 @@ func TestAgent_RunText(t *testing.T) {
 		AgentID:    "test-agent",
 		ResponseID: "resp-1",
 		Messages: []*agent.Message{
-			agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: responseText}),
+			agent.NewMessage(agent.RoleAssistant, &content.Text{Text: responseText}),
 		},
 	})
 
@@ -434,7 +435,7 @@ func TestAgent_MaxRetries(t *testing.T) {
 				AgentID:    a.ID(),
 				ResponseID: "resp",
 				Messages: []*agent.Message{
-					agent.NewMessage(agent.RoleAssistant, &agent.FunctionCallContent{
+					agent.NewMessage(agent.RoleAssistant, &content.FunctionCall{
 						CallID:    "call-1",
 						Name:      "test_tool",
 						Arguments: `{}`,
@@ -447,7 +448,7 @@ func TestAgent_MaxRetries(t *testing.T) {
 			AgentID:    a.ID(),
 			ResponseID: "resp-final",
 			Messages: []*agent.Message{
-				agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: "Final response"}),
+				agent.NewMessage(agent.RoleAssistant, &content.Text{Text: "Final response"}),
 			},
 		}, nil
 	}
@@ -484,7 +485,7 @@ func TestAgent_RunStreamFallback(t *testing.T) {
 		AgentID:    a.ID(),
 		ResponseID: "resp-1",
 		Messages: []*agent.Message{
-			agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: "Fallback response"}),
+			agent.NewMessage(agent.RoleAssistant, &content.Text{Text: "Fallback response"}),
 		},
 	}
 
@@ -513,8 +514,8 @@ func TestAgent_RunStreamFallback(t *testing.T) {
 // Test Message methods
 func TestMessage_Text(t *testing.T) {
 	msg := agent.NewMessage(agent.RoleAssistant,
-		&agent.TextContent{Text: "Hello "},
-		&agent.TextContent{Text: "world!"},
+		&content.Text{Text: "Hello "},
+		&content.Text{Text: "world!"},
 	)
 
 	if msg.Text() != "Hello " {
@@ -523,7 +524,7 @@ func TestMessage_Text(t *testing.T) {
 
 	// Test with no text content
 	msgNoText := agent.NewMessage(agent.RoleAssistant,
-		&agent.FunctionCallContent{Name: "test"},
+		&content.FunctionCall{Name: "test"},
 	)
 	if msgNoText.Text() != "" {
 		t.Errorf("expected empty string for message without text, got %q", msgNoText.Text())
@@ -542,8 +543,8 @@ func TestRunResponse_Text(t *testing.T) {
 		AgentID:    "test",
 		ResponseID: "resp-1",
 		Messages: []*agent.Message{
-			agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: "First "}),
-			agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: "Second"}),
+			agent.NewMessage(agent.RoleAssistant, &content.Text{Text: "First "}),
+			agent.NewMessage(agent.RoleAssistant, &content.Text{Text: "Second"}),
 		},
 	}
 
@@ -558,9 +559,9 @@ func TestRunResponseUpdate_Text(t *testing.T) {
 		AgentID:    "test",
 		ResponseID: "resp-1",
 		Role:       agent.RoleAssistant,
-		Contents: []agent.Content{
-			&agent.TextContent{Text: "Part 1 "},
-			&agent.TextContent{Text: "Part 2"},
+		Contents: []content.Content{
+			&content.Text{Text: "Part 1 "},
+			&content.Text{Text: "Part 2"},
 		},
 	}
 
@@ -572,7 +573,7 @@ func TestRunResponseUpdate_Text(t *testing.T) {
 
 // Test FunctionCallContent
 func TestFunctionCallContent_ParseArgs(t *testing.T) {
-	fc := &agent.FunctionCallContent{
+	fc := &content.FunctionCall{
 		CallID:    "call-1",
 		Name:      "test_func",
 		Arguments: `{"key": "value", "number": 42}`,
@@ -591,7 +592,7 @@ func TestFunctionCallContent_ParseArgs(t *testing.T) {
 	}
 
 	// Test invalid JSON
-	fcInvalid := &agent.FunctionCallContent{
+	fcInvalid := &content.FunctionCall{
 		CallID:    "call-2",
 		Name:      "test_func",
 		Arguments: `invalid json`,
@@ -606,7 +607,7 @@ func TestFunctionCallContent_ParseArgs(t *testing.T) {
 func TestAgent_ToolError(t *testing.T) {
 	client, a := agenttest.NewAgent()
 
-	toolCalls := []*agent.FunctionCallContent{
+	toolCalls := []*content.FunctionCall{
 		{
 			CallID:    "call-1",
 			Name:      "error_tool",
@@ -641,7 +642,7 @@ func TestAgent_ToolError(t *testing.T) {
 func TestAgent_ToolNotFound(t *testing.T) {
 	client, a := agenttest.NewAgent()
 
-	toolCalls := []*agent.FunctionCallContent{
+	toolCalls := []*content.FunctionCall{
 		{
 			CallID:    "call-1",
 			Name:      "nonexistent_tool",
@@ -671,7 +672,7 @@ func TestAgent_ToolNotFound(t *testing.T) {
 func TestAgent_ToolInvalidArgs(t *testing.T) {
 	client, a := agenttest.NewAgent()
 
-	toolCalls := []*agent.FunctionCallContent{
+	toolCalls := []*content.FunctionCall{
 		{
 			CallID:    "call-1",
 			Name:      "test_tool",
@@ -793,7 +794,7 @@ func TestRunOptions_Merge(t *testing.T) {
 
 // Test TextContent
 func TestTextContent_String(t *testing.T) {
-	tc := &agent.TextContent{Text: "test content"}
+	tc := &content.Text{Text: "test content"}
 	if tc.String() != "test content" {
 		t.Errorf("expected 'test content', got %q", tc.String())
 	}
@@ -801,7 +802,7 @@ func TestTextContent_String(t *testing.T) {
 
 // Test TextReasoningContent
 func TestTextReasoningContent_String(t *testing.T) {
-	trc := &agent.TextReasoningContent{Text: "reasoning text"}
+	trc := &content.TextReasoning{Text: "reasoning text"}
 	if trc.String() != "reasoning text" {
 		t.Errorf("expected 'reasoning text', got %q", trc.String())
 	}
@@ -809,12 +810,12 @@ func TestTextReasoningContent_String(t *testing.T) {
 
 // Test UsageDetails
 func TestUsageDetails_Add(t *testing.T) {
-	ud1 := &agent.UsageDetails{
+	ud1 := &content.UsageDetails{
 		InputTokenCount:  10,
 		OutputTokenCount: 20,
 		TotalTokenCount:  30,
 	}
-	ud2 := &agent.UsageDetails{
+	ud2 := &content.UsageDetails{
 		InputTokenCount:  5,
 		OutputTokenCount: 15,
 		TotalTokenCount:  20,
@@ -833,13 +834,13 @@ func TestUsageDetails_Add(t *testing.T) {
 }
 
 func TestUsageDetails_AddWithAdditionalCounts(t *testing.T) {
-	ud1 := &agent.UsageDetails{
+	ud1 := &content.UsageDetails{
 		InputTokenCount: 10,
 		AdditionalCounts: map[string]int64{
 			"cache_read": 5,
 		},
 	}
-	ud2 := &agent.UsageDetails{
+	ud2 := &content.UsageDetails{
 		InputTokenCount: 5,
 		AdditionalCounts: map[string]int64{
 			"cache_read":  3,
@@ -857,13 +858,13 @@ func TestUsageDetails_AddWithAdditionalCounts(t *testing.T) {
 }
 
 func TestUsageDetails_AddWithNil(t *testing.T) {
-	var ud1 *agent.UsageDetails
-	ud2 := &agent.UsageDetails{InputTokenCount: 10}
+	var ud1 *content.UsageDetails
+	ud2 := &content.UsageDetails{InputTokenCount: 10}
 
 	// Should not panic
 	ud1.Add(ud2)
 
-	ud1 = &agent.UsageDetails{InputTokenCount: 10}
+	ud1 = &content.UsageDetails{InputTokenCount: 10}
 	ud1.Add(nil)
 	if ud1.InputTokenCount != 10 {
 		t.Errorf("expected input tokens to remain 10, got %d", ud1.InputTokenCount)

--- a/go/agent/func_test.go
+++ b/go/agent/func_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/internal/agenttest"
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/tool"
 	"github.com/microsoft/agent-framework/go/tool/functool"
 )
@@ -27,7 +28,7 @@ func TestAgentCallTool(t *testing.T) {
 
 	tl := functool.MustNew(funcDef, handler)
 
-	toolCalls := []*agent.FunctionCallContent{
+	toolCalls := []*content.FunctionCall{
 		{
 			CallID:    "call-1",
 			Name:      "get_weather",

--- a/go/agent/internal/agenttest/client.go
+++ b/go/agent/internal/agenttest/client.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 )
 
 // Client is a configurable stub implementation of Client and streamableClient
@@ -67,7 +68,7 @@ func NewAgent() (*Client, *agent.Agent) {
 			AgentID:    id,
 			ResponseID: "response-1",
 			Messages: []*agent.Message{
-				agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: "response"}),
+				agent.NewMessage(agent.RoleAssistant, &content.Text{Text: "response"}),
 			},
 		},
 	}
@@ -114,7 +115,7 @@ func (c *Client) Run(ctx context.Context, thread agent.Thread, opts *agent.RunOp
 		AgentID:    c.ID(),
 		ResponseID: "response",
 		Messages: []*agent.Message{
-			agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: "response"}),
+			agent.NewMessage(agent.RoleAssistant, &content.Text{Text: "response"}),
 		},
 	}, nil
 }
@@ -166,7 +167,7 @@ func (c *Client) RunStream(ctx context.Context, thread agent.Thread, opts *agent
 			MessageID:  "message-1",
 			ResponseID: "response-1",
 			Role:       agent.RoleAssistant,
-			Contents:   []agent.Content{&agent.TextContent{Text: "streaming response"}},
+			Contents:   []content.Content{&content.Text{Text: "streaming response"}},
 		}
 		yield(update, nil)
 	}
@@ -259,7 +260,7 @@ func (c *Client) WithResponseSequence(responses ...*agent.RunResponse) *Client {
 
 // WithToolCalls returns a Client configured to return a response with tool calls
 // followed by a final response.
-func (c *Client) WithToolCalls(toolCalls []*agent.FunctionCallContent, finalResponse string) *Client {
+func (c *Client) WithToolCalls(toolCalls []*content.FunctionCall, finalResponse string) *Client {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -268,7 +269,7 @@ func (c *Client) WithToolCalls(toolCalls []*agent.FunctionCallContent, finalResp
 		callCount++
 		if callCount == 1 {
 			// First call returns tool calls
-			contents := make([]agent.Content, len(toolCalls))
+			contents := make([]content.Content, len(toolCalls))
 			for i, tc := range toolCalls {
 				contents[i] = tc
 			}
@@ -285,7 +286,7 @@ func (c *Client) WithToolCalls(toolCalls []*agent.FunctionCallContent, finalResp
 			AgentID:    c.ID(),
 			ResponseID: "final-response",
 			Messages: []*agent.Message{
-				agent.NewMessage(agent.RoleAssistant, &agent.TextContent{Text: finalResponse}),
+				agent.NewMessage(agent.RoleAssistant, &content.Text{Text: finalResponse}),
 			},
 		}, nil
 	}
@@ -294,7 +295,7 @@ func (c *Client) WithToolCalls(toolCalls []*agent.FunctionCallContent, finalResp
 
 // WithStreamingToolCalls returns a Client configured to return streaming updates
 // with tool calls followed by a final response.
-func (c *Client) WithStreamingToolCalls(toolCalls []*agent.FunctionCallContent, finalResponse string) *Client {
+func (c *Client) WithStreamingToolCalls(toolCalls []*content.FunctionCall, finalResponse string) *Client {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -305,7 +306,7 @@ func (c *Client) WithStreamingToolCalls(toolCalls []*agent.FunctionCallContent, 
 		return func(yield func(*agent.RunResponseUpdate, error) bool) {
 			if currentCall == 1 {
 				// First call returns tool calls
-				contents := make([]agent.Content, len(toolCalls))
+				contents := make([]content.Content, len(toolCalls))
 				for i, tc := range toolCalls {
 					contents[i] = tc
 				}
@@ -324,7 +325,7 @@ func (c *Client) WithStreamingToolCalls(toolCalls []*agent.FunctionCallContent, 
 				MessageID:  "final-message",
 				ResponseID: "final-response",
 				Role:       agent.RoleAssistant,
-				Contents:   []agent.Content{&agent.TextContent{Text: finalResponse}},
+				Contents:   []content.Content{&content.Text{Text: finalResponse}},
 			}, nil)
 		}
 	}

--- a/go/agent/message.go
+++ b/go/agent/message.go
@@ -2,16 +2,18 @@
 
 package agent
 
+import "github.com/microsoft/agent-framework/go/content"
+
 // Message represents a message in a conversation.
 type Message struct {
-	Contents  []Content
+	Contents  []content.Content
 	Role      Role
 	Name      string
 	MessageID string
 }
 
 // NewMessage creates a new [Message] with the given role and contents.
-func NewMessage(role Role, contents ...Content) *Message {
+func NewMessage(role Role, contents ...content.Content) *Message {
 	return &Message{
 		Role:     role,
 		Contents: contents,
@@ -22,7 +24,7 @@ func NewMessage(role Role, contents ...Content) *Message {
 func NewTextMessage(text string) *Message {
 	return &Message{
 		Role:     RoleUser,
-		Contents: []Content{&TextContent{Text: text}},
+		Contents: []content.Content{&content.Text{Text: text}},
 	}
 }
 
@@ -31,8 +33,8 @@ func (m *Message) Text() string {
 	if m == nil {
 		return ""
 	}
-	for _, content := range m.Contents {
-		if textContent, ok := content.(*TextContent); ok {
+	for _, c := range m.Contents {
+		if textContent, ok := c.(*content.Text); ok {
 			return textContent.Text
 		}
 	}

--- a/go/agent/types.go
+++ b/go/agent/types.go
@@ -31,30 +31,3 @@ const (
 	// FinishReasonError indicates an error occurred.
 	FinishReasonError FinishReason = "error"
 )
-
-// UsageDetails provides usage details about a request/response.
-type UsageDetails struct {
-	AdditionalCounts map[string]int64
-	InputTokenCount  int64
-	OutputTokenCount int64
-	TotalTokenCount  int64
-}
-
-func (u *UsageDetails) Add(other *UsageDetails) {
-	if u == nil || other == nil {
-		return
-	}
-	u.InputTokenCount += other.InputTokenCount
-	u.OutputTokenCount += other.OutputTokenCount
-	u.TotalTokenCount += other.TotalTokenCount
-
-	// Merge additional counts
-	if other.AdditionalCounts != nil {
-		if u.AdditionalCounts == nil {
-			u.AdditionalCounts = make(map[string]int64)
-		}
-		for k, v := range other.AdditionalCounts {
-			u.AdditionalCounts[k] += v
-		}
-	}
-}

--- a/go/agent/types.go
+++ b/go/agent/types.go
@@ -15,19 +15,3 @@ const (
 	// RoleTool represents a message from a tool execution.
 	RoleTool Role = "tool"
 )
-
-// FinishReason represents the reason why the agent stopped generating.
-type FinishReason string
-
-const (
-	// FinishReasonStop indicates the agent stopped naturally.
-	FinishReasonStop FinishReason = "stop"
-	// FinishReasonLength indicates the agent stopped due to length limit.
-	FinishReasonLength FinishReason = "length"
-	// FinishReasonToolCalls indicates the agent stopped to execute tools.
-	FinishReasonToolCalls FinishReason = "tool_calls"
-	// FinishReasonContentFilter indicates content was filtered.
-	FinishReasonContentFilter FinishReason = "content_filter"
-	// FinishReasonError indicates an error occurred.
-	FinishReasonError FinishReason = "error"
-)

--- a/go/content/content.go
+++ b/go/content/content.go
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package agent
+package content
 
 import "encoding/json"
+
+// Content represents message content.
+type Content interface {
+	isContent()
+}
 
 // AnnotatedRegion describes the portion of an associated [Content]
 // to which an annotation applies.
@@ -40,13 +45,8 @@ type CitationAnnotation struct {
 
 func (t *CitationAnnotation) isAnnotation() {}
 
-// Content represents message content.
-type Content interface {
-	isContent()
-}
-
-// TextContent represents plain text content.
-type TextContent struct {
+// Text represents plain text content.
+type Text struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -54,16 +54,16 @@ type TextContent struct {
 	Text string
 }
 
-func (t *TextContent) isContent() {}
+func (t *Text) isContent() {}
 
 // String returns the text of the content.
-func (t *TextContent) String() string { return t.Text }
+func (t *Text) String() string { return t.Text }
 
-// DataContent represents binary content with an associated media type.
+// Data represents binary content with an associated media type.
 //
 // The content represents in-memory data. For references to data at a remote URI,
-// use [URIContent] instead.
-type DataContent struct {
+// use [URI] instead.
+type Data struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -74,13 +74,13 @@ type DataContent struct {
 	URI       string
 }
 
-func (t *DataContent) isContent() {}
+func (t *Data) isContent() {}
 
-// ErrorContent represents an error.
+// Error represents an error.
 //
-// Typically, ErrorContent is used for non-fatal errors, where something went wrong as part
+// Typically, Error is used for non-fatal errors, where something went wrong as part
 // of the operation but the operation was still able to continue.
-type ErrorContent struct {
+type Error struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -90,10 +90,10 @@ type ErrorContent struct {
 	Message   string
 }
 
-func (t *ErrorContent) isContent() {}
+func (t *Error) isContent() {}
 
-// FunctionCallContent represents a function call request.
-type FunctionCallContent struct {
+// FunctionCall represents a function call request.
+type FunctionCall struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -104,7 +104,7 @@ type FunctionCallContent struct {
 	Name      string
 }
 
-func (t *FunctionCallContent) ParseArgs() (map[string]any, error) {
+func (t *FunctionCall) ParseArgs() (map[string]any, error) {
 	var args map[string]any
 	if err := json.Unmarshal([]byte(t.Arguments), &args); err != nil {
 		return nil, err
@@ -112,10 +112,10 @@ func (t *FunctionCallContent) ParseArgs() (map[string]any, error) {
 	return args, nil
 }
 
-func (t *FunctionCallContent) isContent() {}
+func (t *FunctionCall) isContent() {}
 
-// FunctionResultContent represents the result of a function call.
-type FunctionResultContent struct {
+// FunctionResult represents the result of a function call.
+type FunctionResult struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -125,14 +125,14 @@ type FunctionResultContent struct {
 	Result any
 }
 
-func (t *FunctionResultContent) isContent() {}
+func (t *FunctionResult) isContent() {}
 
-// HostedFileContent represents a file that is hosted by the AI service.
+// HostedFile represents a file that is hosted by the AI service.
 //
-// Unlike [DataContent] which contains the data for a file or blob, this class represents a file
+// Unlike [Data] which contains the data for a file or blob, this class represents a file
 // that is hosted by the AI service and referenced by an identifier.
 // Such identifiers are specific to the provider.
-type HostedFileContent struct {
+type HostedFile struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -140,13 +140,13 @@ type HostedFileContent struct {
 	FileID string
 }
 
-func (t *HostedFileContent) isContent() {}
+func (t *HostedFile) isContent() {}
 
-// HostedVectorStoreContent represents a vector store that is hosted by the AI service.
+// HostedVectorStore represents a vector store that is hosted by the AI service.
 //
-// Unlike [HostedFileContent] which represents a specific file that is hosted by the AI service,
-// HostedVectorStoreContent represents a vector store that can contain multiple files, indexed for searching.
-type HostedVectorStoreContent struct {
+// Unlike [HostedFile] which represents a specific file that is hosted by the AI service,
+// HostedVectorStore represents a vector store that can contain multiple files, indexed for searching.
+type HostedVectorStore struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -154,14 +154,14 @@ type HostedVectorStoreContent struct {
 	VectorStoreID string
 }
 
-func (t *HostedVectorStoreContent) isContent() {}
+func (t *HostedVectorStore) isContent() {}
 
-// TextReasoningContent represents text reasoning content in a chat.
+// TextReasoning represents text reasoning content in a chat.
 //
-// TextReasoningContent is distinct from [TextContent]. TextReasoningContent represents "thinking" or "reasoning"
+// TextReasoning is distinct from [Text]. TextReasoning represents "thinking" or "reasoning"
 // performed by the model and is distinct from the actual output text from the model,
-// which is represented by [TextContent].
-type TextReasoningContent struct {
+// which is represented by [Text].
+type TextReasoning struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -170,13 +170,13 @@ type TextReasoningContent struct {
 	Text          string
 }
 
-func (t *TextReasoningContent) isContent() {}
+func (t *TextReasoning) isContent() {}
 
 // String returns the text of the reasoning content.
-func (t *TextReasoningContent) String() string { return t.Text }
+func (t *TextReasoning) String() string { return t.Text }
 
-// URIContent represents a URL, typically to hosted content such as an image, audio, or video.
-type URIContent struct {
+// URI represents a URL, typically to hosted content such as an image, audio, or video.
+type URI struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -185,10 +185,37 @@ type URIContent struct {
 	URI       string
 }
 
-func (t *URIContent) isContent() {}
+func (t *URI) isContent() {}
 
-// UsageContent represents usage information associated with a chat request and response.
-type UsageContent struct {
+// UsageDetails provides usage details about a request/response.
+type UsageDetails struct {
+	AdditionalCounts map[string]int64
+	InputTokenCount  int64
+	OutputTokenCount int64
+	TotalTokenCount  int64
+}
+
+func (u *UsageDetails) Add(other *UsageDetails) {
+	if u == nil || other == nil {
+		return
+	}
+	u.InputTokenCount += other.InputTokenCount
+	u.OutputTokenCount += other.OutputTokenCount
+	u.TotalTokenCount += other.TotalTokenCount
+
+	// Merge additional counts
+	if other.AdditionalCounts != nil {
+		if u.AdditionalCounts == nil {
+			u.AdditionalCounts = make(map[string]int64)
+		}
+		for k, v := range other.AdditionalCounts {
+			u.AdditionalCounts[k] += v
+		}
+	}
+}
+
+// Usage represents usage information associated with a chat request and response.
+type Usage struct {
 	AdditionalProperties map[string]any
 	Annotations          []Annotation
 	RawRepresentation    any
@@ -196,4 +223,4 @@ type UsageContent struct {
 	Details UsageDetails
 }
 
-func (t *UsageContent) isContent() {}
+func (t *Usage) isContent() {}

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/format/jsonformat"
 	"github.com/microsoft/agent-framework/go/tool"
 	"github.com/microsoft/agent-framework/go/tool/websearchtool"
@@ -99,16 +100,16 @@ func (a *client) Run(ctx context.Context, t agent.Thread, opts *agent.RunOptions
 		return nil, err
 	}
 	choice := resp.Choices[0]
-	contents := make([]agent.Content, 0, 1+len(choice.Message.ToolCalls))
+	contents := make([]content.Content, 0, 1+len(choice.Message.ToolCalls))
 	for _, tc := range choice.Message.ToolCalls {
-		contents = append(contents, &agent.FunctionCallContent{
+		contents = append(contents, &content.FunctionCall{
 			CallID:    tc.ID,
 			Name:      tc.Function.Name,
 			Arguments: tc.Function.Arguments,
 		})
 	}
 	if choice.Message.Content != "" {
-		contents = append(contents, &agent.TextContent{Text: choice.Message.Content})
+		contents = append(contents, &content.Text{Text: choice.Message.Content})
 	}
 	return &agent.RunResponse{
 		Messages:   []*agent.Message{agent.NewMessage(agent.Role(choice.Message.Role), contents...)},
@@ -127,9 +128,9 @@ func (a *client) RunStream(ctx context.Context, t agent.Thread, opts *agent.RunO
 			if !acc.AddChunk(chunk) {
 				continue
 			}
-			var contents []agent.Content
+			var contents []content.Content
 			if tc, ok := acc.JustFinishedToolCall(); ok {
-				contents = append(contents, &agent.FunctionCallContent{
+				contents = append(contents, &content.FunctionCall{
 					CallID:    tc.ID,
 					Name:      tc.Name,
 					Arguments: tc.Arguments,
@@ -137,7 +138,7 @@ func (a *client) RunStream(ctx context.Context, t agent.Thread, opts *agent.RunO
 			}
 			if len(chunk.Choices) > 0 {
 				if choice := chunk.Choices[0]; choice.Delta.Content != "" {
-					contents = append(contents, &agent.TextContent{Text: choice.Delta.Content})
+					contents = append(contents, &content.Text{Text: choice.Delta.Content})
 				}
 			}
 			resp := &agent.RunResponseUpdate{
@@ -261,8 +262,8 @@ func buildMessageParam(msg *agent.Message) []openai.ChatCompletionMessageParamUn
 	switch msg.Role {
 	case agent.RoleSystem:
 		var contents []openai.ChatCompletionContentPartTextParam
-		for _, content := range msg.Contents {
-			if tc, ok := content.(*agent.TextContent); ok {
+		for _, c := range msg.Contents {
+			if tc, ok := c.(*content.Text); ok {
 				contents = append(contents, openai.ChatCompletionContentPartTextParam{
 					Text: tc.Text,
 				})
@@ -272,28 +273,28 @@ func buildMessageParam(msg *agent.Message) []openai.ChatCompletionMessageParamUn
 
 	case agent.RoleUser:
 		var contents []openai.ChatCompletionContentPartUnionParam
-		for _, content := range msg.Contents {
-			switch content := content.(type) {
-			case *agent.TextContent:
-				contents = append(contents, openai.TextContentPart(content.Text))
-			case *agent.URIContent:
-				switch topLevelMediaType(content.MediaType) {
+		for _, c := range msg.Contents {
+			switch c := c.(type) {
+			case *content.Text:
+				contents = append(contents, openai.TextContentPart(c.Text))
+			case *content.URI:
+				switch topLevelMediaType(c.MediaType) {
 				case "image":
 					contents = append(contents, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
-						URL: content.URI,
+						URL: c.URI,
 					}))
 				default:
 					// For other URI content types, just ignore, they are not supported yet.
 				}
-			case *agent.DataContent:
-				switch topLevelMediaType(content.MediaType) {
+			case *content.Data:
+				switch topLevelMediaType(c.MediaType) {
 				case "image":
 					contents = append(contents, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
-						URL: content.URI,
+						URL: c.URI,
 					}))
 				case "audio":
 					var format string
-					switch content.MediaType {
+					switch c.MediaType {
 					case "audio/wav":
 						format = "wav"
 					case "audio/mp3", "audio/mpeg":
@@ -303,18 +304,18 @@ func buildMessageParam(msg *agent.Message) []openai.ChatCompletionMessageParamUn
 						format = "mp3"
 					}
 					contents = append(contents, openai.InputAudioContentPart(openai.ChatCompletionContentPartInputAudioInputAudioParam{
-						Data:   string(content.Data),
+						Data:   string(c.Data),
 						Format: format,
 					}))
 				default:
 					contents = append(contents, openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
-						FileData: openai.String(string(content.Data)),
-						Filename: openai.String(content.Name),
+						FileData: openai.String(string(c.Data)),
+						Filename: openai.String(c.Name),
 					}))
 				}
-			case *agent.HostedFileContent:
+			case *content.HostedFile:
 				contents = append(contents, openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
-					FileID: openai.String(content.FileID),
+					FileID: openai.String(c.FileID),
 				}))
 			}
 		}
@@ -323,28 +324,28 @@ func buildMessageParam(msg *agent.Message) []openai.ChatCompletionMessageParamUn
 	case agent.RoleAssistant:
 		var contents []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
 		var toolCalls []openai.ChatCompletionMessageToolCallUnionParam
-		for _, content := range msg.Contents {
-			switch content := content.(type) {
-			case *agent.TextContent:
+		for _, c := range msg.Contents {
+			switch c := c.(type) {
+			case *content.Text:
 				contents = append(contents, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
 					OfText: &openai.ChatCompletionContentPartTextParam{
-						Text: content.Text,
+						Text: c.Text,
 					},
 				})
-			case *agent.FunctionCallContent:
+			case *content.FunctionCall:
 				toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
 					OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
-						ID: content.CallID,
+						ID: c.CallID,
 						Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
-							Name:      content.Name,
-							Arguments: content.Arguments,
+							Name:      c.Name,
+							Arguments: c.Arguments,
 						},
 					},
 				})
-			case *agent.ErrorContent:
+			case *content.Error:
 				contents = append(contents, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
 					OfText: &openai.ChatCompletionContentPartTextParam{
-						Text: content.Message,
+						Text: c.Message,
 					},
 				})
 			}
@@ -359,8 +360,8 @@ func buildMessageParam(msg *agent.Message) []openai.ChatCompletionMessageParamUn
 	case agent.RoleTool:
 		// Each tool result needs its own separate message for OpenAI API compliance
 		var messages []openai.ChatCompletionMessageParamUnion
-		for _, content := range msg.Contents {
-			if funcResult, ok := content.(*agent.FunctionResultContent); ok {
+		for _, c := range msg.Contents {
+			if funcResult, ok := c.(*content.FunctionResult); ok {
 				ret := funcResult.Result
 				if funcResult.Error != nil {
 					ret = funcResult.Error

--- a/go/samples/getting_started/middleware/filtering/middleware_filtering.go
+++ b/go/samples/getting_started/middleware/filtering/middleware_filtering.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/middleware"
 	"github.com/microsoft/agent-framework/go/tool/functool"
 )
@@ -46,8 +47,8 @@ func (m *SecurityFilterMiddleware) Process(ctx *middleware.AgentRunContext, next
 // extractTextContent extracts text from a message.
 func (m *SecurityFilterMiddleware) extractTextContent(msg *agent.Message) string {
 	var text strings.Builder
-	for _, content := range msg.Contents {
-		if textContent, ok := content.(*agent.TextContent); ok {
+	for _, c := range msg.Contents {
+		if textContent, ok := c.(*content.Text); ok {
 			text.WriteString(textContent.Text)
 		}
 	}
@@ -131,8 +132,8 @@ func main() {
 		Messages: []agent.Message{
 			{
 				Role: agent.RoleUser,
-				Contents: []agent.Content{
-					&agent.TextContent{Text: "What is the weather today?"},
+				Contents: []content.Content{
+					&content.Text{Text: "What is the weather today?"},
 				},
 			},
 		},
@@ -156,8 +157,8 @@ func main() {
 		Messages: []agent.Message{
 			{
 				Role: agent.RoleUser,
-				Contents: []agent.Content{
-					&agent.TextContent{Text: "What is my API key?"},
+				Contents: []content.Content{
+					&content.Text{Text: "What is my API key?"},
 				},
 			},
 		},

--- a/go/samples/getting_started/middleware/logging/middleware_logging.go
+++ b/go/samples/getting_started/middleware/logging/middleware_logging.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/middleware"
 	"github.com/microsoft/agent-framework/go/tool/functool"
 )
@@ -95,8 +96,8 @@ func main() {
 		Messages: []agent.Message{
 			{
 				Role: agent.RoleUser,
-				Contents: []agent.Content{
-					&agent.TextContent{Text: "What is 2+2?"},
+				Contents: []content.Content{
+					&content.Text{Text: "What is 2+2?"},
 				},
 			},
 		},

--- a/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
+++ b/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/openai"
 )
 
@@ -24,8 +25,8 @@ func main() {
 
 	ctx := context.Background()
 	resp, err := ag.Run(ctx, nil, nil, agent.NewMessage(agent.RoleUser,
-		&agent.TextContent{Text: "Describe the content of this image."},
-		&agent.URIContent{
+		&content.Text{Text: "Describe the content of this image."},
+		&content.URI{
 			URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
 			MediaType: "image/jpeg",
 		}))

--- a/go/telemetry/telemetry.go
+++ b/go/telemetry/telemetry.go
@@ -5,7 +5,7 @@ package telemetry
 import (
 	"context"
 
-	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -61,7 +61,7 @@ func (t *Tracer) StartChatCompletion(ctx context.Context, modelID string, messag
 }
 
 // RecordUsage records token usage metrics.
-func (t *Tracer) RecordUsage(ctx context.Context, modelID string, usage *agent.UsageDetails) {
+func (t *Tracer) RecordUsage(ctx context.Context, modelID string, usage *content.UsageDetails) {
 	if usage == nil {
 		return
 	}

--- a/go/tool/mcptool/content.go
+++ b/go/tool/mcptool/content.go
@@ -5,33 +5,33 @@ package mcptool
 import (
 	"fmt"
 
-	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // mcpContentToAgentContent converts MCP content types to agent framework content types.
-func mcpContentToAgentContent(mcpContents []mcpsdk.Content) []agent.Content {
+func mcpContentToAgentContent(mcpContents []mcpsdk.Content) []content.Content {
 	if len(mcpContents) == 0 {
 		return nil
 	}
 
-	result := make([]agent.Content, 0, len(mcpContents))
+	result := make([]content.Content, 0, len(mcpContents))
 
-	for _, content := range mcpContents {
-		switch c := content.(type) {
+	for _, c := range mcpContents {
+		switch c := c.(type) {
 		case *mcpsdk.TextContent:
-			result = append(result, &agent.TextContent{
+			result = append(result, &content.Text{
 				Text: c.Text,
 			})
 
 		case *mcpsdk.EmbeddedResource:
 			// Handle embedded resources
 			if c.Resource.Text != "" {
-				result = append(result, &agent.TextContent{
+				result = append(result, &content.Text{
 					Text: c.Resource.Text,
 				})
 			} else {
-				result = append(result, &agent.DataContent{
+				result = append(result, &content.Data{
 					Data:      c.Resource.Blob,
 					MediaType: c.Resource.MIMEType,
 					URI:       c.Resource.URI,
@@ -40,7 +40,7 @@ func mcpContentToAgentContent(mcpContents []mcpsdk.Content) []agent.Content {
 
 		default:
 			// Unknown content type - convert to text
-			result = append(result, &agent.TextContent{
+			result = append(result, &content.Text{
 				Text: fmt.Sprintf("[Unknown MCP content type: %T]", c),
 			})
 		}

--- a/go/workflow/value_test.go
+++ b/go/workflow/value_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/agent-framework/go/agent"
+	"github.com/microsoft/agent-framework/go/content"
 	"github.com/microsoft/agent-framework/go/workflow"
 )
 
@@ -18,7 +19,7 @@ func TestValueRoundtrip(t *testing.T) {
 	testRountrip(t, 3.14)
 	testRountrip(t, agent.NewTextMessage("hello"))
 	testRountrip(t, agent.RoleAssistant)
-	testRountrip(t, agent.ErrorContent{Message: "error message"})
+	testRountrip(t, content.Error{Message: "error message"})
 	testRountrip(t, workflow.AnyValue(0))
 }
 


### PR DESCRIPTION
The `agent` package is too crowded, and only advanced callers need to deal with contents, most of its handling is done in the framework itself.

Moving all content-related symbol to it's own package makes the `agent` framework easier to use and learn.

While here, remove `FinishReason`. It is unused.