### PR TITLE
Support thread unmarshaling

### DIFF
--- a/go/internal/jsonx/jsonx.go
+++ b/go/internal/jsonx/jsonx.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package jsonx
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// UnmarshalDiscriminatedUnionSlice unmarshals a JSON array of union types into a slice of type T.
+// The types map should map from a discriminator key to the corresponding reflect.Type of T.
+func UnmarshalDiscriminatedUnionSlice[T any, K comparable](data []byte, types map[K]reflect.Type) ([]T, error) {
+	// Unmarshal just the type fields to determine content types.
+	var items []struct {
+		Type K
+	}
+	if err := json.Unmarshal(data, &items); err != nil {
+		return nil, err
+	}
+
+	// Create appropriate content instances based on type.
+	out := make([]T, 0, len(items))
+	for _, item := range items {
+		typ, ok := types[item.Type]
+		if !ok {
+			return nil, fmt.Errorf("unsupported content type: %v", item.Type)
+		}
+		out = append(out, reflect.New(typ).Interface().(T))
+	}
+
+	// Unmarshal the full data into the content instances.
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/go/message/annotation.go
+++ b/go/message/annotation.go
@@ -49,7 +49,7 @@ type Annotation interface {
 // such as documents, URLs, files, or tool outputs.
 type CitationAnnotation struct {
 	AdditionalProperties map[string]any    `json:"-"`
-	AnnotatedRegions     []AnnotatedRegion `json:",omitempty"`
+	AnnotatedRegions     AnnotatedRegions  `json:",omitempty"`
 	RawRepresentation    any               `json:"-"`
 
 	FileID   string `json:",omitempty"` // Source identifier associated with the annotation.

--- a/go/message/annotation.go
+++ b/go/message/annotation.go
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package message
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/microsoft/agent-framework/go/internal/jsonx"
+)
+
+var supportedAnnotations map[annotationKind]reflect.Type
+var supportedAnnotatedRegions map[annotatedRegionKind]reflect.Type
+
+func init() {
+	supportedAnnotations = make(map[annotationKind]reflect.Type)
+	for _, a := range []Annotation{
+		&CitationAnnotation{},
+	} {
+		supportedAnnotations[a.kind()] = reflect.TypeOf(a).Elem()
+	}
+
+	supportedAnnotatedRegions = make(map[annotatedRegionKind]reflect.Type)
+	for _, ar := range []AnnotatedRegion{
+		&TextSpanAnnotatedRegion{},
+	} {
+		supportedAnnotatedRegions[ar.kind()] = reflect.TypeOf(ar).Elem()
+	}
+}
+
+// annotationKind represents the type of annotation.
+// It is unexported to prevent external implementations of Annotation.
+type annotationKind string
+
+type Annotations []Annotation
+
+func (as *Annotations) UnmarshalJSON(data []byte) error {
+	var err error
+	*as, err = jsonx.UnmarshalDiscriminatedUnionSlice[Annotation](data, supportedAnnotations)
+	return err
+}
+
+// Annotation represents an annotation on content.
+type Annotation interface {
+	kind() annotationKind
+}
+
+// CitationAnnotation represents an annotation that links content to source references,
+// such as documents, URLs, files, or tool outputs.
+type CitationAnnotation struct {
+	AdditionalProperties map[string]any    `json:"-"`
+	AnnotatedRegions     []AnnotatedRegion `json:",omitempty"`
+	RawRepresentation    any               `json:"-"`
+
+	FileID   string `json:",omitempty"` // Source identifier associated with the annotation.
+	Snippet  string `json:",omitempty"` // Snippet or excerpt from the source that was cited.
+	Title    string `json:",omitempty"` // Title or name of the source.
+	ToolName string `json:",omitempty"` // Name of any tool involved in the production of the associated content.
+	URL      string `json:",omitempty"` // URI from which the source material was retrieved.
+}
+
+func (t *CitationAnnotation) MarshalJSON() ([]byte, error) {
+	type alias CitationAnnotation
+	tmp := struct {
+		*alias
+		Type annotationKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t *CitationAnnotation) kind() annotationKind { return "citation" }
+
+type annotatedRegionKind string
+
+type AnnotatedRegions []AnnotatedRegion
+
+func (as *AnnotatedRegions) UnmarshalJSON(data []byte) error {
+	var err error
+	*as, err = jsonx.UnmarshalDiscriminatedUnionSlice[AnnotatedRegion](data, supportedAnnotatedRegions)
+	return err
+}
+
+// AnnotatedRegion describes the portion of an associated [Content]
+// to which an annotation applies.
+type AnnotatedRegion interface {
+	kind() annotatedRegionKind
+}
+
+// TextSpanAnnotatedRegion describes a location in the associated [Content]
+// based on starting and ending character indices.
+type TextSpanAnnotatedRegion struct {
+	Start int // Start character index (inclusive) of the annotated span.
+	End   int // End character index (exclusive) of the annotated span.
+}
+
+func (t *TextSpanAnnotatedRegion) MarshalJSON() ([]byte, error) {
+	type alias TextSpanAnnotatedRegion
+	tmp := struct {
+		*alias
+		Type annotatedRegionKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t *TextSpanAnnotatedRegion) kind() annotatedRegionKind { return "text_span" }

--- a/go/message/annotation_test.go
+++ b/go/message/annotation_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package message_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/agent-framework/go/message"
+)
+
+func TestAnnotationEncoding_Rountrip(t *testing.T) {
+	annotations := message.Annotations{
+		&message.CitationAnnotation{
+			URL:      "http://example.com",
+			Title:    "Example Title",
+			Snippet:  "This is a snippet from the source.",
+			ToolName: "ExampleTool",
+			FileID:   "file123",
+		},
+	}
+	data, err := json.Marshal(annotations)
+	if err != nil {
+		t.Error(err)
+	}
+	var decoded message.Annotations
+	if err = json.Unmarshal(data, &decoded); err != nil {
+		t.Error(err)
+	}
+	if len(decoded) != len(annotations) {
+		t.Errorf("expected %d contents, got %d", len(annotations), len(decoded))
+	}
+	for i, v := range annotations {
+		if !reflect.DeepEqual(v, decoded[i]) {
+			t.Errorf("[%d]: expected content %v, got %v", i, v, decoded[i])
+		}
+	}
+}
+
+func TestAnnotatedRegionEncoding_Roundtrip(t *testing.T) {
+	regions := message.AnnotatedRegions{
+		&message.TextSpanAnnotatedRegion{
+			Start: 10,
+			End:   50,
+		},
+	}
+	data, err := json.Marshal(regions)
+	if err != nil {
+		t.Error(err)
+	}
+	var decoded message.AnnotatedRegions
+	if err = json.Unmarshal(data, &decoded); err != nil {
+		t.Error(err)
+	}
+	if len(decoded) != len(regions) {
+		t.Errorf("expected %d regions, got %d", len(regions), len(decoded))
+	}
+	for i, v := range regions {
+		if !reflect.DeepEqual(v, decoded[i]) {
+			t.Errorf("[%d]: expected region %v, got %v", i, v, decoded[i])
+		}
+	}
+}

--- a/go/message/annotation_test.go
+++ b/go/message/annotation_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/microsoft/agent-framework/go/message"
 )
 
-func TestAnnotationEncoding_Rountrip(t *testing.T) {
+func TestAnnotationEncoding_Roundtrip(t *testing.T) {
 	annotations := message.Annotations{
 		&message.CitationAnnotation{
 			URL:      "http://example.com",

--- a/go/message/content.go
+++ b/go/message/content.go
@@ -407,7 +407,7 @@ func (t *UsageContent) MarshalJSON() ([]byte, error) {
 		Type contentKind
 	}{
 		alias: (*alias)(t),
-		Type:  "usage",
+		Type:  t.kind(),
 	}
 	return json.Marshal(tmp)
 }

--- a/go/message/content.go
+++ b/go/message/content.go
@@ -2,59 +2,75 @@
 
 package message
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+
+	"github.com/microsoft/agent-framework/go/internal/jsonx"
+)
+
+var supportedContents map[contentKind]reflect.Type
+
+func init() {
+	supportedContents = make(map[contentKind]reflect.Type)
+	for _, c := range []Content{
+		&TextContent{},
+		&DataContent{},
+		&ErrorContent{},
+		&FunctionCallContent{},
+		&FunctionResultContent{},
+		&HostedFileContent{},
+		&HostedVectorStoreContent{},
+		&TextReasoningContent{},
+		&URIContent{},
+		&UsageContent{},
+	} {
+		supportedContents[c.kind()] = reflect.TypeOf(c).Elem()
+	}
+}
+
+// contentKind represents the type of content.
+// It is unexported to prevent external implementations of Content.
+type contentKind string
 
 // Content represents message content.
 type Content interface {
-	isContent()
+	json.Marshaler
+	kind() contentKind
 }
 
-// AnnotatedRegion describes the portion of an associated [Content]
-// to which an annotation applies.
-type AnnotatedRegion interface {
-	isRegion()
+// Contents is a slice of Content that supports JSON encoding.
+type Contents []Content
+
+func (cs *Contents) UnmarshalJSON(data []byte) error {
+	var err error
+	*cs, err = jsonx.UnmarshalDiscriminatedUnionSlice[Content](data, supportedContents)
+	return err
 }
-
-// TextSpanAnnotatedRegion describes a location in the associated [Content]
-// based on starting and ending character indices.
-type TextSpanAnnotatedRegion struct {
-	Start int // Start character index (inclusive) of the annotated span.
-	End   int // End character index (exclusive) of the annotated span.
-}
-
-func (t *TextSpanAnnotatedRegion) isRegion() {}
-
-// Annotation represents an annotation on content.
-type Annotation interface {
-	isAnnotation()
-}
-
-// CitationAnnotation represents an annotation that links content to source references,
-// such as documents, URLs, files, or tool outputs.
-type CitationAnnotation struct {
-	AdditionalProperties map[string]any
-	AnnotatedRegions     []AnnotatedRegion
-	RawRepresentation    any
-
-	FileID   string // Source identifier associated with the annotation.
-	Snippet  string // Snippet or excerpt from the source that was cited.
-	Title    string // Title or name of the source.
-	ToolName string // Name of any tool involved in the production of the associated content.
-	URL      string // URI from which the source material was retrieved.
-}
-
-func (t *CitationAnnotation) isAnnotation() {}
 
 // TextContent represents plain text content.
 type TextContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	Text string
 }
 
-func (t *TextContent) isContent() {}
+func (t *TextContent) MarshalJSON() ([]byte, error) {
+	type alias TextContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t TextContent) kind() contentKind { return "text" }
 
 // String returns the text of the content.
 func (t *TextContent) String() string { return t.Text }
@@ -64,44 +80,114 @@ func (t *TextContent) String() string { return t.Text }
 // The content represents in-memory data. For references to data at a remote URI,
 // use [URIContent] instead.
 type DataContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	Data      []byte
 	MediaType string
-	Name      string
-	URI       string
+	Name      string `json:",omitempty"`
+	URI       string `json:",omitempty"`
 }
 
-func (t *DataContent) isContent() {}
+func (t *DataContent) MarshalJSON() ([]byte, error) {
+	type alias DataContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t DataContent) kind() contentKind { return "data" }
 
 // ErrorContent represents an error.
 //
 // Typically, ErrorContent is used for non-fatal errors, where something went wrong as part
 // of the operation but the operation was still able to continue.
 type ErrorContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
-	Details   string
-	ErrorCode string
 	Message   string
+	Details   string `json:",omitempty"`
+	ErrorCode string `json:",omitempty"`
 }
 
-func (t *ErrorContent) isContent() {}
+func (t *ErrorContent) MarshalJSON() ([]byte, error) {
+	type alias ErrorContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t ErrorContent) kind() contentKind { return "error" }
+
+type serializedFunctionCallContent struct {
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
+
+	Arguments string
+	CallID    string
+	Error     string `json:",omitempty"`
+	Name      string `json:",omitempty"`
+
+	Type contentKind
+}
 
 // FunctionCallContent represents a function call request.
 type FunctionCallContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	Arguments string // Arguments as a JSON-encoded string.
 	CallID    string
 	Error     error // Error that occurred while mapping the original function call data to this object.
 	Name      string
+}
+
+func (t *FunctionCallContent) MarshalJSON() ([]byte, error) {
+	tmp := serializedFunctionCallContent{
+		AdditionalProperties: t.AdditionalProperties,
+		Annotations:          t.Annotations,
+		RawRepresentation:    t.RawRepresentation,
+		Arguments:            t.Arguments,
+		CallID:               t.CallID,
+		Name:                 t.Name,
+		Type:                 t.kind(),
+	}
+	if t.Error != nil {
+		tmp.Error = t.Error.Error()
+	}
+	return json.Marshal(tmp)
+}
+
+func (t *FunctionCallContent) UnmarshalJSON(data []byte) error {
+	var tmp serializedFunctionCallContent
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	t.AdditionalProperties = tmp.AdditionalProperties
+	t.Annotations = tmp.Annotations
+	t.RawRepresentation = tmp.RawRepresentation
+	t.Arguments = tmp.Arguments
+	t.CallID = tmp.CallID
+	t.Name = tmp.Name
+	if tmp.Error != "" {
+		t.Error = errors.New(tmp.Error)
+	}
+	return nil
 }
 
 func (t *FunctionCallContent) ParseArgs() (map[string]any, error) {
@@ -112,20 +198,63 @@ func (t *FunctionCallContent) ParseArgs() (map[string]any, error) {
 	return args, nil
 }
 
-func (t *FunctionCallContent) isContent() {}
+func (t FunctionCallContent) kind() contentKind { return "function_call" }
+
+type serializedFunctionResultContent struct {
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
+
+	CallID string
+	Error  string `json:",omitempty"`
+	Result any    `json:",omitempty"`
+
+	Type contentKind
+}
 
 // FunctionResultContent represents the result of a function call.
 type FunctionResultContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	CallID string
-	Error  error // Error that occurred if the function call failed.
-	Result any
+	Error  error `json:",omitempty"` // Error that occurred if the function call failed.
+	Result any   `json:",omitempty"`
 }
 
-func (t *FunctionResultContent) isContent() {}
+func (t *FunctionResultContent) MarshalJSON() ([]byte, error) {
+	tmp := serializedFunctionResultContent{
+		AdditionalProperties: t.AdditionalProperties,
+		Annotations:          t.Annotations,
+		RawRepresentation:    t.RawRepresentation,
+		CallID:               t.CallID,
+		Result:               t.Result,
+		Type:                 t.kind(),
+	}
+	if t.Error != nil {
+		tmp.Error = t.Error.Error()
+	}
+	return json.Marshal(tmp)
+}
+
+func (t *FunctionResultContent) UnmarshalJSON(data []byte) error {
+	var tmp serializedFunctionResultContent
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	t.AdditionalProperties = tmp.AdditionalProperties
+	t.Annotations = tmp.Annotations
+	t.RawRepresentation = tmp.RawRepresentation
+	t.CallID = tmp.CallID
+	t.Result = tmp.Result
+	if tmp.Error != "" {
+		t.Error = errors.New(tmp.Error)
+	}
+	return nil
+}
+
+func (t FunctionResultContent) kind() contentKind { return "function_result" }
 
 // HostedFileContent represents a file that is hosted by the AI service.
 //
@@ -133,28 +262,52 @@ func (t *FunctionResultContent) isContent() {}
 // that is hosted by the AI service and referenced by an identifier.
 // Such identifiers are specific to the provider.
 type HostedFileContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	FileID string
 }
 
-func (t *HostedFileContent) isContent() {}
+func (t *HostedFileContent) MarshalJSON() ([]byte, error) {
+	type alias HostedFileContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t HostedFileContent) kind() contentKind { return "hosted_file" }
 
 // HostedVectorStoreContent represents a vector store that is hosted by the AI service.
 //
 // Unlike [HostedFileContent] which represents a specific file that is hosted by the AI service,
 // HostedVectorStoreContent represents a vector store that can contain multiple files, indexed for searching.
 type HostedVectorStoreContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	VectorStoreID string
 }
 
-func (t *HostedVectorStoreContent) isContent() {}
+func (t *HostedVectorStoreContent) MarshalJSON() ([]byte, error) {
+	type alias HostedVectorStoreContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t HostedVectorStoreContent) kind() contentKind { return "hosted_vector_store" }
 
 // TextReasoningContent represents text reasoning content in a chat.
 //
@@ -162,30 +315,54 @@ func (t *HostedVectorStoreContent) isContent() {}
 // performed by the model and is distinct from the actual output text from the model,
 // which is represented by [TextContent].
 type TextReasoningContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
-	ProtectedData string // Opaque blob of data associated with this reasoning content.
+	ProtectedData string `json:",omitempty"`
 	Text          string
 }
 
-func (t *TextReasoningContent) isContent() {}
+func (t *TextReasoningContent) MarshalJSON() ([]byte, error) {
+	type alias TextReasoningContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t TextReasoningContent) kind() contentKind { return "text_reasoning" }
 
 // String returns the text of the reasoning content.
 func (t *TextReasoningContent) String() string { return t.Text }
 
 // URIContent represents a URL, typically to hosted content such as an image, audio, or video.
 type URIContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	MediaType string
 	URI       string
 }
 
-func (t *URIContent) isContent() {}
+func (t *URIContent) MarshalJSON() ([]byte, error) {
+	type alias URIContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t URIContent) kind() contentKind { return "uri" }
 
 // UsageDetails provides usage details about a request/response.
 type UsageDetails struct {
@@ -216,11 +393,23 @@ func (u *UsageDetails) Add(other *UsageDetails) {
 
 // UsageContent represents usage information associated with a chat request and response.
 type UsageContent struct {
-	AdditionalProperties map[string]any
-	Annotations          []Annotation
-	RawRepresentation    any
+	AdditionalProperties map[string]any `json:"-"`
+	Annotations          Annotations    `json:",omitempty"`
+	RawRepresentation    any            `json:"-"`
 
 	Details UsageDetails
 }
 
-func (t *UsageContent) isContent() {}
+func (t *UsageContent) MarshalJSON() ([]byte, error) {
+	type alias UsageContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  "usage",
+	}
+	return json.Marshal(tmp)
+}
+
+func (t UsageContent) kind() contentKind { return "usage" }

--- a/go/message/content_test.go
+++ b/go/message/content_test.go
@@ -3,6 +3,9 @@
 package message_test
 
 import (
+	"encoding/json"
+	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/microsoft/agent-framework/go/message"
@@ -84,5 +87,63 @@ func TestUsageDetails_AddWithNil(t *testing.T) {
 	ud1.Add(nil)
 	if ud1.InputTokenCount != 10 {
 		t.Errorf("expected input tokens to remain 10, got %d", ud1.InputTokenCount)
+	}
+}
+
+func TestContentEncoding_Rountrip(t *testing.T) {
+	contents := message.Contents{
+		&message.TextContent{Text: "sample text"},
+		&message.TextReasoningContent{Text: "sample reasoning"},
+		&message.FunctionCallContent{
+			Arguments: "sample args",
+		},
+		&message.FunctionResultContent{
+			CallID: "call-123",
+			Result: map[string]any{"key": "value"},
+			Error:  errors.New("sample error"),
+		},
+		&message.URIContent{
+			URI: "https://example.com/resource",
+		},
+		&message.UsageContent{
+			Details: message.UsageDetails{
+				InputTokenCount:  10,
+				OutputTokenCount: 20,
+				TotalTokenCount:  30,
+			},
+		},
+		&message.ErrorContent{
+			ErrorCode: "1",
+			Message:   "sample error message",
+			Details:   "sample error details",
+		},
+		&message.DataContent{
+			Data:      []byte("sample data"),
+			Name:      "sample data name",
+			URI:       "sample data uri",
+			MediaType: "sample media type",
+		},
+		&message.HostedFileContent{
+			FileID: "file-123",
+		},
+		&message.HostedVectorStoreContent{
+			VectorStoreID: "store-123",
+		},
+	}
+	data, err := json.Marshal(contents)
+	if err != nil {
+		t.Error(err)
+	}
+	var decoded message.Contents
+	if err = json.Unmarshal(data, &decoded); err != nil {
+		t.Error(err)
+	}
+	if len(decoded) != len(contents) {
+		t.Errorf("expected %d contents, got %d", len(contents), len(decoded))
+	}
+	for i, v := range contents {
+		if !reflect.DeepEqual(v, decoded[i]) {
+			t.Errorf("[%d]: expected content %v, got %v", i, v, decoded[i])
+		}
 	}
 }

--- a/go/message/content_test.go
+++ b/go/message/content_test.go
@@ -90,7 +90,7 @@ func TestUsageDetails_AddWithNil(t *testing.T) {
 	}
 }
 
-func TestContentEncoding_Rountrip(t *testing.T) {
+func TestContentEncoding_Roundtrip(t *testing.T) {
 	contents := message.Contents{
 		&message.TextContent{Text: "sample text"},
 		&message.TextReasoningContent{Text: "sample reasoning"},

--- a/go/message/message.go
+++ b/go/message/message.go
@@ -18,7 +18,7 @@ const (
 
 // Message represents a message in a conversation.
 type Message struct {
-	Contents  []Content
+	Contents  Contents
 	Role      Role
 	Name      string
 	MessageID string

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -113,7 +113,7 @@ func (a *client) Run(ctx context.Context, t memory.Thread, opts *agent.RunOption
 		contents = append(contents, &message.TextContent{Text: choice.Message.Content})
 	}
 	return &agent.RunResponse{
-		Messages:   []*message.Message{&message.Message{Role: message.Role(choice.Message.Role), Contents: contents}},
+		Messages:   []*message.Message{{Role: message.Role(choice.Message.Role), Contents: contents}},
 		AgentID:    a.config.ID,
 		ResponseID: resp.ID,
 	}, nil

--- a/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
+++ b/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
@@ -20,7 +20,7 @@ func main() {
 	ag = openai.NewChatAgent(openai.AgentConfig{
 		Model:              "gpt-4o-mini",
 		SystemInstructions: "You are a friendly assistant. Always address the user by their name.",
-		//NewContextProvider: func() memory.ContextProvider { return &UserInfoMemory{Agent: ag} },
+		NewContextProvider: func() memory.ContextProvider { return &UserInfoMemory{Agent: ag} },
 	})
 
 	fmt.Println(">> Use thread with blank memory")


### PR DESCRIPTION
`memory.Thread` contains a slice of `message.Message`, each containing a slice of `message.Content`. The problem with this last type is that it is an interface, so it can't be directly unmarshaled without manually using a discriminator to infer the type of each element.

This PR implements the necessary logic to unmarshal all supported contents.