### PR TITLE
Simplify examples

### DIFF
--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -140,7 +140,7 @@ func (a *Agent) Run(ctx context.Context, thread memory.Thread, opts *RunOptions,
 		AgentID:    id,
 	}
 	if opts.Response != nil {
-		if err := opts.Response.UnmarshalBinary([]byte(response.Text())); err != nil {
+		if err := opts.Response.UnmarshalBinary([]byte(response.String())); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	}
@@ -355,17 +355,17 @@ type RunResponse struct {
 	Messages   []*message.Message
 }
 
-// Text returns the concatenated text contents of the response messages.
-func (r *RunResponse) Text() string {
-	var text string
+// String returns the concatenated text contents of the response messages.
+func (r *RunResponse) String() string {
+	var sb strings.Builder
 	for _, msg := range r.Messages {
 		for _, c := range msg.Contents {
 			if textContent, ok := c.(*message.TextContent); ok {
-				text += textContent.Text
+				sb.WriteString(textContent.Text)
 			}
 		}
 	}
-	return text
+	return sb.String()
 }
 
 // RunResponseUpdate represents a streaming update from an agent execution.
@@ -377,8 +377,8 @@ type RunResponseUpdate struct {
 	Contents   []message.Content
 }
 
-// Text returns the concatenated text contents of the response messages.
-func (r *RunResponseUpdate) Text() string {
+// String returns the concatenated text contents of the response messages.
+func (r *RunResponseUpdate) String() string {
 	var sb strings.Builder
 	for _, c := range r.Contents {
 		if textContent, ok := c.(*message.TextContent); ok {

--- a/go/agent/agent_test.go
+++ b/go/agent/agent_test.go
@@ -56,8 +56,8 @@ func TestAgent_CustomResponse(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if resp.Text() != respTest {
-		t.Errorf("expected %q, got %q", respTest, resp.Text())
+	if resp.String() != respTest {
+		t.Errorf("expected %q, got %q", respTest, resp.String())
 	}
 }
 
@@ -128,16 +128,16 @@ func TestAgent_ResponseSequence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error on first call, got: %v", err)
 	}
-	if resp1.Text() != respText1 {
-		t.Errorf("expected %q, got %q", respText1, resp1.Text())
+	if resp1.String() != respText1 {
+		t.Errorf("expected %q, got %q", respText1, resp1.String())
 	}
 
 	resp2, err := a.Run(t.Context(), nil, nil, message.NewText("Test 2"))
 	if err != nil {
 		t.Fatalf("expected no error on second call, got: %v", err)
 	}
-	if resp2.Text() != respText2 {
-		t.Errorf("expected %q, got %q", respText2, resp2.Text())
+	if resp2.String() != respText2 {
+		t.Errorf("expected %q, got %q", respText2, resp2.String())
 	}
 }
 
@@ -169,8 +169,8 @@ func TestAgent_WithToolCalls(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if resp.Text() != respText {
-		t.Errorf("expected final response %q, got %q", respText, resp.Text())
+	if resp.String() != respText {
+		t.Errorf("expected final response %q, got %q", respText, resp.String())
 	}
 
 	if client.GetRunCallCount() < 2 {
@@ -206,13 +206,13 @@ func TestAgent_CustomFunction(t *testing.T) {
 	}
 
 	resp1, _ := a.Run(t.Context(), nil, nil, message.NewText("Test"))
-	if resp1.Text() != respText1 {
-		t.Errorf("expected %q, got %q", respText1, resp1.Text())
+	if resp1.String() != respText1 {
+		t.Errorf("expected %q, got %q", respText1, resp1.String())
 	}
 
 	resp2, _ := a.Run(t.Context(), nil, nil, message.NewText("Yes"))
-	if resp2.Text() != respText2 {
-		t.Errorf("expected %q, got %q", respText2, resp2.Text())
+	if resp2.String() != respText2 {
+		t.Errorf("expected %q, got %q", respText2, resp2.String())
 	}
 }
 
@@ -242,8 +242,8 @@ func TestAgent_RunText(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if resp.Text() != responseText {
-		t.Errorf("expected %q, got %q", responseText, resp.Text())
+	if resp.String() != responseText {
+		t.Errorf("expected %q, got %q", responseText, resp.String())
 	}
 }
 
@@ -476,8 +476,8 @@ func TestAgent_MaxRetries(t *testing.T) {
 		t.Errorf("expected 6 calls, got %d", callCount)
 	}
 
-	if resp.Text() != "Final response" {
-		t.Errorf("expected final response, got %q", resp.Text())
+	if resp.String() != "Final response" {
+		t.Errorf("expected final response, got %q", resp.String())
 	}
 }
 
@@ -507,7 +507,7 @@ func TestAgent_RunStreamFallback(t *testing.T) {
 
 	var text string
 	for _, u := range updates {
-		text += u.Text()
+		text += u.String()
 	}
 	if text != "Fallback response" {
 		t.Errorf("expected 'Fallback response', got %q", text)
@@ -553,8 +553,8 @@ func TestRunResponse_Text(t *testing.T) {
 	}
 
 	expected := "First Second"
-	if resp.Text() != expected {
-		t.Errorf("expected %q, got %q", expected, resp.Text())
+	if resp.String() != expected {
+		t.Errorf("expected %q, got %q", expected, resp.String())
 	}
 }
 
@@ -570,8 +570,8 @@ func TestRunResponseUpdate_Text(t *testing.T) {
 	}
 
 	expected := "Part 1 Part 2"
-	if update.Text() != expected {
-		t.Errorf("expected %q, got %q", expected, update.Text())
+	if update.String() != expected {
+		t.Errorf("expected %q, got %q", expected, update.String())
 	}
 }
 
@@ -637,8 +637,8 @@ func TestAgent_ToolError(t *testing.T) {
 	}
 
 	// Agent should handle the tool error and return final response
-	if resp.Text() != "Handled error" {
-		t.Errorf("expected final response, got %q", resp.Text())
+	if resp.String() != "Handled error" {
+		t.Errorf("expected final response, got %q", resp.String())
 	}
 }
 
@@ -705,8 +705,8 @@ func TestAgent_ToolInvalidArgs(t *testing.T) {
 		t.Errorf("expected tool not to be called, but was called %d times", tl.CallCount)
 	}
 
-	if resp.Text() != "Handled invalid args" {
-		t.Errorf("expected final response, got %q", resp.Text())
+	if resp.String() != "Handled invalid args" {
+		t.Errorf("expected final response, got %q", resp.String())
 	}
 }
 

--- a/go/agent/func_test.go
+++ b/go/agent/func_test.go
@@ -45,8 +45,8 @@ func TestAgentCallTool(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if resp.Text() != "Final response" {
-		t.Errorf("expected 'Final response', got %q", resp.Text())
+	if resp.String() != "Final response" {
+		t.Errorf("expected 'Final response', got %q", resp.String())
 	}
 }
 

--- a/go/message/annotation.go
+++ b/go/message/annotation.go
@@ -48,9 +48,9 @@ type Annotation interface {
 // CitationAnnotation represents an annotation that links content to source references,
 // such as documents, URLs, files, or tool outputs.
 type CitationAnnotation struct {
-	AdditionalProperties map[string]any    `json:"-"`
-	AnnotatedRegions     AnnotatedRegions  `json:",omitempty"`
-	RawRepresentation    any               `json:"-"`
+	AdditionalProperties map[string]any   `json:"-"`
+	AnnotatedRegions     AnnotatedRegions `json:",omitempty"`
+	RawRepresentation    any              `json:"-"`
 
 	FileID   string `json:",omitempty"` // Source identifier associated with the annotation.
 	Snippet  string `json:",omitempty"` // Snippet or excerpt from the source that was cited.

--- a/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
+++ b/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
@@ -20,24 +20,12 @@ This sample demonstrates basic usage of openai.Agent for direct chat-based
 interactions, showing both streaming and non-streaming responses.
 */
 
-type weatherRequest struct {
-	Location string `json:"location"`
-}
-
-type weatherResponse struct {
-	Conditions string `json:"conditions"`
-	HighTemp   int    `json:"high_temp"`
-}
-
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, req weatherRequest) (weatherResponse, error) {
-	fmt.Printf("🔧 Weather tool called for location: %s\n", req.Location)
-	return weatherResponse{
-		Conditions: []string{"sunny", "cloudy", "rainy", "stormy"}[rand.Intn(4)],
-		HighTemp:   rand.Intn(21) + 10,
-	}, nil
+}, func(_ context.Context, location string) (string, error) {
+	conditions := []string{"sunny", "cloudy", "rainy", "stormy"}
+	return fmt.Sprintf("The weather in %s is %s with a high of %d°C.", location, conditions[rand.Intn(len(conditions))], rand.Intn(21)+10), nil
 })
 
 func main() {
@@ -86,28 +74,32 @@ func main() {
 
 func nonStreamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("\n=== Non-streaming Response Example ===\n")
-	fmt.Printf("User: %s\n", query)
-	resp, err := ag.RunText(ctx, query)
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	fmt.Printf("Assistant: %s\n", resp.Text())
+	fmt.Println("\n=== Non-streaming Response Example ===")
+	fmt.Println("User: " + query)
+	fmt.Println("Assistant: ", must(ag.RunText(ctx, query)))
 }
 
 func streamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("\n=== Streaming Response Example ===\n")
-	fmt.Printf("User: %s\n", query)
+	fmt.Println("\n=== Streaming Response Example ===")
+	fmt.Println("User: " + query)
 	fmt.Print("Assistant: ")
 	stream := ag.RunStream(ctx, nil, nil, message.NewText(query))
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)
-			return
+			break
 		}
-		fmt.Print(update.Text())
+		fmt.Print(update)
 	}
 	fmt.Print("\n")
+}
+
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }

--- a/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
+++ b/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
@@ -75,14 +75,14 @@ func main() {
 func nonStreamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
 	fmt.Println("\n=== Non-streaming Response Example ===")
-	fmt.Println("User: " + query)
+	fmt.Println("User: ", query)
 	fmt.Println("Assistant: ", must(ag.RunText(ctx, query)))
 }
 
 func streamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
 	fmt.Println("\n=== Streaming Response Example ===")
-	fmt.Println("User: " + query)
+	fmt.Println("User: ", query)
 	fmt.Print("Assistant: ")
 	stream := ag.RunStream(ctx, nil, nil, message.NewText(query))
 	for update, err := range stream {

--- a/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
+++ b/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 
@@ -21,37 +20,18 @@ This sample demonstrates basic usage of openai.Agent for direct chat-based
 interactions, showing both streaming and non-streaming responses.
 */
 
-type weatherRequest struct {
-	Location string `json:"location"`
-}
-
-type weatherResponse struct {
-	Conditions string `json:"conditions"`
-	HighTemp   int    `json:"high_temp"`
-}
-
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, req weatherRequest) (weatherResponse, error) {
-	return weatherResponse{
-		Conditions: []string{"sunny", "cloudy", "rainy", "stormy"}[rand.Intn(4)],
-		HighTemp:   rand.Intn(21) + 10,
-	}, nil
+}, func(_ context.Context, location string) (string, error) {
+	conditions := []string{"sunny", "cloudy", "rainy", "stormy"}
+	return fmt.Sprintf("The weather in %s is %s with a high of %d°C.", location, conditions[rand.Intn(len(conditions))], rand.Intn(21)+10), nil
 })
 
 func main() {
-	// OpenAI configuration
-	// Set your API key via environment variable: export OPENAI_API_KEY=your-key-here
-	// Or get one from: https://platform.openai.com/account/api-keys
-	apiKey := os.Getenv("OPENAI_API_KEY")
-	if apiKey == "" {
-		log.Fatal("OPENAI_API_KEY environment variable is required. Get your key from https://platform.openai.com/account/api-keys")
-	}
-
 	ag := openai.NewChatAgent(openai.AgentConfig{
 		Model:              "gpt-5-nano",
-		APIKey:             apiKey,
+		APIKey:             os.Getenv("OPENAI_API_KEY"),
 		SystemInstructions: "You are a helpful weather agent.",
 		Opts: &agent.RunOptions{
 			Tools: []tool.Tool{weatherTool},
@@ -64,27 +44,31 @@ func main() {
 
 func nonStreamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("=== Non-streaming Response Example ===\n")
-	fmt.Printf("User: %s\n", query)
-	resp, err := ag.RunText(ctx, query)
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	fmt.Printf("Result: %s\n", resp.Text())
+	fmt.Println("=== Non-streaming Response Example ===")
+	fmt.Println("User: ", query)
+	fmt.Println("Result: ", must(ag.RunText(ctx, query)))
 }
 
 func streamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("=== Streaming Response Example ===\n")
-	fmt.Printf("User: %s\n", query)
+	fmt.Println("=== Streaming Response Example ===")
+	fmt.Println("User: ", query)
 	stream := ag.RunStream(ctx, nil, nil, message.NewText(query))
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)
-			return
+			break
 		}
-		fmt.Print(update.Text())
+		fmt.Print(update)
 	}
 	fmt.Print("\n")
+}
+
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }

--- a/go/samples/getting_started/openai/chat_client_with_thread/openai_chat_with_thread.go
+++ b/go/samples/getting_started/openai/chat_client_with_thread/openai_chat_with_thread.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -20,23 +19,12 @@ This sample demonstrates thread management with OpenAI Chat Agent, showing
 conversation threads and message history preservation across interactions.
 */
 
-type weatherRequest struct {
-	Location string `json:"location"`
-}
-
-type weatherResponse struct {
-	Conditions string `json:"conditions"`
-	HighTemp   int    `json:"high_temp"`
-}
-
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, req weatherRequest) (weatherResponse, error) {
-	return weatherResponse{
-		Conditions: []string{"sunny", "cloudy", "rainy", "stormy"}[rand.Intn(4)],
-		HighTemp:   rand.Intn(21) + 10,
-	}, nil
+}, func(_ context.Context, location string) (string, error) {
+	conditions := []string{"sunny", "cloudy", "rainy", "stormy"}
+	return fmt.Sprintf("The weather in %s is %s with a high of %d°C.", location, conditions[rand.Intn(len(conditions))], rand.Intn(21)+10), nil
 })
 
 func main() {
@@ -64,23 +52,13 @@ func exampleWithAutomaticThreadCreation() {
 
 	// First conversation - no thread provided, will be created automatically
 	query1 := "What's the weather like in Seattle?"
-	fmt.Printf("User: %s\n", query1)
-	result1, err := ag.Run(ctx, nil, nil, message.NewText(query1))
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-		return
-	}
-	fmt.Printf("Agent: %s\n", result1.Text())
+	fmt.Println("User: ", query1)
+	fmt.Println("Agent: ", must(ag.Run(ctx, nil, nil, message.NewText(query1))))
 
 	// Second conversation - still no thread provided, will create another new thread
 	query2 := "What was the last city I asked about?"
-	fmt.Printf("\nUser: %s\n", query2)
-	result2, err := ag.Run(ctx, nil, nil, message.NewText(query2))
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-		return
-	}
-	fmt.Printf("Agent: %s\n", result2.Text())
+	fmt.Println("User: ", query2)
+	fmt.Println("Agent: ", must(ag.Run(ctx, nil, nil, message.NewText(query2))))
 	fmt.Println("Note: Each call creates a separate thread, so the agent doesn't remember previous context.")
 	fmt.Println()
 }
@@ -105,33 +83,18 @@ func exampleWithThreadPersistence() {
 
 	// First conversation
 	query1 := "What's the weather like in Tokyo?"
-	fmt.Printf("User: %s\n", query1)
-	result1, err := ag.Run(ctx, thread, nil, message.NewText(query1))
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-		return
-	}
-	fmt.Printf("Agent: %s\n", result1.Text())
+	fmt.Println("User: ", query1)
+	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query1))))
 
 	// Second conversation using the same thread - maintains context
 	query2 := "How about London?"
-	fmt.Printf("\nUser: %s\n", query2)
-	result2, err := ag.Run(ctx, thread, nil, message.NewText(query2))
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-		return
-	}
-	fmt.Printf("Agent: %s\n", result2.Text())
+	fmt.Println("User: ", query2)
+	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query2))))
 
 	// Third conversation - agent should remember both previous cities
 	query3 := "Which of the cities I asked about has better weather?"
-	fmt.Printf("\nUser: %s\n", query3)
-	result3, err := ag.Run(ctx, thread, nil, message.NewText(query3))
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-		return
-	}
-	fmt.Printf("Agent: %s\n", result3.Text())
+	fmt.Println("User: ", query3)
+	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query3))))
 	fmt.Println("Note: The agent remembers context from previous messages in the same thread.")
 	fmt.Println()
 }
@@ -153,13 +116,8 @@ func exampleWithExistingThreadMessages() {
 	thread := ag.NewThread()
 
 	query1 := "What's the weather in Paris?"
-	fmt.Printf("User: %s\n", query1)
-	result1, err := ag.Run(ctx, thread, nil, message.NewText(query1))
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-		return
-	}
-	fmt.Printf("Agent: %s\n", result1.Text())
+	fmt.Println("User: ", query1)
+	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query1))))
 
 	fmt.Println("\n--- Continuing with the same thread in a new agent instance ---")
 
@@ -173,13 +131,17 @@ func exampleWithExistingThreadMessages() {
 
 	// Use the same thread object which contains the conversation history
 	query2 := "What was the last city I asked about?"
-	fmt.Printf("User: %s\n", query2)
-	result2, err := newAgent.Run(ctx, thread, nil, message.NewText(query2))
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-		return
-	}
-	fmt.Printf("Agent: %s\n", result2.Text())
+	fmt.Println("User: ", query2)
+	fmt.Println("Agent: ", must(newAgent.Run(ctx, thread, nil, message.NewText(query2))))
 	fmt.Println("Note: The agent continues the conversation using the thread message history.")
 	fmt.Println()
+}
+
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }

--- a/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
+++ b/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
@@ -23,15 +23,21 @@ func main() {
 	})
 
 	ctx := context.Background()
-	resp, err := ag.Run(ctx, nil, nil, &message.Message{Role: message.RoleUser, Contents: []message.Content{
-		&message.TextContent{Text: "Describe the content of this image."},
-		&message.URIContent{
-			URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
-			MediaType: "image/jpeg",
-		}}})
+	fmt.Println("Result: ", must(
+		ag.Run(ctx, nil, nil, &message.Message{Role: message.RoleUser, Contents: []message.Content{
+			&message.TextContent{Text: "Describe the content of this image."},
+			&message.URIContent{
+				URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+				MediaType: "image/jpeg",
+			}}}),
+	))
+}
+
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
 	if err != nil {
-		fmt.Print(err)
-		return
+		panic(err)
 	}
-	fmt.Printf("Result: %s\n", resp.Text())
+	return resp
 }

--- a/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
+++ b/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
@@ -44,27 +44,31 @@ func main() {
 
 func nonStreamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("=== Non-streaming Response Example ===\n")
-	fmt.Printf("User: %s\n", query)
-	resp, err := ag.RunText(ctx, query)
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	fmt.Printf("Result: %s\n", resp.Text())
+	fmt.Println("=== Non-streaming Response Example ===")
+	fmt.Println("User: ", query)
+	fmt.Println("Result: ", must(ag.RunText(ctx, query)))
 }
 
 func streamingExample(ag *agent.Agent, query string) {
 	ctx := context.Background()
-	fmt.Printf("=== Streaming Response Example ===\n")
-	fmt.Printf("User: %s\n", query)
+	fmt.Println("=== Streaming Response Example ===")
+	fmt.Println("User: ", query)
 	stream := ag.RunStream(ctx, nil, nil, message.NewText(query))
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)
-			return
+			break
 		}
-		fmt.Print(update.Text())
+		fmt.Print(update)
 	}
 	fmt.Print("\n")
+}
+
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }

--- a/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
+++ b/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
@@ -27,49 +27,20 @@ func main() {
 
 	thread := ag.NewThread()
 
-	resp, err := ag.Run(ctx, thread, nil, message.NewText("Hello, what is the square root of 9?"))
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	fmt.Println(resp.Text())
+	fmt.Println(must(ag.Run(ctx, thread, nil, message.NewText("Hello, what is the square root of 9?"))))
 
-	resp, err = ag.Run(ctx, thread, nil, message.NewText("My name is Ruaidhrí"))
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	fmt.Println(resp.Text())
+	fmt.Println(must(ag.Run(ctx, thread, nil, message.NewText("My name is Ruaidhrí"))))
 
-	resp, err = ag.Run(ctx, thread, nil, message.NewText("I am 20 years old"))
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	fmt.Println(resp.Text())
+	fmt.Println(must(ag.Run(ctx, thread, nil, message.NewText("I am 20 years old"))))
 
 	// We can serialize the thread. The serialized state will include the state of the memory component.
-	serializedThread, err := json.Marshal(thread)
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
+	serializedThread := must(json.Marshal(thread))
 
 	fmt.Println(">> Use new thread with previously created memories")
 
-	// TODO: Fix message.Content unmarshaling
-	deserializedThread, err := ag.UnmarshalThread(serializedThread)
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	resp, err = ag.Run(ctx, deserializedThread, nil, message.NewText("What is my name and age?"))
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	fmt.Println(resp.Text())
+	deserializedThread := must(ag.UnmarshalThread(serializedThread))
 
+	fmt.Println(must(ag.Run(ctx, deserializedThread, nil, message.NewText("What is my name and age?"))))
 }
 
 type UserInfo struct {
@@ -123,4 +94,13 @@ func (u *UserInfoMemory) Invoking(ctx *memory.InvokingContext) (*memory.Context,
 	return &memory.Context{
 		Instructions: instructions,
 	}, nil
+}
+
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }

--- a/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
+++ b/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
@@ -9,7 +9,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/message"
@@ -22,18 +21,14 @@ func main() {
 	fmt.Println("=== OpenAI Chat Agent with MCP Tools Examples ===")
 
 	// Run both examples
-	if err := mcpToolsOnAgentLevel(); err != nil {
-		log.Fatalf("Agent level example failed: %v", err)
-	}
+	mcpToolsOnAgentLevel()
 
-	if err := mcpToolsOnRunLevel(); err != nil {
-		log.Fatalf("Run level example failed: %v", err)
-	}
+	mcpToolsOnRunLevel()
 }
 
 // mcpToolsOnAgentLevel demonstrates tools defined when creating the agent.
 // The agent can use these tools for any query during its lifetime.
-func mcpToolsOnAgentLevel() error {
+func mcpToolsOnAgentLevel() {
 	fmt.Println("=== Tools Defined on Agent Level ===")
 
 	// Create MCP HTTP tool for Microsoft Learn
@@ -54,29 +49,19 @@ func mcpToolsOnAgentLevel() error {
 
 	// First query - uses the tools defined at agent creation
 	const query1 = "How to create an Azure storage account using az cli?"
-	fmt.Printf("User: %s\n", query1)
-	result1, err := ag.RunText(ctx, query1)
-	if err != nil {
-		return fmt.Errorf("agent run failed: %w", err)
-	}
-	fmt.Printf("%s: %s\n\n", ag.Name(), result1.Text())
+	fmt.Println("User: ", query1)
+	fmt.Println(ag.Name(), ": ", must(ag.RunText(ctx, query1)))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	const query2 = "What is Microsoft Agent Framework?"
-	fmt.Printf("User: %s\n", query2)
-	result2, err := ag.RunText(ctx, query2)
-	if err != nil {
-		return fmt.Errorf("agent run failed: %w", err)
-	}
-	fmt.Printf("%s: %s\n\n", ag.Name(), result2.Text())
-
-	return nil
+	fmt.Println("User: ", query2)
+	fmt.Println(ag.Name(), ": ", must(ag.RunText(ctx, query2)))
 }
 
 // mcpToolsOnRunLevel demonstrates MCP tools defined when running the agent.
-func mcpToolsOnRunLevel() error {
+func mcpToolsOnRunLevel() {
 	fmt.Println("=== Tools Defined on Run Level ===")
 
 	// Create MCP HTTP tool for Microsoft Learn
@@ -93,39 +78,28 @@ func mcpToolsOnRunLevel() error {
 
 	// First query
 	query1 := "How to create an Azure storage account using az cli?"
-	fmt.Printf("User: %s\n", query1)
-	result1, err := ag.Run(
-		ctx,
-		nil,
-		&agent.RunOptions{
-			Tools:    []tool.Tool{mcpServer},
-			ToolMode: tool.ToolModeAuto,
-		},
-		message.NewText(query1),
-	)
-	if err != nil {
-		return fmt.Errorf("agent run failed: %w", err)
-	}
-	fmt.Printf("%s: %s\n\n", ag.Name(), result1.Text())
+	fmt.Println("User: ", query1)
+	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, nil, &agent.RunOptions{
+		Tools:    []tool.Tool{mcpServer},
+		ToolMode: tool.ToolModeAuto,
+	}, message.NewText(query1))))
 
-	fmt.Print("\n=======================================\n")
+	fmt.Println("\n=======================================")
 
 	// Second query
 	query2 := "What is Microsoft Agent Framework?"
-	fmt.Printf("User: %s\n", query2)
-	result2, err := ag.Run(
-		ctx,
-		nil,
-		&agent.RunOptions{
-			Tools:    []tool.Tool{mcpServer},
-			ToolMode: tool.ToolModeAuto,
-		},
-		message.NewText(query2),
-	)
-	if err != nil {
-		return fmt.Errorf("agent run failed: %w", err)
-	}
-	fmt.Printf("%s: %s\n\n", ag.Name(), result2.Text())
+	fmt.Println("User: ", query2)
+	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, nil, &agent.RunOptions{
+		Tools:    []tool.Tool{mcpServer},
+		ToolMode: tool.ToolModeAuto,
+	}, message.NewText(query2))))
+}
 
-	return nil
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -32,7 +32,7 @@ func main() {
 	})
 
 	const query = "Tell me about Paris, France"
-	fmt.Println("User: " + query)
+	fmt.Println("User: ", query)
 
 	var out jsonformat.Value[CityInfo]
 	fmt.Println("Agent raw response: ", must(ag.Run(ctx, nil, &agent.RunOptions{Response: &out}, message.NewText(query))))

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -35,16 +35,19 @@ func main() {
 	fmt.Println("User: " + query)
 
 	var out jsonformat.Value[CityInfo]
-	resp, err := ag.Run(ctx, nil, &agent.RunOptions{Response: &out}, message.NewText(query))
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-
-	fmt.Printf("Agent raw response: %s\n", resp.Text())
+	fmt.Println("Agent raw response: ", must(ag.Run(ctx, nil, &agent.RunOptions{Response: &out}, message.NewText(query))))
 
 	city := out.Unwrap()
-	fmt.Printf("City Name: %v\n", city.Name)
-	fmt.Printf("Population: %v\n", city.Population)
-	fmt.Printf("Area: %v\n", city.Area)
+	fmt.Println("City Name: ", city.Name)
+	fmt.Println("Population: ", city.Population)
+	fmt.Println("Area: ", city.Area)
+}
+
+// must is a helper to panic on error for samples.
+// In production code, handle errors appropriately.
+func must[T any](resp T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }


### PR DESCRIPTION
Examples are a bit verbose with so much error handling. We can make then much more simpler by making `agent.RunResponse` and `agent.RunResponseUpdate` implement `fmt.Stringer` so that they can be passed directly into `fmt.Print` and friends.

Also, avoid explicit error handling by using a helper function (`must`) that promotes run errors into panics.