### PR TITLE
Consolidate run parameters into RunContext

### DIFF
--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -33,8 +33,8 @@ type Config struct {
 
 	NewContextProvider func() memory.ContextProvider
 
-	Run       func(ctx context.Context, thread memory.Thread, opts *RunOptions, messages ...*message.Message) (*RunResponse, error)
-	RunStream func(ctx context.Context, thread memory.Thread, opts *RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error]
+	Run       func(ctx *RunContext, messages ...*message.Message) (*RunResponse, error)
+	RunStream func(ctx *RunContext, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error]
 }
 
 // Agent represents an AI agent that can execute tasks using a client and tools.
@@ -80,9 +80,10 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return thread, nil
 }
 
-func (a *Agent) Run(ctx context.Context, thread memory.Thread, opts *RunOptions, messages ...*message.Message) (*RunResponse, error) {
+// Run executes the agent with the given messages and returns the response.
+func (a *Agent) Run(ctx *RunContext, messages ...*message.Message) (*RunResponse, error) {
 	// Prepare messages with system instructions
-	opts, threadMessages, err := a.prepareRun(ctx, thread, opts, messages)
+	ctx, threadMessages, err := a.prepareRun(ctx, messages)
 	if err != nil {
 		return nil, err
 	}
@@ -92,13 +93,13 @@ func (a *Agent) Run(ctx context.Context, thread memory.Thread, opts *RunOptions,
 	const maxRetries = 5
 	for range maxRetries {
 		// Call the chat client
-		response, err := a.Config.Run(ctx, thread, opts, threadMessages...)
+		response, err := a.Config.Run(ctx, threadMessages...)
 		if err != nil {
 			return nil, err
 		}
 		msg := response.Messages[0]
 		threadMessages = append(threadMessages, msg)
-		toolResult := runToolCalls(ctx, opts, msg.Contents...)
+		toolResult := runToolCalls(ctx.Context, ctx.Options, msg.Contents...)
 		if len(toolResult) > 0 {
 			// Add a single Message to the response with the results
 			threadMessages = append(threadMessages, &message.Message{Role: message.RoleTool, Contents: toolResult})
@@ -110,8 +111,8 @@ func (a *Agent) Run(ctx context.Context, thread memory.Thread, opts *RunOptions,
 	if finalResponse == nil {
 		// Exceeded max retries with tool calls pending, disable tools and try one last time
 		// to get a final response.
-		opts.ToolMode = tool.ToolModeNone
-		finalResponse, err = a.Config.Run(ctx, thread, opts, threadMessages...)
+		ctx.Options.ToolMode = tool.ToolModeNone
+		finalResponse, err = a.Config.Run(ctx, threadMessages...)
 		if err != nil {
 			return nil, err
 		}
@@ -119,12 +120,12 @@ func (a *Agent) Run(ctx context.Context, thread memory.Thread, opts *RunOptions,
 		threadMessages = append(threadMessages, message)
 	}
 	outMessages := threadMessages[startLength:]
-	if thread != nil {
-		if err := thread.AddMessage(ctx, outMessages...); err != nil {
+	if ctx.Thread != nil {
+		if err := ctx.Thread.AddMessage(ctx, outMessages...); err != nil {
 			return nil, err
 		}
 	}
-	if ctxprovider := a.contextProvider(thread); ctxprovider != nil {
+	if ctxprovider := a.contextProvider(ctx.Thread); ctxprovider != nil {
 		if err := ctxprovider.Invoked(&memory.InvokedContext{
 			Context:   ctx,
 			Messages:  messages,
@@ -139,23 +140,25 @@ func (a *Agent) Run(ctx context.Context, thread memory.Thread, opts *RunOptions,
 		ResponseID: finalResponse.ResponseID,
 		AgentID:    id,
 	}
-	if opts.Response != nil {
-		if err := opts.Response.UnmarshalBinary([]byte(response.String())); err != nil {
+	if ctx.Options.Response != nil {
+		if err := ctx.Options.Response.UnmarshalBinary([]byte(response.String())); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	}
 	return response, nil
 }
 
-func (a *Agent) RunText(ctx context.Context, msg string) (*RunResponse, error) {
-	return a.Run(ctx, nil, nil, message.NewText(msg))
+// RunText executes the agent with a single text message and returns the response.
+func (a *Agent) RunText(ctx *RunContext, msg string) (*RunResponse, error) {
+	return a.Run(ctx, message.NewText(msg))
 }
 
-func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
+// RunStream executes the agent with the given messages and returns a streaming response.
+func (a *Agent) RunStream(ctx *RunContext, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
 	if a.Config.RunStream == nil {
-		return a.runStreamFallback(ctx, thread, opts, messages...)
+		return a.runStreamFallback(ctx, messages...)
 	}
-	opts, threadMessages, err := a.prepareRun(ctx, thread, opts, messages)
+	ctx, threadMessages, err := a.prepareRun(ctx, messages)
 	startLength := len(threadMessages)
 	id := a.ID()
 	return func(yield func(*RunResponseUpdate, error) bool) {
@@ -168,7 +171,7 @@ func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOp
 
 		for range maxRetries {
 			var contents []message.Content
-			for update, err := range a.Config.RunStream(ctx, thread, opts, threadMessages...) {
+			for update, err := range a.Config.RunStream(ctx, threadMessages...) {
 				if err != nil {
 					yield(nil, err)
 					return
@@ -193,7 +196,7 @@ func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOp
 			}
 
 			// Execute tools
-			toolResult := runToolCalls(ctx, opts, contents...)
+			toolResult := runToolCalls(ctx.Context, ctx.Options, contents...)
 			if len(toolResult) > 0 {
 				// Add a single Message to the response with the results
 				if !yield(&RunResponseUpdate{
@@ -213,8 +216,8 @@ func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOp
 		if !success {
 			// Exceeded max retries with tool calls pending, disable tools and try one last time
 			// to get a final response.
-			opts.ToolMode = tool.ToolModeNone
-			for update, err := range a.Config.RunStream(ctx, thread, opts, threadMessages...) {
+			ctx.Options.ToolMode = tool.ToolModeNone
+			for update, err := range a.Config.RunStream(ctx, threadMessages...) {
 				if err != nil {
 					yield(nil, err)
 					return
@@ -224,14 +227,14 @@ func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOp
 				}
 			}
 		}
-		if thread != nil {
-			if err := thread.AddMessage(ctx, threadMessages[startLength:]...); err != nil {
+		if ctx.Thread != nil {
+			if err := ctx.Thread.AddMessage(ctx, threadMessages[startLength:]...); err != nil {
 				yield(nil, err)
 				return
 			}
 		}
 
-		if ctxprovider := a.contextProvider(thread); ctxprovider != nil {
+		if ctxprovider := a.contextProvider(ctx.Thread); ctxprovider != nil {
 			if err := ctxprovider.Invoked(&memory.InvokedContext{
 				Context:   ctx,
 				Messages:  messages,
@@ -242,7 +245,7 @@ func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOp
 				return
 			}
 		}
-		if opts.Response != nil {
+		if ctx.Options.Response != nil {
 			var finalText strings.Builder
 			for _, msg := range threadMessages[startLength:] {
 				for _, c := range msg.Contents {
@@ -251,7 +254,7 @@ func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOp
 					}
 				}
 			}
-			if err := opts.Response.UnmarshalBinary([]byte(finalText.String())); err != nil {
+			if err := ctx.Options.Response.UnmarshalBinary([]byte(finalText.String())); err != nil {
 				yield(nil, fmt.Errorf("failed to unmarshal response: %w", err))
 				return
 			}
@@ -259,8 +262,8 @@ func (a *Agent) RunStream(ctx context.Context, thread memory.Thread, opts *RunOp
 	}
 }
 
-func (a *Agent) runStreamFallback(ctx context.Context, thread memory.Thread, options *RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
-	resp, err := a.Run(ctx, thread, options, messages...)
+func (a *Agent) runStreamFallback(ctx *RunContext, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
+	resp, err := a.Run(ctx, messages...)
 	id := a.ID()
 	return func(yield func(*RunResponseUpdate, error) bool) {
 		if err != nil {
@@ -280,6 +283,13 @@ func (a *Agent) runStreamFallback(ctx context.Context, thread memory.Thread, opt
 			}
 		}
 	}
+}
+
+// RunContext contains context for agent execution.
+type RunContext struct {
+	context.Context
+	Thread  memory.Thread
+	Options *RunOptions
 }
 
 // RunOptions contains options for agent execution.
@@ -397,13 +407,21 @@ func (a *Agent) contextProvider(thread memory.Thread) memory.ContextProvider {
 	return nil
 }
 
-func (a *Agent) prepareRun(ctx context.Context, thread memory.Thread, opts *RunOptions, messages []*message.Message) (*RunOptions, []*message.Message, error) {
-	opts = a.Config.Opts.Merge(opts)
-	if opts.ResponseFormat == nil && opts.Response != nil {
+func (a *Agent) prepareRun(c *RunContext, messages []*message.Message) (*RunContext, []*message.Message, error) {
+	var ctx RunContext
+	if c != nil {
+		ctx = *c
+		c = nil // prevent reuse
+	}
+	if ctx.Context == nil {
+		ctx.Context = context.Background()
+	}
+	ctx.Options = a.Config.Opts.Merge(ctx.Options)
+	if ctx.Options.ResponseFormat == nil && ctx.Options.Response != nil {
 		// Try to get the format from the response object.
-		if rf, ok := opts.Response.(format.FormatProvider); ok {
+		if rf, ok := ctx.Options.Response.(format.FormatProvider); ok {
 			var err error
-			opts.ResponseFormat, err = rf.Format()
+			ctx.Options.ResponseFormat, err = rf.Format()
 			if err != nil {
 				return nil, nil, err
 			}
@@ -413,17 +431,17 @@ func (a *Agent) prepareRun(ctx context.Context, thread memory.Thread, opts *RunO
 	if a.Config.SystemInstructions != "" {
 		messages = append([]*message.Message{{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: a.Config.SystemInstructions}}}}, messages...)
 	}
-	if opts != nil {
-		if err := initTools(ctx, opts.Tools); err != nil {
+	if ctx.Options != nil {
+		if err := initTools(ctx, ctx.Options.Tools); err != nil {
 			return nil, nil, err
 		}
-		extraTools, err := loadTools(ctx, opts.Tools)
+		extraTools, err := loadTools(ctx, ctx.Options.Tools)
 		if err != nil {
 			return nil, nil, err
 		}
-		opts.Tools = append(opts.Tools, extraTools...)
+		ctx.Options.Tools = append(ctx.Options.Tools, extraTools...)
 	}
-	ctxProvider := a.contextProvider(thread)
+	ctxProvider := a.contextProvider(ctx.Thread)
 	if ctxProvider != nil {
 		ctxData, err := ctxProvider.Invoking(&memory.InvokingContext{
 			Context:  ctx,
@@ -433,14 +451,14 @@ func (a *Agent) prepareRun(ctx context.Context, thread memory.Thread, opts *RunO
 			return nil, nil, err
 		}
 		if ctxData != nil {
-			opts.Tools = append(opts.Tools, ctxData.Tools...)
+			ctx.Options.Tools = append(ctx.Options.Tools, ctxData.Tools...)
 			if ctxData.Instructions != "" {
 				messages = append([]*message.Message{{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: ctxData.Instructions}}}}, messages...)
 			}
 			messages = append(messages, ctxData.Messages...)
 		}
 	}
-	return opts, messages, nil
+	return &ctx, messages, nil
 }
 
 func loadTools(ctx context.Context, tools []tool.Tool) ([]tool.Tool, error) {

--- a/go/agent/agent_test.go
+++ b/go/agent/agent_test.go
@@ -9,16 +9,19 @@ import (
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/internal/agenttest"
-	"github.com/microsoft/agent-framework/go/memory"
 	"github.com/microsoft/agent-framework/go/memory/inmemory"
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/tool"
 )
 
+func testRunContext(t *testing.T) *agent.RunContext {
+	return &agent.RunContext{Context: context.Background()}
+}
+
 func TestAgent_BasicRun(t *testing.T) {
 	client, a := agenttest.NewAgent()
 
-	resp, err := a.Run(t.Context(), nil, nil, message.NewText("Hello"))
+	resp, err := a.Run(testRunContext(t), message.NewText("Hello"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -51,7 +54,7 @@ func TestAgent_CustomResponse(t *testing.T) {
 	}
 	client.SetResponse(customResponse)
 
-	resp, err := a.Run(t.Context(), nil, nil, message.NewText("Test"))
+	resp, err := a.Run(testRunContext(t), message.NewText("Test"))
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -67,7 +70,7 @@ func TestAgent_ErrorHandling(t *testing.T) {
 	expectedError := errors.New("an error")
 	client.SetError(expectedError)
 
-	_, err := a.Run(t.Context(), nil, nil, message.NewText("Test"))
+	_, err := a.Run(testRunContext(t), message.NewText("Test"))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -91,7 +94,7 @@ func TestAgent_RunStream(t *testing.T) {
 	})
 
 	var receivedUpdates []*agent.RunResponseUpdate
-	for update, err := range a.RunStream(t.Context(), nil, nil, message.NewText("Test")) {
+	for update, err := range a.RunStream(testRunContext(t), message.NewText("Test")) {
 		if err != nil {
 			t.Fatalf("expected no error, got: %v", err)
 		}
@@ -124,7 +127,7 @@ func TestAgent_ResponseSequence(t *testing.T) {
 	}
 	client.WithResponseSequence(responses...)
 
-	resp1, err := a.Run(t.Context(), nil, nil, message.NewText("Test 1"))
+	resp1, err := a.Run(testRunContext(t), message.NewText("Test 1"))
 	if err != nil {
 		t.Fatalf("expected no error on first call, got: %v", err)
 	}
@@ -132,7 +135,7 @@ func TestAgent_ResponseSequence(t *testing.T) {
 		t.Errorf("expected %q, got %q", respText1, resp1.String())
 	}
 
-	resp2, err := a.Run(t.Context(), nil, nil, message.NewText("Test 2"))
+	resp2, err := a.Run(testRunContext(t), message.NewText("Test 2"))
 	if err != nil {
 		t.Fatalf("expected no error on second call, got: %v", err)
 	}
@@ -161,9 +164,9 @@ func TestAgent_WithToolCalls(t *testing.T) {
 		},
 	}
 
-	resp, err := a.Run(t.Context(), nil, &agent.RunOptions{
+	resp, err := a.Run(&agent.RunContext{Context: t.Context(), Options: &agent.RunOptions{
 		Tools: []tool.Tool{tl},
-	}, message.NewText("What's the weather?"))
+	}}, message.NewText("What's the weather?"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -189,7 +192,7 @@ func TestAgent_CustomFunction(t *testing.T) {
 	const respText2 = "Confirmed!"
 
 	callCount := 0
-	client.RunFunc = func(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) (*agent.RunResponse, error) {
+	client.RunFunc = func(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
 		callCount++
 		if callCount == 1 {
 			return &agent.RunResponse{
@@ -205,12 +208,12 @@ func TestAgent_CustomFunction(t *testing.T) {
 		}, nil
 	}
 
-	resp1, _ := a.Run(t.Context(), nil, nil, message.NewText("Test"))
+	resp1, _ := a.Run(testRunContext(t), message.NewText("Test"))
 	if resp1.String() != respText1 {
 		t.Errorf("expected %q, got %q", respText1, resp1.String())
 	}
 
-	resp2, _ := a.Run(t.Context(), nil, nil, message.NewText("Yes"))
+	resp2, _ := a.Run(testRunContext(t), message.NewText("Yes"))
 	if resp2.String() != respText2 {
 		t.Errorf("expected %q, got %q", respText2, resp2.String())
 	}
@@ -237,7 +240,7 @@ func TestAgent_RunText(t *testing.T) {
 		},
 	})
 
-	resp, err := a.RunText(context.Background(), "hello")
+	resp, err := a.RunText(testRunContext(t), "hello")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -252,7 +255,7 @@ func TestAgent_SystemInstructions(t *testing.T) {
 	const sysInstr = "You are a helpful assistant."
 	a.Config.SystemInstructions = sysInstr
 
-	_, err := a.Run(context.Background(), nil, nil, message.NewText("Test"))
+	_, err := a.Run(testRunContext(t), message.NewText("Test"))
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -286,7 +289,7 @@ func TestAgent_WithThread(t *testing.T) {
 	}
 
 	// Run with the thread
-	resp, err := a.Run(context.Background(), thread, nil, message.NewText("Second message"))
+	resp, err := a.Run(&agent.RunContext{Context: context.Background(), Thread: thread}, message.NewText("Second message"))
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -306,9 +309,9 @@ func TestAgent_RunOptionsTemperature(t *testing.T) {
 	client, a := agenttest.NewAgent()
 
 	temp := 0.7
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	_, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		Temperature: &temp,
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -327,9 +330,9 @@ func TestAgent_RunOptionsMaxTokens(t *testing.T) {
 	client, a := agenttest.NewAgent()
 
 	maxTokens := 100
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	_, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		MaxTokens: &maxTokens,
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -352,9 +355,9 @@ func TestAgent_RunOptionsAdditionalMetadata(t *testing.T) {
 		"number":     42,
 	}
 
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	_, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		AdditionalMetadata: metadata,
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -377,7 +380,7 @@ func TestAgent_DefaultRunOptions(t *testing.T) {
 		ToolMode:    tool.ToolModeAuto,
 	}
 
-	_, err := a.Run(context.Background(), nil, nil, message.NewText("Test"))
+	_, err := a.Run(testRunContext(t), message.NewText("Test"))
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -403,9 +406,9 @@ func TestAgent_RunOptionsMerge(t *testing.T) {
 		ToolMode:    tool.ToolModeAuto,
 	}
 
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	_, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		Temperature: &overrideTemp,
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -430,7 +433,7 @@ func TestAgent_MaxRetries(t *testing.T) {
 
 	callCount := 0
 	// Return tool calls on every call except when we've been called 5 times
-	client.RunFunc = func(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) (*agent.RunResponse, error) {
+	client.RunFunc = func(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
 		callCount++
 		if callCount <= 5 {
 			// Return a tool call
@@ -463,9 +466,9 @@ func TestAgent_MaxRetries(t *testing.T) {
 		},
 	}
 
-	resp, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	resp, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		Tools: []tool.Tool{tl},
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -494,7 +497,7 @@ func TestAgent_RunStreamFallback(t *testing.T) {
 
 	// Should use fallback since client doesn't implement streaming
 	var updates []*agent.RunResponseUpdate
-	for update, err := range a.RunStream(context.Background(), nil, nil, message.NewText("Test")) {
+	for update, err := range a.RunStream(testRunContext(t), message.NewText("Test")) {
 		if err != nil {
 			t.Fatalf("expected no error, got: %v", err)
 		}
@@ -628,9 +631,9 @@ func TestAgent_ToolError(t *testing.T) {
 		},
 	}
 
-	resp, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	resp, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		Tools: []tool.Tool{tl},
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error from agent, got: %v", err)
@@ -657,10 +660,10 @@ func TestAgent_ToolNotFound(t *testing.T) {
 
 	// Provide an empty tool list - the agent will still process the response
 	// Tool call will fail but agent continues
-	resp, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	resp, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		Tools:    []tool.Tool{}, // No tools provided
 		ToolMode: tool.ToolModeAuto,
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error from agent, got: %v", err)
@@ -692,9 +695,9 @@ func TestAgent_ToolInvalidArgs(t *testing.T) {
 		},
 	}
 
-	resp, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	resp, err := a.Run(&agent.RunContext{Context: context.Background(), Options: &agent.RunOptions{
 		Tools: []tool.Tool{tl},
-	}, message.NewText("Test"))
+	}}, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error from agent, got: %v", err)

--- a/go/agent/func_test.go
+++ b/go/agent/func_test.go
@@ -37,9 +37,10 @@ func TestAgentCallTool(t *testing.T) {
 	}
 	client.WithToolCalls(toolCalls, "Final response")
 
-	resp, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	ctx := &agent.RunContext{Options: &agent.RunOptions{
 		Tools: []tool.Tool{tl},
-	}, message.NewText("What's the weather?"))
+	}}
+	resp, err := a.Run(ctx, message.NewText("What's the weather?"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -64,10 +65,10 @@ func TestAgent_ToolInit(t *testing.T) {
 			return nil
 		},
 	}
-
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	ctx := &agent.RunContext{Options: &agent.RunOptions{
 		Tools: []tool.Tool{tl},
-	}, message.NewText("Test"))
+	}}
+	_, err := a.Run(ctx, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -91,9 +92,10 @@ func TestAgent_ToolInitError(t *testing.T) {
 		},
 	}
 
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	ctx := &agent.RunContext{Options: &agent.RunOptions{
 		Tools: []tool.Tool{tl},
-	}, message.NewText("Test"))
+	}}
+	_, err := a.Run(ctx, message.NewText("Test"))
 
 	if err == nil {
 		t.Fatal("expected error from tool init, got nil")
@@ -117,9 +119,10 @@ func TestAgent_ToolLoader(t *testing.T) {
 		},
 	}
 
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	ctx := &agent.RunContext{Options: &agent.RunOptions{
 		Tools: []tool.Tool{loaderTool},
-	}, message.NewText("Test"))
+	}}
+	_, err := a.Run(ctx, message.NewText("Test"))
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -149,10 +152,10 @@ func TestAgent_ToolLoaderError(t *testing.T) {
 		},
 	}
 
-	_, err := a.Run(context.Background(), nil, &agent.RunOptions{
+	ctx := &agent.RunContext{Options: &agent.RunOptions{
 		Tools: []tool.Tool{loaderTool},
-	}, message.NewText("Test"))
-
+	}}
+	_, err := a.Run(ctx, message.NewText("Test"))
 	if err == nil {
 		t.Fatal("expected error from tool loader, got nil")
 	}

--- a/go/agent/internal/agenttest/client.go
+++ b/go/agent/internal/agenttest/client.go
@@ -20,10 +20,10 @@ type Client struct {
 	agent *agent.Agent
 
 	// RunFunc is called when Run is invoked. If nil, uses default behavior.
-	RunFunc func(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) (*agent.RunResponse, error)
+	RunFunc func(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error)
 
 	// RunStreamFunc is called when RunStream is invoked. If nil, uses default behavior.
-	RunStreamFunc func(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error]
+	RunStreamFunc func(ctx *agent.RunContext, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error]
 
 	// RunCalls records all calls to Run.
 	RunCalls []RunCall
@@ -84,21 +84,21 @@ func NewAgent() (*Client, *agent.Agent) {
 }
 
 // Run implements the Client interface.
-func (c *Client) Run(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) (*agent.RunResponse, error) {
+func (c *Client) Run(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	// Record the call
 	c.RunCalls = append(c.RunCalls, RunCall{
 		Ctx:      ctx,
-		Thread:   thread,
-		Opts:     opts,
+		Thread:   ctx.Thread,
+		Opts:     ctx.Options,
 		Messages: messages,
 	})
 
 	// Use custom function if provided
 	if c.RunFunc != nil {
-		return c.RunFunc(ctx, thread, opts, messages...)
+		return c.RunFunc(ctx, messages...)
 	}
 
 	// Return error if configured
@@ -122,13 +122,13 @@ func (c *Client) Run(ctx context.Context, thread memory.Thread, opts *agent.RunO
 }
 
 // RunStream implements the streamableClient interface.
-func (c *Client) RunStream(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (c *Client) RunStream(ctx *agent.RunContext, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
 	c.mu.Lock()
 	// Record the call
 	c.RunStreamCalls = append(c.RunStreamCalls, RunStreamCall{
 		Ctx:      ctx,
-		Thread:   thread,
-		Opts:     opts,
+		Thread:   ctx.Thread,
+		Opts:     ctx.Options,
 		Messages: messages,
 	})
 
@@ -141,7 +141,7 @@ func (c *Client) RunStream(ctx context.Context, thread memory.Thread, opts *agen
 
 	// Use custom function if provided
 	if runStreamFunc != nil {
-		return runStreamFunc(ctx, thread, opts, messages...)
+		return runStreamFunc(ctx, messages...)
 	}
 
 	// Return an iterator
@@ -248,7 +248,7 @@ func (c *Client) WithResponseSequence(responses ...*agent.RunResponse) *Client {
 	defer c.mu.Unlock()
 
 	index := 0
-	c.RunFunc = func(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) (*agent.RunResponse, error) {
+	c.RunFunc = func(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
 		if index >= len(responses) {
 			return responses[len(responses)-1], nil
 		}
@@ -266,7 +266,7 @@ func (c *Client) WithToolCalls(toolCalls []*message.FunctionCallContent, finalRe
 	defer c.mu.Unlock()
 
 	callCount := 0
-	c.RunFunc = func(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) (*agent.RunResponse, error) {
+	c.RunFunc = func(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
 		callCount++
 		if callCount == 1 {
 			// First call returns tool calls
@@ -301,7 +301,7 @@ func (c *Client) WithStreamingToolCalls(toolCalls []*message.FunctionCallContent
 	defer c.mu.Unlock()
 
 	callCount := 0
-	c.RunStreamFunc = func(ctx context.Context, thread memory.Thread, opts *agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
+	c.RunStreamFunc = func(ctx *agent.RunContext, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
 		callCount++
 		currentCall := callCount
 		return func(yield func(*agent.RunResponseUpdate, error) bool) {

--- a/go/agent/workflow.go
+++ b/go/agent/workflow.go
@@ -115,14 +115,14 @@ func (e *hostExecutor) ensureThread() memory.Thread {
 
 func (e *hostExecutor) takeTurnHandler(ctx context.Context, wctx workflow.Context, emitEvents bool, messages []*message.Message) error {
 	if !emitEvents {
-		response, err := e.agent.Run(ctx, e.ensureThread(), nil, messages...)
+		response, err := e.agent.Run(&RunContext{Context: ctx, Thread: e.ensureThread()}, messages...)
 		if err != nil {
 			return err
 		}
 		return wctx.SendMessage(ctx, response.Messages, "")
 	}
 	var updates []*RunResponseUpdate
-	for update, err := range e.agent.RunStream(ctx, e.ensureThread(), nil, messages...) {
+	for update, err := range e.agent.RunStream(&RunContext{Context: ctx, Thread: e.ensureThread()}, messages...) {
 		if err != nil {
 			return err
 		}

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -4,7 +4,6 @@ package openai
 
 import (
 	"cmp"
-	"context"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -95,8 +94,8 @@ func NewChatAgentAzure(config AgentConfig) *agent.Agent {
 	return newChatAgent(true, config)
 }
 
-func (a *client) Run(ctx context.Context, t memory.Thread, opts *agent.RunOptions, messages ...*message.Message) (*agent.RunResponse, error) {
-	resp, err := a.client.Chat.Completions.New(ctx, a.buildCompletionParams(opts, messages...))
+func (a *client) Run(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
+	resp, err := a.client.Chat.Completions.New(ctx, a.buildCompletionParams(ctx.Options, messages...))
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +118,8 @@ func (a *client) Run(ctx context.Context, t memory.Thread, opts *agent.RunOption
 	}, nil
 }
 
-func (a *client) RunStream(ctx context.Context, t memory.Thread, opts *agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
-	stream := a.client.Chat.Completions.NewStreaming(ctx, a.buildCompletionParams(opts, messages...))
+func (a *client) RunStream(ctx *agent.RunContext, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
+	stream := a.client.Chat.Completions.NewStreaming(ctx, a.buildCompletionParams(ctx.Options, messages...))
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		defer stream.Close()
 		var acc openai.ChatCompletionAccumulator

--- a/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
+++ b/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
@@ -73,18 +73,16 @@ func main() {
 }
 
 func nonStreamingExample(ag *agent.Agent, query string) {
-	ctx := context.Background()
 	fmt.Println("\n=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Assistant: ", must(ag.RunText(ctx, query)))
+	fmt.Println("Assistant: ", must(ag.RunText(nil, query)))
 }
 
 func streamingExample(ag *agent.Agent, query string) {
-	ctx := context.Background()
 	fmt.Println("\n=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
 	fmt.Print("Assistant: ")
-	stream := ag.RunStream(ctx, nil, nil, message.NewText(query))
+	stream := ag.RunStream(nil, message.NewText(query))
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)

--- a/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
+++ b/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
@@ -43,17 +43,15 @@ func main() {
 }
 
 func nonStreamingExample(ag *agent.Agent, query string) {
-	ctx := context.Background()
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(ag.RunText(ctx, query)))
+	fmt.Println("Result: ", must(ag.RunText(nil, query)))
 }
 
 func streamingExample(ag *agent.Agent, query string) {
-	ctx := context.Background()
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	stream := ag.RunStream(ctx, nil, nil, message.NewText(query))
+	stream := ag.RunStream(nil, message.NewText(query))
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)

--- a/go/samples/getting_started/openai/chat_client_with_thread/openai_chat_with_thread.go
+++ b/go/samples/getting_started/openai/chat_client_with_thread/openai_chat_with_thread.go
@@ -48,17 +48,15 @@ func exampleWithAutomaticThreadCreation() {
 		},
 	})
 
-	ctx := context.Background()
-
 	// First conversation - no thread provided, will be created automatically
 	query1 := "What's the weather like in Seattle?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(ag.Run(ctx, nil, nil, message.NewText(query1))))
+	fmt.Println("Agent: ", must(ag.Run(nil, message.NewText(query1))))
 
 	// Second conversation - still no thread provided, will create another new thread
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(ag.Run(ctx, nil, nil, message.NewText(query2))))
+	fmt.Println("Agent: ", must(ag.Run(nil, message.NewText(query2))))
 	fmt.Println("Note: Each call creates a separate thread, so the agent doesn't remember previous context.")
 	fmt.Println()
 }
@@ -76,25 +74,23 @@ func exampleWithThreadPersistence() {
 		},
 	})
 
-	ctx := context.Background()
-
 	// Create a new thread that will be reused
 	thread := ag.NewThread()
 
 	// First conversation
 	query1 := "What's the weather like in Tokyo?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query1))))
+	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query1))))
 
 	// Second conversation using the same thread - maintains context
 	query2 := "How about London?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query2))))
+	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query2))))
 
 	// Third conversation - agent should remember both previous cities
 	query3 := "Which of the cities I asked about has better weather?"
 	fmt.Println("User: ", query3)
-	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query3))))
+	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query3))))
 	fmt.Println("Note: The agent remembers context from previous messages in the same thread.")
 	fmt.Println()
 }
@@ -110,14 +106,12 @@ func exampleWithExistingThreadMessages() {
 		},
 	})
 
-	ctx := context.Background()
-
 	// Start a conversation and build up message history
 	thread := ag.NewThread()
 
 	query1 := "What's the weather in Paris?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(ag.Run(ctx, thread, nil, message.NewText(query1))))
+	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query1))))
 
 	fmt.Println("\n--- Continuing with the same thread in a new agent instance ---")
 
@@ -132,7 +126,7 @@ func exampleWithExistingThreadMessages() {
 	// Use the same thread object which contains the conversation history
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(newAgent.Run(ctx, thread, nil, message.NewText(query2))))
+	fmt.Println("Agent: ", must(newAgent.Run(&agent.RunContext{Thread: thread}, message.NewText(query2))))
 	fmt.Println("Note: The agent continues the conversation using the thread message history.")
 	fmt.Println()
 }

--- a/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
+++ b/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/message"
@@ -22,9 +21,8 @@ func main() {
 		SystemInstructions: "You are a helpful agent that can analyze images.",
 	})
 
-	ctx := context.Background()
 	fmt.Println("Result: ", must(
-		ag.Run(ctx, nil, nil, &message.Message{Role: message.RoleUser, Contents: []message.Content{
+		ag.Run(nil, &message.Message{Role: message.RoleUser, Contents: []message.Content{
 			&message.TextContent{Text: "Describe the content of this image."},
 			&message.URIContent{
 				URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",

--- a/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
+++ b/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
@@ -50,7 +50,7 @@ func nonStreamingExample(ag *agent.Agent, query string) {
 func streamingExample(ag *agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	stream := ag.RunStream(nil, nil, message.NewText(query))
+	stream := ag.RunStream(nil, message.NewText(query))
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)

--- a/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
+++ b/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -43,17 +42,15 @@ func main() {
 }
 
 func nonStreamingExample(ag *agent.Agent, query string) {
-	ctx := context.Background()
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(ag.RunText(ctx, query)))
+	fmt.Println("Result: ", must(ag.RunText(nil, query)))
 }
 
 func streamingExample(ag *agent.Agent, query string) {
-	ctx := context.Background()
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	stream := ag.RunStream(ctx, nil, nil, message.NewText(query))
+	stream := ag.RunStream(nil, nil, message.NewText(query))
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)

--- a/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
+++ b/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"cmp"
-	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -15,7 +14,6 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
 	var ag *agent.Agent
 	ag = openai.NewChatAgent(openai.AgentConfig{
 		Model:              "gpt-4o-mini",
@@ -25,22 +23,22 @@ func main() {
 
 	fmt.Println(">> Use thread with blank memory")
 
-	thread := ag.NewThread()
+	ctx := &agent.RunContext{Thread: ag.NewThread()}
 
-	fmt.Println(must(ag.Run(ctx, thread, nil, message.NewText("Hello, what is the square root of 9?"))))
+	fmt.Println(must(ag.Run(ctx, message.NewText("Hello, what is the square root of 9?"))))
 
-	fmt.Println(must(ag.Run(ctx, thread, nil, message.NewText("My name is Ruaidhrí"))))
+	fmt.Println(must(ag.Run(ctx, message.NewText("My name is Ruaidhrí"))))
 
-	fmt.Println(must(ag.Run(ctx, thread, nil, message.NewText("I am 20 years old"))))
+	fmt.Println(must(ag.Run(ctx, message.NewText("I am 20 years old"))))
 
 	// We can serialize the thread. The serialized state will include the state of the memory component.
-	serializedThread := must(json.Marshal(thread))
+	serializedThread := must(json.Marshal(ctx.Thread))
 
 	fmt.Println(">> Use new thread with previously created memories")
 
 	deserializedThread := must(ag.UnmarshalThread(serializedThread))
 
-	fmt.Println(must(ag.Run(ctx, deserializedThread, nil, message.NewText("What is my name and age?"))))
+	fmt.Println(must(ag.Run(&agent.RunContext{Thread: deserializedThread}, message.NewText("What is my name and age?"))))
 }
 
 type UserInfo struct {
@@ -65,7 +63,7 @@ func (u *UserInfoMemory) Invoked(ctx *memory.InvokedContext) error {
 		return nil
 	}
 	var out jsonformat.Value[UserInfo]
-	_, err := u.Agent.Run(ctx.Context, nil, &agent.RunOptions{Response: &out}, append(ctx.Messages,
+	_, err := u.Agent.Run(&agent.RunContext{Context: ctx.Context, Options: &agent.RunOptions{Response: &out}}, append(ctx.Messages,
 		message.NewText("Extract the user's name and age from the message if present. If not present return empty values."),
 	)...)
 	if err != nil {

--- a/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
+++ b/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
@@ -7,7 +7,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -34,8 +33,6 @@ func mcpToolsOnAgentLevel() {
 	// Create MCP HTTP tool for Microsoft Learn
 	mcpTool := mcptool.NewHTTP("https://learn.microsoft.com/api/mcp")
 
-	ctx := context.Background()
-
 	// Create the OpenAI agent with MCP tools
 	// In Go, we configure tools as default options that will be used for all runs
 	ag := openai.NewChatAgent(openai.AgentConfig{
@@ -50,14 +47,14 @@ func mcpToolsOnAgentLevel() {
 	// First query - uses the tools defined at agent creation
 	const query1 = "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(ag.Name(), ": ", must(ag.RunText(ctx, query1)))
+	fmt.Println(ag.Name(), ": ", must(ag.RunText(nil, query1)))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	const query2 = "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(ag.Name(), ": ", must(ag.RunText(ctx, query2)))
+	fmt.Println(ag.Name(), ": ", must(ag.RunText(nil, query2)))
 }
 
 // mcpToolsOnRunLevel demonstrates MCP tools defined when running the agent.
@@ -67,8 +64,6 @@ func mcpToolsOnRunLevel() {
 	// Create MCP HTTP tool for Microsoft Learn
 	mcpServer := mcptool.NewHTTP("https://learn.microsoft.com/api/mcp")
 
-	ctx := context.Background()
-
 	// Create the OpenAI agent
 	ag := openai.NewChatAgent(openai.AgentConfig{
 		Model:              "gpt-4o-mini",
@@ -76,23 +71,24 @@ func mcpToolsOnRunLevel() {
 		SystemInstructions: "You are a helpful assistant that can help with microsoft documentation questions.",
 	})
 
+	ctx := &agent.RunContext{
+		Options: &agent.RunOptions{
+			Tools:    []tool.Tool{mcpServer},
+			ToolMode: tool.ToolModeAuto,
+		},
+	}
+
 	// First query
 	query1 := "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, nil, &agent.RunOptions{
-		Tools:    []tool.Tool{mcpServer},
-		ToolMode: tool.ToolModeAuto,
-	}, message.NewText(query1))))
+	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, message.NewText(query1))))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	query2 := "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, nil, &agent.RunOptions{
-		Tools:    []tool.Tool{mcpServer},
-		ToolMode: tool.ToolModeAuto,
-	}, message.NewText(query2))))
+	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, message.NewText(query2))))
 }
 
 // must is a helper to panic on error for samples.

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -24,7 +23,6 @@ type CityInfo struct {
 }
 
 func main() {
-	ctx := context.Background()
 	ag := openai.NewChatAgent(openai.AgentConfig{
 		Model:              "gpt-5-nano",
 		Name:               "CityAgent",
@@ -35,7 +33,12 @@ func main() {
 	fmt.Println("User: ", query)
 
 	var out jsonformat.Value[CityInfo]
-	fmt.Println("Agent raw response: ", must(ag.Run(ctx, nil, &agent.RunOptions{Response: &out}, message.NewText(query))))
+	ctx := &agent.RunContext{
+		Options: &agent.RunOptions{
+			Response: &out,
+		},
+	}
+	fmt.Println("Agent raw response: ", must(ag.Run(ctx, message.NewText(query))))
 
 	city := out.Unwrap()
 	fmt.Println("City Name: ", city.Name)


### PR DESCRIPTION
`Agent.Run` and `Agent.RunStream` have 3 optional parameters (out of 4). That makes basic calls a bit too verbose. Also, it will make those foundational methods hard to keep in sync with their the .NET counterparts, as .NET allows adding new optional parameters to function without producing a breaking change, while you can't do that in Go.

The solution is to consolidate those 3 parameters into a single struct, `agent.RunContext`, with all its fields being optional. 