### PR TITLE
Improve tool API

### DIFF
--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -4,7 +4,8 @@ package agent
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"fmt"
 	"iter"
 	"strings"
 	"time"
@@ -207,21 +208,29 @@ func (t functool) ReturnSchema() any {
 	}
 }
 
-func (t functool) Call(ctx context.Context, args map[string]any) (any, error) {
-	query, ok := args["query"]
-	if !ok {
-		return nil, errors.New("missing required argument 'query'")
+func (t functool) Call(ctx context.Context, args any) (any, error) {
+	var in struct {
+		Query string `json:"query"`
 	}
-	queryStr, ok := query.(string)
-	if !ok {
-		return nil, errors.New("argument 'query' must be a string")
+	var raw json.RawMessage
+	if args == nil {
+		raw = json.RawMessage("{}")
+	} else {
+		var ok bool
+		raw, ok = args.(json.RawMessage)
+		if !ok {
+			return nil, fmt.Errorf("expected json.RawMessage arguments, got %T", args)
+		}
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
 	}
 	resp, err := t.agent.Run(&RunContext{
 		Context: ctx,
 		Thread:  t.thread,
 	}, &message.Message{
 		Role:     message.RoleUser,
-		Contents: []message.Content{&message.TextContent{Text: queryStr}},
+		Contents: []message.Content{&message.TextContent{Text: in.Query}},
 	})
 	if err != nil {
 		return "", err

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -165,7 +165,7 @@ func (r *RunResponseUpdate) UserInputRequests() iter.Seq[message.Content] {
 // The provided thread is used for the agent's context during invocations,
 // or nil to create a new thread for each invocation.
 func FuncTool(agent Agent, thread memory.Thread) tool.FuncTool {
-	return &functool{
+	return functool{
 		name:        agent.Name(),
 		description: agent.Description(),
 		thread:      thread,

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -3,8 +3,8 @@
 package agent
 
 import (
-	"cmp"
 	"context"
+	"errors"
 	"iter"
 	"strings"
 	"time"
@@ -13,7 +13,6 @@ import (
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/param"
 	"github.com/microsoft/agent-framework/go/tool"
-	"github.com/microsoft/agent-framework/go/tool/functool"
 )
 
 // RunContext contains context for agent execution.
@@ -163,24 +162,69 @@ func (r *RunResponseUpdate) UserInputRequests() iter.Seq[message.Content] {
 }
 
 // FuncTool creates a function tool that invokes the given agent.
-func FuncTool(agent Agent, name, description string, thread memory.Thread) tool.FuncTool {
-	type funcToolIn struct {
-		Query string `jsonschema:"input query to invoke the agent"`
+// The provided thread is used for the agent's context during invocations,
+// or nil to create a new thread for each invocation.
+func FuncTool(agent Agent, thread memory.Thread) tool.FuncTool {
+	return &functool{
+		name:        agent.Name(),
+		description: agent.Description(),
+		thread:      thread,
+		agent:       agent,
 	}
-	return functool.MustNew(&functool.Func{
-		Name:        cmp.Or(name, agent.Name()),
-		Description: cmp.Or(description, agent.Description()),
-	}, func(ctx context.Context, in funcToolIn) (string, error) {
-		resp, err := agent.Run(&RunContext{
-			Context: ctx,
-			Thread:  thread,
-		}, &message.Message{
-			Role:     message.RoleUser,
-			Contents: []message.Content{&message.TextContent{Text: in.Query}},
-		})
-		if err != nil {
-			return "", err
-		}
-		return resp.String(), nil
+}
+
+type functool struct {
+	name        string
+	description string
+	thread      memory.Thread
+	agent       Agent
+}
+
+func (t functool) Name() string {
+	return t.name
+}
+
+func (t functool) Description() string {
+	return t.description
+}
+
+func (t functool) Schema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "input query to invoke the agent",
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+func (t functool) ReturnSchema() any {
+	return map[string]any{
+		"type": "string",
+	}
+}
+
+func (t functool) Call(ctx context.Context, args map[string]any) (any, error) {
+	query, ok := args["query"]
+	if !ok {
+		return nil, errors.New("missing required argument 'query'")
+	}
+	queryStr, ok := query.(string)
+	if !ok {
+		return nil, errors.New("argument 'query' must be a string")
+	}
+	resp, err := t.agent.Run(&RunContext{
+		Context: ctx,
+		Thread:  t.thread,
+	}, &message.Message{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: queryStr}},
 	})
+	if err != nil {
+		return "", err
+	}
+	return resp.String(), nil
 }

--- a/go/agent/chatagent/chatclient/funcinvoke.go
+++ b/go/agent/chatagent/chatclient/funcinvoke.go
@@ -398,7 +398,7 @@ func checkForApprovalRequiringFCC(functionCalls []*message.FunctionCallContent, 
 	for ; lastApprovalCheckedFCCIdx < len(functionCalls); lastApprovalCheckedFCCIdx++ {
 		fcc := functionCalls[lastApprovalCheckedFCCIdx]
 		for _, t := range approvalRequiredFunctions {
-			if tname, _ := t.ToolInfo(); tname == fcc.Name {
+			if t.Name() == fcc.Name {
 				hasApprovalRequiringFcc = true
 				break
 			}
@@ -532,8 +532,7 @@ func (f *functionInvoking) createToolsMap(opts *ChatOptions) (mtools map[string]
 		if mtools == nil {
 			mtools = make(map[string]tool.Tool)
 		}
-		name, _ := t.ToolInfo()
-		mtools[name] = t
+		mtools[t.Name()] = t
 		if !anyRequiredApproval {
 			if _, ok := t.(tool.ApprovalRequiredTool); ok {
 				anyRequiredApproval = true
@@ -590,7 +589,7 @@ func replaceFunctionCallsWithApprovalRequests(msgs []*message.Message, tools map
 			allFunctionCallContentIndices = append(allFunctionCallContentIndices, entry{i, j})
 			if !requiresApproval {
 				for _, t := range tools {
-					if tname, _ := t.ToolInfo(); tname == fcc.Name {
+					if t.Name() == fcc.Name {
 						if _, ok := t.(tool.ApprovalRequiredTool); ok {
 							requiresApproval = true
 							break

--- a/go/agent/chatagent/chatclient/funcinvoke.go
+++ b/go/agent/chatagent/chatclient/funcinvoke.go
@@ -5,7 +5,6 @@ package chatclient
 import (
 	"cmp"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -701,25 +700,6 @@ func (f *functionInvoking) processFunctionCall(ctx context.Context, tools map[st
 			nil,
 		)
 	}
-	var args map[string]any
-	if funcCall.Arguments != nil {
-		switch v := funcCall.Arguments.(type) {
-		case map[string]any:
-			args = v
-		default:
-			data, err := json.Marshal(v)
-			if err == nil {
-				err = json.Unmarshal(data, &args)
-			}
-			if err != nil {
-				return f.createFunctionResult(
-					funcCall.CallID,
-					fmt.Sprintf("Error: Unable to parse function arguments: %v", err),
-					nil,
-				)
-			}
-		}
-	}
 	var result any
 	var err error
 	func() {
@@ -732,7 +712,7 @@ func (f *functionInvoking) processFunctionCall(ctx context.Context, tools map[st
 				}
 			}
 		}()
-		result, err = tl.Call(ctx, args)
+		result, err = tl.Call(ctx, funcCall.Arguments)
 	}()
 
 	return f.createFunctionResult(funcCall.CallID, result, err)

--- a/go/agent/chatagent/chatclient/funcinvoke_approval_test.go
+++ b/go/agent/chatagent/chatclient/funcinvoke_approval_test.go
@@ -4,6 +4,7 @@ package chatclient_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"iter"
 	"testing"
@@ -228,14 +229,14 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAllRequireApp
 			downstreamClientOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 				}},
 			}
 
 			expectedOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 				}},
 			}
 
@@ -267,14 +268,14 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequireApp
 	downstreamClientOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 	}
 
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 	}
 
@@ -322,14 +323,14 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequestOrA
 			downstreamClientOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 				}},
 			}
 
 			expectedOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 				}},
 			}
 
@@ -353,11 +354,11 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 	}
 
@@ -366,7 +367,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -385,7 +386,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -418,13 +419,13 @@ func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExe
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
 		}},
 		{Role: message.RoleAssistant, ID: "resp2", Contents: []message.Content{
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
 		),
 		message.New(
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 	}
 
@@ -435,7 +436,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExe
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
 		}},
 		{Role: message.RoleAssistant, ID: "resp2", Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -453,7 +454,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExe
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
 		}},
 		{Role: message.RoleAssistant, ID: "resp2", Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -479,11 +480,11 @@ func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 	}
 
@@ -491,7 +492,7 @@ func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -508,7 +509,7 @@ func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -537,11 +538,11 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, ID: "resp1", Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 	}
 
@@ -549,7 +550,7 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -569,7 +570,7 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 	expectedOutputNonStreaming := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -586,7 +587,7 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 	expectedOutputStreaming := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -615,11 +616,11 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 	}
 
@@ -627,7 +628,7 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -638,7 +639,7 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 	// Downstream client returns a new FunctionCallContent for Func2 with different arguments
 	downstreamClientOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 3}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":3}`)},
 		}},
 	}
 
@@ -646,14 +647,14 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 3}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":3}`)}},
 		}},
 	}
 
@@ -677,17 +678,17 @@ func TestFunctionInvoking_AlreadyExecutedApprovalsAreIgnored(t *testing.T) {
 		// Previous turn: approval requests
 		{Role: message.RoleAssistant, ID: "resp1", Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 		// Previous turn: approval responses
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 		// Previous turn: already executed - function calls
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		// Previous turn: already executed - function results
 		{Role: message.RoleTool, Contents: []message.Content{
@@ -709,7 +710,7 @@ func TestFunctionInvoking_AlreadyExecutedApprovalsAreIgnored(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -769,7 +770,7 @@ func TestFunctionInvoking_MixedApprovalRequiredToolsWithNonApprovalRequiringFunc
 			// Round 1: Only Func2 is called (doesn't require approval, so it's executed immediately)
 			{
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 				}},
 			},
 			// Round 2: Final response after Func2 execution
@@ -784,7 +785,7 @@ func TestFunctionInvoking_MixedApprovalRequiredToolsWithNonApprovalRequiringFunc
 	// Expected output: Func2 call, result, and final response
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
@@ -816,7 +817,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExec
 		message.New(&message.TextContent{Text: "hello"}),
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 	}
 
@@ -824,7 +825,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExec
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -841,7 +842,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExec
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -871,7 +872,7 @@ func TestFunctionInvoking_FunctionCallContentIsNotPassedToDownstreamServiceWithS
 	input := []*message.Message{
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		),
 	}
 
@@ -893,7 +894,7 @@ func TestFunctionInvoking_FunctionCallContentIsNotPassedToDownstreamServiceWithS
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -929,7 +930,7 @@ func TestFunctionInvoking_FunctionCallContentIsYieldedImmediatelyIfNoApprovalReq
 			{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 				}},
 			},
 			// Round 2: After executing functions, downstream returns final response
@@ -945,7 +946,7 @@ func TestFunctionInvoking_FunctionCallContentIsYieldedImmediatelyIfNoApprovalReq
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -981,7 +982,7 @@ func TestFunctionInvoking_FunctionCallsAreBufferedUntilApprovalRequirementEncoun
 	downstreamClientOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 	}
 
@@ -989,7 +990,7 @@ func TestFunctionInvoking_FunctionCallsAreBufferedUntilApprovalRequirementEncoun
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
 		}},
 	}
 

--- a/go/agent/chatagent/chatclient/funcinvoke_test.go
+++ b/go/agent/chatagent/chatclient/funcinvoke_test.go
@@ -68,19 +68,19 @@ func TestFunctionInvoking_SupportsSingleFunctionCallPerRequest(t *testing.T) {
 	plan := []*message.Message{
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: map[string]any{}},
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: json.RawMessage(`{}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: map[string]any{"i": 43}},
+			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId3", Result: "Success: Function completed."},
@@ -136,9 +136,9 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 			plan := []*message.Message{
 				message.New(&message.TextContent{Text: "hello"}),
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: map[string]any{"i": nil}},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 34}},
-					&message.FunctionCallContent{CallID: "callId3", Name: "Func2", Arguments: map[string]any{"i": 56}},
+					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: json.RawMessage(`{"i":null}`)},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":34}`)},
+					&message.FunctionCallContent{CallID: "callId3", Name: "Func2", Arguments: json.RawMessage(`{"i":56}`)},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -146,8 +146,8 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 					&message.FunctionResultContent{CallID: "callId3", Result: "Result 2: 56"},
 				}},
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId4", Name: "Func2", Arguments: map[string]any{"i": 78}},
-					&message.FunctionCallContent{CallID: "callId5", Name: "Func1", Arguments: map[string]any{"i": nil}},
+					&message.FunctionCallContent{CallID: "callId4", Name: "Func2", Arguments: json.RawMessage(`{"i":78}`)},
+					&message.FunctionCallContent{CallID: "callId5", Name: "Func1", Arguments: json.RawMessage(`{"i":null}`)},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId4", Result: "Result 2: 78"},
@@ -437,19 +437,19 @@ func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 			plan := []*message.Message{
 				message.New(&message.TextContent{Text: "hello"}),
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: map[string]any{}},
+					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: json.RawMessage(`{}`)},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 				}},
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 				}},
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: map[string]any{"i": 43}},
+					&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId3", Result: "Success: Function completed."},
@@ -507,13 +507,13 @@ func TestFunctionInvoking_PrefersToolsProvidedByChatOptions(t *testing.T) {
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: map[string]any{"i": 43}},
+			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId3", Result: "Success: Function completed."},
@@ -550,8 +550,8 @@ func TestFunctionInvoking_ParallelFunctionCallsMayBeInvokedConcurrently(t *testi
 		plan := []*message.Message{
 			message.New(&message.TextContent{Text: "hello"}),
 			{Role: message.RoleAssistant, Contents: []message.Content{
-				&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: map[string]any{"Arg": "hello"}},
-				&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: map[string]any{"Arg": "world"}},
+				&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
+				&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
 			}},
 			{Role: message.RoleTool, Contents: []message.Content{
 				&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
@@ -590,8 +590,8 @@ func TestFunctionInvoking_ParallelFunctionCallsMayBeInvokedConcurrently(t *testi
 		plan := []*message.Message{
 			message.New(&message.TextContent{Text: "hello"}),
 			{Role: message.RoleAssistant, Contents: []message.Content{
-				&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: map[string]any{"Arg": "hello"}},
-				&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: map[string]any{"Arg": "world"}},
+				&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
+				&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
 			}},
 			{Role: message.RoleTool, Contents: []message.Content{
 				&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
@@ -632,8 +632,8 @@ func TestFunctionInvoking_ConcurrentInvocationOfParallelCallsDisabledByDefault(t
 	plan := []*message.Message{
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: map[string]any{"Arg": "hello"}},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: map[string]any{"Arg": "world"}},
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
@@ -826,10 +826,11 @@ func createFunctionCallIterationPlan(callIndex *int, shouldThrow ...bool) []*mes
 		*callIndex++
 		callID := fmt.Sprintf("callId%d", thisCallIndex)
 
+		arguments, _ := json.Marshal(map[string]any{"shouldThrow": callShouldThrow, "callIndex": thisCallIndex})
 		assistantContents = append(assistantContents, &message.FunctionCallContent{
 			CallID:    callID,
 			Name:      "Func",
-			Arguments: map[string]any{"shouldThrow": callShouldThrow, "callIndex": thisCallIndex},
+			Arguments: json.RawMessage(arguments),
 		})
 
 		result := "Success"
@@ -969,13 +970,13 @@ func TestFunctionInvoking_KeepsFunctionCallingContent(t *testing.T) {
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: map[string]any{"i": 42}},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: map[string]any{"i": 43}},
+			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
 			&message.TextContent{Text: "more"},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
@@ -1041,8 +1042,8 @@ func TestFunctionInvoking_TerminateOnUnknownCalls(t *testing.T) {
 			fullPlan := []*message.Message{
 				message.New(&message.TextContent{Text: "hello"}),
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId1", Name: "UnknownFunc", Arguments: map[string]any{"i": 1}},
-					&message.FunctionCallContent{CallID: "callId2", Name: "KnownFunc", Arguments: map[string]any{"i": 2}},
+					&message.FunctionCallContent{CallID: "callId1", Name: "UnknownFunc", Arguments: json.RawMessage(`{"i":1}`)},
+					&message.FunctionCallContent{CallID: "callId2", Name: "KnownFunc", Arguments: json.RawMessage(`{"i":2}`)},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId1", Result: "Error: Requested function \"UnknownFunc\" not found."},

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -133,14 +133,10 @@ func (a *client) Response(ctx context.Context, opts *chatclient.ChatOptions, mes
 	choice := resp.Choices[0]
 	contents := make([]message.Content, 0, 1+len(choice.Message.ToolCalls))
 	for _, tc := range choice.Message.ToolCalls {
-		args, err := unmarshalArgs(tc.Function.Arguments)
-		if err != nil {
-			return nil, err
-		}
 		contents = append(contents, &message.FunctionCallContent{
 			CallID:    tc.ID,
 			Name:      tc.Function.Name,
-			Arguments: args,
+			Arguments: json.RawMessage(tc.Function.Arguments),
 		})
 	}
 	if choice.Message.Content != "" {

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -270,7 +270,7 @@ func (a *client) buildCompletionParams(options *chatclient.ChatOptions, messages
 						}
 					}
 				}
-				if contextSize, ok := tl.AdditionalProperties["context_size"]; ok {
+				if contextSize, ok := tl.AdditionalProperties["search_context_size"]; ok {
 					if contextSize, ok := contextSize.(string); ok && contextSize != "" {
 						params.WebSearchOptions.SearchContextSize = contextSize
 					}

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -17,12 +17,31 @@ import (
 	"github.com/microsoft/agent-framework/go/format/jsonformat"
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/tool"
-	"github.com/microsoft/agent-framework/go/tool/websearchtool"
+	"github.com/microsoft/agent-framework/go/tool/hostedtool"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/azure"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
 )
+
+// NewWebSearchTool creates a new [hostedtool.WebSearch] with the specified user location.
+// All parameters are optional; pass empty strings for any unknown values.
+//
+// SearchContextSize is the high level guidance for the amount of context window space to use for the
+// search. One of `low`, `medium`, or `high`. `medium` is the default.
+func NewWebSearchTool(city, region, country, timezone, searchContextSize string) *hostedtool.WebSearch {
+	return &hostedtool.WebSearch{
+		AdditionalProperties: map[string]any{
+			"user_location": map[string]string{
+				"city":     city,
+				"region":   region,
+				"country":  country,
+				"timezone": timezone,
+			},
+			"search_context_size": searchContextSize,
+		},
+	}
+}
 
 var _ chatclient.Client = (*client)(nil)
 var _ chatclient.StructuredResponseClient = (*client)(nil)
@@ -234,25 +253,30 @@ func (a *client) buildCompletionParams(options *chatclient.ChatOptions, messages
 		}
 		for _, tl := range options.Tools {
 			switch tl := tl.(type) {
-			case *websearchtool.HostedWebSearch:
+			case *hostedtool.WebSearch:
 				if location, ok := tl.AdditionalProperties["user_location"]; ok {
 					if location, ok := location.(map[string]string); ok {
-						if city, ok := location["city"]; ok {
+						if city, ok := location["city"]; ok && city != "" {
 							params.WebSearchOptions.UserLocation.Approximate.City = openai.String(city)
 						}
-						if region, ok := location["region"]; ok {
+						if region, ok := location["region"]; ok && region != "" {
 							params.WebSearchOptions.UserLocation.Approximate.Region = openai.String(region)
 						}
-						if country, ok := location["country"]; ok {
+						if country, ok := location["country"]; ok && country != "" {
 							params.WebSearchOptions.UserLocation.Approximate.Country = openai.String(country)
 						}
-						if timezone, ok := location["timezone"]; ok {
+						if timezone, ok := location["timezone"]; ok && timezone != "" {
 							params.WebSearchOptions.UserLocation.Approximate.Timezone = openai.String(timezone)
 						}
 					}
 				}
+				if contextSize, ok := tl.AdditionalProperties["context_size"]; ok {
+					if contextSize, ok := contextSize.(string); ok && contextSize != "" {
+						params.WebSearchOptions.SearchContextSize = contextSize
+					}
+				}
 			case tool.FuncTool:
-				name, description := tl.ToolInfo()
+				name, description := tl.Name(), tl.Description()
 				var funcParams map[string]any
 				switch schema := tl.Schema().(type) {
 				case map[string]any:

--- a/go/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
+++ b/go/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
@@ -38,7 +38,7 @@ func main() {
 	}, &chatagent.Options{
 		Instructions: "You are a helpful assistant who responds in French.",
 		ChatOptions: &chatagent.ChatOptions{
-			Tools: []tool.Tool{agent.FuncTool(weatherAgent, "", "", nil)},
+			Tools: []tool.Tool{agent.FuncTool(weatherAgent, nil)},
 		},
 	})
 

--- a/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
+++ b/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
@@ -8,13 +8,12 @@ import (
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
 	"github.com/microsoft/agent-framework/go/tool"
-	"github.com/microsoft/agent-framework/go/tool/websearchtool"
 )
 
 /*
 OpenAI Chat Agent with Web Search Example
 
-This sample demonstrates using HostedWebSearchTool with OpenAI Chat Agent
+This sample demonstrates using hostedtool.WebSearch with OpenAI Chat Agent
 for real-time information retrieval and current data access.
 */
 
@@ -24,14 +23,7 @@ func main() {
 	}, &chatagent.Options{
 		Instructions: "You are a helpful weather agent.",
 		ChatOptions: &chatagent.ChatOptions{
-			Tools: []tool.Tool{&websearchtool.HostedWebSearch{
-				AdditionalProperties: map[string]any{
-					"user_location": map[string]string{
-						"country": "US",
-						"city":    "Seattle",
-					},
-				},
-			}},
+			Tools: []tool.Tool{openai.NewWebSearchTool("Seattle", "", "US", "", "")},
 		},
 	})
 

--- a/go/tool/functool/func.go
+++ b/go/tool/functool/func.go
@@ -28,7 +28,7 @@ type Func struct {
 // request or result: the params contain raw arguments, no input validation
 // is performed, and the result is returned to the user as-is, without any
 // validation of the output.
-type Handler func(_ context.Context, args string) (any, error)
+type Handler func(_ context.Context, args json.RawMessage) (any, error)
 
 // A HandlerFor handles a call to tools/call with typed arguments and results.
 //
@@ -64,18 +64,18 @@ func (t *Tool) ReturnSchema() any {
 	return t.Func.outputFormat.Schema()
 }
 
-func (t *Tool) Call(ctx context.Context, args map[string]any) (any, error) {
-	var argsBytes []byte
-	if args != nil {
-		var err error
-		argsBytes, err = json.Marshal(args)
-		if err != nil {
-			return nil, err
-		}
+func (t *Tool) Call(ctx context.Context, args any) (any, error) {
+	var raw json.RawMessage
+	if args == nil {
+		raw = json.RawMessage("{}")
 	} else {
-		argsBytes = []byte("{}")
+		var ok bool
+		raw, ok = args.(json.RawMessage)
+		if !ok {
+			return nil, fmt.Errorf("expected json.RawMessage arguments, got %T", args)
+		}
 	}
-	return t.Handler(ctx, string(argsBytes))
+	return t.Handler(ctx, raw)
 }
 
 func MustNew[In, Out any](fnp *Func, h HandlerFor[In, Out]) *Tool {
@@ -121,17 +121,17 @@ func New[In, Out any](fnp *Func, h HandlerFor[In, Out]) (*Tool, error) {
 		return nil, fmt.Errorf("resolving output schema: %w", err)
 	}
 
-	t.Handler = func(ctx context.Context, args string) (any, error) {
+	t.Handler = func(ctx context.Context, args json.RawMessage) (any, error) {
 		var in In
 		if t.Func.inputWrapped {
 			// Extract wrapped value.
 			var decodedArgs inputWrapper[In]
-			if err := jsonformat.Unmarshal(t.Func.inputFormat, []byte(args), &decodedArgs); err != nil {
+			if err := jsonformat.Unmarshal(t.Func.inputFormat, args, &decodedArgs); err != nil {
 				return nil, err
 			}
 			in = decodedArgs.Arg0
 		} else {
-			if err := jsonformat.Unmarshal(t.Func.inputFormat, []byte(args), &in); err != nil {
+			if err := jsonformat.Unmarshal(t.Func.inputFormat, args, &in); err != nil {
 				return nil, err
 			}
 		}

--- a/go/tool/functool/func.go
+++ b/go/tool/functool/func.go
@@ -48,8 +48,12 @@ type Tool struct {
 	Handler Handler
 }
 
-func (t *Tool) ToolInfo() (name string, description string) {
-	return t.Func.Name, t.Func.Description
+func (t *Tool) Name() string {
+	return t.Func.Name
+}
+
+func (t *Tool) Description() string {
+	return t.Func.Description
 }
 
 func (t *Tool) Schema() any {

--- a/go/tool/functool/func_test.go
+++ b/go/tool/functool/func_test.go
@@ -30,7 +30,7 @@ func TestFuncTool_Basic(t *testing.T) {
 		t.Fatalf("expected no error creating FuncTool, got: %v", err)
 	}
 
-	name, desc := tl.ToolInfo()
+	name, desc := tl.Name(), tl.Description()
 	if name != "test_func" {
 		t.Errorf("expected name 'test_func', got %q", name)
 	}
@@ -60,7 +60,7 @@ func TestFuncTool_MustNew(t *testing.T) {
 		t.Fatal("expected tool, got nil")
 	}
 
-	name, _ := tl.ToolInfo()
+	name, _ := tl.Name(), tl.Description()
 	if name != "must_func" {
 		t.Errorf("expected name 'must_func', got %q", name)
 	}

--- a/go/tool/functool/func_test.go
+++ b/go/tool/functool/func_test.go
@@ -4,6 +4,7 @@ package functool_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -77,7 +78,7 @@ func TestFuncTool_CallMissingArg0(t *testing.T) {
 	)
 
 	// Call without required arg0
-	_, err := tl.Call(t.Context(), map[string]any{})
+	_, err := tl.Call(t.Context(), json.RawMessage(`{}`))
 	if err == nil {
 		t.Error("expected error for missing arg0, got nil")
 	}
@@ -96,7 +97,7 @@ func TestFuncTool_CallStruct(t *testing.T) {
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), map[string]any{"v": "hello"})
+	ret, err := tl.Call(t.Context(), json.RawMessage(`{"v":"hello"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +116,7 @@ func TestFuncTool_CallString(t *testing.T) {
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), map[string]any{"arg0": "hello"})
+	ret, err := tl.Call(t.Context(), json.RawMessage(`{"arg0":"hello"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +180,7 @@ func TestFuncTool_CallError(t *testing.T) {
 		handler,
 	)
 
-	_, err := tl.Call(t.Context(), map[string]any{"value": "test"})
+	_, err := tl.Call(t.Context(), json.RawMessage(`{"value":"test"}`))
 	if err != expectedErr {
 		t.Errorf("expected error %v, got %v", expectedErr, err)
 	}

--- a/go/tool/hostedtool/hostedtool.go
+++ b/go/tool/hostedtool/hostedtool.go
@@ -1,17 +1,21 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+// Package hostedtool provides definitions for hosted tools.
+//
+// Hosted tools do not themselves implement functionality. They are markers that can
+// be used to inform a service that the service is allowed to perform certain actions
+// if the service is capable of doing so.
 package hostedtool
 
-import "github.com/microsoft/agent-framework/go/tool"
+import (
+	"github.com/microsoft/agent-framework/go/message"
+	"github.com/microsoft/agent-framework/go/tool"
+)
 
 var _ tool.Tool = (*WebSearch)(nil)
 
 // WebSearch represents a hosted tool that can be specified to an
 // AI service to enable it to perform web searches.
-//
-// This tool does not itself implement web searches. It is a marker that can
-// be used to inform a service that the service is allowed to perform web
-// searches if the service is capable of doing so.
 type WebSearch struct {
 	AdditionalProperties map[string]any
 }
@@ -24,6 +28,39 @@ func (t *WebSearch) Description() string {
 	return ""
 }
 
+var _ tool.Tool = (*FileSearch)(nil)
+
+// FileSearch represents a hosted tool that can be specified to an AI service
+// to enable it to perform file search operations.
 type FileSearch struct {
 	AdditionalProperties map[string]any
+
+	Inputs             []message.Content
+	MaximumResultCount int
+}
+
+func (t *FileSearch) Name() string {
+	return "file_search"
+}
+
+func (t *FileSearch) Description() string {
+	return ""
+}
+
+var _ tool.Tool = (*CodeInterpreter)(nil)
+
+// CodeInterpreter represents a hosted tool that can be specified to an AI service
+// to enable it to execute code it generates.
+type CodeInterpreter struct {
+	AdditionalProperties map[string]any
+
+	Inputs []message.Content
+}
+
+func (t *CodeInterpreter) Name() string {
+	return "code_interpreter"
+}
+
+func (t *CodeInterpreter) Description() string {
+	return ""
 }

--- a/go/tool/hostedtool/hostedtool.go
+++ b/go/tool/hostedtool/hostedtool.go
@@ -1,22 +1,29 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package websearchtool
+package hostedtool
 
 import "github.com/microsoft/agent-framework/go/tool"
 
-var _ tool.Tool = (*HostedWebSearch)(nil)
+var _ tool.Tool = (*WebSearch)(nil)
 
-// HostedWebSearch represents a hosted tool that can be specified to an
+// WebSearch represents a hosted tool that can be specified to an
 // AI service to enable it to perform web searches.
 //
 // This tool does not itself implement web searches. It is a marker that can
 // be used to inform a service that the service is allowed to perform web
 // searches if the service is capable of doing so.
-type HostedWebSearch struct {
-	Description          string
+type WebSearch struct {
 	AdditionalProperties map[string]any
 }
 
-func (t *HostedWebSearch) ToolInfo() (name string, description string) {
-	return "web_search", t.Description
+func (t *WebSearch) Name() string {
+	return "web_search"
+}
+
+func (t *WebSearch) Description() string {
+	return ""
+}
+
+type FileSearch struct {
+	AdditionalProperties map[string]any
 }

--- a/go/tool/mcptool/mcp.go
+++ b/go/tool/mcptool/mcp.go
@@ -94,8 +94,12 @@ func newMCPToolWrapper(session *mcp.ClientSession, tool *mcp.Tool) *mcpWrapper {
 	}
 }
 
-func (w *mcpWrapper) ToolInfo() (name string, description string) {
-	return w.tool.Name, w.tool.Description
+func (w *mcpWrapper) Name() string {
+	return w.tool.Name
+}
+
+func (w *mcpWrapper) Description() string {
+	return w.tool.Description
 }
 
 func (w *mcpWrapper) Schema() any {

--- a/go/tool/mcptool/mcp.go
+++ b/go/tool/mcptool/mcp.go
@@ -111,7 +111,7 @@ func (w *mcpWrapper) ReturnSchema() any {
 }
 
 // Call implements the Func-like calling pattern for MCP tools.
-func (w *mcpWrapper) Call(ctx context.Context, args map[string]any) (any, error) {
+func (w *mcpWrapper) Call(ctx context.Context, args any) (any, error) {
 	// Call the MCP tool
 	result, err := w.session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      w.tool.Name,

--- a/go/tool/tool.go
+++ b/go/tool/tool.go
@@ -29,7 +29,7 @@ type FuncTool interface {
 	Schema() any
 	ReturnSchema() any
 
-	Call(ctx context.Context, args map[string]any) (any, error)
+	Call(ctx context.Context, args any) (any, error)
 }
 
 // ApprovalRequiredTool indicates that a tool requires user approval before invocation.

--- a/go/tool/tool.go
+++ b/go/tool/tool.go
@@ -19,7 +19,8 @@ const (
 )
 
 type Tool interface {
-	ToolInfo() (name string, description string)
+	Name() string
+	Description() string
 }
 
 type FuncTool interface {


### PR DESCRIPTION
The `tool.Tool` interface no longer requires the clunky `ToolInfo() (string, string)` method. Also, `agent.FuncTool` no longer depends on `tool/functool` and `websearchtool.WebSearchTool` has been moved to the `hostedtool` package as `hostedtool.WebSearch`, together with other new hosted tools.