### PR TITLE
Make the agent package more idiomatic

### DIFF
--- a/go/agent/a2aagent/a2a.go
+++ b/go/agent/a2aagent/a2a.go
@@ -136,12 +136,12 @@ func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *
 			yield(nil, err)
 			return
 		}
-		var contextID, taskID string
-		var update *agent.RunResponseUpdate
 		switch e := e.(type) {
 		case *a2a.Task:
-			contextID = e.ContextID
-			taskID = string(e.ID)
+			if err := a.updateThreadContextID(thread, e.ContextID, string(e.ID)); err != nil {
+				yield(nil, err)
+				return
+			}
 			now := time.Now()
 			for _, artifact := range e.Artifacts {
 				contents, err := partsToContents(artifact.Parts)
@@ -153,7 +153,7 @@ func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *
 				if e.Status.Timestamp != nil {
 					timestamp = *e.Status.Timestamp
 				}
-				update = &agent.RunResponseUpdate{
+				if !yield(&agent.RunResponseUpdate{
 					RawRepresentation:    artifact,
 					AdditionalProperties: artifact.Metadata,
 					AgentID:              id,
@@ -163,10 +163,15 @@ func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *
 					Role:                 message.RoleAssistant,
 					CreatedAt:            timestamp,
 					AuthorName:           name,
+				}, nil) {
+					return
 				}
 			}
 		case *a2a.Message:
-			contextID = e.ContextID
+			if err := a.updateThreadContextID(thread, e.ContextID, ""); err != nil {
+				yield(nil, err)
+				return
+			}
 			contents, err := partsToContents(e.Parts)
 			if err != nil {
 				yield(nil, err)
@@ -176,7 +181,7 @@ func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *
 			if e.Role == a2a.MessageRoleAgent {
 				role = message.RoleAssistant
 			}
-			update = &agent.RunResponseUpdate{
+			if !yield(&agent.RunResponseUpdate{
 				RawRepresentation:    e,
 				AdditionalProperties: e.Metadata,
 				AgentID:              id,
@@ -186,16 +191,11 @@ func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *
 				Contents:             contents,
 				AuthorName:           name,
 				CreatedAt:            time.Now(),
+			}, nil) {
+				return
 			}
 		default:
 			yield(nil, fmt.Errorf("unsupported response type: %T", e))
-			return
-		}
-		if err := a.updateThreadContextID(thread, contextID, taskID); err != nil {
-			yield(nil, err)
-			return
-		}
-		if !yield(update, nil) {
 			return
 		}
 	}

--- a/go/agent/a2aagent/a2a.go
+++ b/go/agent/a2aagent/a2a.go
@@ -4,16 +4,17 @@ package a2aagent
 
 import (
 	"cmp"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
+	"time"
 
 	"github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2aclient"
-	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/memory"
 	"github.com/microsoft/agent-framework/go/message"
@@ -33,7 +34,7 @@ type Agent struct {
 	Client  *a2aclient.Client
 	Options Options
 
-	id string
+	iden agent.Identity
 }
 
 func NewAgent(client *a2aclient.Client, options *Options) *Agent {
@@ -48,25 +49,18 @@ func NewAgent(client *a2aclient.Client, options *Options) *Agent {
 	return &Agent{
 		Client:  client,
 		Options: opts,
+		iden:    agent.NewIdentity(opts.ID, opts.Name, opts.Description),
 	}
 }
 
-func (a *Agent) ID() string {
-	if a.Options.ID != "" {
-		return a.Options.ID
-	}
-	if a.id == "" {
-		a.id = uuid.NewString()
-	}
-	return a.id
+func (a *Agent) Identity() agent.Identity {
+	return a.iden
 }
 
-func (a *Agent) Name() string {
-	return a.Options.Name
-}
-
-func (a *Agent) Description() string {
-	return a.Options.Description
+func (a *Agent) Capabilities() agent.Capabilities {
+	return agent.Capabilities{
+		Streaming: true,
+	}
 }
 
 func (a *Agent) NewThread() memory.Thread {
@@ -87,120 +81,137 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return &thread, nil
 }
 
-func (a *Agent) Run(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
-	a2aMessage, err := toMessage(messages)
-	if err != nil {
-		return nil, err
-	}
-	var thread *Thread
-	if t := ctx.GetThread(); t == nil {
-		thread = a.NewThread().(*Thread)
-	} else if t, ok := t.(*Thread); ok {
-		thread = t
-	} else {
-		return nil, errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used")
-	}
-	a2aMessage.ContextID = thread.ContextID
-	resp, err := a.Client.SendMessage(ctx.GetContext(), &a2a.MessageSendParams{Message: a2aMessage})
-	if err != nil {
-		return nil, err
-	}
-	switch e := resp.(type) {
-	case *a2a.Message:
-		if err := a.updateThreadContextID(thread, e.ContextID); err != nil {
-			return nil, err
-		}
-		msg, err := fromMessage(e)
-		if err != nil {
-			return nil, err
-		}
-		return &agent.RunResponse{
-			ID:                   e.ID,
-			AgentID:              a.ID(),
-			Messages:             []*message.Message{msg},
-			RawRepresentation:    e,
-			AdditionalProperties: e.Metadata,
-		}, nil
-
-	case *a2a.Task:
-		if err := a.updateThreadContextID(thread, e.ContextID); err != nil {
-			return nil, err
-		}
-		msgs, err := fromTask(e)
-		if err != nil {
-			return nil, err
-		}
-		return &agent.RunResponse{
-			ID:                   string(e.ID),
-			AgentID:              a.ID(),
-			Messages:             msgs,
-			RawRepresentation:    e,
-			AdditionalProperties: e.Metadata,
-		}, nil
-	default:
-		return nil, fmt.Errorf("unexpected A2A response type: %T", resp)
-	}
-}
-
-func (a *Agent) RunStream(ctx *agent.RunContext, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, options agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
-		a2aMessage, err := toMessage(messages)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
 		var thread *Thread
-		if t := ctx.GetThread(); t == nil {
+		if options.Thread == nil {
 			thread = a.NewThread().(*Thread)
-		} else if t, ok := t.(*Thread); ok {
+			options.Thread = thread
+		} else if t, ok := options.Thread.(*Thread); ok {
 			thread = t
 		} else {
 			yield(nil, errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
 			return
 		}
-		a2aMessage.ContextID = thread.ContextID
-		for e, err := range a.Client.SendStreamingMessage(ctx.GetContext(), &a2a.MessageSendParams{Message: a2aMessage}) {
+		var parts []a2a.Part
+		for _, msg := range messages {
+			parts = parts[:0] // reset parts slice
+			parts, err := contentsToParts(msg.Contents, parts)
 			if err != nil {
 				yield(nil, err)
 				return
 			}
-			e, ok := e.(*a2a.Message)
-			if !ok {
-				yield(nil, fmt.Errorf("unexpected A2A streaming response type: %T", e))
-				return
+			var taskIDs []a2a.TaskID
+			if thread.TaskID != "" {
+				taskIDs = append(taskIDs, a2a.TaskID(thread.TaskID))
 			}
-			if err := a.updateThreadContextID(thread, e.ContextID); err != nil {
-				yield(nil, err)
-				return
+			params := &a2a.MessageSendParams{
+				Message: &a2a.Message{
+					ID:             msg.ID,
+					Role:           a2a.MessageRoleUser,
+					Parts:          parts,
+					ReferenceTasks: taskIDs,
+					ContextID:      thread.ContextID,
+				},
 			}
+			a.sendMsg(ctx, &options, params, yield)
+		}
+	}
+}
+
+func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *a2a.MessageSendParams, yield func(*agent.RunResponseUpdate, error) bool) {
+	var seq iter.Seq2[a2a.Event, error]
+	if options.Streaming.Or(false) {
+		seq = a.Client.SendStreamingMessage(ctx, params)
+	} else {
+		resp, err := a.Client.SendMessage(ctx, params)
+		seq = func(yield func(a2a.Event, error) bool) {
+			yield(resp, err)
+		}
+	}
+	id, name := a.iden.ID(), a.iden.Name()
+	thread := options.Thread.(*Thread)
+	for e, err := range seq {
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		var contextID, taskID string
+		var update *agent.RunResponseUpdate
+		switch e := e.(type) {
+		case *a2a.Task:
+			contextID = e.ContextID
+			taskID = string(e.ID)
+			now := time.Now()
+			for _, artifact := range e.Artifacts {
+				contents, err := partsToContents(artifact.Parts)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				timestamp := now
+				if e.Status.Timestamp != nil {
+					timestamp = *e.Status.Timestamp
+				}
+				update = &agent.RunResponseUpdate{
+					RawRepresentation:    artifact,
+					AdditionalProperties: artifact.Metadata,
+					AgentID:              id,
+					MessageID:            string(artifact.ID),
+					ResponseID:           string(e.ID),
+					Contents:             contents,
+					Role:                 message.RoleAssistant,
+					CreatedAt:            timestamp,
+					AuthorName:           name,
+				}
+			}
+		case *a2a.Message:
+			contextID = e.ContextID
 			contents, err := partsToContents(e.Parts)
 			if err != nil {
 				yield(nil, err)
 				return
 			}
-			yield(&agent.RunResponseUpdate{
+			role := message.RoleUser
+			if e.Role == a2a.MessageRoleAgent {
+				role = message.RoleAssistant
+			}
+			update = &agent.RunResponseUpdate{
 				RawRepresentation:    e,
 				AdditionalProperties: e.Metadata,
-				AgentID:              a.ID(),
+				AgentID:              id,
 				MessageID:            e.ID,
 				ResponseID:           e.ID,
-				Role:                 message.RoleAssistant,
+				Role:                 role,
 				Contents:             contents,
-			}, nil)
+				AuthorName:           name,
+				CreatedAt:            time.Now(),
+			}
+		default:
+			yield(nil, fmt.Errorf("unsupported response type: %T", e))
+			return
+		}
+		if err := a.updateThreadContextID(thread, contextID, taskID); err != nil {
+			yield(nil, err)
+			return
+		}
+		if !yield(update, nil) {
+			return
 		}
 	}
 }
 
-func (a *Agent) updateThreadContextID(thread *Thread, id string) error {
+func (a *Agent) updateThreadContextID(thread *Thread, contextID, taskID string) error {
 	if thread == nil {
 		return nil
 	}
 	// Surface cases where the A2A agent responds with a response that
 	// has a different context ID than the thread's context ID.
-	if thread.ContextID != "" && thread.ContextID != id {
-		return fmt.Errorf("mismatched context ID: thread has %q but A2A response has %q", thread.ContextID, id)
+	if thread.ContextID != "" && thread.ContextID != contextID {
+		return fmt.Errorf("mismatched context ID: thread has %q but A2A response has %q", thread.ContextID, contextID)
 	}
-	thread.ContextID = id
+	thread.ContextID = contextID
+	thread.TaskID = taskID
 	return nil
 }
 
@@ -301,62 +312,4 @@ func contentsToParts(contents []message.Content, parts []a2a.Part) ([]a2a.Part, 
 		}
 	}
 	return parts, nil
-}
-
-func toMessage(messages []*message.Message) (*a2a.Message, error) {
-	var parts []a2a.Part
-	for _, msg := range messages {
-		var err error
-		parts, err = contentsToParts(msg.Contents, parts)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &a2a.Message{
-		ID:    uuid.NewString(),
-		Role:  a2a.MessageRoleUser,
-		Parts: parts,
-	}, nil
-}
-
-func fromMessage(msg *a2a.Message) (*message.Message, error) {
-	contents, err := partsToContents(msg.Parts)
-	if err != nil {
-		return nil, err
-	}
-	role := message.RoleUser
-	if msg.Role == a2a.MessageRoleAgent {
-		role = message.RoleAssistant
-	}
-	return &message.Message{
-		ID:                msg.ID,
-		Contents:          contents,
-		Role:              role,
-		RawRepresentation: msg,
-	}, nil
-}
-
-func fromTask(task *a2a.Task) ([]*message.Message, error) {
-	messages := make([]*message.Message, 0, len(task.Artifacts))
-	for _, artifact := range task.Artifacts {
-		msg, err := fromArtifact(artifact)
-		if err != nil {
-			return nil, err
-		}
-		messages = append(messages, msg)
-	}
-	return messages, nil
-}
-
-func fromArtifact(task *a2a.Artifact) (*message.Message, error) {
-	contents, err := partsToContents(task.Parts)
-	if err != nil {
-		return nil, err
-	}
-	return &message.Message{
-		AdditionalProperties: task.Metadata,
-		Contents:             contents,
-		Role:                 message.RoleAssistant,
-		RawRepresentation:    task,
-	}, nil
 }

--- a/go/agent/a2aagent/a2a_test.go
+++ b/go/agent/a2aagent/a2a_test.go
@@ -135,14 +135,14 @@ func TestConstructorWithAllParameters(t *testing.T) {
 	}
 	a := newTestAgent(transport, opts)
 
-	if a.ID() != testID {
-		t.Errorf("ID() = %q, want %q", a.ID(), testID)
+	if a.Identity().ID() != testID {
+		t.Errorf("ID() = %q, want %q", a.Identity().ID(), testID)
 	}
-	if a.Name() != testName {
-		t.Errorf("Name() = %q, want %q", a.Name(), testName)
+	if a.Identity().Name() != testName {
+		t.Errorf("Name() = %q, want %q", a.Identity().Name(), testName)
 	}
-	if a.Description() != testDescription {
-		t.Errorf("Description() = %q, want %q", a.Description(), testDescription)
+	if a.Identity().Description() != testDescription {
+		t.Errorf("Description() = %q, want %q", a.Identity().Description(), testDescription)
 	}
 }
 
@@ -161,15 +161,15 @@ func TestConstructorWithDefaultParameters(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, nil)
 
-	id := a.ID()
+	id := a.Identity().ID()
 	if id == "" {
 		t.Error("ID() returned empty string, want non-empty")
 	}
-	if a.Name() != "" {
-		t.Errorf("Name() = %q, want empty string", a.Name())
+	if a.Identity().Name() != "" {
+		t.Errorf("Name() = %q, want empty string", a.Identity().Name())
 	}
-	if a.Description() != "" {
-		t.Errorf("Description() = %q, want empty string", a.Description())
+	if a.Identity().Description() != "" {
+		t.Errorf("Description() = %q, want empty string", a.Identity().Description())
 	}
 }
 
@@ -184,8 +184,7 @@ func TestRunAllowsNonUserRoleMessages(t *testing.T) {
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}},
 	}
 
-	ctx := &agent.RunContext{Context: t.Context()}
-	_, err := a.Run(ctx, inputMessages...)
+	_, err := agent.Run(t.Context(), a, agent.RunOptions{}, inputMessages...)
 	if err != nil {
 		t.Errorf("Run() error = %v, want nil", err)
 	}
@@ -208,8 +207,7 @@ func TestRunWithValidUserMessage(t *testing.T) {
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Hello, world!"}}},
 	}
 
-	ctx := &agent.RunContext{Context: t.Context()}
-	result, err := a.Run(ctx, inputMessages...)
+	result, err := agent.Run(t.Context(), a, agent.RunOptions{}, inputMessages...)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -240,8 +238,8 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	if result == nil {
 		t.Fatal("result is nil")
 	}
-	if result.AgentID != a.ID() {
-		t.Errorf("result.AgentID = %q, want %q", result.AgentID, a.ID())
+	if result.AgentID != a.Identity().ID() {
+		t.Errorf("result.AgentID = %q, want %q", result.AgentID, a.Identity().ID())
 	}
 	if result.ID != "response-123" {
 		t.Errorf("result.ID = %q, want %q", result.ID, "response-123")
@@ -287,12 +285,7 @@ func TestRunWithNewThread(t *testing.T) {
 	}
 
 	thread := a.NewThread()
-	ctx := &agent.RunContext{
-		Context: t.Context(),
-		Thread:  thread,
-	}
-
-	_, err := a.Run(ctx, inputMessages...)
+	_, err := agent.Run(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -316,12 +309,8 @@ func TestRunWithExistingThread(t *testing.T) {
 	}
 
 	thread := a.NewThreadWithContextID("existing-context-id")
-	ctx := &agent.RunContext{
-		Context: t.Context(),
-		Thread:  thread,
-	}
 
-	_, err := a.Run(ctx, inputMessages...)
+	_, err := agent.Run(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -352,12 +341,8 @@ func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 
 	thread := a.NewThreadWithContextID("existing-context-id")
-	ctx := &agent.RunContext{
-		Context: t.Context(),
-		Thread:  thread,
-	}
 
-	_, err := a.Run(ctx, inputMessages...)
+	_, err := agent.Run(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...)
 	if err == nil {
 		t.Error("Run() error = nil, want error")
 	}
@@ -379,10 +364,8 @@ func TestRunStreamingAsyncWithValidUserMessage(t *testing.T) {
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Hello, streaming!"}}},
 	}
 
-	ctx := &agent.RunContext{Context: t.Context()}
-
 	var updates []*agent.RunResponseUpdate
-	for update, err := range a.RunStream(ctx, inputMessages...) {
+	for update, err := range agent.RunStream(t.Context(), a, agent.RunOptions{}, inputMessages...) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -429,8 +412,8 @@ func TestRunStreamingAsyncWithValidUserMessage(t *testing.T) {
 	if update.MessageID != "stream-1" {
 		t.Errorf("update.MessageID = %q, want %q", update.MessageID, "stream-1")
 	}
-	if update.AgentID != a.ID() {
-		t.Errorf("update.AgentID = %q, want %q", update.AgentID, a.ID())
+	if update.AgentID != a.Identity().ID() {
+		t.Errorf("update.AgentID = %q, want %q", update.AgentID, a.Identity().ID())
 	}
 	if update.ResponseID != "stream-1" {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, "stream-1")
@@ -466,12 +449,8 @@ func TestRunStreamingAsyncWithThread(t *testing.T) {
 	}
 
 	thread := a.NewThread()
-	ctx := &agent.RunContext{
-		Context: t.Context(),
-		Thread:  thread,
-	}
 
-	for _, err := range a.RunStream(ctx, inputMessages...) {
+	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -498,12 +477,8 @@ func TestRunStreamingAsyncWithExistingThread(t *testing.T) {
 	}
 
 	thread := a.NewThreadWithContextID("existing-context-id")
-	ctx := &agent.RunContext{
-		Context: t.Context(),
-		Thread:  thread,
-	}
 
-	for _, err := range a.RunStream(ctx, inputMessages...) {
+	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -535,13 +510,8 @@ func TestRunStreamingAsyncWithThreadHavingDifferentContextID(t *testing.T) {
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test streaming"}}},
 	}
 
-	ctx := &agent.RunContext{
-		Context: t.Context(),
-		Thread:  thread,
-	}
-
 	gotError := false
-	for _, err := range a.RunStream(ctx, inputMessages...) {
+	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...) {
 		if err != nil {
 			gotError = true
 			break
@@ -571,9 +541,7 @@ func TestRunStreamingAsyncAllowsNonUserRoleMessages(t *testing.T) {
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}},
 	}
 
-	ctx := &agent.RunContext{Context: t.Context()}
-
-	for _, err := range a.RunStream(ctx, inputMessages...) {
+	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{}, inputMessages...) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -598,8 +566,7 @@ func TestRunWithHostedFileContent(t *testing.T) {
 		},
 	}
 
-	ctx := &agent.RunContext{Context: t.Context()}
-	_, err := a.Run(ctx, inputMessages...)
+	_, err := agent.Run(t.Context(), a, agent.RunOptions{}, inputMessages...)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}

--- a/go/agent/a2aagent/thread.go
+++ b/go/agent/a2aagent/thread.go
@@ -11,6 +11,7 @@ import (
 // Thread represents a thread identified by a service-managed identifier.
 type Thread struct {
 	ContextID string
+	TaskID    string
 }
 
 func (t *Thread) MessagesReceived(ctx context.Context, messages ...*message.Message) error {

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -170,7 +170,7 @@ func processUpdate(r *RunResponse, update *RunResponseUpdate) {
 			if r.Usage == nil {
 				r.Usage = new(message.UsageDetails)
 			}
-			r.Usage.Add(&c.Details)
+			r.Usage.Add(c.Details)
 		default:
 			msg.Contents = append(msg.Contents, content)
 		}

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -6,13 +6,13 @@ import (
 	"cmp"
 	"context"
 	"errors"
-	"fmt"
 	"iter"
 	"maps"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/microsoft/agent-framework/go/format"
 	"github.com/microsoft/agent-framework/go/memory"
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/param"
@@ -23,10 +23,7 @@ type RunOptions struct {
 	Streaming                param.Opt[bool]
 	AllowBackgroundResponses param.Opt[bool]
 	ContinuationToken        any
-
-	// StructuredOutput specifies an optional output structure for the agent to
-	// populate. The agent must support structured output for this to be used.
-	StructuredOutput any
+	ResponseFormat           format.Format
 
 	Options any
 }
@@ -62,7 +59,7 @@ func (iden Identity) Description() string {
 
 type Capabilities struct {
 	Streaming        bool
-	StructuredOutput bool
+	StructuredOutput format.Formatter // nil if structured output is not supported
 }
 
 type Agent interface {
@@ -105,10 +102,6 @@ func run(ctx context.Context, a Agent, options RunOptions, messages ...*message.
 	if a == nil {
 		return retErr(errors.New("agent cannot be nil"))
 	}
-	caps := a.Capabilities()
-	if !caps.StructuredOutput && options.StructuredOutput != nil {
-		return retErr(fmt.Errorf("agent does not support structured output"))
-	}
 	return a.Run(ctx, options, messages...)
 }
 
@@ -124,8 +117,20 @@ func RunTextStream(ctx context.Context, a Agent, msg string) iter.Seq2[*RunRespo
 // RunFor executes the agent with the given messages and returns the result of type T.
 func RunFor[T any](ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) (T, *RunResponse, error) {
 	var v T
-	options.StructuredOutput = &v
+	formatter := a.Capabilities().StructuredOutput
+	if formatter == nil {
+		return v, nil, errors.New("agent does not support structured output")
+	}
+	format, err := formatter.Format(v)
+	if err != nil {
+		return v, nil, err
+	}
+	options.ResponseFormat = format
 	resp, err := Run(ctx, a, options, messages...)
+	if err != nil {
+		return v, resp, err
+	}
+	err = formatter.Unmarshal([]byte(resp.String()), options.ResponseFormat, &v)
 	return v, resp, err
 }
 

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -3,87 +3,202 @@
 package agent
 
 import (
+	"cmp"
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework/go/memory"
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/param"
-	"github.com/microsoft/agent-framework/go/tool"
 )
 
-// RunContext contains context for agent execution.
-type RunContext struct {
-	context.Context
-	Thread  memory.Thread
-	Options *RunOptions
-}
-
-// GetContext returns the context.Context from the RunContext, or a background context if nil.
-func (ctx *RunContext) GetContext() context.Context {
-	if ctx == nil || ctx.Context == nil {
-		return context.Background()
-	}
-	return ctx.Context
-}
-
-// GetThread returns the memory.Thread from the RunContext, or nil if none.
-func (ctx *RunContext) GetThread() memory.Thread {
-	if ctx == nil {
-		return nil
-	}
-	return ctx.Thread
-}
-
-// GetOptions returns the RunOptions from the RunContext, or nil if none.
-func (ctx *RunContext) GetOptions() *RunOptions {
-	if ctx == nil {
-		return nil
-	}
-	return ctx.Options
-}
-
 type RunOptions struct {
-	ContinuationToken        any
+	Thread                   memory.Thread
+	Streaming                param.Opt[bool]
 	AllowBackgroundResponses param.Opt[bool]
+	ContinuationToken        any
+
+	// StructuredOutput specifies an optional output structure for the agent to
+	// populate. The agent must support structured output for this to be used.
+	StructuredOutput any
 
 	Options any
 }
 
-type Agent interface {
-	ID() string
-	Name() string
-	Description() string
+type Identity struct {
+	id          string
+	name        string
+	description string
+}
 
-	Run(ctx *RunContext, messages ...*message.Message) (*RunResponse, error)
-	RunStream(ctx *RunContext, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error]
+func NewIdentity(id, name, description string) Identity {
+	if id == "" {
+		id = uuid.NewString()
+	}
+	return Identity{
+		id:          id,
+		name:        name,
+		description: description,
+	}
+}
+
+func (iden Identity) ID() string {
+	return iden.id
+}
+
+func (iden Identity) Name() string {
+	return iden.name
+}
+
+func (iden Identity) Description() string {
+	return iden.description
+}
+
+type Capabilities struct {
+	Streaming        bool
+	StructuredOutput bool
+}
+
+type Agent interface {
+	Identity() Identity
+	Capabilities() Capabilities
+
+	Run(ctx context.Context, options RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error]
 
 	NewThread() memory.Thread
 	UnmarshalThread(data []byte) (memory.Thread, error)
 }
 
-// Config contains configuration for an [Agent].
-type Config struct {
-	ID   string
-	Name string
-	Opts *RunOptions
+func Run(ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) (*RunResponse, error) {
+	resp := RunResponse{
+		AgentID: a.Identity().ID(),
+	}
+	for update, err := range run(ctx, a, options, messages...) {
+		if err != nil {
+			return nil, err
+		}
+		processUpdate(&resp, update)
+	}
+	for _, msg := range resp.Messages {
+		msg.Contents = message.CoalesceContents(msg.Contents)
+	}
+	return &resp, nil
+}
 
-	SystemInstructions string
+func RunStream(ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
+	options.Streaming = param.NewOpt(true)
+	return run(ctx, a, options, messages...)
+}
 
-	// The following functions implement the core behavior of the agent.
-	// If any of these are nil, the corresponding functionality is not supported,
-	// and the [Agent] might fall back to default behavior or return an error.
-	// The input parameters will always be non-nil and can be mutated as needed.
-	NewThread          func() memory.Thread
-	UnmarshalThread    func(data []byte) (memory.Thread, error)
-	NewContextProvider func() memory.ContextProvider
-	Run                func(ctx *RunContext, messages ...*message.Message) (*RunResponse, error)
-	RunStream          func(ctx *RunContext, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error]
-	RunOf              func(v any, ctx *RunContext, messages ...*message.Message) (*RunResponse, error)
+func run(ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
+	retErr := func(err error) iter.Seq2[*RunResponseUpdate, error] {
+		return func(yield func(*RunResponseUpdate, error) bool) {
+			yield(nil, err)
+		}
+	}
+	if a == nil {
+		return retErr(errors.New("agent cannot be nil"))
+	}
+	caps := a.Capabilities()
+	if !caps.StructuredOutput && options.StructuredOutput != nil {
+		return retErr(fmt.Errorf("agent does not support structured output"))
+	}
+	return a.Run(ctx, options, messages...)
+}
+
+// RunText executes the agent with a single text message and returns the response.
+func RunText(ctx context.Context, a Agent, msg string) (*RunResponse, error) {
+	return Run(ctx, a, RunOptions{}, message.NewText(msg))
+}
+
+func RunTextStream(ctx context.Context, a Agent, msg string) iter.Seq2[*RunResponseUpdate, error] {
+	return RunStream(ctx, a, RunOptions{}, message.NewText(msg))
+}
+
+// RunFor executes the agent with the given messages and returns the result of type T.
+func RunFor[T any](ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) (T, *RunResponse, error) {
+	var v T
+	options.StructuredOutput = &v
+	resp, err := Run(ctx, a, options, messages...)
+	return v, resp, err
+}
+
+// processUpdate updates the ChatResponse r with the information from the ChatResponseUpdate update.
+func processUpdate(r *RunResponse, update *RunResponseUpdate) {
+	if update == nil {
+		return
+	}
+	// If there is no message created yet, or if the last update we saw had a different
+	// identifying parts, create a new message.
+	isNewMessage := true
+	if len(r.Messages) > 0 {
+		lastMsg := r.Messages[len(r.Messages)-1]
+		isNewMessage = notEmptyNorEqual(update.AuthorName, lastMsg.AuthorName) ||
+			notEmptyNorEqual(update.MessageID, lastMsg.ID) ||
+			notEmptyNorEqual(string(update.Role), string(lastMsg.Role))
+	}
+	// Get the message to target, either a new one or the last ones.
+	var msg *message.Message
+	if isNewMessage {
+		msg = &message.Message{
+			Role: message.RoleAssistant,
+		}
+		r.Messages = append(r.Messages, msg)
+	} else {
+		msg = r.Messages[len(r.Messages)-1]
+	}
+	// Some members on ChatResponseUpdate map to members of ChatMessage.
+	// Incorporate those into the latest message; in cases where the message
+	// stores a single value, prefer the latest update's value over anything
+	// stored in the message.
+	msg.AuthorName = cmp.Or(update.AuthorName, msg.AuthorName)
+	msg.Role = cmp.Or(update.Role, msg.Role)
+	msg.ID = cmp.Or(update.MessageID, msg.ID)
+	if msg.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(msg.CreatedAt)) {
+		msg.CreatedAt = update.CreatedAt
+	}
+	for _, content := range update.Contents {
+		switch c := content.(type) {
+		case *message.UsageContent:
+			// Usage content is treated specially and propagated to the response's Usage.
+			if r.Usage == nil {
+				r.Usage = new(message.UsageDetails)
+			}
+			r.Usage.Add(&c.Details)
+		default:
+			msg.Contents = append(msg.Contents, content)
+		}
+	}
+	// Other members on a ChatResponseUpdate map to members of the ChatResponse.
+	// Update the response object with those, preferring the values from later updates.
+	r.ID = cmp.Or(update.ResponseID, r.ID)
+	if r.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(r.CreatedAt)) {
+		r.CreatedAt = update.CreatedAt
+	}
+	if update.AdditionalProperties != nil {
+		if r.AdditionalProperties == nil {
+			r.AdditionalProperties = make(map[string]any)
+		}
+		maps.Copy(r.AdditionalProperties, update.AdditionalProperties)
+	}
+	if r.RawRepresentation == nil {
+		r.RawRepresentation = update.RawRepresentation
+	} else if s, ok := r.RawRepresentation.([]any); ok {
+		r.RawRepresentation = append(s, update.RawRepresentation)
+	} else {
+		r.RawRepresentation = []any{r.RawRepresentation, update.RawRepresentation}
+	}
+}
+
+// notEmptyNorEqual returns true if both strings are not empty and not the same as each other.
+func notEmptyNorEqual(s1, s2 string) bool {
+	return s1 != "" && s2 != "" && s1 != s2
 }
 
 // RunResponse represents the result of an agent execution.
@@ -160,80 +275,4 @@ func (r *RunResponseUpdate) UserInputRequests() iter.Seq[message.Content] {
 			}
 		}
 	}
-}
-
-// FuncTool creates a function tool that invokes the given agent.
-// The provided thread is used for the agent's context during invocations,
-// or nil to create a new thread for each invocation.
-func FuncTool(agent Agent, thread memory.Thread) tool.FuncTool {
-	return functool{
-		name:        agent.Name(),
-		description: agent.Description(),
-		thread:      thread,
-		agent:       agent,
-	}
-}
-
-type functool struct {
-	name        string
-	description string
-	thread      memory.Thread
-	agent       Agent
-}
-
-func (t functool) Name() string {
-	return t.name
-}
-
-func (t functool) Description() string {
-	return t.description
-}
-
-func (t functool) Schema() any {
-	return map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"query": map[string]any{
-				"type":        "string",
-				"description": "input query to invoke the agent",
-			},
-		},
-		"required": []string{"query"},
-	}
-}
-
-func (t functool) ReturnSchema() any {
-	return map[string]any{
-		"type": "string",
-	}
-}
-
-func (t functool) Call(ctx context.Context, args any) (any, error) {
-	var in struct {
-		Query string `json:"query"`
-	}
-	var raw json.RawMessage
-	if args == nil {
-		raw = json.RawMessage("{}")
-	} else {
-		var ok bool
-		raw, ok = args.(json.RawMessage)
-		if !ok {
-			return nil, fmt.Errorf("expected json.RawMessage arguments, got %T", args)
-		}
-	}
-	if err := json.Unmarshal(raw, &in); err != nil {
-		return nil, err
-	}
-	resp, err := t.agent.Run(&RunContext{
-		Context: ctx,
-		Thread:  t.thread,
-	}, &message.Message{
-		Role:     message.RoleUser,
-		Contents: []message.Content{&message.TextContent{Text: in.Query}},
-	})
-	if err != nil {
-		return "", err
-	}
-	return resp.String(), nil
 }

--- a/go/agent/chatagent/chatagent.go
+++ b/go/agent/chatagent/chatagent.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"iter"
 
-	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent/chatclient"
 	"github.com/microsoft/agent-framework/go/memory"
@@ -24,7 +23,7 @@ type Agent struct {
 	Client  chatclient.Client
 	Options Options
 
-	id string
+	iden agent.Identity
 }
 
 // NewAgent creates a new chat agent with the given chat client and options.
@@ -42,25 +41,20 @@ func NewAgent(client chatclient.Client, options *Options) *Agent {
 	return &Agent{
 		Client:  client,
 		Options: opts,
+		iden:    agent.NewIdentity(opts.ID, opts.Name, opts.Description),
 	}
 }
 
-func (a *Agent) ID() string {
-	if a.Options.ID != "" {
-		return a.Options.ID
-	}
-	if a.id == "" {
-		a.id = uuid.NewString()
-	}
-	return a.id
+func (a *Agent) Identity() agent.Identity {
+	return a.iden
 }
 
-func (a *Agent) Name() string {
-	return a.Options.Name
-}
-
-func (a *Agent) Description() string {
-	return a.Options.Description
+func (a *Agent) Capabilities() agent.Capabilities {
+	caps := agent.Capabilities{
+		Streaming: true,
+	}
+	_, caps.StructuredOutput = a.Client.(chatclient.StructuredResponseClient)
+	return caps
 }
 
 func (a *Agent) Instructions() string {
@@ -89,73 +83,74 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
 }
 
-// RunOf executes the agent with the given value type and messages, and stores the result
-// in the value pointed to by v.
-func (a *Agent) RunOf(v any, ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
-	return a.run(ctx, func(ctx context.Context, client chatclient.Client, opts *chatclient.ChatOptions, messages []*message.Message) (*chatclient.ChatResponse, error) {
-		c, ok := client.(chatclient.StructuredResponseClient)
-		if !ok {
-			return nil, fmt.Errorf("the %T chat client doesn't support structured responses", client)
-		}
-		return c.StructuredResponse(v, ctx, opts, messages...)
-	}, messages)
-}
-
-// RunFor executes the agent with the given messages and returns the result of type T.
-func RunFor[T any](a *Agent, ctx *agent.RunContext, messages ...*message.Message) (T, *agent.RunResponse, error) {
-	var v T
-	resp, err := a.RunOf(&v, ctx, messages...)
-	return v, resp, err
-}
-
-// RunText executes the agent with a single text message and returns the response.
-func (a *Agent) RunText(ctx *agent.RunContext, msg string) (*agent.RunResponse, error) {
-	return a.Run(ctx, message.NewText(msg))
-}
-
 // Run executes the agent with the given messages and returns the response.
-func (a *Agent) Run(ctx *agent.RunContext, messages ...*message.Message) (*agent.RunResponse, error) {
-	return a.run(ctx, func(ctx context.Context, client chatclient.Client, opts *chatclient.ChatOptions, messages []*message.Message) (*chatclient.ChatResponse, error) {
-		return client.Response(ctx, opts, messages...)
-	}, messages)
+func (a *Agent) Run(ctx context.Context, options agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
+	if options.Streaming.Or(false) {
+		return a.runStream(ctx, &options, messages...)
+	} else {
+		return a.run(ctx, &options, func(ctx context.Context, client chatclient.Client, opts *chatclient.ChatOptions, messages []*message.Message) (*chatclient.ChatResponse, error) {
+			if options.StructuredOutput != nil {
+				c, ok := client.(chatclient.StructuredResponseClient)
+				if !ok {
+					return nil, fmt.Errorf("the %T chat client doesn't support structured responses", client)
+				}
+				return c.StructuredResponse(options.StructuredOutput, ctx, opts, messages...)
+			}
+			return client.Response(ctx, opts, messages...)
+		}, messages)
+	}
 }
 
-func (a *Agent) run(actx *agent.RunContext,
+func (a *Agent) run(ctx context.Context, options *agent.RunOptions,
 	runFn func(context.Context, chatclient.Client, *chatclient.ChatOptions, []*message.Message) (*chatclient.ChatResponse, error),
-	messages []*message.Message) (*agent.RunResponse, error) {
+	messages []*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
 
-	ctx, thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(actx, messages)
-	if err != nil {
-		return nil, err
-	}
-	client := applyRunOptionsTransformations(actx.GetOptions(), a.Client)
-	resp, err := runFn(ctx, client, opts, messages)
-	if err != nil {
-		a.notifyContextProviderOfFailure(ctx, thread, err, messages, ctxMessages)
-		return nil, err
-	}
+	id, name := a.iden.ID(), a.iden.Name()
+	return func(yield func(*agent.RunResponseUpdate, error) bool) {
+		thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, options, messages)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		client := applyRunOptionsTransformations(options, a.Client)
+		resp, err := runFn(ctx, client, opts, messages)
+		if err != nil {
+			a.notifyContextProviderOfFailure(ctx, thread, err, messages, ctxMessages)
+			yield(nil, err)
+			return
+		}
 
-	// Ensure that the author name is set for each message in the response.
-	for _, msg := range resp.Messages {
-		msg.AuthorName = cmp.Or(msg.AuthorName, a.Name())
+		// Ensure that the author name is set for each message in the response.
+		for _, msg := range resp.Messages {
+			msg.AuthorName = cmp.Or(msg.AuthorName, name)
+		}
+		if err := a.finishRun(ctx, thread, resp, messages, ctxMessages); err != nil {
+			yield(nil, err)
+			return
+		}
+		for _, msg := range resp.Messages {
+			if !yield(&agent.RunResponseUpdate{
+				AgentID:              id,
+				AuthorName:           msg.AuthorName,
+				MessageID:            msg.ID,
+				ResponseID:           resp.ID,
+				CreatedAt:            msg.CreatedAt,
+				Role:                 msg.Role,
+				Contents:             msg.Contents,
+				RawRepresentation:    msg.RawRepresentation,
+				AdditionalProperties: msg.AdditionalProperties,
+			}, nil) {
+				return
+			}
+		}
 	}
-	if err := a.finishRun(ctx, thread, resp, messages, ctxMessages); err != nil {
-		return nil, err
-	}
-	return &agent.RunResponse{
-		AgentID:   a.ID(),
-		ID:        resp.ID,
-		CreatedAt: resp.CreatedAt,
-		Messages:  resp.Messages,
-		Usage:     resp.Usage,
-	}, nil
 }
 
 // RunStream executes the agent with the given messages and returns a streaming response.
-func (a *Agent) RunStream(actx *agent.RunContext, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
-	client := applyRunOptionsTransformations(actx.GetOptions(), a.Client)
+func (a *Agent) runStream(ctx context.Context, options *agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
+	client := applyRunOptionsTransformations(options, a.Client)
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
-		ctx, thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(actx, messages)
+		thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, options, messages)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -168,16 +163,18 @@ func (a *Agent) RunStream(actx *agent.RunContext, messages ...*message.Message) 
 				return
 			}
 			if update != nil {
-				update.AuthorName = cmp.Or(update.AuthorName, a.Name())
+				update.AuthorName = cmp.Or(update.AuthorName, a.Identity().Name())
 				updates = append(updates, update)
 				if !yield(&agent.RunResponseUpdate{
-					AgentID:    a.ID(),
-					AuthorName: update.AuthorName,
-					MessageID:  update.MessageID,
-					ResponseID: update.ResponseID,
-					CreatedAt:  update.CreatedAt,
-					Role:       update.Role,
-					Contents:   update.Contents,
+					AgentID:              a.Identity().ID(),
+					AuthorName:           update.AuthorName,
+					MessageID:            update.MessageID,
+					ResponseID:           update.ResponseID,
+					CreatedAt:            update.CreatedAt,
+					Role:                 update.Role,
+					Contents:             update.Contents,
+					RawRepresentation:    update.RawRepresentation,
+					AdditionalProperties: update.AdditionalProperties,
 				}, nil) {
 					return
 				}
@@ -250,19 +247,19 @@ func (a *Agent) updateThreadWithTypeAndConversationID(thread *Thread, convID str
 	return nil
 }
 
-func (a *Agent) prepareThreadAndMessages(ctx *agent.RunContext, messages []*message.Message) (_ context.Context, thread *Thread, opts *ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
-	retError := func(e error) (context.Context, *Thread, *ChatOptions, []*message.Message, []*message.Message, error) {
-		return nil, nil, nil, nil, nil, e
+func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.RunOptions, messages []*message.Message) (thread *Thread, opts *ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
+	retError := func(e error) (*Thread, *ChatOptions, []*message.Message, []*message.Message, error) {
+		return nil, nil, nil, nil, e
 	}
-	opts = a.createConfiguredChatOptions(ctx.GetOptions())
+	opts = a.createConfiguredChatOptions(options)
 	if opts != nil {
 		if v, ok := opts.AllowBackgroundResponses.Value(); ok && v && thread == nil {
 			return retError(errors.New("a thread must be provided when continuing a background response with a continuation token"))
 		}
 	}
-	if cthread := ctx.GetThread(); cthread != nil {
+	if options.Thread != nil {
 		var ok bool
-		thread, ok = cthread.(*Thread)
+		thread, ok = options.Thread.(*Thread)
 		if !ok {
 			return retError(errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
 		}
@@ -278,7 +275,7 @@ func (a *Agent) prepareThreadAndMessages(ctx *agent.RunContext, messages []*mess
 	if opts == nil || opts.ContinuationToken == nil {
 		if thread.MessageStore != nil {
 			//  Add any existing messages from the thread to the messages to be sent to the chat client.
-			for msg, err := range thread.MessageStore.All(ctx.GetContext()) {
+			for msg, err := range thread.MessageStore.All(ctx) {
 				if err != nil {
 					return retError(err)
 				}
@@ -289,7 +286,7 @@ func (a *Agent) prepareThreadAndMessages(ctx *agent.RunContext, messages []*mess
 			// If we have a ContextProvider, we should get context from it, and update our
 			// messages and options with the additional context.
 			ctxData, err := thread.ContextProvider.Invoking(&memory.InvokingContext{
-				Context:  ctx.GetContext(),
+				Context:  ctx,
 				Messages: messages,
 			})
 			if err != nil {
@@ -339,7 +336,7 @@ func (a *Agent) prepareThreadAndMessages(ctx *agent.RunContext, messages []*mess
 		}
 		opts.ConversationID = thread.ConversationID
 	}
-	return ctx.GetContext(), thread, opts, msgsForClient, ctxMessages, nil
+	return thread, opts, msgsForClient, ctxMessages, nil
 }
 
 func (a *Agent) createConfiguredChatOptions(runOpts *agent.RunOptions) *ChatOptions {
@@ -370,9 +367,6 @@ func (a *Agent) createConfiguredChatOptions(runOpts *agent.RunOptions) *ChatOpti
 }
 
 func applyRunOptionsTransformations(opts *agent.RunOptions, client chatclient.Client) chatclient.Client {
-	if opts == nil {
-		return client
-	}
 	if v, ok := opts.Options.(*RunOptions); ok && v.NewClient != nil {
 		// If we have a custom chat client factory, we should use it to create a new chat client with the transformed tools.
 		client = v.NewClient(client)

--- a/go/agent/chatagent/chatagent.go
+++ b/go/agent/chatagent/chatagent.go
@@ -6,7 +6,6 @@ import (
 	"cmp"
 	"context"
 	"errors"
-	"fmt"
 	"iter"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -50,11 +49,11 @@ func (a *Agent) Identity() agent.Identity {
 }
 
 func (a *Agent) Capabilities() agent.Capabilities {
-	caps := agent.Capabilities{
-		Streaming: true,
+	caps := a.Client.Capabilities()
+	return agent.Capabilities{
+		Streaming:        caps.Streaming,
+		StructuredOutput: caps.StructuredOutput,
 	}
-	_, caps.StructuredOutput = a.Client.(chatclient.StructuredResponseClient)
-	return caps
 }
 
 func (a *Agent) Instructions() string {
@@ -83,80 +82,16 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
 }
 
-// Run executes the agent with the given messages and returns the response.
 func (a *Agent) Run(ctx context.Context, options agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
-	if options.Streaming.Or(false) {
-		return a.runStream(ctx, &options, messages...)
-	} else {
-		return a.run(ctx, &options, func(ctx context.Context, client chatclient.Client, opts *chatclient.ChatOptions, messages []*message.Message) (*chatclient.ChatResponse, error) {
-			if options.StructuredOutput != nil {
-				c, ok := client.(chatclient.StructuredResponseClient)
-				if !ok {
-					return nil, fmt.Errorf("the %T chat client doesn't support structured responses", client)
-				}
-				return c.StructuredResponse(options.StructuredOutput, ctx, opts, messages...)
-			}
-			return client.Response(ctx, opts, messages...)
-		}, messages)
-	}
-}
-
-func (a *Agent) run(ctx context.Context, options *agent.RunOptions,
-	runFn func(context.Context, chatclient.Client, *chatclient.ChatOptions, []*message.Message) (*chatclient.ChatResponse, error),
-	messages []*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
-
-	id, name := a.iden.ID(), a.iden.Name()
+	client := applyRunOptionsTransformations(&options, a.Client)
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
-		thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, options, messages)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		client := applyRunOptionsTransformations(options, a.Client)
-		resp, err := runFn(ctx, client, opts, messages)
-		if err != nil {
-			a.notifyContextProviderOfFailure(ctx, thread, err, messages, ctxMessages)
-			yield(nil, err)
-			return
-		}
-
-		// Ensure that the author name is set for each message in the response.
-		for _, msg := range resp.Messages {
-			msg.AuthorName = cmp.Or(msg.AuthorName, name)
-		}
-		if err := a.finishRun(ctx, thread, resp, messages, ctxMessages); err != nil {
-			yield(nil, err)
-			return
-		}
-		for _, msg := range resp.Messages {
-			if !yield(&agent.RunResponseUpdate{
-				AgentID:              id,
-				AuthorName:           msg.AuthorName,
-				MessageID:            msg.ID,
-				ResponseID:           resp.ID,
-				CreatedAt:            msg.CreatedAt,
-				Role:                 msg.Role,
-				Contents:             msg.Contents,
-				RawRepresentation:    msg.RawRepresentation,
-				AdditionalProperties: msg.AdditionalProperties,
-			}, nil) {
-				return
-			}
-		}
-	}
-}
-
-// RunStream executes the agent with the given messages and returns a streaming response.
-func (a *Agent) runStream(ctx context.Context, options *agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
-	client := applyRunOptionsTransformations(options, a.Client)
-	return func(yield func(*agent.RunResponseUpdate, error) bool) {
-		thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, options, messages)
+		thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, &options, messages)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 		var updates []*chatclient.ChatResponseUpdate
-		for update, err := range client.StreamingResponse(ctx, opts, messages...) {
+		for update, err := range client.Response(ctx, opts, messages...) {
 			if err != nil {
 				a.notifyContextProviderOfFailure(ctx, thread, err, messages, ctxMessages)
 				yield(nil, err)
@@ -180,26 +115,28 @@ func (a *Agent) runStream(ctx context.Context, options *agent.RunOptions, messag
 				}
 			}
 		}
-		resp := chatclient.NewChatResponseFromUpdates(updates)
-		if err := a.finishRun(ctx, thread, resp, messages, ctxMessages); err != nil {
+		convID := ""
+		if len(updates) > 0 {
+			convID = updates[len(updates)-1].ConversationID
+		}
+		// We can derive the type of supported thread from whether we have a conversation id,
+		// so let's update it and set the conversation id for the service thread case.
+		if err := a.updateThreadWithTypeAndConversationID(thread, convID); err != nil {
+			yield(nil, err)
+			return
+		}
+		msgs := chatclient.NewMessageFromUpdates(updates)
+		// Only notify the thread of new messages if the chatResponse was successful to avoid inconsistent message state in the thread.
+		if err := thread.MessagesReceived(ctx, append(ctxMessages, msgs...)...); err != nil {
+			yield(nil, err)
+			return
+		}
+		// Notify the ContextProvider of all new messages.
+		if err := a.notifyContextProviderOfSuccess(ctx, thread, messages, ctxMessages, msgs); err != nil {
 			yield(nil, err)
 			return
 		}
 	}
-}
-
-func (a *Agent) finishRun(ctx context.Context, thread *Thread, resp *chatclient.ChatResponse, messages, ctxMessages []*message.Message) error {
-	// We can derive the type of supported thread from whether we have a conversation id,
-	// so let's update it and set the conversation id for the service thread case.
-	if err := a.updateThreadWithTypeAndConversationID(thread, resp.ConversationID); err != nil {
-		return err
-	}
-	// Only notify the thread of new messages if the chatResponse was successful to avoid inconsistent message state in the thread.
-	if err := thread.MessagesReceived(ctx, append(ctxMessages, resp.Messages...)...); err != nil {
-		return err
-	}
-	// Notify the ContextProvider of all new messages.
-	return a.notifyContextProviderOfSuccess(ctx, thread, messages, ctxMessages, resp.Messages)
 }
 
 func (a *Agent) notifyContextProviderOfSuccess(ctx context.Context, thread *Thread, messages, contextProviderMessages, respMessages []*message.Message) error {
@@ -247,15 +184,13 @@ func (a *Agent) updateThreadWithTypeAndConversationID(thread *Thread, convID str
 	return nil
 }
 
-func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.RunOptions, messages []*message.Message) (thread *Thread, opts *ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
-	retError := func(e error) (*Thread, *ChatOptions, []*message.Message, []*message.Message, error) {
-		return nil, nil, nil, nil, e
+func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.RunOptions, messages []*message.Message) (thread *Thread, opts ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
+	retError := func(e error) (*Thread, ChatOptions, []*message.Message, []*message.Message, error) {
+		return nil, ChatOptions{}, nil, nil, e
 	}
 	opts = a.createConfiguredChatOptions(options)
-	if opts != nil {
-		if v, ok := opts.AllowBackgroundResponses.Value(); ok && v && thread == nil {
-			return retError(errors.New("a thread must be provided when continuing a background response with a continuation token"))
-		}
+	if v, ok := opts.AllowBackgroundResponses.Value(); ok && v && thread == nil {
+		return retError(errors.New("a thread must be provided when continuing a background response with a continuation token"))
 	}
 	if options.Thread != nil {
 		var ok bool
@@ -266,13 +201,13 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.Run
 	} else {
 		thread = a.newThread("")
 	}
-	if opts != nil && opts.ContinuationToken != nil {
+	if opts.ContinuationToken != nil {
 		if len(messages) > 0 {
 			return retError(errors.New("messages are not allowed when continuing a background response using a continuation token"))
 		}
 	}
 
-	if opts == nil || opts.ContinuationToken == nil {
+	if opts.ContinuationToken == nil {
 		if thread.MessageStore != nil {
 			//  Add any existing messages from the thread to the messages to be sent to the chat client.
 			for msg, err := range thread.MessageStore.All(ctx) {
@@ -296,15 +231,9 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.Run
 				ctxMessages = ctxData.Messages
 				msgsForClient = append(msgsForClient, ctxData.Messages...)
 				if len(ctxData.Tools) > 0 {
-					if opts == nil {
-						opts = &ChatOptions{}
-					}
 					opts.Tools = append(opts.Tools, ctxData.Tools...)
 				}
 				if ctxData.Instructions != "" {
-					if opts == nil {
-						opts = &ChatOptions{}
-					}
 					if opts.Instructions != "" {
 						opts.Instructions += "\n"
 					}
@@ -317,52 +246,38 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.Run
 	}
 	// If a user provided two different thread ids, via the thread object and options, we should throw
 	// since we don't know which one to use.
-	if thread.ConversationID != "" && opts != nil && opts.ConversationID != "" && thread.ConversationID != opts.ConversationID {
+	if thread.ConversationID != "" && opts.ConversationID != "" && thread.ConversationID != opts.ConversationID {
 		return retError(errors.New("conflicting conversation IDs provided in thread and chat options"))
 	}
 	if a.Instructions() != "" {
-		if opts == nil {
-			opts = &ChatOptions{}
-		}
 		if opts.Instructions != "" {
 			opts.Instructions = "\n" + opts.Instructions
 		}
 		opts.Instructions = a.Instructions() + opts.Instructions
 	}
-	if thread.ConversationID != "" && opts != nil && opts.ConversationID != thread.ConversationID {
-		// Only create or update ChatOptions if we have an id on the thread and we don't have the same one already in ChatOptions.
-		if opts == nil {
-			opts = &ChatOptions{}
-		}
+	if thread.ConversationID != "" && opts.ConversationID != thread.ConversationID {
 		opts.ConversationID = thread.ConversationID
 	}
 	return thread, opts, msgsForClient, ctxMessages, nil
 }
 
-func (a *Agent) createConfiguredChatOptions(runOpts *agent.RunOptions) *ChatOptions {
-	var opts *ChatOptions
+func (a *Agent) createConfiguredChatOptions(runOpts *agent.RunOptions) ChatOptions {
+	var opts ChatOptions
 	// Try to get ChatOptions from RunOptions
-	if runOpts != nil && runOpts.Options != nil {
+	if runOpts.Options != nil {
 		if v, ok := runOpts.Options.(*ChatOptions); ok {
-			opts = v.Clone()
+			opts = *v.Clone()
 		}
 	}
 	// Merge in Agent-level ChatOptions
 	if a.Options.ChatOptions != nil {
-		if opts == nil {
-			opts = a.Options.ChatOptions.Clone()
-		} else {
-			opts.Copy(a.Options.ChatOptions)
-		}
+		opts.Copy(a.Options.ChatOptions)
 	}
 	// Merge in RunOptions specific fields
-	if runOpts != nil && (runOpts.AllowBackgroundResponses.Valid() || runOpts.ContinuationToken != nil) {
-		if opts == nil {
-			opts = &ChatOptions{}
-		}
-		opts.AllowBackgroundResponses = runOpts.AllowBackgroundResponses
-		opts.ContinuationToken = runOpts.ContinuationToken
-	}
+	opts.AllowBackgroundResponses = runOpts.AllowBackgroundResponses
+	opts.ContinuationToken = runOpts.ContinuationToken
+	opts.Streaming = runOpts.Streaming
+	opts.StructuredOutput = runOpts.StructuredOutput
 	return opts
 }
 

--- a/go/agent/chatagent/chatagent.go
+++ b/go/agent/chatagent/chatagent.go
@@ -277,7 +277,7 @@ func (a *Agent) createConfiguredChatOptions(runOpts *agent.RunOptions) ChatOptio
 	opts.AllowBackgroundResponses = runOpts.AllowBackgroundResponses
 	opts.ContinuationToken = runOpts.ContinuationToken
 	opts.Streaming = runOpts.Streaming
-	opts.StructuredOutput = runOpts.StructuredOutput
+	opts.ResponseFormat = runOpts.ResponseFormat
 	return opts
 }
 

--- a/go/agent/chatagent/chatclient/chatclient.go
+++ b/go/agent/chatagent/chatclient/chatclient.go
@@ -17,41 +17,14 @@ import (
 	"github.com/microsoft/agent-framework/go/tool"
 )
 
+type Capabilities struct {
+	Streaming        bool
+	StructuredOutput bool
+}
+
 type Client interface {
-	Response(context.Context, *ChatOptions, ...*message.Message) (*ChatResponse, error)
-	StreamingResponse(context.Context, *ChatOptions, ...*message.Message) iter.Seq2[*ChatResponseUpdate, error]
-}
-
-type StructuredResponseClient interface {
-	Client
-
-	StructuredResponse(any, context.Context, *ChatOptions, ...*message.Message) (*ChatResponse, error)
-}
-
-type ChatResponse struct {
-	AdditionalProperties map[string]any
-	ConversationID       string
-	FinishReason         string
-	ModelID              string
-	ID                   string
-	Role                 message.Role
-	CreatedAt            time.Time
-	RawRepresentation    any
-	Usage                *message.UsageDetails
-	Messages             []*message.Message
-}
-
-// String returns the concatenated text contents of the response messages.
-func (r *ChatResponse) String() string {
-	var sb strings.Builder
-	for _, msg := range r.Messages {
-		for _, c := range msg.Contents {
-			if textContent, ok := c.(*message.TextContent); ok {
-				sb.WriteString(textContent.Text)
-			}
-		}
-	}
-	return sb.String()
+	Capabilities() Capabilities
+	Response(context.Context, ChatOptions, ...*message.Message) iter.Seq2[*ChatResponseUpdate, error]
 }
 
 type ChatResponseUpdate struct {
@@ -80,6 +53,7 @@ func (r *ChatResponseUpdate) String() string {
 }
 
 type ChatOptions struct {
+	Streaming                param.Opt[bool]
 	AllowBackgroundResponses param.Opt[bool]
 
 	ContinuationToken any
@@ -111,6 +85,8 @@ type ChatOptions struct {
 
 	// MaxTokens limits the response length.
 	MaxTokens param.Opt[int]
+
+	StructuredOutput any
 
 	// AdditionalProperties for provider-specific options.
 	AdditionalProperties map[string]any
@@ -154,80 +130,42 @@ func (o *ChatOptions) Copy(other *ChatOptions) {
 	}
 }
 
-func NewChatResponseFromUpdates(updates []*ChatResponseUpdate) *ChatResponse {
-	r := &ChatResponse{}
+func NewMessageFromUpdates(updates []*ChatResponseUpdate) []*message.Message {
+	var msgs []*message.Message
 	for _, update := range updates {
-		processUpdate(r, update)
+		isNewMessage := true
+		if len(msgs) > 0 {
+			lastMsg := msgs[len(msgs)-1]
+			isNewMessage = notEmptyNorEqual(update.AuthorName, lastMsg.AuthorName) ||
+				notEmptyNorEqual(update.MessageID, lastMsg.ID) ||
+				notEmptyNorEqual(string(update.Role), string(lastMsg.Role))
+		}
+		// Get the message to target, either a new one or the last ones.
+		var msg *message.Message
+		if isNewMessage {
+			msg = &message.Message{
+				Role: message.RoleAssistant,
+			}
+			msgs = append(msgs, msg)
+		} else {
+			msg = msgs[len(msgs)-1]
+		}
+		// Some members on ChatResponseUpdate map to members of ChatMessage.
+		// Incorporate those into the latest message; in cases where the message
+		// stores a single value, prefer the latest update's value over anything
+		// stored in the message.
+		msg.AuthorName = cmp.Or(update.AuthorName, msg.AuthorName)
+		msg.Role = cmp.Or(update.Role, msg.Role)
+		msg.ID = cmp.Or(update.MessageID, msg.ID)
+		if msg.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(msg.CreatedAt)) {
+			msg.CreatedAt = update.CreatedAt
+		}
+		msg.Contents = append(msg.Contents, update.Contents...)
 	}
-	finalizeResponse(r)
-	return r
-}
-
-func finalizeResponse(r *ChatResponse) {
-	for _, msg := range r.Messages {
+	for _, msg := range msgs {
 		msg.Contents = message.CoalesceContents(msg.Contents)
 	}
-}
-
-// processUpdate updates the ChatResponse r with the information from the ChatResponseUpdate update.
-func processUpdate(r *ChatResponse, update *ChatResponseUpdate) {
-	// If there is no message created yet, or if the last update we saw had a different
-	// identifying parts, create a new message.
-	isNewMessage := true
-	if len(r.Messages) > 0 {
-		lastMsg := r.Messages[len(r.Messages)-1]
-		isNewMessage = notEmptyNorEqual(update.AuthorName, lastMsg.AuthorName) ||
-			notEmptyNorEqual(update.MessageID, lastMsg.ID) ||
-			notEmptyNorEqual(string(update.Role), string(lastMsg.Role))
-	}
-	// Get the message to target, either a new one or the last ones.
-	var msg *message.Message
-	if isNewMessage {
-		msg = &message.Message{
-			Role: message.RoleAssistant,
-		}
-		r.Messages = append(r.Messages, msg)
-	} else {
-		msg = r.Messages[len(r.Messages)-1]
-	}
-	// Some members on ChatResponseUpdate map to members of ChatMessage.
-	// Incorporate those into the latest message; in cases where the message
-	// stores a single value, prefer the latest update's value over anything
-	// stored in the message.
-	msg.AuthorName = cmp.Or(update.AuthorName, msg.AuthorName)
-	msg.Role = cmp.Or(update.Role, msg.Role)
-	msg.ID = cmp.Or(update.MessageID, msg.ID)
-	if msg.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(msg.CreatedAt)) {
-		msg.CreatedAt = update.CreatedAt
-	}
-	for _, content := range update.Contents {
-		switch c := content.(type) {
-		case *message.UsageContent:
-			// Usage content is treated specially and propagated to the response's Usage.
-			if r.Usage == nil {
-				r.Usage = new(message.UsageDetails)
-			}
-			r.Usage.Add(&c.Details)
-		default:
-			msg.Contents = append(msg.Contents, content)
-		}
-	}
-	// Other members on a ChatResponseUpdate map to members of the ChatResponse.
-	// Update the response object with those, preferring the values from later updates.
-	r.ID = cmp.Or(update.ResponseID, r.ID)
-	r.ConversationID = cmp.Or(update.ConversationID, r.ConversationID)
-	r.FinishReason = cmp.Or(update.FinishReason, r.FinishReason)
-	r.Role = cmp.Or(update.Role, r.Role)
-	r.ModelID = cmp.Or(update.ModelID, r.ModelID)
-	if r.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(r.CreatedAt)) {
-		r.CreatedAt = update.CreatedAt
-	}
-	if update.AdditionalProperties != nil {
-		if r.AdditionalProperties == nil {
-			r.AdditionalProperties = make(map[string]any)
-		}
-		maps.Copy(r.AdditionalProperties, update.AdditionalProperties)
-	}
+	return msgs
 }
 
 // notEmptyNorEqual returns true if both strings are not empty and not the same as each other.

--- a/go/agent/chatagent/chatclient/chatclient.go
+++ b/go/agent/chatagent/chatclient/chatclient.go
@@ -19,7 +19,7 @@ import (
 
 type Capabilities struct {
 	Streaming        bool
-	StructuredOutput bool
+	StructuredOutput format.Formatter // nil if structured output is not supported
 }
 
 type Client interface {
@@ -85,8 +85,6 @@ type ChatOptions struct {
 
 	// MaxTokens limits the response length.
 	MaxTokens param.Opt[int]
-
-	StructuredOutput any
 
 	// AdditionalProperties for provider-specific options.
 	AdditionalProperties map[string]any

--- a/go/agent/chatagent/chatclient/chatclient_test.go
+++ b/go/agent/chatagent/chatclient/chatclient_test.go
@@ -22,7 +22,7 @@ func messageText(msg *message.Message) string {
 	return sb.String()
 }
 
-func TestNewChatResponseFromUpdates_SuccessfullyCreatesResponse(t *testing.T) {
+func TestNewMessageFromUpdates_SuccessfullyCreatesResponse(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		{
 			Role:       message.RoleAssistant,
@@ -52,42 +52,36 @@ func TestNewChatResponseFromUpdates_SuccessfullyCreatesResponse(t *testing.T) {
 		},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if response == nil {
-		t.Fatal("expected non-nil response")
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	msg := msgs[0]
+
+	// Verify usage is aggregated in the message contents
+	var inputTokens, outputTokens int64
+	for _, c := range msg.Contents {
+		if uc, ok := c.(*message.UsageContent); ok {
+			inputTokens += uc.Details.InputTokenCount
+			outputTokens += uc.Details.OutputTokenCount
+		}
 	}
 
-	if response.Usage == nil {
-		t.Fatal("expected non-nil usage")
+	if inputTokens != 5 {
+		t.Errorf("expected input token count 5, got %d", inputTokens)
 	}
-	if response.Usage.InputTokenCount != 5 {
-		t.Errorf("expected input token count 5, got %d", response.Usage.InputTokenCount)
-	}
-	if response.Usage.OutputTokenCount != 7 {
-		t.Errorf("expected output token count 7, got %d", response.Usage.OutputTokenCount)
+	if outputTokens != 7 {
+		t.Errorf("expected output token count 7, got %d", outputTokens)
 	}
 
-	if response.ID != "someResponse" {
-		t.Errorf("expected response ID 'someResponse', got %q", response.ID)
-	}
-	expectedCreatedAt := time.Date(2, 2, 3, 4, 5, 6, 0, time.UTC)
-	if !response.CreatedAt.Equal(expectedCreatedAt) {
-		t.Errorf("expected created at %v, got %v", expectedCreatedAt, response.CreatedAt)
-	}
-	if response.ModelID != "model123" {
-		t.Errorf("expected model ID 'model123', got %q", response.ModelID)
-	}
-	if response.ConversationID != "123" {
-		t.Errorf("expected conversation ID '123', got %q", response.ConversationID)
-	}
-
-	if len(response.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(response.Messages))
-	}
-	msg := response.Messages[0]
 	if msg.ID != "12345" {
 		t.Errorf("expected message ID '12345', got %q", msg.ID)
 	}
+	expectedCreatedAt := time.Date(2, 2, 3, 4, 5, 6, 0, time.UTC)
+	if !msg.CreatedAt.Equal(expectedCreatedAt) {
+		t.Errorf("expected created at %v, got %v", expectedCreatedAt, msg.CreatedAt)
+	}
+
 	if msg.Role != message.RoleAssistant {
 		t.Errorf("expected role Assistant, got %v", msg.Role)
 	}
@@ -98,25 +92,12 @@ func TestNewChatResponseFromUpdates_SuccessfullyCreatesResponse(t *testing.T) {
 		t.Errorf("expected nil additional properties on message, got %v", msg.AdditionalProperties)
 	}
 
-	if response.AdditionalProperties == nil {
-		t.Fatal("expected non-nil additional properties on response")
-	}
-	if len(response.AdditionalProperties) != 2 {
-		t.Errorf("expected 2 additional properties, got %d", len(response.AdditionalProperties))
-	}
-	if response.AdditionalProperties["a"] != "b" {
-		t.Errorf("expected additional property 'a' = 'b', got %v", response.AdditionalProperties["a"])
-	}
-	if response.AdditionalProperties["c"] != "d" {
-		t.Errorf("expected additional property 'c' = 'd', got %v", response.AdditionalProperties["c"])
-	}
-
-	if response.String() != "Hello, world!" {
-		t.Errorf("expected text 'Hello, world!', got %q", response.String())
+	if msg.String() != "Hello, world!" {
+		t.Errorf("expected text 'Hello, world!', got %q", msg.String())
 	}
 }
 
-func TestNewChatResponseFromUpdates_RoleOrIdOrAuthorNameChangeDictatesMessageChange(t *testing.T) {
+func TestNewMessageFromUpdates_RoleOrIdOrAuthorNameChangeDictatesMessageChange(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		{Contents: []message.Content{&message.TextContent{Text: "!"}}, MessageID: "1"},
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "a"}}, MessageID: "1"},
@@ -132,46 +113,46 @@ func TestNewChatResponseFromUpdates_RoleOrIdOrAuthorNameChangeDictatesMessageCha
 		{Role: message.Role("other"), Contents: []message.Content{&message.TextContent{Text: "k"}}, MessageID: "6"},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
+	msgs := chatclient.NewMessageFromUpdates(updates)
 
 	// In Go, empty role defaults to Assistant, so going from empty->Assistant doesn't create a boundary
 	// This differs from .NET where null vs explicit Assistant are treated differently
 	// So we expect one fewer message than .NET (messages[0] and [1] are combined)
-	if len(response.Messages) != 8 {
+	if len(msgs) != 8 {
 		t.Logf("Messages:")
-		for i, msg := range response.Messages {
+		for i, msg := range msgs {
 			t.Logf("  [%d] Role=%v, ID=%q, Text=%q", i, msg.Role, msg.ID, messageText(msg))
 		}
-		t.Fatalf("expected 8 messages, got %d", len(response.Messages))
+		t.Fatalf("expected 8 messages, got %d", len(msgs))
 	}
 
-	if messageText(response.Messages[0]) != "!a" {
-		t.Errorf("message 0: expected '!a', got %q", messageText(response.Messages[0]))
+	if messageText(msgs[0]) != "!a" {
+		t.Errorf("message 0: expected '!a', got %q", messageText(msgs[0]))
 	}
-	if messageText(response.Messages[1]) != "b" {
-		t.Errorf("message 1: expected 'b', got %q", messageText(response.Messages[1]))
+	if messageText(msgs[1]) != "b" {
+		t.Errorf("message 1: expected 'b', got %q", messageText(msgs[1]))
 	}
-	if messageText(response.Messages[2]) != "cd" {
-		t.Errorf("message 2: expected 'cd', got %q", messageText(response.Messages[2]))
+	if messageText(msgs[2]) != "cd" {
+		t.Errorf("message 2: expected 'cd', got %q", messageText(msgs[2]))
 	}
-	if messageText(response.Messages[3]) != "e" {
-		t.Errorf("message 3: expected 'e', got %q", messageText(response.Messages[3]))
+	if messageText(msgs[3]) != "e" {
+		t.Errorf("message 3: expected 'e', got %q", messageText(msgs[3]))
 	}
-	if messageText(response.Messages[4]) != "fg" {
-		t.Errorf("message 4: expected 'fg', got %q", messageText(response.Messages[4]))
+	if messageText(msgs[4]) != "fg" {
+		t.Errorf("message 4: expected 'fg', got %q", messageText(msgs[4]))
 	}
-	if messageText(response.Messages[5]) != "h" {
-		t.Errorf("message 5: expected 'h', got %q", messageText(response.Messages[5]))
+	if messageText(msgs[5]) != "h" {
+		t.Errorf("message 5: expected 'h', got %q", messageText(msgs[5]))
 	}
-	if messageText(response.Messages[6]) != "ij" {
-		t.Errorf("message 6: expected 'ij', got %q", messageText(response.Messages[6]))
+	if messageText(msgs[6]) != "ij" {
+		t.Errorf("message 6: expected 'ij', got %q", messageText(msgs[6]))
 	}
-	if messageText(response.Messages[7]) != "k" {
-		t.Errorf("message 7: expected 'k', got %q", messageText(response.Messages[7]))
+	if messageText(msgs[7]) != "k" {
+		t.Errorf("message 7: expected 'k', got %q", messageText(msgs[7]))
 	}
 }
 
-func TestNewChatResponseFromUpdates_AuthorNameChangeDictatesMessageBoundary(t *testing.T) {
+func TestNewMessageFromUpdates_AuthorNameChangeDictatesMessageBoundary(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// First message with AuthorName "Alice"
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "Hello "}}, AuthorName: "Alice"},
@@ -191,53 +172,53 @@ func TestNewChatResponseFromUpdates_AuthorNameChangeDictatesMessageBoundary(t *t
 		{Contents: []message.Content{&message.TextContent{Text: " And more."}}},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 4 {
-		t.Fatalf("expected 4 messages, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "Hello from Alice!" {
-		t.Errorf("message 0: expected 'Hello from Alice!', got %q", response.Messages[0].String())
+	if msgs[0].String() != "Hello from Alice!" {
+		t.Errorf("message 0: expected 'Hello from Alice!', got %q", msgs[0].String())
 	}
-	if response.Messages[0].AuthorName != "Alice" {
-		t.Errorf("message 0: expected author 'Alice', got %q", response.Messages[0].AuthorName)
+	if msgs[0].AuthorName != "Alice" {
+		t.Errorf("message 0: expected author 'Alice', got %q", msgs[0].AuthorName)
 	}
-	if response.Messages[0].Role != message.RoleAssistant {
-		t.Errorf("message 0: expected role Assistant, got %v", response.Messages[0].Role)
-	}
-
-	if response.Messages[1].String() != "Hi from Bob!" {
-		t.Errorf("message 1: expected 'Hi from Bob!', got %q", response.Messages[1].String())
-	}
-	if response.Messages[1].AuthorName != "Bob" {
-		t.Errorf("message 1: expected author 'Bob', got %q", response.Messages[1].AuthorName)
-	}
-	if response.Messages[1].Role != message.RoleAssistant {
-		t.Errorf("message 1: expected role Assistant, got %v", response.Messages[1].Role)
+	if msgs[0].Role != message.RoleAssistant {
+		t.Errorf("message 0: expected role Assistant, got %v", msgs[0].Role)
 	}
 
-	if response.Messages[2].String() != "Greetings from Charlie!" {
-		t.Errorf("message 2: expected 'Greetings from Charlie!', got %q", response.Messages[2].String())
+	if msgs[1].String() != "Hi from Bob!" {
+		t.Errorf("message 1: expected 'Hi from Bob!', got %q", msgs[1].String())
 	}
-	if response.Messages[2].AuthorName != "Charlie" {
-		t.Errorf("message 2: expected author 'Charlie', got %q", response.Messages[2].AuthorName)
+	if msgs[1].AuthorName != "Bob" {
+		t.Errorf("message 1: expected author 'Bob', got %q", msgs[1].AuthorName)
 	}
-	if response.Messages[2].Role != message.RoleAssistant {
-		t.Errorf("message 2: expected role Assistant, got %v", response.Messages[2].Role)
+	if msgs[1].Role != message.RoleAssistant {
+		t.Errorf("message 1: expected role Assistant, got %v", msgs[1].Role)
 	}
 
-	if response.Messages[3].String() != "Back to Alice. Still Alice. And more." {
-		t.Errorf("message 3: expected 'Back to Alice. Still Alice. And more.', got %q", response.Messages[3].String())
+	if msgs[2].String() != "Greetings from Charlie!" {
+		t.Errorf("message 2: expected 'Greetings from Charlie!', got %q", msgs[2].String())
 	}
-	if response.Messages[3].AuthorName != "Alice" {
-		t.Errorf("message 3: expected author 'Alice', got %q", response.Messages[3].AuthorName)
+	if msgs[2].AuthorName != "Charlie" {
+		t.Errorf("message 2: expected author 'Charlie', got %q", msgs[2].AuthorName)
 	}
-	if response.Messages[3].Role != message.RoleAssistant {
-		t.Errorf("message 3: expected role Assistant, got %v", response.Messages[3].Role)
+	if msgs[2].Role != message.RoleAssistant {
+		t.Errorf("message 2: expected role Assistant, got %v", msgs[2].Role)
+	}
+
+	if msgs[3].String() != "Back to Alice. Still Alice. And more." {
+		t.Errorf("message 3: expected 'Back to Alice. Still Alice. And more.', got %q", msgs[3].String())
+	}
+	if msgs[3].AuthorName != "Alice" {
+		t.Errorf("message 3: expected author 'Alice', got %q", msgs[3].AuthorName)
+	}
+	if msgs[3].Role != message.RoleAssistant {
+		t.Errorf("message 3: expected role Assistant, got %v", msgs[3].Role)
 	}
 }
 
-func TestNewChatResponseFromUpdates_AuthorNameWithOtherBoundaries(t *testing.T) {
+func TestNewMessageFromUpdates_AuthorNameWithOtherBoundaries(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// Message 1: Role=Assistant, MessageId="1", AuthorName="Alice"
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "A"}}, MessageID: "1", AuthorName: "Alice"},
@@ -253,48 +234,48 @@ func TestNewChatResponseFromUpdates_AuthorNameWithOtherBoundaries(t *testing.T) 
 		{Role: message.RoleTool, Contents: []message.Content{&message.TextContent{Text: "G"}}, MessageID: "3", AuthorName: "Charlie"},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 5 {
-		t.Fatalf("expected 5 messages, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 5 {
+		t.Fatalf("expected 5 messages, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "AB" {
-		t.Errorf("message 0: expected 'AB', got %q", response.Messages[0].String())
+	if msgs[0].String() != "AB" {
+		t.Errorf("message 0: expected 'AB', got %q", msgs[0].String())
 	}
-	if response.Messages[0].AuthorName != "Alice" {
-		t.Errorf("message 0: expected author 'Alice', got %q", response.Messages[0].AuthorName)
-	}
-
-	if response.Messages[1].String() != "C" {
-		t.Errorf("message 1: expected 'C', got %q", response.Messages[1].String())
-	}
-	if response.Messages[1].AuthorName != "Bob" {
-		t.Errorf("message 1: expected author 'Bob', got %q", response.Messages[1].AuthorName)
+	if msgs[0].AuthorName != "Alice" {
+		t.Errorf("message 0: expected author 'Alice', got %q", msgs[0].AuthorName)
 	}
 
-	if response.Messages[2].String() != "DE" {
-		t.Errorf("message 2: expected 'DE', got %q", response.Messages[2].String())
+	if msgs[1].String() != "C" {
+		t.Errorf("message 1: expected 'C', got %q", msgs[1].String())
 	}
-	if response.Messages[2].AuthorName != "Bob" {
-		t.Errorf("message 2: expected author 'Bob', got %q", response.Messages[2].AuthorName)
-	}
-
-	if response.Messages[3].String() != "F" {
-		t.Errorf("message 3: expected 'F', got %q", response.Messages[3].String())
-	}
-	if response.Messages[3].AuthorName != "Bob" {
-		t.Errorf("message 3: expected author 'Bob', got %q", response.Messages[3].AuthorName)
+	if msgs[1].AuthorName != "Bob" {
+		t.Errorf("message 1: expected author 'Bob', got %q", msgs[1].AuthorName)
 	}
 
-	if response.Messages[4].String() != "G" {
-		t.Errorf("message 4: expected 'G', got %q", response.Messages[4].String())
+	if msgs[2].String() != "DE" {
+		t.Errorf("message 2: expected 'DE', got %q", msgs[2].String())
 	}
-	if response.Messages[4].AuthorName != "Charlie" {
-		t.Errorf("message 4: expected author 'Charlie', got %q", response.Messages[4].AuthorName)
+	if msgs[2].AuthorName != "Bob" {
+		t.Errorf("message 2: expected author 'Bob', got %q", msgs[2].AuthorName)
+	}
+
+	if msgs[3].String() != "F" {
+		t.Errorf("message 3: expected 'F', got %q", msgs[3].String())
+	}
+	if msgs[3].AuthorName != "Bob" {
+		t.Errorf("message 3: expected author 'Bob', got %q", msgs[3].AuthorName)
+	}
+
+	if msgs[4].String() != "G" {
+		t.Errorf("message 4: expected 'G', got %q", msgs[4].String())
+	}
+	if msgs[4].AuthorName != "Charlie" {
+		t.Errorf("message 4: expected author 'Charlie', got %q", msgs[4].AuthorName)
 	}
 }
 
-func TestNewChatResponseFromUpdates_EmptyOrNullAuthorNameDoesNotCreateBoundary(t *testing.T) {
+func TestNewMessageFromUpdates_EmptyOrNullAuthorNameDoesNotCreateBoundary(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// First message with AuthorName "Assistant"
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "Hello"}}, AuthorName: "Assistant"},
@@ -309,23 +290,23 @@ func TestNewChatResponseFromUpdates_EmptyOrNullAuthorNameDoesNotCreateBoundary(t
 		{Contents: []message.Content{&message.TextContent{Text: " you?"}}},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "Hello world! How are you?" {
-		t.Errorf("expected 'Hello world! How are you?', got %q", response.Messages[0].String())
+	if msgs[0].String() != "Hello world! How are you?" {
+		t.Errorf("expected 'Hello world! How are you?', got %q", msgs[0].String())
 	}
-	if response.Messages[0].AuthorName != "Assistant" {
-		t.Errorf("expected author 'Assistant', got %q", response.Messages[0].AuthorName)
+	if msgs[0].AuthorName != "Assistant" {
+		t.Errorf("expected author 'Assistant', got %q", msgs[0].AuthorName)
 	}
-	if response.Messages[0].Role != message.RoleAssistant {
-		t.Errorf("expected role Assistant, got %v", response.Messages[0].Role)
+	if msgs[0].Role != message.RoleAssistant {
+		t.Errorf("expected role Assistant, got %v", msgs[0].Role)
 	}
 }
 
-func TestNewChatResponseFromUpdates_AuthorNameNullToNonNullDoesNotCreateBoundary(t *testing.T) {
+func TestNewMessageFromUpdates_AuthorNameNullToNonNullDoesNotCreateBoundary(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// First message with no AuthorName
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "Hello"}}, MessageID: "1"},
@@ -337,33 +318,33 @@ func TestNewChatResponseFromUpdates_AuthorNameNullToNonNullDoesNotCreateBoundary
 		{Contents: []message.Content{&message.TextContent{Text: "Now Alice"}}, MessageID: "1", AuthorName: "Alice"},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "Hello there I'm Bob speaking" {
-		t.Errorf("message 0: expected 'Hello there I'm Bob speaking', got %q", response.Messages[0].String())
+	if msgs[0].String() != "Hello there I'm Bob speaking" {
+		t.Errorf("message 0: expected 'Hello there I'm Bob speaking', got %q", msgs[0].String())
 	}
-	if response.Messages[0].AuthorName != "Bob" {
-		t.Errorf("message 0: expected author 'Bob', got %q", response.Messages[0].AuthorName)
+	if msgs[0].AuthorName != "Bob" {
+		t.Errorf("message 0: expected author 'Bob', got %q", msgs[0].AuthorName)
 	}
-	if response.Messages[0].ID != "1" {
-		t.Errorf("message 0: expected ID '1', got %q", response.Messages[0].ID)
+	if msgs[0].ID != "1" {
+		t.Errorf("message 0: expected ID '1', got %q", msgs[0].ID)
 	}
 
-	if response.Messages[1].String() != "Now Alice" {
-		t.Errorf("message 1: expected 'Now Alice', got %q", response.Messages[1].String())
+	if msgs[1].String() != "Now Alice" {
+		t.Errorf("message 1: expected 'Now Alice', got %q", msgs[1].String())
 	}
-	if response.Messages[1].AuthorName != "Alice" {
-		t.Errorf("message 1: expected author 'Alice', got %q", response.Messages[1].AuthorName)
+	if msgs[1].AuthorName != "Alice" {
+		t.Errorf("message 1: expected author 'Alice', got %q", msgs[1].AuthorName)
 	}
-	if response.Messages[1].ID != "1" {
-		t.Errorf("message 1: expected ID '1', got %q", response.Messages[1].ID)
+	if msgs[1].ID != "1" {
+		t.Errorf("message 1: expected ID '1', got %q", msgs[1].ID)
 	}
 }
 
-func TestNewChatResponseFromUpdates_MessageIdNullToNonNullDoesNotCreateBoundary(t *testing.T) {
+func TestNewMessageFromUpdates_MessageIdNullToNonNullDoesNotCreateBoundary(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// First message with no MessageId
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "Hello"}}},
@@ -375,33 +356,33 @@ func TestNewChatResponseFromUpdates_MessageIdNullToNonNullDoesNotCreateBoundary(
 		{Contents: []message.Content{&message.TextContent{Text: "Next message"}}, MessageID: "msg2"},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "Hello there from AI" {
-		t.Errorf("message 0: expected 'Hello there from AI', got %q", response.Messages[0].String())
+	if msgs[0].String() != "Hello there from AI" {
+		t.Errorf("message 0: expected 'Hello there from AI', got %q", msgs[0].String())
 	}
-	if response.Messages[0].ID != "msg1" {
-		t.Errorf("message 0: expected ID 'msg1', got %q", response.Messages[0].ID)
+	if msgs[0].ID != "msg1" {
+		t.Errorf("message 0: expected ID 'msg1', got %q", msgs[0].ID)
 	}
-	if response.Messages[0].Role != message.RoleAssistant {
-		t.Errorf("message 0: expected role Assistant, got %v", response.Messages[0].Role)
+	if msgs[0].Role != message.RoleAssistant {
+		t.Errorf("message 0: expected role Assistant, got %v", msgs[0].Role)
 	}
 
-	if response.Messages[1].String() != "Next message" {
-		t.Errorf("message 1: expected 'Next message', got %q", response.Messages[1].String())
+	if msgs[1].String() != "Next message" {
+		t.Errorf("message 1: expected 'Next message', got %q", msgs[1].String())
 	}
-	if response.Messages[1].ID != "msg2" {
-		t.Errorf("message 1: expected ID 'msg2', got %q", response.Messages[1].ID)
+	if msgs[1].ID != "msg2" {
+		t.Errorf("message 1: expected ID 'msg2', got %q", msgs[1].ID)
 	}
-	if response.Messages[1].Role != message.RoleAssistant {
-		t.Errorf("message 1: expected role Assistant, got %v", response.Messages[1].Role)
+	if msgs[1].Role != message.RoleAssistant {
+		t.Errorf("message 1: expected role Assistant, got %v", msgs[1].Role)
 	}
 }
 
-func TestNewChatResponseFromUpdates_EmptyMessageIdDoesNotCreateBoundary(t *testing.T) {
+func TestNewMessageFromUpdates_EmptyMessageIdDoesNotCreateBoundary(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// First message with MessageId
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "Hello"}}, MessageID: "msg1"},
@@ -415,23 +396,23 @@ func TestNewChatResponseFromUpdates_EmptyMessageIdDoesNotCreateBoundary(t *testi
 		{Contents: []message.Content{&message.TextContent{Text: " you?"}}},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "Hello world! How are you?" {
-		t.Errorf("expected 'Hello world! How are you?', got %q", response.Messages[0].String())
+	if msgs[0].String() != "Hello world! How are you?" {
+		t.Errorf("expected 'Hello world! How are you?', got %q", msgs[0].String())
 	}
-	if response.Messages[0].ID != "msg1" {
-		t.Errorf("expected ID 'msg1', got %q", response.Messages[0].ID)
+	if msgs[0].ID != "msg1" {
+		t.Errorf("expected ID 'msg1', got %q", msgs[0].ID)
 	}
-	if response.Messages[0].Role != message.RoleAssistant {
-		t.Errorf("expected role Assistant, got %v", response.Messages[0].Role)
+	if msgs[0].Role != message.RoleAssistant {
+		t.Errorf("expected role Assistant, got %v", msgs[0].Role)
 	}
 }
 
-func TestNewChatResponseFromUpdates_RoleNullToNonNullDoesNotCreateBoundary(t *testing.T) {
+func TestNewMessageFromUpdates_RoleNullToNonNullDoesNotCreateBoundary(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// First message with no explicit Role (will default to Assistant)
 		{Contents: []message.Content{&message.TextContent{Text: "Hello"}}, MessageID: "1"},
@@ -443,33 +424,33 @@ func TestNewChatResponseFromUpdates_RoleNullToNonNullDoesNotCreateBoundary(t *te
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "User message"}}, MessageID: "1"},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "Hello there from AI" {
-		t.Errorf("message 0: expected 'Hello there from AI', got %q", response.Messages[0].String())
+	if msgs[0].String() != "Hello there from AI" {
+		t.Errorf("message 0: expected 'Hello there from AI', got %q", msgs[0].String())
 	}
-	if response.Messages[0].Role != message.RoleAssistant {
-		t.Errorf("message 0: expected role Assistant, got %v", response.Messages[0].Role)
+	if msgs[0].Role != message.RoleAssistant {
+		t.Errorf("message 0: expected role Assistant, got %v", msgs[0].Role)
 	}
-	if response.Messages[0].ID != "1" {
-		t.Errorf("message 0: expected ID '1', got %q", response.Messages[0].ID)
+	if msgs[0].ID != "1" {
+		t.Errorf("message 0: expected ID '1', got %q", msgs[0].ID)
 	}
 
-	if response.Messages[1].String() != "User message" {
-		t.Errorf("message 1: expected 'User message', got %q", response.Messages[1].String())
+	if msgs[1].String() != "User message" {
+		t.Errorf("message 1: expected 'User message', got %q", msgs[1].String())
 	}
-	if response.Messages[1].Role != message.RoleUser {
-		t.Errorf("message 1: expected role User, got %v", response.Messages[1].Role)
+	if msgs[1].Role != message.RoleUser {
+		t.Errorf("message 1: expected role User, got %v", msgs[1].Role)
 	}
-	if response.Messages[1].ID != "1" {
-		t.Errorf("message 1: expected ID '1', got %q", response.Messages[1].ID)
+	if msgs[1].ID != "1" {
+		t.Errorf("message 1: expected ID '1', got %q", msgs[1].ID)
 	}
 }
 
-func TestNewChatResponseFromUpdates_CustomRolesCreateBoundaries(t *testing.T) {
+func TestNewMessageFromUpdates_CustomRolesCreateBoundaries(t *testing.T) {
 	updates := []*chatclient.ChatResponseUpdate{
 		// First message with custom role "agent1"
 		{Role: message.Role("agent1"), Contents: []message.Content{&message.TextContent{Text: "Hello"}}, MessageID: "1"},
@@ -483,29 +464,29 @@ func TestNewChatResponseFromUpdates_CustomRolesCreateBoundaries(t *testing.T) {
 		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "Assistant here"}}, MessageID: "1"},
 	}
 
-	response := chatclient.NewChatResponseFromUpdates(updates)
-	if len(response.Messages) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(response.Messages))
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
 	}
 
-	if response.Messages[0].String() != "Hello from agent1" {
-		t.Errorf("message 0: expected 'Hello from agent1', got %q", response.Messages[0].String())
+	if msgs[0].String() != "Hello from agent1" {
+		t.Errorf("message 0: expected 'Hello from agent1', got %q", msgs[0].String())
 	}
-	if response.Messages[0].Role != message.Role("agent1") {
-		t.Errorf("message 0: expected role 'agent1', got %v", response.Messages[0].Role)
-	}
-
-	if response.Messages[1].String() != "Hi from agent2" {
-		t.Errorf("message 1: expected 'Hi from agent2', got %q", response.Messages[1].String())
-	}
-	if response.Messages[1].Role != message.Role("agent2") {
-		t.Errorf("message 1: expected role 'agent2', got %v", response.Messages[1].Role)
+	if msgs[0].Role != message.Role("agent1") {
+		t.Errorf("message 0: expected role 'agent1', got %v", msgs[0].Role)
 	}
 
-	if response.Messages[2].String() != "Assistant here" {
-		t.Errorf("message 2: expected 'Assistant here', got %q", response.Messages[2].String())
+	if msgs[1].String() != "Hi from agent2" {
+		t.Errorf("message 1: expected 'Hi from agent2', got %q", msgs[1].String())
 	}
-	if response.Messages[2].Role != message.RoleAssistant {
-		t.Errorf("message 2: expected role Assistant, got %v", response.Messages[2].Role)
+	if msgs[1].Role != message.Role("agent2") {
+		t.Errorf("message 1: expected role 'agent2', got %v", msgs[1].Role)
+	}
+
+	if msgs[2].String() != "Assistant here" {
+		t.Errorf("message 2: expected 'Assistant here', got %q", msgs[2].String())
+	}
+	if msgs[2].Role != message.RoleAssistant {
+		t.Errorf("message 2: expected role Assistant, got %v", msgs[2].Role)
 	}
 }

--- a/go/agent/chatagent/chatclient/funcinvoke.go
+++ b/go/agent/chatagent/chatclient/funcinvoke.go
@@ -154,7 +154,7 @@ func (f *functionInvoking) Response(ctx context.Context, opts ChatOptions, messa
 						if totalUsage == nil {
 							totalUsage = new(message.UsageDetails)
 						}
-						totalUsage.Add(&c.Details)
+						totalUsage.Add(c.Details)
 					}
 				}
 				// We're streaming updates back to the caller. However, approvals requires extra handling. We should not yield any

--- a/go/agent/chatagent/chatclient/funcinvoke.go
+++ b/go/agent/chatagent/chatclient/funcinvoke.go
@@ -20,7 +20,6 @@ import (
 )
 
 var _ Client = (*functionInvoking)(nil)
-var _ StructuredResponseClient = (*functionInvoking)(nil)
 
 type FunctionInvokingOptions struct {
 	Logger                             *slog.Logger
@@ -60,128 +59,16 @@ func NewFunctionInvoking(client Client, options *FunctionInvokingOptions) Client
 	}
 }
 
-func (f *functionInvoking) StructuredResponse(v any, ctx context.Context, opts *ChatOptions, messages ...*message.Message) (*ChatResponse, error) {
-	if c, ok := f.Client.(StructuredResponseClient); ok {
-		return c.StructuredResponse(v, ctx, opts, messages...)
-	}
-	return nil, fmt.Errorf("inner client %T does not support structured responses", f.Client)
+func (f *functionInvoking) Capabilities() Capabilities {
+	return f.Client.Capabilities()
 }
 
-func (f *functionInvoking) Response(ctx context.Context, opts *ChatOptions, messages ...*message.Message) (*ChatResponse, error) {
-	originalMessages := messages
-	tools, requiresApproval := f.createToolsMap(opts)
-	var responseMsgs []*message.Message
-	var errCount int
-	var totalUsage *message.UsageDetails
-	if hasAnyApprovalContent(originalMessages) {
-		// A previous turn may have translated FunctionCallContents from the inner client into approval requests sent back to the caller,
-		// for any function that were actually ApprovalRequiredFunctions. If the incoming chat messages include responses to those
-		// approval requests, we need to process them now. This entails removing these manufactured approval requests from the chat message
-		// list and replacing them with the appropriate FunctionCallContents and FunctionResultContents that would have been generated if
-		// the inner client had returned them directly.
-		var notInvokedMsgs []approvalResultWithRequestMessage
-		var err error
-		originalMessages = slices.Clone(originalMessages) // Clone to avoid modifying caller's slice
-		originalMessages, responseMsgs, notInvokedMsgs, err = processFunctionApprovalResponses(originalMessages, opts != nil && opts.ConversationID != "", "", "")
-		if err != nil {
-			return nil, err
-		}
-		var newMsg *message.Message
-		newMsg, errCount, err = f.invokeApprovedFunctionApprovalResponses(ctx, notInvokedMsgs, tools, 0)
-		if err != nil {
-			return nil, err
-		}
-		if newMsg != nil {
-			originalMessages = append(originalMessages, newMsg)
-			// Add any generated FRCs to the list we'll return to callers as part of the next response.
-			responseMsgs = append(responseMsgs, newMsg)
-		}
-	}
-	// At this point, we've fully handled all approval responses that were part of the original messages,
-	// and we can now enter the main function calling loop.
-	var functionCallContents []*message.FunctionCallContent
-	var lastIterHadConvID bool
-	var augmentedHistory []*message.Message
-	var resp *ChatResponse
-	for i := 0; ; i++ {
-		functionCallContents = functionCallContents[:0] // Reset slice without reallocating.
-		// Make the call to the inner client.
-		var err error
-		resp, err = f.Client.Response(ctx, opts, messages...)
-		if err != nil {
-			return nil, err
-		}
-		if resp == nil {
-			return nil, fmt.Errorf("inner client %T returned nil response", f.Client)
-		}
-		// Before we do any function execution, make sure that any functions that require approval have been turned into
-		// approval requests so that they don't get executed here.
-		if requiresApproval {
-			if tools == nil {
-				panic("requiresApproval can only be true if there are tools")
-			}
-			resp.Messages = replaceFunctionCallsWithApprovalRequests(resp.Messages, tools)
-		}
-		responseMsgs = append(responseMsgs, resp.Messages...)
-		requiresFunctionInvocation := i < f.maximumIterationsPerRequest()
-		if requiresFunctionInvocation {
-			// Accumulate function call contents from the response messages.
-			for _, msg := range resp.Messages {
-				for _, c := range msg.Contents {
-					if fcc, ok := c.(*message.FunctionCallContent); ok {
-						functionCallContents = append(functionCallContents, fcc)
-					}
-				}
-			}
-			requiresFunctionInvocation = len(functionCallContents) > 0
-		}
-		if !requiresFunctionInvocation && i == 0 {
-			// In a common case where we make an initial request and there's no function calling work required,
-			// fast path out by just returning the original response. We may already have some messages
-			// in responseMessages from processing function approval responses, and we need to ensure
-			// those are included in the final response, too.
-			resp.Messages = responseMsgs
-			return resp, nil
-		}
-		// Track aggregate details from the response, including all of the response messages and usage details.
-		if resp.Usage != nil {
-			if totalUsage == nil {
-				totalUsage = new(message.UsageDetails)
-			}
-			totalUsage.Add(resp.Usage)
-		}
-		// If there's nothing more to do, break out of the loop and allow the handling at the
-		// end to configure the response with aggregated data from previous requests.
-		if !requiresFunctionInvocation || f.shouldTerminateLoopBasedOnHandleableFunctions(functionCallContents, tools) {
-			break
-		}
-		// Prepare the history for the next iteration.
-		augmentedHistory = fixupHistories(originalMessages, augmentedHistory, resp, responseMsgs, &lastIterHadConvID)
-
-		// Add the responses from the function calls into the augmented history and also into the tracked
-		// list of response messages.
-		var newMsg *message.Message
-		newMsg, errCount, err = f.processFunctionCalls(ctx, tools, functionCallContents, errCount)
-		if err != nil {
-			return nil, err
-		}
-		augmentedHistory = append(augmentedHistory, newMsg)
-		responseMsgs = append(responseMsgs, newMsg)
-		updateOptionsForNextIteration(&opts, resp.ConversationID)
-		// Use the augmented history as the new set of messages to send.
-		messages = augmentedHistory
-	}
-	resp.Messages = responseMsgs
-	resp.Usage = totalUsage
-	return resp, nil
-}
-
-func (f *functionInvoking) StreamingResponse(ctx context.Context, opts *ChatOptions, messages ...*message.Message) iter.Seq2[*ChatResponseUpdate, error] {
+func (f *functionInvoking) Response(ctx context.Context, opts ChatOptions, messages ...*message.Message) iter.Seq2[*ChatResponseUpdate, error] {
 	// A single request into this StreamingResponse may result in multiple requests to the inner client.
 	// Create an activity to group them together for better observability.
 	originalMessages := messages
 
-	tools, requiresApproval := f.createToolsMap(opts)
+	tools, requiresApproval := f.createToolsMap(&opts)
 
 	// This is a synthetic ID since we're generating the tool messages instead of getting them from
 	// the underlying provider. When emitting the streamed chunks, it's perfectly valid for us to
@@ -189,16 +76,13 @@ func (f *functionInvoking) StreamingResponse(ctx context.Context, opts *ChatOpti
 	// message with multiple content items. We could also use different message IDs per tool content,
 	// but there's no benefit to doing so.
 	toolMsgID := uuid.NewString()
-	var convID string
-	if opts != nil {
-		convID = opts.ConversationID
-	}
 	var errCount int
 	return func(yield func(*ChatResponseUpdate, error) bool) {
 		if hasAnyApprovalContent(originalMessages) {
 			// We also need a synthetic ID for the function call content for approved function calls
 			// where we don't know what the original message id of the function call was.
 			funcCallFallbackMsgID := uuid.NewString()
+			convID := opts.ConversationID
 
 			// A previous turn may have translated FunctionCallContents from the inner client into approval requests sent back to the caller,
 			// for any functions that were actually ApprovalRequiredFunctions. If the incoming chat messages include responses to those
@@ -208,6 +92,7 @@ func (f *functionInvoking) StreamingResponse(ctx context.Context, opts *ChatOpti
 			var notInvokedMsgs []approvalResultWithRequestMessage
 			var preDownstreamCallHistory []*message.Message
 			var err error
+			originalMessages = slices.Clone(originalMessages) // Clone to avoid modifying caller's slice
 			originalMessages, preDownstreamCallHistory, notInvokedMsgs, err = processFunctionApprovalResponses(originalMessages, convID != "", toolMsgID, funcCallFallbackMsgID)
 			if err != nil {
 				yield(nil, err)
@@ -247,7 +132,7 @@ func (f *functionInvoking) StreamingResponse(ctx context.Context, opts *ChatOpti
 			functionCallContents = functionCallContents[:0]
 			var hasApprovalRequiringFcc bool
 			var lastApprovalCheckedFCCIdx, lastYieldedUpdateIdx int
-			for update, err := range f.Client.StreamingResponse(ctx, opts, messages...) {
+			for update, err := range f.Client.Response(ctx, opts, messages...) {
 				if err != nil {
 					yield(nil, err)
 					return
@@ -282,11 +167,9 @@ func (f *functionInvoking) StreamingResponse(ctx context.Context, opts *ChatOpti
 				// or the first time we get an FCC that requires approval. At that point, we can yield all of the updates buffered thus far
 				// and anything further, replacing FCCs with approval if any required it, or yielding them as is.
 				if requiresApproval && approvalRequiredFunctions == nil && len(functionCallContents) > 0 {
-					if opts != nil {
-						for _, tl := range opts.Tools {
-							if tl, ok := tl.(tool.ApprovalRequiredTool); ok {
-								approvalRequiredFunctions = append(approvalRequiredFunctions, tl)
-							}
+					for _, tl := range opts.Tools {
+						if tl, ok := tl.(tool.ApprovalRequiredTool); ok {
+							approvalRequiredFunctions = append(approvalRequiredFunctions, tl)
 						}
 					}
 					for _, tl := range f.AdditionalTools {
@@ -342,10 +225,14 @@ func (f *functionInvoking) StreamingResponse(ctx context.Context, opts *ChatOpti
 			// We need to invoke functions.
 
 			// Reconstitute a response from the response updates.
-			resp := NewChatResponseFromUpdates(updates)
-			responseMsgs = append(responseMsgs, resp.Messages...)
+			convID := ""
+			if len(updates) > 0 {
+				convID = updates[len(updates)-1].ConversationID
+			}
+			currentMsgs := NewMessageFromUpdates(updates)
+			responseMsgs = append(responseMsgs, currentMsgs...)
 			// Prepare the history for the next iteration.
-			augmentedHistory = fixupHistories(originalMessages, augmentedHistory, resp, responseMsgs, &lastIterHadConvID)
+			augmentedHistory = fixupHistories(originalMessages, augmentedHistory, convID, currentMsgs, responseMsgs, &lastIterHadConvID)
 
 			// Process all of the functions, adding their results into the history.
 			var newMsg *message.Message
@@ -363,7 +250,7 @@ func (f *functionInvoking) StreamingResponse(ctx context.Context, opts *ChatOpti
 			if !yield(convertToolResultMsgToUpdate(newMsg, convID, toolMsgID), nil) {
 				return
 			}
-			updateOptionsForNextIteration(&opts, resp.ConversationID)
+			updateOptionsForNextIteration(&opts, convID)
 			// Use the augmented history as the new set of messages to send.
 			messages = augmentedHistory
 		}
@@ -421,43 +308,29 @@ func convertToolResultMsgToUpdate(msg *message.Message, convID, msgID string) *C
 	}
 }
 
-func updateOptionsForNextIteration(popts **ChatOptions, convID string) {
-	opts := *popts
-	if opts == nil {
-		if convID != "" {
-			*popts = &ChatOptions{ConversationID: convID}
-		}
-	} else if opts.ToolMode == tool.ToolModeRequired {
+func updateOptionsForNextIteration(opts *ChatOptions, convID string) {
+	if opts.ToolMode == tool.ToolModeRequired {
 		// We have to reset the tool mode to be non-required after the first iteration,
 		// as otherwise we'll be in an infinite loop.
-		*popts = opts.Clone()
-		opts = *popts
 		opts.ToolMode = tool.ToolModeAuto
-		opts.ConversationID = convID
 	} else if opts.ConversationID != convID {
 		// As with the other modes, ensure we've propagated the chat conversation ID to the options.
 		// We only need to clone the options if we're actually mutating it.
-		*popts = opts.Clone()
-		opts = *popts
 		opts.ConversationID = convID
-	} else if opts.ContinuationToken != nil {
-		// Clone options before resetting the continuation token below.
-		*popts = opts.Clone()
-		opts = *popts
 	}
 	// Reset the continuation token of a background response operation
 	// to signal the inner client to handle function call result rather
 	// than getting the result of the operation.
-	if opts != nil && opts.ContinuationToken != nil {
+	if opts.ContinuationToken != nil {
 		opts.ContinuationToken = nil
 	}
 }
 
 // fixupHistories prepares the various chat message lists after a response from the inner client and before invoking functions.
-func fixupHistories(originalMsgs []*message.Message, augmentedHistory []*message.Message, resp *ChatResponse, allTurnsResponseMsgs []*message.Message, lastIterHadConvID *bool) []*message.Message {
+func fixupHistories(originalMsgs []*message.Message, augmentedHistory []*message.Message, convID string, responseMsgs []*message.Message, allTurnsResponseMsgs []*message.Message, lastIterHadConvID *bool) []*message.Message {
 	// We're now going to need to augment the history with function result contents.
 	// That means we need a separate list to store the augmented history.
-	if resp.ConversationID != "" {
+	if convID != "" {
 		// The response indicates the inner client is tracking the history, so we don't want to send
 		// anything we've already sent or received.
 		augmentedHistory = augmentedHistory[:0]
@@ -478,7 +351,7 @@ func fixupHistories(originalMsgs []*message.Message, augmentedHistory []*message
 			augmentedHistory = slices.Clone(originalMsgs)
 		}
 		// Now add the most recent response messages.
-		augmentedHistory = append(augmentedHistory, resp.Messages...)
+		augmentedHistory = append(augmentedHistory, responseMsgs...)
 		*lastIterHadConvID = false
 	}
 	return augmentedHistory
@@ -541,10 +414,8 @@ func (f *functionInvoking) createToolsMap(opts *ChatOptions) (mtools map[string]
 	for _, t := range f.AdditionalTools {
 		fn(t)
 	}
-	if opts != nil {
-		for _, t := range opts.Tools {
-			fn(t)
-		}
+	for _, t := range opts.Tools {
+		fn(t)
 	}
 	return mtools, anyRequiredApproval
 }

--- a/go/agent/chatagent/chatclient/funcinvoke_approval_test.go
+++ b/go/agent/chatagent/chatclient/funcinvoke_approval_test.go
@@ -23,35 +23,33 @@ type approvalTestClient struct {
 	streamingCallback func(messages []*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error]
 }
 
-func (c *approvalTestClient) Response(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-	if c.currentRound >= len(c.responses) {
-		return nil, fmt.Errorf("unexpected call to Response, round %d, expected %d rounds", c.currentRound, len(c.responses))
-	}
-
-	response := c.responses[c.currentRound]
-	c.currentRound++
-
-	return &chatclient.ChatResponse{Messages: response}, nil
+func (c *approvalTestClient) Capabilities() chatclient.Capabilities {
+	return chatclient.Capabilities{}
 }
 
-func (c *approvalTestClient) StreamingResponse(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+func (c *approvalTestClient) Response(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
 	if c.streamingCallback != nil {
 		return c.streamingCallback(messages)
 	}
 
-	// Default streaming implementation: convert Response to streaming
-	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
-		resp, err := c.Response(ctx, opts, messages...)
-		if err != nil {
-			yield(nil, err)
-			return
+	if c.currentRound >= len(c.responses) {
+		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+			yield(nil, fmt.Errorf("unexpected call to Response, round %d, expected %d rounds", c.currentRound, len(c.responses)))
 		}
+	}
 
-		for _, msg := range resp.Messages {
+	responseMessages := c.responses[c.currentRound]
+	c.currentRound++
+
+	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+		for _, msg := range responseMessages {
 			for _, content := range msg.Contents {
 				update := &chatclient.ChatResponseUpdate{
-					Role:     msg.Role,
-					Contents: []message.Content{content},
+					Role:           msg.Role,
+					Contents:       []message.Content{content},
+					AuthorName:     msg.AuthorName,
+					MessageID:      msg.ID,
+					ConversationID: opts.ConversationID,
 				}
 				if !yield(update, nil) {
 					return
@@ -61,8 +59,8 @@ func (c *approvalTestClient) StreamingResponse(ctx context.Context, opts *chatcl
 	}
 }
 
-// invokeAndAssertApproval is the main helper for non-streaming approval tests
-func invokeAndAssertApproval(t *testing.T, options *chatclient.ChatOptions, input []*message.Message,
+// invokeAndAssertApproval is the helper for approval tests
+func invokeAndAssertApproval(t *testing.T, options chatclient.ChatOptions, input []*message.Message,
 	downstreamClientOutput []*message.Message, expectedOutput []*message.Message,
 	expectedDownstreamClientInput []*message.Message, additionalTools []tool.Tool) {
 
@@ -77,46 +75,9 @@ func invokeAndAssertApproval(t *testing.T, options *chatclient.ChatOptions, inpu
 	invokeAndAssertApprovalWithClient(t, client, options, input, expectedOutput, additionalTools)
 }
 
-// invokeAndAssertApprovalWithClient performs the actual test execution
+// invokeAndAssertApprovalWithClient performs streaming test execution
 func invokeAndAssertApprovalWithClient(t *testing.T, innerClient chatclient.Client,
-	options *chatclient.ChatOptions, input []*message.Message,
-	expectedOutput []*message.Message, additionalTools []tool.Tool) {
-
-	functionInvokingOptions := &chatclient.FunctionInvokingOptions{}
-	if additionalTools != nil {
-		functionInvokingOptions.AdditionalTools = additionalTools
-	}
-
-	client := chatclient.NewFunctionInvoking(innerClient, functionInvokingOptions)
-	ctx := context.Background()
-
-	response, err := client.Response(ctx, options, input...)
-	if err != nil {
-		t.Fatalf("Response failed: %v", err)
-	}
-
-	assertMessageListsEqual(t, expectedOutput, response.Messages)
-}
-
-// invokeAndAssertStreamingApproval is the helper for streaming approval tests
-func invokeAndAssertStreamingApproval(t *testing.T, options *chatclient.ChatOptions, input []*message.Message,
-	downstreamClientOutput []*message.Message, expectedOutput []*message.Message,
-	expectedDownstreamClientInput []*message.Message, additionalTools []tool.Tool) {
-
-	client := &approvalTestClient{
-		responses: [][]*message.Message{downstreamClientOutput},
-	}
-
-	if expectedDownstreamClientInput != nil {
-		client.expectedInputs = [][]*message.Message{expectedDownstreamClientInput}
-	}
-
-	invokeAndAssertStreamingApprovalWithClient(t, client, options, input, expectedOutput, additionalTools)
-}
-
-// invokeAndAssertStreamingApprovalWithClient performs streaming test execution
-func invokeAndAssertStreamingApprovalWithClient(t *testing.T, innerClient chatclient.Client,
-	options *chatclient.ChatOptions, input []*message.Message,
+	options chatclient.ChatOptions, input []*message.Message,
 	expectedOutput []*message.Message, additionalTools []tool.Tool) {
 
 	functionInvokingOptions := &chatclient.FunctionInvokingOptions{}
@@ -130,44 +91,18 @@ func invokeAndAssertStreamingApprovalWithClient(t *testing.T, innerClient chatcl
 	// Collect all streaming updates into messages
 
 	var updates []*chatclient.ChatResponseUpdate
-	for update, err := range client.StreamingResponse(ctx, options, input...) {
+	for update, err := range client.Response(ctx, options, input...) {
 		if err != nil {
 			t.Fatalf("StreamingResponse failed: %v", err)
 		}
 		updates = append(updates, update)
 	}
-	resp := chatclient.NewChatResponseFromUpdates(updates)
-	assertMessageListsEqual(t, expectedOutput, resp.Messages)
+	msgs := chatclient.NewMessageFromUpdates(updates)
+	assertMessageListsEqual(t, expectedOutput, msgs)
 }
 
-// expectApprovalError expects an error to be thrown during invocation
-func expectApprovalError(t *testing.T, options *chatclient.ChatOptions, input []*message.Message,
-	downstreamClientOutput []*message.Message, expectedErrorMsg string, additionalTools []tool.Tool) {
-
-	client := &approvalTestClient{
-		responses: [][]*message.Message{downstreamClientOutput},
-	}
-
-	functionInvokingOptions := &chatclient.FunctionInvokingOptions{}
-	if additionalTools != nil {
-		functionInvokingOptions.AdditionalTools = additionalTools
-	}
-
-	fiClient := chatclient.NewFunctionInvoking(client, functionInvokingOptions)
-	ctx := context.Background()
-
-	_, err := fiClient.Response(ctx, options, input...)
-	if err == nil {
-		t.Fatalf("Expected error with message %q, but got nil", expectedErrorMsg)
-	}
-
-	if err.Error() != expectedErrorMsg {
-		t.Fatalf("Expected error message %q, got %q", expectedErrorMsg, err.Error())
-	}
-}
-
-// expectStreamingApprovalError expects an error during streaming invocation
-func expectStreamingApprovalError(t *testing.T, options *chatclient.ChatOptions, input []*message.Message,
+// expectApprovalError expects an error during streaming invocation
+func expectApprovalError(t *testing.T, options chatclient.ChatOptions, input []*message.Message,
 	downstreamClientOutput []*message.Message, expectedErrorMsg string, additionalTools []tool.Tool) {
 
 	client := &approvalTestClient{
@@ -183,7 +118,7 @@ func expectStreamingApprovalError(t *testing.T, options *chatclient.ChatOptions,
 	ctx := context.Background()
 
 	var lastErr error
-	for _, err := range fiClient.StreamingResponse(ctx, options, input...) {
+	for _, err := range fiClient.Response(ctx, options, input...) {
 		if err != nil {
 			lastErr = err
 			break
@@ -217,7 +152,7 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAllRequireApp
 				tool.ApprovalRequiredFunc(createFunc2()),
 			}
 
-			options := &chatclient.ChatOptions{Tools: tools}
+			options := chatclient.ChatOptions{Tools: tools}
 			if tt.useAdditionalTools {
 				options.Tools = nil
 			}
@@ -246,7 +181,6 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAllRequireApp
 			}
 
 			invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, additionalTools)
-			invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, additionalTools)
 		})
 	}
 }
@@ -254,7 +188,7 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAllRequireApp
 // TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequireApproval tests that
 // all function calls are replaced with approval requests when any function requires approval
 func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequireApproval(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -280,7 +214,6 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequireApp
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, nil)
 }
 
 // TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequestOrAdditionalRequireApproval tests that
@@ -312,7 +245,7 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequestOrA
 				additionalTools = []tool.Tool{func1}
 			}
 
-			options := &chatclient.ChatOptions{
+			options := chatclient.ChatOptions{
 				Tools: chatOptionsTools,
 			}
 
@@ -335,14 +268,13 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequestOrA
 			}
 
 			invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, additionalTools)
-			invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, additionalTools)
 		})
 	}
 }
 
 // TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted tests that approved approval responses are executed
 func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -398,13 +330,12 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExecuted tests that approved approval responses
 // from separate assistant messages (each with their own MessageId) are properly aggregated and executed
 func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExecuted(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -464,12 +395,11 @@ func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExe
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_RejectedApprovalResponsesAreFailed tests that rejected approval responses fail with error messages
 func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -521,13 +451,12 @@ func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAndFailed tests that
 // mixed approved and rejected approval responses are handled correctly
 func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAndFailed(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -566,25 +495,7 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 		}},
 	}
 
-	// Non-streaming output: separate Tool messages for each function result
-	expectedOutputNonStreaming := []*message.Message{
-		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
-		}},
-		{Role: message.RoleTool, Contents: []message.Content{
-			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
-		}},
-		{Role: message.RoleTool, Contents: []message.Content{
-			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
-		}},
-		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.TextContent{Text: "world"},
-		}},
-	}
-
-	// Streaming output: combined Tool message with both function results
-	expectedOutputStreaming := []*message.Message{
+	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
 			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
@@ -598,14 +509,13 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 		}},
 	}
 
-	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutputNonStreaming, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutputStreaming, expectedDownstreamClientInput, nil)
+	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverted tests that
 // approved inputs are executed and function results are converted back to approval requests
 func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverted(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			createFunc1(),
 			tool.ApprovalRequiredFunc(createFunc2()),
@@ -659,13 +569,12 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_AlreadyExecutedApprovalsAreIgnored tests that already executed approvals
 // (ones that have both FunctionCallContent and FunctionResultContent in history) are ignored
 func TestFunctionInvoking_AlreadyExecutedApprovalsAreIgnored(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			createFunc1(),
 			tool.ApprovalRequiredFunc(createFunc2()),
@@ -744,14 +653,13 @@ func TestFunctionInvoking_AlreadyExecutedApprovalsAreIgnored(t *testing.T) {
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_MixedApprovalRequiredToolsWithNonApprovalRequiringFunctionCall tests that
 // when only some tools require approval, non-approval-requiring function calls are executed immediately
 // and don't trigger approval requests for all calls
 func TestFunctionInvoking_MixedApprovalRequiredToolsWithNonApprovalRequiringFunctionCall(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()), // Func1 requires approval
 			createFunc2(),                            // Func2 does NOT require approval
@@ -796,16 +704,12 @@ func TestFunctionInvoking_MixedApprovalRequiredToolsWithNonApprovalRequiringFunc
 	}
 
 	invokeAndAssertApprovalWithClient(t, client, options, input, expectedOutput, nil)
-
-	// Reset for streaming test
-	client.currentRound = 0
-	invokeAndAssertStreamingApprovalWithClient(t, client, options, input, expectedOutput, nil)
 }
 
 // TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExecuted tests that
 // approval responses without preceding approval requests are still executed
 func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExecuted(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -854,13 +758,12 @@ func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExec
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_FunctionCallContentIsNotPassedToDownstreamServiceWithServiceThreads tests that
 // when using ConversationId (service threads), FunctionCallContent is not passed to downstream service
 func TestFunctionInvoking_FunctionCallContentIsNotPassedToDownstreamServiceWithServiceThreads(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -906,13 +809,12 @@ func TestFunctionInvoking_FunctionCallContentIsNotPassedToDownstreamServiceWithS
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, expectedDownstreamClientInput, nil)
 }
 
 // TestFunctionInvoking_FunctionCallContentIsYieldedImmediatelyIfNoApprovalRequiredWhenStreaming tests that
 // function call content is yielded immediately when no approval is required (no approval-required functions)
 func TestFunctionInvoking_FunctionCallContentIsYieldedImmediatelyIfNoApprovalRequiredWhenStreaming(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			createFunc1(), // No approval required
 			createFunc2(), // No approval required
@@ -957,17 +859,14 @@ func TestFunctionInvoking_FunctionCallContentIsYieldedImmediatelyIfNoApprovalReq
 		}},
 	}
 
-	invokeAndAssertApprovalWithClient(t, client, options, input, expectedOutput, nil)
-
-	// Reset for streaming test
 	client.currentRound = 0
-	invokeAndAssertStreamingApprovalWithClient(t, client, options, input, expectedOutput, nil)
+	invokeAndAssertApprovalWithClient(t, client, options, input, expectedOutput, nil)
 }
 
 // TestFunctionInvoking_FunctionCallsAreBufferedUntilApprovalRequirementEncounteredWhenStreaming tests that
 // when some functions require approval, function calls are buffered and converted to approval requests
 func TestFunctionInvoking_FunctionCallsAreBufferedUntilApprovalRequirementEncounteredWhenStreaming(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			createFunc1(),                            // No approval required
 			tool.ApprovalRequiredFunc(createFunc2()), // Approval required
@@ -995,13 +894,12 @@ func TestFunctionInvoking_FunctionCallsAreBufferedUntilApprovalRequirementEncoun
 	}
 
 	invokeAndAssertApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, nil)
-	invokeAndAssertStreamingApproval(t, options, input, downstreamClientOutput, expectedOutput, nil, nil)
 }
 
 // TestFunctionInvoking_ApprovalRequestWithoutApprovalResponseThrows tests that an approval request
 // without a matching approval response throws an error
 func TestFunctionInvoking_ApprovalRequestWithoutApprovalResponseThrows(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			tool.ApprovalRequiredFunc(createFunc1()),
 			createFunc2(),
@@ -1019,7 +917,6 @@ func TestFunctionInvoking_ApprovalRequestWithoutApprovalResponseThrows(t *testin
 
 	// Note: We don't pass any downstream client output since the error should occur during approval processing
 	expectApprovalError(t, options, input, nil, expectedErrorMsg, nil)
-	expectStreamingApprovalError(t, options, input, nil, expectedErrorMsg, nil)
 }
 
 // Helper functions to create test tools

--- a/go/agent/chatagent/chatclient/funcinvoke_test.go
+++ b/go/agent/chatagent/chatclient/funcinvoke_test.go
@@ -22,20 +22,16 @@ import (
 
 // testChatClient is a minimal test implementation of Client
 type testChatClient struct {
-	responseFunc          func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error)
-	streamingResponseFunc func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error]
+	responseFunc func(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error]
 }
 
-func (t *testChatClient) Response(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
+func (t *testChatClient) Capabilities() chatclient.Capabilities {
+	return chatclient.Capabilities{}
+}
+
+func (t *testChatClient) Response(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
 	if t.responseFunc != nil {
 		return t.responseFunc(ctx, opts, messages...)
-	}
-	return &chatclient.ChatResponse{}, nil
-}
-
-func (t *testChatClient) StreamingResponse(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
-	if t.streamingResponseFunc != nil {
-		return t.streamingResponseFunc(ctx, opts, messages...)
 	}
 	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 		// Default empty implementation
@@ -48,7 +44,7 @@ func TestFunctionInvoking_SupportsSingleFunctionCallPerRequest(t *testing.T) {
 		I int `json:"i"`
 	}
 
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func1", Description: "Function 1"},
 				func(ctx context.Context, args EmptyArgs) (string, error) {
@@ -91,7 +87,6 @@ func TestFunctionInvoking_SupportsSingleFunctionCallPerRequest(t *testing.T) {
 	}
 
 	invokeAndAssert(t, options, plan, nil, nil)
-	invokeAndAssertStreaming(t, options, plan, nil, nil)
 }
 
 func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) {
@@ -112,7 +107,7 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			options := &chatclient.ChatOptions{
+			options := chatclient.ChatOptions{
 				Tools: []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "Func1"},
 						func(ctx context.Context, args Func1Args) (string, error) {
@@ -163,7 +158,6 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 			}
 
 			invokeAndAssert(t, options, plan, nil, functionInvokingOptions)
-			invokeAndAssertStreaming(t, options, plan, nil, functionInvokingOptions)
 		})
 	}
 }
@@ -173,7 +167,7 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 // Returns the final chat history.
 // Plan should start with the initial user message and contain all expected messages.
 // functionInvokingOptions can be nil to use default settings.
-func invokeAndAssert(t *testing.T, options *chatclient.ChatOptions, plan []*message.Message, expected []*message.Message, functionInvokingOptions *chatclient.FunctionInvokingOptions) []*message.Message {
+func invokeAndAssert(t *testing.T, options chatclient.ChatOptions, plan []*message.Message, expected []*message.Message, functionInvokingOptions *chatclient.FunctionInvokingOptions) []*message.Message {
 	t.Helper()
 
 	if len(plan) == 0 {
@@ -185,57 +179,11 @@ func invokeAndAssert(t *testing.T, options *chatclient.ChatOptions, plan []*mess
 	}
 
 	innerClient := &testChatClient{
-		responseFunc: func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-			idx := len(messages)
-			if idx >= len(plan) {
-				t.Fatalf("unexpected call to Response, message count=%d, len(plan)=%d", idx, len(plan))
-			}
-			msg := plan[idx]
-			return &chatclient.ChatResponse{Messages: []*message.Message{msg}}, nil
-		},
-	}
-
-	client := chatclient.NewFunctionInvoking(innerClient, functionInvokingOptions)
-	ctx := context.Background()
-	initialMessages := []*message.Message{plan[0]}
-
-	response, err := client.Response(ctx, options, initialMessages...)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if response == nil {
-		t.Fatal("expected non-nil response")
-	}
-
-	// Build actual chat history
-	actual := append(initialMessages, response.Messages...)
-
-	// Assert messages match expected
-	assertMessageListsEqual(t, expected, actual)
-
-	return actual
-}
-
-// invokeAndAssertStreaming is similar to invokeAndAssert but tests streaming response.
-// functionInvokingOptions can be nil to use default settings.
-func invokeAndAssertStreaming(t *testing.T, options *chatclient.ChatOptions, plan []*message.Message, expected []*message.Message, functionInvokingOptions *chatclient.FunctionInvokingOptions) []*message.Message {
-	t.Helper()
-
-	if len(plan) == 0 {
-		t.Fatal("plan must not be empty")
-	}
-
-	if expected == nil {
-		expected = plan
-	}
-
-	innerClient := &testChatClient{
-		streamingResponseFunc: func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+		responseFunc: func(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
 			return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 				idx := len(messages)
 				if idx >= len(plan) {
-					t.Fatalf("unexpected call to StreamingResponse, message count=%d, len(plan)=%d", idx, len(plan))
+					t.Fatalf("unexpected call to Response, message count=%d, len(plan)=%d", idx, len(plan))
 				}
 				msg := plan[idx]
 
@@ -259,7 +207,7 @@ func invokeAndAssertStreaming(t *testing.T, options *chatclient.ChatOptions, pla
 
 	// Collect all updates
 	var updates []*chatclient.ChatResponseUpdate
-	for update, err := range client.StreamingResponse(ctx, options, initialMessages...) {
+	for update, err := range client.Response(ctx, options, initialMessages...) {
 		if err != nil {
 			t.Fatalf("unexpected error during streaming: %v", err)
 		}
@@ -271,10 +219,10 @@ func invokeAndAssertStreaming(t *testing.T, options *chatclient.ChatOptions, pla
 	}
 
 	// Convert streaming updates back to consolidated messages
-	consolidated := chatclient.NewChatResponseFromUpdates(updates)
+	consolidated := chatclient.NewMessageFromUpdates(updates)
 
 	// Build actual chat history
-	actual := append(initialMessages, consolidated.Messages...)
+	actual := append(initialMessages, consolidated...)
 
 	// Assert messages match expected
 	assertMessageListsEqual(t, expected, actual)
@@ -404,9 +352,9 @@ func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var options *chatclient.ChatOptions
+			var options chatclient.ChatOptions
 			if tt.provideOptions {
-				options = &chatclient.ChatOptions{
+				options = chatclient.ChatOptions{
 					Tools: []tool.Tool{
 						functool.MustNew(&functool.Func{Name: "ChatOptionsFunc"},
 							func(ctx context.Context, args struct{}) (string, error) {
@@ -460,7 +408,6 @@ func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 			}
 
 			invokeAndAssert(t, options, plan, nil, functionInvokingOptions)
-			invokeAndAssertStreaming(t, options, plan, nil, functionInvokingOptions)
 		})
 	}
 }
@@ -471,7 +418,7 @@ func TestFunctionInvoking_PrefersToolsProvidedByChatOptions(t *testing.T) {
 		I int `json:"i"`
 	}
 
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func1"},
 				func(ctx context.Context, args struct{}) (string, error) {
@@ -524,97 +471,54 @@ func TestFunctionInvoking_PrefersToolsProvidedByChatOptions(t *testing.T) {
 	}
 
 	invokeAndAssert(t, options, plan, nil, functionInvokingOptions)
-	invokeAndAssertStreaming(t, options, plan, nil, functionInvokingOptions)
 }
 
 // TestFunctionInvoking_ParallelFunctionCallsMayBeInvokedConcurrently tests concurrent invocation
 func TestFunctionInvoking_ParallelFunctionCallsMayBeInvokedConcurrently(t *testing.T) {
-	t.Run("Response", func(t *testing.T) {
-		var remaining atomic.Int32
-		remaining.Store(2)
-		done := make(chan bool)
+	var remaining atomic.Int32
+	remaining.Store(2)
+	done := make(chan bool)
 
-		options := &chatclient.ChatOptions{
-			Tools: []tool.Tool{
-				functool.MustNew(&functool.Func{Name: "Func"},
-					func(ctx context.Context, args struct{ Arg string }) (string, error) {
-						if remaining.Add(-1) == 0 {
-							close(done)
-						}
-						<-done
-						return args.Arg + args.Arg, nil
-					}),
-			},
-		}
+	options := chatclient.ChatOptions{
+		Tools: []tool.Tool{
+			functool.MustNew(&functool.Func{Name: "Func"},
+				func(ctx context.Context, args struct{ Arg string }) (string, error) {
+					if remaining.Add(-1) == 0 {
+						close(done)
+					}
+					<-done
+					return args.Arg + args.Arg, nil
+				}),
+		},
+	}
 
-		plan := []*message.Message{
-			message.New(&message.TextContent{Text: "hello"}),
-			{Role: message.RoleAssistant, Contents: []message.Content{
-				&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
-				&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
-			}},
-			{Role: message.RoleTool, Contents: []message.Content{
-				&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
-				&message.FunctionResultContent{CallID: "callId2", Result: "worldworld"},
-			}},
-			{Role: message.RoleAssistant, Contents: []message.Content{
-				&message.TextContent{Text: "done"},
-			}},
-		}
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
+			&message.FunctionResultContent{CallID: "callId2", Result: "worldworld"},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
 
-		functionInvokingOptions := &chatclient.FunctionInvokingOptions{
-			AllowConcurrentInvocations: param.NewOpt(true),
-		}
+	functionInvokingOptions := &chatclient.FunctionInvokingOptions{
+		AllowConcurrentInvocations: param.NewOpt(true),
+	}
 
-		invokeAndAssert(t, options, plan, nil, functionInvokingOptions)
-	})
-
-	t.Run("StreamingResponse", func(t *testing.T) {
-		var remaining atomic.Int32
-		remaining.Store(2)
-		done := make(chan bool)
-
-		options := &chatclient.ChatOptions{
-			Tools: []tool.Tool{
-				functool.MustNew(&functool.Func{Name: "Func"},
-					func(ctx context.Context, args struct{ Arg string }) (string, error) {
-						if remaining.Add(-1) == 0 {
-							close(done)
-						}
-						<-done
-						return args.Arg + args.Arg, nil
-					}),
-			},
-		}
-
-		plan := []*message.Message{
-			message.New(&message.TextContent{Text: "hello"}),
-			{Role: message.RoleAssistant, Contents: []message.Content{
-				&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
-				&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
-			}},
-			{Role: message.RoleTool, Contents: []message.Content{
-				&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
-				&message.FunctionResultContent{CallID: "callId2", Result: "worldworld"},
-			}},
-			{Role: message.RoleAssistant, Contents: []message.Content{
-				&message.TextContent{Text: "done"},
-			}},
-		}
-
-		functionInvokingOptions := &chatclient.FunctionInvokingOptions{
-			AllowConcurrentInvocations: param.NewOpt(true),
-		}
-
-		invokeAndAssertStreaming(t, options, plan, nil, functionInvokingOptions)
-	})
+	invokeAndAssert(t, options, plan, nil, functionInvokingOptions)
 }
 
 // TestFunctionInvoking_ConcurrentInvocationOfParallelCallsDisabledByDefault tests serial invocation by default
 func TestFunctionInvoking_ConcurrentInvocationOfParallelCallsDisabledByDefault(t *testing.T) {
 	var activeCount atomic.Int32
 
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func"},
 				func(ctx context.Context, args struct{ Arg string }) (string, error) {
@@ -645,7 +549,6 @@ func TestFunctionInvoking_ConcurrentInvocationOfParallelCallsDisabledByDefault(t
 	}
 
 	invokeAndAssert(t, options, plan, nil, nil)
-	invokeAndAssertStreaming(t, options, plan, nil, nil)
 }
 
 // TestFunctionInvoking_ContinuesWithSuccessfulCallsUntilMaximumIterations tests MaximumIterationsPerRequest
@@ -653,7 +556,7 @@ func TestFunctionInvoking_ContinuesWithSuccessfulCallsUntilMaximumIterations(t *
 	maxIterations := 7
 	actualCallCount := 0
 
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "VoidReturn"},
 				func(ctx context.Context, args struct{}) (string, error) {
@@ -696,11 +599,7 @@ func TestFunctionInvoking_ContinuesWithSuccessfulCallsUntilMaximumIterations(t *
 	}
 
 	actualCallCount = 0
-	invokeAndAssertStreaming(t, options, plan, expectedPlan, functionInvokingOptions)
 
-	if actualCallCount != maxIterations {
-		t.Errorf("Expected %d function calls (streaming), got %d", maxIterations, actualCallCount)
-	}
 }
 
 // TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors tests MaximumConsecutiveErrorsPerRequest
@@ -717,7 +616,7 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 		t.Run(tt.name, func(t *testing.T) {
 			callIndex := 0
 
-			options := &chatclient.ChatOptions{
+			options := chatclient.ChatOptions{
 				Tools: []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "Func"},
 						func(ctx context.Context, args struct {
@@ -758,13 +657,24 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 
 			// The test expects an error to be thrown
 			innerClient := &testChatClient{
-				responseFunc: func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-					idx := len(messages)
-					if idx >= len(plan) {
-						t.Fatalf("unexpected call to Response, message count=%d, len(plan)=%d", idx, len(plan))
+				responseFunc: func(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+					return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+						idx := len(messages)
+						if idx >= len(plan) {
+							t.Fatalf("unexpected call to Response, message count=%d, len(plan)=%d", idx, len(plan))
+						}
+						msg := plan[idx]
+
+						for _, content := range msg.Contents {
+							update := &chatclient.ChatResponseUpdate{
+								Role:     msg.Role,
+								Contents: []message.Content{content},
+							}
+							if !yield(update, nil) {
+								return
+							}
+						}
 					}
-					msg := plan[idx]
-					return &chatclient.ChatResponse{Messages: []*message.Message{msg}}, nil
 				},
 			}
 
@@ -772,37 +682,8 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 			ctx := context.Background()
 			initialMessages := []*message.Message{plan[0]}
 
-			_, err := client.Response(ctx, options, initialMessages...)
-			if err == nil {
-				t.Error("Expected error due to MaximumConsecutiveErrors exceeded, got nil")
-			} else if !errors.Is(err, context.Canceled) && err.Error() != "maximum consecutive function call errors reached" {
-				// Check for expected error message
-				t.Logf("Got error: %v", err)
-			}
-
-			// Test streaming as well
-			innerClient.streamingResponseFunc = func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
-				return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
-					idx := len(messages)
-					if idx >= len(plan) {
-						t.Fatalf("unexpected call to StreamingResponse, message count=%d, len(plan)=%d", idx, len(plan))
-					}
-					msg := plan[idx]
-
-					for _, content := range msg.Contents {
-						update := &chatclient.ChatResponseUpdate{
-							Role:     msg.Role,
-							Contents: []message.Content{content},
-						}
-						if !yield(update, nil) {
-							return
-						}
-					}
-				}
-			}
-
 			var streamErr error
-			for _, err := range client.StreamingResponse(ctx, options, initialMessages...) {
+			for _, err := range client.Response(ctx, options, initialMessages...) {
 				if err != nil {
 					streamErr = err
 					break
@@ -811,6 +692,9 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 
 			if streamErr == nil {
 				t.Error("Expected error in streaming due to MaximumConsecutiveErrors exceeded, got nil")
+			} else if !errors.Is(streamErr, context.Canceled) && streamErr.Error() != "maximum consecutive function call errors reached" {
+				// Check for expected error message
+				t.Logf("Got error: %v", streamErr)
 			}
 		})
 	}
@@ -863,7 +747,7 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			callIndex := 0
 
-			options := &chatclient.ChatOptions{
+			options := chatclient.ChatOptions{
 				Tools: []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "Func"},
 						func(ctx context.Context, args struct{}) (string, error) {
@@ -883,46 +767,31 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 			}
 
 			innerClient := &testChatClient{
-				responseFunc: func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-					idx := len(messages)
-					if idx >= len(plan) {
-						t.Fatalf("unexpected call to Response")
+				responseFunc: func(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+					return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+						idx := len(messages)
+						if idx >= len(plan) {
+							t.Fatalf("unexpected call to StreamingResponse")
+						}
+						msg := plan[idx]
+						for _, content := range msg.Contents {
+							update := &chatclient.ChatResponseUpdate{
+								Role:     msg.Role,
+								Contents: []message.Content{content},
+							}
+							if !yield(update, nil) {
+								return
+							}
+						}
 					}
-					msg := plan[idx]
-					return &chatclient.ChatResponse{Messages: []*message.Message{msg}}, nil
 				},
 			}
 
 			client := chatclient.NewFunctionInvoking(innerClient, functionInvokingOptions)
 			ctx := context.Background()
 
-			_, err := client.Response(ctx, options, plan[0])
-			if err == nil {
-				t.Error("Expected error on first exception, got nil")
-			}
-
-			// Test streaming
-			innerClient.streamingResponseFunc = func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
-				return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
-					idx := len(messages)
-					if idx >= len(plan) {
-						t.Fatalf("unexpected call to StreamingResponse")
-					}
-					msg := plan[idx]
-					for _, content := range msg.Contents {
-						update := &chatclient.ChatResponseUpdate{
-							Role:     msg.Role,
-							Contents: []message.Content{content},
-						}
-						if !yield(update, nil) {
-							return
-						}
-					}
-				}
-			}
-
 			var streamErr error
-			for _, err := range client.StreamingResponse(ctx, options, plan[0]) {
+			for _, err := range client.Response(ctx, options, plan[0]) {
 				if err != nil {
 					streamErr = err
 					break
@@ -942,7 +811,7 @@ func TestFunctionInvoking_KeepsFunctionCallingContent(t *testing.T) {
 		I int `json:"i"`
 	}
 
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func1"},
 				func(ctx context.Context, args struct{}) (string, error) {
@@ -989,9 +858,6 @@ func TestFunctionInvoking_KeepsFunctionCallingContent(t *testing.T) {
 
 	finalChat := invokeAndAssert(t, options, plan, nil, nil)
 	validateFunctionContent(t, finalChat)
-
-	finalChat = invokeAndAssertStreaming(t, options, plan, nil, nil)
-	validateFunctionContent(t, finalChat)
 }
 
 func validateFunctionContent(t *testing.T, messages []*message.Message) {
@@ -1026,7 +892,7 @@ func TestFunctionInvoking_TerminateOnUnknownCalls(t *testing.T) {
 				I int `json:"i"`
 			}
 
-			options := &chatclient.ChatOptions{
+			options := chatclient.ChatOptions{
 				Tools: []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "KnownFunc"},
 						func(ctx context.Context, args Func2Args) (string, error) {
@@ -1058,11 +924,9 @@ func TestFunctionInvoking_TerminateOnUnknownCalls(t *testing.T) {
 				// Should terminate after the assistant message with unknown function call
 				expectedPlan := fullPlan[:2]
 				invokeAndAssert(t, options, fullPlan, expectedPlan, functionInvokingOptions)
-				invokeAndAssertStreaming(t, options, fullPlan, expectedPlan, functionInvokingOptions)
 			} else {
 				// Should continue and add error result for unknown function
 				invokeAndAssert(t, options, fullPlan, nil, functionInvokingOptions)
-				invokeAndAssertStreaming(t, options, fullPlan, nil, functionInvokingOptions)
 			}
 		})
 	}
@@ -1081,7 +945,7 @@ func TestFunctionInvoking_ExceptionDetailsOnlyReportedWhenRequested(t *testing.T
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			options := &chatclient.ChatOptions{
+			options := chatclient.ChatOptions{
 				Tools: []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "Func1"},
 						func(ctx context.Context, args struct{}) (string, error) {
@@ -1108,14 +972,13 @@ func TestFunctionInvoking_ExceptionDetailsOnlyReportedWhenRequested(t *testing.T
 			}
 
 			invokeAndAssert(t, options, plan, nil, functionInvokingOptions)
-			invokeAndAssertStreaming(t, options, plan, nil, functionInvokingOptions)
 		})
 	}
 }
 
 // TestFunctionInvoking_AllResponseMessagesReturned tests that all response messages are returned
 func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func1"},
 				func(ctx context.Context, args struct{}) (string, error) {
@@ -1130,61 +993,78 @@ func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 
 	callCount := 0
 	innerClient := &testChatClient{
-		responseFunc: func(ctx context.Context, opts *chatclient.ChatOptions, msgs ...*message.Message) (*chatclient.ChatResponse, error) {
-			callCount++
-			var msg *message.Message
-			if len(msgs) == 1 || len(msgs) == 3 {
-				// First and third call - return function call
-				msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: fmt.Sprintf("callId%d", len(msgs)), Name: "Func1"},
-				}}
-			} else {
-				// Second call - return final answer
-				msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.TextContent{Text: "The answer is 42."},
-				}}
+		responseFunc: func(ctx context.Context, opts chatclient.ChatOptions, msgs ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+			return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+				callCount++
+				var msg *message.Message
+				if len(msgs) == 1 || len(msgs) == 3 {
+					// First and third call - return function call
+					msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{
+						&message.FunctionCallContent{CallID: fmt.Sprintf("callId%d", len(msgs)), Name: "Func1"},
+					}}
+				} else {
+					// Second call - return final answer
+					msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{
+						&message.TextContent{Text: "The answer is 42."},
+					}}
+				}
+				for _, content := range msg.Contents {
+					update := &chatclient.ChatResponseUpdate{
+						Role:     msg.Role,
+						Contents: []message.Content{content},
+					}
+					if !yield(update, nil) {
+						return
+					}
+				}
 			}
-			return &chatclient.ChatResponse{Messages: []*message.Message{msg}}, nil
 		},
 	}
 
 	client := chatclient.NewFunctionInvoking(innerClient, nil)
 	ctx := context.Background()
 
-	response, err := client.Response(ctx, options, messages...)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	var updates []*chatclient.ChatResponseUpdate
+	for update, err := range client.Response(ctx, options, messages...) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		updates = append(updates, update)
 	}
 
-	if len(response.Messages) != 5 {
-		t.Errorf("Expected 5 messages, got %d", len(response.Messages))
+	responseMessages := chatclient.NewMessageFromUpdates(updates)
+
+	if len(responseMessages) != 5 {
+		t.Errorf("Expected 5 messages, got %d", len(responseMessages))
 	}
 
-	if response.String() != "The answer is 42." {
-		t.Errorf("Expected text 'The answer is 42.', got %q", response.String())
+	// Check last message text
+	lastMsg := responseMessages[len(responseMessages)-1]
+	if lastMsg.String() != "The answer is 42." {
+		t.Errorf("Expected text 'The answer is 42.', got %q", lastMsg.String())
 	}
 
 	// Verify message types
-	if _, ok := response.Messages[0].Contents[0].(*message.FunctionCallContent); !ok {
+	if _, ok := responseMessages[0].Contents[0].(*message.FunctionCallContent); !ok {
 		t.Error("Expected first message to be FunctionCallContent")
 	}
-	if _, ok := response.Messages[1].Contents[0].(*message.FunctionResultContent); !ok {
+	if _, ok := responseMessages[1].Contents[0].(*message.FunctionResultContent); !ok {
 		t.Error("Expected second message to be FunctionResultContent")
 	}
-	if _, ok := response.Messages[2].Contents[0].(*message.FunctionCallContent); !ok {
+	if _, ok := responseMessages[2].Contents[0].(*message.FunctionCallContent); !ok {
 		t.Error("Expected third message to be FunctionCallContent")
 	}
-	if _, ok := response.Messages[3].Contents[0].(*message.FunctionResultContent); !ok {
+	if _, ok := responseMessages[3].Contents[0].(*message.FunctionResultContent); !ok {
 		t.Error("Expected fourth message to be FunctionResultContent")
 	}
-	if _, ok := response.Messages[4].Contents[0].(*message.TextContent); !ok {
+	if _, ok := responseMessages[4].Contents[0].(*message.TextContent); !ok {
 		t.Error("Expected fifth message to be TextContent")
 	}
 }
 
 // TestFunctionInvoking_PropagatesResponseConversationIdToOptions tests conversation ID propagation
 func TestFunctionInvoking_PropagatesResponseConversationIdToOptions(t *testing.T) {
-	options := &chatclient.ChatOptions{
+	options := chatclient.ChatOptions{
 		Tools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func1"},
 				func(ctx context.Context, args struct{}) (string, error) {
@@ -1194,145 +1074,117 @@ func TestFunctionInvoking_PropagatesResponseConversationIdToOptions(t *testing.T
 	}
 
 	iteration := 0
-	responseFunc := func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-		iteration++
+	responseFunc := func(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+			iteration++
+			var msg *message.Message
+			var convID string
 
-		switch iteration {
-		case 1:
-			if opts != nil && opts.ConversationID != "" {
-				t.Errorf("First call should have empty ConversationID, got %q", opts.ConversationID)
+			switch iteration {
+			case 1:
+				if opts.ConversationID != "" {
+					t.Errorf("First call should have empty ConversationID, got %q", opts.ConversationID)
+				}
+				msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.FunctionCallContent{CallID: "callId-abc", Name: "Func1"}}}
+				convID = "12345"
+			case 2:
+				if opts.ConversationID != "12345" {
+					t.Errorf("Second call should have ConversationID '12345', got %q", opts.ConversationID)
+				}
+				msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "done!"}}}
+			default:
+				t.Fatal("Unexpected iteration")
 			}
-			return &chatclient.ChatResponse{
-				Messages:       []*message.Message{{Role: message.RoleAssistant, Contents: []message.Content{&message.FunctionCallContent{CallID: "callId-abc", Name: "Func1"}}}},
-				ConversationID: "12345",
-			}, nil
-		case 2:
-			if opts == nil || opts.ConversationID != "12345" {
-				t.Errorf("Second call should have ConversationID '12345', got %q", opts.ConversationID)
+
+			for _, content := range msg.Contents {
+				update := &chatclient.ChatResponseUpdate{
+					Role:           msg.Role,
+					Contents:       []message.Content{content},
+					ConversationID: convID,
+				}
+				if !yield(update, nil) {
+					return
+				}
 			}
-			return &chatclient.ChatResponse{
-				Messages: []*message.Message{{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "done!"}}}},
-			}, nil
-		default:
-			t.Fatal("Unexpected iteration")
-			return nil, nil
 		}
 	}
 
 	innerClient := &testChatClient{
 		responseFunc: responseFunc,
-		streamingResponseFunc: func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
-			return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
-				var response *chatclient.ChatResponse
-				var err error
-				if responseFunc != nil {
-					response, err = responseFunc(ctx, opts, messages...)
-					if err != nil {
-						yield(nil, err)
-						return
-					}
-				}
-				if response != nil {
-					for _, msg := range response.Messages {
-						for _, content := range msg.Contents {
-							update := &chatclient.ChatResponseUpdate{
-								Role:           msg.Role,
-								Contents:       []message.Content{content},
-								ConversationID: response.ConversationID,
-							}
-							if !yield(update, nil) {
-								return
-							}
-						}
-					}
-				}
-			}
-		},
 	}
 
 	client := chatclient.NewFunctionInvoking(innerClient, nil)
 	ctx := context.Background()
 
 	iteration = 0
-	response, err := client.Response(ctx, options, message.New(&message.TextContent{Text: "hey"}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if response.String() != "done!" {
-		t.Errorf("Expected 'done!', got %q", response.String())
-	}
-
-	iteration = 0
-	response, err = nil, nil
-	for update, e := range client.StreamingResponse(ctx, options, message.New(&message.TextContent{Text: "hey"})) {
-		if e != nil {
-			err = e
-			break
+	var updates []*chatclient.ChatResponseUpdate
+	for update, err := range client.Response(ctx, options, message.New(&message.TextContent{Text: "hey"})) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-		if response == nil {
-			response = &chatclient.ChatResponse{}
-		}
-		// Consolidate updates
-		if len(response.Messages) == 0 || response.Messages[len(response.Messages)-1].Role != update.Role {
-			response.Messages = append(response.Messages, &message.Message{Role: update.Role, Contents: update.Contents})
-		} else {
-			response.Messages[len(response.Messages)-1].Contents = append(response.Messages[len(response.Messages)-1].Contents, update.Contents...)
-		}
+		updates = append(updates, update)
 	}
-	if err != nil {
-		t.Fatalf("unexpected streaming error: %v", err)
-	}
-	if response.String() != "done!" {
-		t.Errorf("Expected streaming 'done!', got %q", response.String())
+	response := chatclient.NewMessageFromUpdates(updates)
+	if len(response) == 0 || response[len(response)-1].String() != "done!" {
+		t.Errorf("Expected 'done!', got %v", response)
 	}
 }
 
 // TestFunctionInvoking_ClonesChatOptionsAndResetContinuationToken tests continuation token handling
 func TestFunctionInvoking_ClonesChatOptionsAndResetContinuationToken(t *testing.T) {
-	var actualChatOptions *chatclient.ChatOptions
+	var actualChatOptions chatclient.ChatOptions
 
 	innerClient := &testChatClient{
-		responseFunc: func(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-			actualChatOptions = opts
+		responseFunc: func(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+			return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+				actualChatOptions = opts
 
-			// Simulate the model returning a function call for the first call only
-			hasFunctionCall := false
-			for _, m := range messages {
-				for _, c := range m.Contents {
-					if _, ok := c.(*message.FunctionCallContent); ok {
-						hasFunctionCall = true
-						break
+				// Simulate the model returning a function call for the first call only
+				hasFunctionCall := false
+				for _, m := range messages {
+					for _, c := range m.Contents {
+						if _, ok := c.(*message.FunctionCallContent); ok {
+							hasFunctionCall = true
+							break
+						}
+					}
+				}
+
+				var msg *message.Message
+				if !hasFunctionCall {
+					msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.FunctionCallContent{CallID: "callId1", Name: "Func1"}}}
+				} else {
+					msg = &message.Message{Role: message.RoleAssistant, Contents: []message.Content{}}
+				}
+
+				for _, content := range msg.Contents {
+					update := &chatclient.ChatResponseUpdate{
+						Role:     msg.Role,
+						Contents: []message.Content{content},
+					}
+					if !yield(update, nil) {
+						return
 					}
 				}
 			}
-
-			if !hasFunctionCall {
-				return &chatclient.ChatResponse{
-					Messages: []*message.Message{{Role: message.RoleAssistant, Contents: []message.Content{&message.FunctionCallContent{CallID: "callId1", Name: "Func1"}}}},
-				}, nil
-			}
-
-			return &chatclient.ChatResponse{Messages: []*message.Message{}}, nil
 		},
 	}
 
 	client := chatclient.NewFunctionInvoking(innerClient, nil)
 	ctx := context.Background()
 
-	originalChatOptions := &chatclient.ChatOptions{
+	originalChatOptions := chatclient.ChatOptions{
 		Tools:             []tool.Tool{functool.MustNew(&functool.Func{Name: "Func1"}, func(ctx context.Context, args struct{}) (string, error) { return "", nil })},
 		ContinuationToken: []byte{1, 2, 3, 4},
 	}
 
-	_, err := client.Response(ctx, originalChatOptions, message.New(&message.TextContent{Text: "hi"}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	for _, err := range client.Response(ctx, originalChatOptions, message.New(&message.TextContent{Text: "hi"})) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	}
 
-	// The original options should be cloned and have a nil ContinuationToken
-	if actualChatOptions == originalChatOptions {
-		t.Error("ChatOptions should have been cloned")
-	}
+	// The original options should have a nil ContinuationToken
 	if actualChatOptions.ContinuationToken != nil {
 		t.Error("ContinuationToken should be nil in cloned options")
 	}

--- a/go/agent/tool.go
+++ b/go/agent/tool.go
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/microsoft/agent-framework/go/memory"
+	"github.com/microsoft/agent-framework/go/message"
+	"github.com/microsoft/agent-framework/go/tool"
+)
+
+// FuncTool creates a function tool that invokes the given agent.
+// The provided thread is used for the agent's context during invocations,
+// or nil to create a new thread for each invocation.
+func FuncTool(agent Agent, thread memory.Thread) tool.FuncTool {
+	iden := agent.Identity()
+	return functool{
+		name:        iden.Name(),
+		description: iden.Description(),
+		thread:      thread,
+		agent:       agent,
+	}
+}
+
+type functool struct {
+	name        string
+	description string
+	thread      memory.Thread
+	agent       Agent
+}
+
+func (t functool) Name() string {
+	return t.name
+}
+
+func (t functool) Description() string {
+	return t.description
+}
+
+func (t functool) Schema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "input query to invoke the agent",
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+func (t functool) ReturnSchema() any {
+	return map[string]any{
+		"type": "string",
+	}
+}
+
+func (t functool) Call(ctx context.Context, args any) (any, error) {
+	var in struct {
+		Query string `json:"query"`
+	}
+	var raw json.RawMessage
+	if args == nil {
+		raw = json.RawMessage("{}")
+	} else {
+		var ok bool
+		raw, ok = args.(json.RawMessage)
+		if !ok {
+			return nil, fmt.Errorf("expected json.RawMessage arguments, got %T", args)
+		}
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	resp, err := Run(ctx, t.agent, RunOptions{Thread: t.thread}, &message.Message{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: in.Query}},
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.String(), nil
+}

--- a/go/agent/workflow.go
+++ b/go/agent/workflow.go
@@ -21,17 +21,17 @@ func (e RunUpdateEvent) Data() any {
 	return e.Update
 }
 
-func newExecutor(ag Agent, emitEvents bool) *workflow.Executor {
+func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 	var thread memory.Thread
 	var threadStateKey string
 	ensureThread := func() memory.Thread {
 		if thread == nil {
-			thread = ag.NewThread()
+			thread = a.NewThread()
 		}
 		threadStateKey = reflect.ValueOf(thread).String()
 		return thread
 	}
-	id := agentDescriptiveID(ag)
+	id := agentDescriptiveID(a)
 	ex := &workflow.Executor{
 		ID: id,
 		Config: []*workflow.ExecutorConfig{
@@ -54,7 +54,7 @@ func newExecutor(ag Agent, emitEvents bool) *workflow.Executor {
 					if data == nil {
 						return nil
 					}
-					thread, err = ag.UnmarshalThread(data.([]byte))
+					thread, err = a.UnmarshalThread(data.([]byte))
 					return err
 				},
 			},
@@ -64,7 +64,7 @@ func newExecutor(ag Agent, emitEvents bool) *workflow.Executor {
 		StateKey: "agent_messages",
 		TakeTurnHandler: func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
 			if !token.EmitEventsOr(emitEvents) {
-				response, err := ag.Run(&RunContext{Context: ctx.GetContext(), Thread: ensureThread()}, messages...)
+				response, err := Run(ctx, a, RunOptions{Thread: ensureThread()}, messages...)
 				if err != nil {
 					return err
 				}
@@ -72,7 +72,7 @@ func newExecutor(ag Agent, emitEvents bool) *workflow.Executor {
 			}
 			// Run the agent in streaming mode only when agent run update events are to be emitted.
 			var updates []*RunResponseUpdate
-			for update, err := range ag.RunStream(&RunContext{Context: ctx.GetContext(), Thread: ensureThread()}, messages...) {
+			for update, err := range RunStream(ctx, a, RunOptions{Thread: ensureThread()}, messages...) {
 				if err != nil {
 					return err
 				}
@@ -104,8 +104,9 @@ func Bind(ag Agent, emitEvents bool) *workflow.ExecutorBinding {
 }
 
 func agentDescriptiveID(ag Agent) string {
-	id := ag.ID()
-	name := ag.Name()
+	iden := ag.Identity()
+	id := iden.ID()
+	name := iden.Name()
 	if name != "" {
 		return name + "_" + id
 	}

--- a/go/anthropic/chat.go
+++ b/go/anthropic/chat.go
@@ -55,14 +55,44 @@ func (a *client) Capabilities() chatclient.Capabilities {
 }
 
 func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
-	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
-		params, err := a.buildMessageParams(&opts, messages...)
-		if err != nil {
+	params, err := a.buildMessageParams(&opts, messages...)
+	if err != nil {
+		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 			yield(nil, err)
-			return
+		}
+	}
+	if !opts.Streaming.Or(false) {
+		resp, err := a.client.Messages.New(ctx, params)
+		if err != nil {
+			return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+				yield(nil, err)
+			}
 		}
 
-		// TODO: support non-streaming responses
+		contents := make([]message.Content, 0, len(resp.Content))
+		for _, c := range resp.Content {
+			contents = a.buildBlock(c.AsAny(), contents)
+		}
+		contents = append(contents, &message.UsageContent{
+			Details: message.UsageDetails{
+				InputTokenCount:  resp.Usage.InputTokens,
+				OutputTokenCount: resp.Usage.OutputTokens,
+			},
+		})
+		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+			yield(&chatclient.ChatResponseUpdate{
+				Contents:          contents,
+				Role:              message.RoleAssistant,
+				MessageID:         resp.ID,
+				ResponseID:        resp.ID,
+				ModelID:           string(resp.Model),
+				FinishReason:      string(resp.StopReason),
+				CreatedAt:         time.Now(),
+				RawRepresentation: resp,
+			}, nil)
+		}
+	}
+	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 		stream := a.client.Messages.NewStreaming(ctx, params)
 
 		var currentMessageID string
@@ -74,43 +104,30 @@ func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, mess
 
 			var contents []message.Content
 			var finishReason string
-
-			switch event.Type {
-			case "message_start":
+			switch event := event.AsAny().(type) {
+			case anthropic.MessageStartEvent:
 				currentMessageID = event.Message.ID
 				currentModel = string(event.Message.Model)
-				currentRole = message.Role(event.Message.Role)
-			case "content_block_start":
-				if event.ContentBlock.Type == "tool_use" {
-					contents = append(contents, &message.FunctionCallContent{
-						CallID:    event.ContentBlock.ID,
-						Name:      event.ContentBlock.Name,
-						Arguments: event.ContentBlock.Input,
-					})
-				}
-			case "content_block_delta":
-				if event.Delta.Type == "text_delta" {
-					contents = append(contents, &message.TextContent{Text: event.Delta.Text})
-				}
-			case "message_delta":
-				if event.Delta.StopReason != "" {
-					finishReason = string(event.Delta.StopReason)
-				}
+				currentRole = message.RoleAssistant
+			case anthropic.ContentBlockStartEvent:
+				contents = a.buildBlock(event.ContentBlock.AsAny(), contents)
+			case anthropic.ContentBlockDeltaEvent:
+				contents = a.buildDelta(event.Delta.AsAny(), contents)
+			case anthropic.MessageDeltaEvent:
+				finishReason = string(event.Delta.StopReason)
 			}
 
-			if len(contents) > 0 || finishReason != "" {
-				resp := &chatclient.ChatResponseUpdate{
-					Contents:     contents,
-					Role:         currentRole,
-					ResponseID:   currentMessageID,
-					MessageID:    currentMessageID,
-					ModelID:      currentModel,
-					FinishReason: finishReason,
-					CreatedAt:    time.Now(),
-				}
-				if !yield(resp, nil) {
-					return
-				}
+			if !yield(&chatclient.ChatResponseUpdate{
+				Contents:          contents,
+				Role:              currentRole,
+				ResponseID:        currentMessageID,
+				MessageID:         currentMessageID,
+				ModelID:           currentModel,
+				FinishReason:      finishReason,
+				CreatedAt:         time.Now(),
+				RawRepresentation: event,
+			}, nil) {
+				return
 			}
 		}
 
@@ -118,6 +135,28 @@ func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, mess
 			yield(nil, err)
 		}
 	}
+}
+
+func (a *client) buildBlock(v any, contents []message.Content) []message.Content {
+	switch v := v.(type) {
+	case anthropic.TextBlock:
+		contents = append(contents, &message.TextContent{Text: v.Text})
+	case anthropic.ToolUseBlock:
+		contents = append(contents, &message.FunctionCallContent{
+			CallID:    v.ID,
+			Name:      v.Name,
+			Arguments: v.Input,
+		})
+	}
+	return contents
+}
+
+func (a *client) buildDelta(v any, contents []message.Content) []message.Content {
+	switch d := v.(type) {
+	case anthropic.TextDelta:
+		contents = append(contents, &message.TextContent{Text: d.Text})
+	}
+	return contents
 }
 
 func (a *client) buildMessageParams(options *chatclient.ChatOptions, messages ...*message.Message) (anthropic.MessageNewParams, error) {
@@ -251,9 +290,10 @@ func buildMessageParam(msg *message.Message) (anthropic.MessageParam, error) {
 		}
 	}
 
-	if msg.Role == message.RoleAssistant {
+	switch msg.Role {
+	case message.RoleAssistant:
 		return anthropic.NewAssistantMessage(content...), nil
-	} else if msg.Role == message.RoleTool {
+	case message.RoleTool:
 		// Tool results are user messages in Anthropic
 		return anthropic.NewUserMessage(content...), nil
 	}

--- a/go/anthropic/chat.go
+++ b/go/anthropic/chat.go
@@ -47,50 +47,22 @@ func NewChatAgent(config ClientConfig, options *chatagent.Options) *chatagent.Ag
 	return chatagent.NewAgent(c, options)
 }
 
-func (a *client) Response(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-	params, err := a.buildMessageParams(opts, messages...)
-	if err != nil {
-		return nil, err
+func (a *client) Capabilities() chatclient.Capabilities {
+	return chatclient.Capabilities{
+		Streaming:        true,
+		StructuredOutput: false,
 	}
-	resp, err := a.client.Messages.New(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-
-	contents := make([]message.Content, 0, len(resp.Content))
-	for _, c := range resp.Content {
-		switch c.Type {
-		case "text":
-			contents = append(contents, &message.TextContent{Text: c.Text})
-		case "tool_use":
-			contents = append(contents, &message.FunctionCallContent{
-				CallID:    c.ID,
-				Name:      c.Name,
-				Arguments: c.Input,
-			})
-		}
-	}
-
-	return &chatclient.ChatResponse{
-		Messages:     []*message.Message{{Role: message.RoleAssistant, Contents: contents}},
-		ID:           resp.ID,
-		FinishReason: string(resp.StopReason),
-		ModelID:      string(resp.Model),
-		Usage: &message.UsageDetails{
-			InputTokenCount:  resp.Usage.InputTokens,
-			OutputTokenCount: resp.Usage.OutputTokens,
-		},
-	}, nil
 }
 
-func (a *client) StreamingResponse(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
 	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
-		params, err := a.buildMessageParams(opts, messages...)
+		params, err := a.buildMessageParams(&opts, messages...)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
+		// TODO: support non-streaming responses
 		stream := a.client.Messages.NewStreaming(ctx, params)
 
 		var currentMessageID string
@@ -155,84 +127,82 @@ func (a *client) buildMessageParams(options *chatclient.ChatOptions, messages ..
 		MaxTokens: 1024, // Default max tokens
 	}
 
-	if options != nil {
-		if options.Instructions != "" {
-			params.System = []anthropic.TextBlockParam{
-				{Text: options.Instructions, Type: constant.Text("text")},
-			}
+	if options.Instructions != "" {
+		params.System = []anthropic.TextBlockParam{
+			{Text: options.Instructions, Type: constant.Text("text")},
 		}
-		if options.Temperature.Valid() {
-			params.Temperature = anthropic.Float(options.Temperature.MustValue())
-		}
-		if options.TopP.Valid() {
-			params.TopP = anthropic.Float(options.TopP.MustValue())
-		}
-		if options.MaxTokens.Valid() {
-			params.MaxTokens = int64(options.MaxTokens.MustValue())
-		}
+	}
+	if options.Temperature.Valid() {
+		params.Temperature = anthropic.Float(options.Temperature.MustValue())
+	}
+	if options.TopP.Valid() {
+		params.TopP = anthropic.Float(options.TopP.MustValue())
+	}
+	if options.MaxTokens.Valid() {
+		params.MaxTokens = int64(options.MaxTokens.MustValue())
+	}
 
-		var tools []anthropic.ToolUnionParam
-		for _, tl := range options.Tools {
-			if ft, ok := tl.(tool.FuncTool); ok {
-				name, description := ft.Name(), ft.Description()
-				var properties any
-				var required []string
+	var tools []anthropic.ToolUnionParam
+	for _, tl := range options.Tools {
+		if ft, ok := tl.(tool.FuncTool); ok {
+			name, description := ft.Name(), ft.Description()
+			var properties any
+			var required []string
 
-				// Extract schema details
-				switch schema := ft.Schema().(type) {
-				case map[string]any:
-					if props, ok := schema["properties"]; ok {
-						properties = props
-					}
-					if reqs, ok := schema["required"]; ok {
-						if reqList, ok := reqs.([]interface{}); ok {
-							for _, r := range reqList {
-								if s, ok := r.(string); ok {
-									required = append(required, s)
-								}
+			// Extract schema details
+			switch schema := ft.Schema().(type) {
+			case map[string]any:
+				if props, ok := schema["properties"]; ok {
+					properties = props
+				}
+				if reqs, ok := schema["required"]; ok {
+					if reqList, ok := reqs.([]interface{}); ok {
+						for _, r := range reqList {
+							if s, ok := r.(string); ok {
+								required = append(required, s)
 							}
-						} else if reqList, ok := reqs.([]string); ok {
-							required = reqList
 						}
+					} else if reqList, ok := reqs.([]string); ok {
+						required = reqList
 					}
-				default:
-					// Fallback or error handling
-				}
-
-				schemaParam := anthropic.ToolInputSchemaParam{
-					Type:       constant.Object("object"),
-					Properties: properties,
-					Required:   required,
-				}
-
-				toolParam := anthropic.ToolUnionParamOfTool(schemaParam, name)
-				if toolParam.OfTool != nil {
-					toolParam.OfTool.Description = anthropic.String(description)
-				}
-				tools = append(tools, toolParam)
-			}
-		}
-		if len(tools) > 0 {
-			params.Tools = tools
-		}
-
-		if options.ToolMode != "" {
-			switch options.ToolMode {
-			case tool.ToolModeAuto:
-				params.ToolChoice = anthropic.ToolChoiceUnionParam{
-					OfAuto: &anthropic.ToolChoiceAutoParam{Type: constant.Auto("auto")},
-				}
-			case tool.ToolModeRequired:
-				params.ToolChoice = anthropic.ToolChoiceUnionParam{
-					OfAny: &anthropic.ToolChoiceAnyParam{Type: constant.Any("any")},
 				}
 			default:
-				params.ToolChoice = anthropic.ToolChoiceUnionParam{
-					OfTool: &anthropic.ToolChoiceToolParam{
-						Type: constant.Tool("tool"),
-						Name: string(options.ToolMode),
-					},
-				}
+				// Fallback or error handling
+			}
+
+			schemaParam := anthropic.ToolInputSchemaParam{
+				Type:       constant.Object("object"),
+				Properties: properties,
+				Required:   required,
+			}
+
+			toolParam := anthropic.ToolUnionParamOfTool(schemaParam, name)
+			if toolParam.OfTool != nil {
+				toolParam.OfTool.Description = anthropic.String(description)
+			}
+			tools = append(tools, toolParam)
+		}
+	}
+	if len(tools) > 0 {
+		params.Tools = tools
+	}
+
+	if options.ToolMode != "" {
+		switch options.ToolMode {
+		case tool.ToolModeAuto:
+			params.ToolChoice = anthropic.ToolChoiceUnionParam{
+				OfAuto: &anthropic.ToolChoiceAutoParam{Type: constant.Auto("auto")},
+			}
+		case tool.ToolModeRequired:
+			params.ToolChoice = anthropic.ToolChoiceUnionParam{
+				OfAny: &anthropic.ToolChoiceAnyParam{Type: constant.Any("any")},
+			}
+		default:
+			params.ToolChoice = anthropic.ToolChoiceUnionParam{
+				OfTool: &anthropic.ToolChoiceToolParam{
+					Type: constant.Tool("tool"),
+					Name: string(options.ToolMode),
+				},
 			}
 		}
 	}

--- a/go/anthropic/chat.go
+++ b/go/anthropic/chat.go
@@ -3,10 +3,13 @@
 package anthropic
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"iter"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -68,16 +71,18 @@ func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, mess
 				yield(nil, err)
 			}
 		}
-
+		functions := make(map[int]*message.FunctionCallContent)
 		contents := make([]message.Content, 0, len(resp.Content))
-		for _, c := range resp.Content {
-			contents = a.buildBlock(c.AsAny(), contents)
+		for i, c := range resp.Content {
+			contents = a.buildBlock(i, c.AsAny(), contents, functions)
+		}
+		indices := slices.Collect(maps.Keys(functions))
+		slices.Sort(indices)
+		for _, f := range indices {
+			contents = append(contents, functions[f])
 		}
 		contents = append(contents, &message.UsageContent{
-			Details: message.UsageDetails{
-				InputTokenCount:  resp.Usage.InputTokens,
-				OutputTokenCount: resp.Usage.OutputTokens,
-			},
+			Details: toUsageDetails(resp.Usage),
 		})
 		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 			yield(&chatclient.ChatResponseUpdate{
@@ -95,34 +100,44 @@ func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, mess
 	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 		stream := a.client.Messages.NewStreaming(ctx, params)
 
-		var currentMessageID string
-		var currentModel string
-		var currentRole message.Role
+		var messageID string
+		var modelID string
+		var usage message.UsageDetails
+		var finishReason string
+		var functions = make(map[int]*message.FunctionCallContent)
 
 		for stream.Next() {
 			event := stream.Current()
 
 			var contents []message.Content
-			var finishReason string
 			switch event := event.AsAny().(type) {
 			case anthropic.MessageStartEvent:
-				currentMessageID = event.Message.ID
-				currentModel = string(event.Message.Model)
-				currentRole = message.RoleAssistant
-			case anthropic.ContentBlockStartEvent:
-				contents = a.buildBlock(event.ContentBlock.AsAny(), contents)
-			case anthropic.ContentBlockDeltaEvent:
-				contents = a.buildDelta(event.Delta.AsAny(), contents)
+				messageID = cmp.Or(messageID, event.Message.ID)
+				modelID = cmp.Or(modelID, string(event.Message.Model))
+				usage.Add(toUsageDetails(event.Message.Usage))
 			case anthropic.MessageDeltaEvent:
 				finishReason = string(event.Delta.StopReason)
+				usage.Add(toUsageDetailsDelta(event.Usage))
+			case anthropic.ContentBlockStartEvent:
+				contents = a.buildBlock(int(event.Index), event.ContentBlock.AsAny(), contents, functions)
+			case anthropic.ContentBlockDeltaEvent:
+				contents = a.buildDelta(int(event.Index), event.Delta.AsAny(), contents, functions)
+			case anthropic.ContentBlockStopEvent:
+				indices := slices.Collect(maps.Keys(functions))
+				slices.Sort(indices)
+				for _, id := range indices {
+					fn := functions[id]
+					fn.Arguments = json.RawMessage(fn.Arguments.(string))
+					contents = append(contents, fn)
+				}
 			}
 
 			if !yield(&chatclient.ChatResponseUpdate{
 				Contents:          contents,
-				Role:              currentRole,
-				ResponseID:        currentMessageID,
-				MessageID:         currentMessageID,
-				ModelID:           currentModel,
+				Role:              message.RoleAssistant,
+				ResponseID:        messageID,
+				MessageID:         messageID,
+				ModelID:           modelID,
 				FinishReason:      finishReason,
 				CreatedAt:         time.Now(),
 				RawRepresentation: event,
@@ -130,31 +145,124 @@ func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, mess
 				return
 			}
 		}
-
+		if !yield(&chatclient.ChatResponseUpdate{
+			CreatedAt:    time.Now(),
+			FinishReason: finishReason,
+			Role:         message.RoleAssistant,
+			MessageID:    messageID,
+			Contents: []message.Content{
+				&message.UsageContent{
+					Details: usage,
+				},
+			},
+		}, nil) {
+			return
+		}
 		if err := stream.Err(); err != nil {
 			yield(nil, err)
 		}
 	}
 }
 
-func (a *client) buildBlock(v any, contents []message.Content) []message.Content {
+func toUsageDetails(usage anthropic.Usage) message.UsageDetails {
+	details := message.UsageDetails{
+		InputTokenCount:  usage.InputTokens,
+		OutputTokenCount: usage.OutputTokens,
+		TotalTokenCount:  usage.InputTokens + usage.OutputTokens,
+	}
+	if usage.CacheCreationInputTokens != 0 {
+		if details.AdditionalCounts == nil {
+			details.AdditionalCounts = make(map[string]int64)
+		}
+		details.AdditionalCounts["cache_creation_input_tokens"] = usage.CacheCreationInputTokens
+	}
+	if usage.CacheReadInputTokens != 0 {
+		if details.AdditionalCounts == nil {
+			details.AdditionalCounts = make(map[string]int64)
+		}
+		details.AdditionalCounts["cache_read_input_tokens"] = usage.CacheReadInputTokens
+	}
+	return details
+}
+
+func toUsageDetailsDelta(usage anthropic.MessageDeltaUsage) message.UsageDetails {
+	return toUsageDetails(anthropic.Usage{
+		InputTokens:              usage.InputTokens,
+		OutputTokens:             usage.OutputTokens,
+		CacheCreationInputTokens: usage.CacheCreationInputTokens,
+		CacheReadInputTokens:     usage.CacheReadInputTokens,
+	})
+}
+
+func (a *client) buildBlock(index int, v any, contents []message.Content, functions map[int]*message.FunctionCallContent) []message.Content {
 	switch v := v.(type) {
 	case anthropic.TextBlock:
-		contents = append(contents, &message.TextContent{Text: v.Text})
+		contents = append(contents, &message.TextContent{
+			Text: v.Text,
+			ContentHeader: message.ContentHeader{
+				RawRepresentation: v,
+			},
+		})
+	case anthropic.ThinkingBlock:
+		contents = append(contents, &message.TextReasoningContent{
+			ProtectedData: v.Signature,
+			Text:          v.Thinking,
+			ContentHeader: message.ContentHeader{
+				RawRepresentation: v,
+			},
+		})
+	case anthropic.RedactedThinkingBlock:
+		contents = append(contents, &message.TextReasoningContent{
+			ProtectedData: v.Data,
+			ContentHeader: message.ContentHeader{
+				RawRepresentation: v,
+			},
+		})
 	case anthropic.ToolUseBlock:
-		contents = append(contents, &message.FunctionCallContent{
+		var input any
+		if v.Input != nil {
+			input = v.Input
+		}
+		functions[index] = &message.FunctionCallContent{
 			CallID:    v.ID,
 			Name:      v.Name,
-			Arguments: v.Input,
-		})
+			Arguments: input,
+		}
 	}
 	return contents
 }
 
-func (a *client) buildDelta(v any, contents []message.Content) []message.Content {
+func (a *client) buildDelta(index int, v any, contents []message.Content, functions map[int]*message.FunctionCallContent) []message.Content {
 	switch d := v.(type) {
 	case anthropic.TextDelta:
-		contents = append(contents, &message.TextContent{Text: d.Text})
+		contents = append(contents, &message.TextContent{
+			Text: d.Text,
+			ContentHeader: message.ContentHeader{
+				RawRepresentation: d,
+			},
+		})
+	case anthropic.InputJSONDelta:
+		if fnContent, ok := functions[index]; ok {
+			if fnContent.Arguments == nil {
+				fnContent.Arguments = d.PartialJSON
+			} else {
+				fnContent.Arguments = fnContent.Arguments.(string) + d.PartialJSON
+			}
+		}
+	case anthropic.ThinkingDelta:
+		contents = append(contents, &message.TextReasoningContent{
+			Text: d.Thinking,
+			ContentHeader: message.ContentHeader{
+				RawRepresentation: d,
+			},
+		})
+	case anthropic.SignatureDelta:
+		contents = append(contents, &message.TextReasoningContent{
+			ProtectedData: d.Signature,
+			ContentHeader: message.ContentHeader{
+				RawRepresentation: d,
+			},
+		})
 	}
 	return contents
 }

--- a/go/anthropic/chat.go
+++ b/go/anthropic/chat.go
@@ -52,8 +52,7 @@ func NewChatAgent(config ClientConfig, options *chatagent.Options) *chatagent.Ag
 
 func (a *client) Capabilities() chatclient.Capabilities {
 	return chatclient.Capabilities{
-		Streaming:        true,
-		StructuredOutput: false,
+		Streaming: true,
 	}
 }
 

--- a/go/format/format.go
+++ b/go/format/format.go
@@ -2,20 +2,11 @@
 
 package format
 
-import "encoding"
-
 // Format represents the desired format, e.g., for agent responses or tool input/output.
 type Format interface {
 	// Kind is the format type.
 	// For example, "text" or "json".
 	Kind() string
-}
-
-type Formattable interface {
-	encoding.BinaryUnmarshaler
-
-	// Format returns the desired format for the object.
-	Format() (Format, error)
 }
 
 type simple struct {
@@ -48,4 +39,9 @@ type SchemaFormat interface {
 
 	// Schema returns the JSON Schema that defines the format.
 	Schema() any
+}
+
+type Formatter interface {
+	Format(v any) (Format, error)
+	Unmarshal(data []byte, format Format, v any) error
 }

--- a/go/internal/concurrent/hashmap.go
+++ b/go/internal/concurrent/hashmap.go
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package concurrent
+
+import (
+	"fmt"
+	"iter"
+)
+
+type Hasher[T any] interface {
+	Hash(T) uint64
+	Equal(T, T) bool
+}
+
+type entry[K, V any] struct {
+	key   K
+	value V
+}
+
+// Map is a mapping from keys of type K to values of type V,
+// using key-equivalence relation H.
+type HashMap[K, V any] struct {
+	entries Map[uint64, entry[K, V]]
+	h       Hasher[K]
+}
+
+// NewMap returns a new mapping.
+func NewHashMap[K, V any](h Hasher[K]) *HashMap[K, V] {
+	return &HashMap[K, V]{
+		h: h,
+	}
+}
+
+// All returns an iterator over the key/value entries of the map in undefined order.
+func (m *HashMap[K, V]) All() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for entry := range m.entries.Values() {
+			if !yield(entry.key, entry.value) {
+				return
+			}
+		}
+	}
+}
+
+// Load returns the map entry for the given key.
+func (m *HashMap[K, V]) Load(key K) (V, bool) {
+	entry, ok := m.entries.Load(m.h.Hash(key))
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return entry.value, ok
+}
+
+// Delete removes th//e entry with the given key, if any.
+func (m *HashMap[K, V]) Delete(key K) {
+	m.entries.Delete(m.h.Hash(key))
+}
+
+// Keys returns an iterator over the map keys in unspecified order.
+func (m *HashMap[K, V]) Keys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for entry := range m.entries.Values() {
+			if !yield(entry.key) {
+				return
+			}
+		}
+	}
+}
+
+// Values returns an iterator over the map values in unspecified order.
+func (m *HashMap[K, V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for entry := range m.entries.Values() {
+			if !yield(entry.value) {
+				return
+			}
+		}
+	}
+}
+
+// Swap updates the map entry for key to value, and returns the previous entry, if any.
+func (m *HashMap[K, V]) Swap(key K, value V) (V, bool) {
+	hash := m.h.Hash(key)
+	entry, ok := m.entries.Swap(hash, entry[K, V]{key: key, value: value})
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return entry.value, ok
+}
+
+func (m *HashMap[K, V]) Clear() {
+	m.entries.Clear()
+}
+
+// String returns a string representation of the map's entries in unspecified order.
+// Values are printed as if by fmt.Sprint.
+func (m *HashMap[K, V]) String() string {
+	s := "{"
+	first := true
+	for entry := range m.entries.Values() {
+		if !first {
+			s += " "
+		}
+		s += fmt.Sprintf("%v: %v", entry.key, entry.value)
+		first = false
+	}
+	s += "}"
+	return s
+}

--- a/go/internal/concurrent/map.go
+++ b/go/internal/concurrent/map.go
@@ -96,6 +96,14 @@ func (m *Map[K, V]) Keys() iter.Seq[K] {
 	}
 }
 
+func (m *Map[K, V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		m.data.Range(func(key, value any) bool {
+			return yield(value.(V))
+		})
+	}
+}
+
 // All returns an iterator over the key-value pairs in the map.
 // The iteration order is not specified and is not guaranteed to be the same from one iteration to the next.
 //

--- a/go/internal/hashmap/hashmap.go
+++ b/go/internal/hashmap/hashmap.go
@@ -43,8 +43,8 @@ func (m *Map[K, V]) All() iter.Seq2[K, V] {
 	}
 }
 
-// At returns the map entry for the given key.
-func (m *Map[K, V]) At(key K) (V, bool) {
+// Load returns the map entry for the given key.
+func (m *Map[K, V]) Load(key K) (V, bool) {
 	entry, ok := m.entries[m.h.Hash(key)]
 	return entry.value, ok
 }

--- a/go/message/content.go
+++ b/go/message/content.go
@@ -442,10 +442,7 @@ type UsageDetails struct {
 	TotalTokenCount  int64
 }
 
-func (u *UsageDetails) Add(other *UsageDetails) {
-	if u == nil || other == nil {
-		return
-	}
+func (u *UsageDetails) Add(other UsageDetails) {
 	u.InputTokenCount += other.InputTokenCount
 	u.OutputTokenCount += other.OutputTokenCount
 	u.TotalTokenCount += other.TotalTokenCount

--- a/go/message/content_test.go
+++ b/go/message/content_test.go
@@ -30,12 +30,12 @@ func TestTextReasoningContent_String(t *testing.T) {
 
 // Test UsageDetails
 func TestUsageDetails_Add(t *testing.T) {
-	ud1 := &message.UsageDetails{
+	ud1 := message.UsageDetails{
 		InputTokenCount:  10,
 		OutputTokenCount: 20,
 		TotalTokenCount:  30,
 	}
-	ud2 := &message.UsageDetails{
+	ud2 := message.UsageDetails{
 		InputTokenCount:  5,
 		OutputTokenCount: 15,
 		TotalTokenCount:  20,
@@ -54,13 +54,13 @@ func TestUsageDetails_Add(t *testing.T) {
 }
 
 func TestUsageDetails_AddWithAdditionalCounts(t *testing.T) {
-	ud1 := &message.UsageDetails{
+	ud1 := message.UsageDetails{
 		InputTokenCount: 10,
 		AdditionalCounts: map[string]int64{
 			"cache_read": 5,
 		},
 	}
-	ud2 := &message.UsageDetails{
+	ud2 := message.UsageDetails{
 		InputTokenCount: 5,
 		AdditionalCounts: map[string]int64{
 			"cache_read":  3,
@@ -74,20 +74,6 @@ func TestUsageDetails_AddWithAdditionalCounts(t *testing.T) {
 	}
 	if ud1.AdditionalCounts["cache_write"] != 2 {
 		t.Errorf("expected cache_write 2, got %d", ud1.AdditionalCounts["cache_write"])
-	}
-}
-
-func TestUsageDetails_AddWithNil(t *testing.T) {
-	var ud1 *message.UsageDetails
-	ud2 := &message.UsageDetails{InputTokenCount: 10}
-
-	// Should not panic
-	ud1.Add(ud2)
-
-	ud1 = &message.UsageDetails{InputTokenCount: 10}
-	ud1.Add(nil)
-	if ud1.InputTokenCount != 10 {
-		t.Errorf("expected input tokens to remain 10, got %d", ud1.InputTokenCount)
 	}
 }
 

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -135,7 +135,7 @@ func (a *client) Response(ctx context.Context, options chatclient.ChatOptions, m
 		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 			update := &chatclient.ChatResponseUpdate{
 				Contents:   contents,
-				Role:       message.Role(choice.Message.Role),
+				Role:       message.RoleAssistant,
 				ResponseID: resp.ID,
 				MessageID:  resp.ID,
 				ModelID:    resp.Model,
@@ -176,14 +176,17 @@ func (a *client) Response(ctx context.Context, options chatclient.ChatOptions, m
 					Arguments: args,
 				})
 			}
+			var role message.Role
 			if len(chunk.Choices) > 0 {
-				if choice := chunk.Choices[0]; choice.Delta.Content != "" {
+				choice := chunk.Choices[0]
+				if choice.Delta.Content != "" {
 					contents = append(contents, &message.TextContent{Text: choice.Delta.Content})
 				}
+				role = mapRole(choice.Delta.Role)
 			}
 			resp := &chatclient.ChatResponseUpdate{
 				Contents:   contents,
-				Role:       message.RoleAssistant,
+				Role:       role,
 				ResponseID: chunk.ID,
 				MessageID:  chunk.ID,
 				ModelID:    chunk.Model,
@@ -196,6 +199,21 @@ func (a *client) Response(ctx context.Context, options chatclient.ChatOptions, m
 		if stream.Err() != nil {
 			yield(nil, stream.Err())
 		}
+	}
+}
+
+func mapRole(r string) message.Role {
+	switch r {
+	case "user":
+		return message.RoleUser
+	case "system":
+		return message.RoleSystem
+	case "tool":
+		return message.RoleTool
+	case "assistant", "developer":
+		return message.RoleAssistant
+	default:
+		return message.RoleAssistant
 	}
 }
 

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -44,7 +44,6 @@ func NewWebSearchTool(city, region, country, timezone, searchContextSize string)
 }
 
 var _ chatclient.Client = (*client)(nil)
-var _ chatclient.StructuredResponseClient = (*client)(nil)
 
 type client struct {
 	client openai.Client
@@ -97,68 +96,65 @@ func NewChatAgentAzure(config ClientConfig, options *chatagent.Options) *chatage
 	return newChatAgent(true, config, options)
 }
 
-func (a *client) StructuredResponse(v any, ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-	// The OpenAI models that support structured outputs use JSON Schema for defining the response format.
-	format, err := jsonformat.ForType(reflect.TypeOf(v))
-	if err != nil {
-		return nil, err
+func (a *client) Capabilities() chatclient.Capabilities {
+	return chatclient.Capabilities{
+		Streaming:        true,
+		StructuredOutput: true,
 	}
-	if opts == nil {
-		opts = &chatclient.ChatOptions{}
-	} else {
-		opts = opts.Clone()
-	}
-	opts.ResponseFormat = format
-	resp, err := a.Response(ctx, opts, messages...)
-	if err != nil {
-		return nil, err
-	}
-	if txt := resp.String(); txt != "" {
-		if err := jsonformat.Unmarshal(format, []byte(txt), v); err != nil {
-			return nil, err
-		}
-	}
-	return resp, nil
 }
 
-func (a *client) Response(ctx context.Context, opts *chatclient.ChatOptions, messages ...*message.Message) (*chatclient.ChatResponse, error) {
-	body, err := a.buildCompletionParams(opts, messages...)
+func (a *client) Response(ctx context.Context, options chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
+	body, err := a.buildCompletionParams(&options, messages...)
 	if err != nil {
-		return nil, err
-	}
-	resp, err := a.client.Chat.Completions.New(ctx, body)
-	if err != nil {
-		return nil, err
-	}
-	choice := resp.Choices[0]
-	contents := make([]message.Content, 0, 1+len(choice.Message.ToolCalls))
-	for _, tc := range choice.Message.ToolCalls {
-		contents = append(contents, &message.FunctionCallContent{
-			CallID:    tc.ID,
-			Name:      tc.Function.Name,
-			Arguments: json.RawMessage(tc.Function.Arguments),
-		})
-	}
-	if choice.Message.Content != "" {
-		contents = append(contents, &message.TextContent{Text: choice.Message.Content})
-	}
-	if choice.Message.Refusal != "" {
-		contents = append(contents, &message.ErrorContent{Message: choice.Message.Refusal})
-	}
-	return &chatclient.ChatResponse{
-		Messages:     []*message.Message{{Role: message.Role(choice.Message.Role), Contents: contents}},
-		ID:           resp.ID,
-		FinishReason: choice.FinishReason,
-	}, nil
-}
-
-func (a *client) StreamingResponse(ctx context.Context, options *chatclient.ChatOptions, messages ...*message.Message) iter.Seq2[*chatclient.ChatResponseUpdate, error] {
-	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
-		body, err := a.buildCompletionParams(options, messages...)
-		if err != nil {
+		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 			yield(nil, err)
-			return
 		}
+	}
+	if !options.Streaming.Or(false) {
+		resp, err := a.client.Chat.Completions.New(ctx, body)
+		if err != nil {
+			return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+				yield(nil, err)
+			}
+		}
+		choice := resp.Choices[0]
+		contents := make([]message.Content, 0, 1+len(choice.Message.ToolCalls))
+		for _, tc := range choice.Message.ToolCalls {
+			contents = append(contents, &message.FunctionCallContent{
+				CallID:    tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: json.RawMessage(tc.Function.Arguments),
+			})
+		}
+		if choice.Message.Content != "" {
+			contents = append(contents, &message.TextContent{Text: choice.Message.Content})
+		}
+		if choice.Message.Refusal != "" {
+			contents = append(contents, &message.ErrorContent{Message: choice.Message.Refusal})
+		}
+		return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
+			update := &chatclient.ChatResponseUpdate{
+				Contents:   contents,
+				Role:       message.Role(choice.Message.Role),
+				ResponseID: resp.ID,
+				MessageID:  resp.ID,
+				ModelID:    resp.Model,
+				CreatedAt:  time.Unix(resp.Created, 0),
+			}
+			if !yield(update, nil) {
+				return
+			}
+
+			if options.StructuredOutput != nil {
+				if txt := update.String(); txt != "" {
+					if err := jsonformat.Unmarshal(options.ResponseFormat.(*jsonformat.Format), []byte(txt), options.StructuredOutput); err != nil {
+						yield(nil, err)
+					}
+				}
+			}
+		}
+	}
+	return func(yield func(*chatclient.ChatResponseUpdate, error) bool) {
 		stream := a.client.Chat.Completions.NewStreaming(ctx, body)
 		defer stream.Close()
 		var acc openai.ChatCompletionAccumulator
@@ -209,101 +205,106 @@ func (a *client) buildCompletionParams(options *chatclient.ChatOptions, messages
 		Model:    a.config.Model,
 		Messages: make([]openai.ChatCompletionMessageParamUnion, 0, len(messages)+1),
 	}
-	if options != nil {
-		if options.Instructions != "" {
-			params.Messages = append(params.Messages, openai.SystemMessage([]openai.ChatCompletionContentPartTextParam{
-				{Text: options.Instructions},
-			}))
+	if options.Instructions != "" {
+		params.Messages = append(params.Messages, openai.SystemMessage([]openai.ChatCompletionContentPartTextParam{
+			{Text: options.Instructions},
+		}))
+	}
+	if options.Temperature.Valid() {
+		params.Temperature = openai.Float(options.Temperature.MustValue())
+	}
+	if options.TopP.Valid() {
+		params.TopP = openai.Float(options.TopP.MustValue())
+	}
+	if options.MaxTokens.Valid() {
+		params.MaxTokens = openai.Int(int64(options.MaxTokens.MustValue()))
+	}
+	if options.ResponseFormat == nil && options.StructuredOutput != nil {
+		format, err := jsonformat.ForType(reflect.TypeOf(options.StructuredOutput))
+		if err != nil {
+			return params, err
 		}
-		if options.Temperature.Valid() {
-			params.Temperature = openai.Float(options.Temperature.MustValue())
-		}
-		if options.TopP.Valid() {
-			params.TopP = openai.Float(options.TopP.MustValue())
-		}
-		if options.MaxTokens.Valid() {
-			params.MaxTokens = openai.Int(int64(options.MaxTokens.MustValue()))
-		}
-		if options.ResponseFormat != nil {
-			switch options.ResponseFormat.Kind() {
-			case "json":
-				if schema, ok := options.ResponseFormat.(format.SchemaFormat); ok {
-					params.ResponseFormat.OfJSONSchema = &shared.ResponseFormatJSONSchemaParam{
-						JSONSchema: shared.ResponseFormatJSONSchemaJSONSchemaParam{
-							Name:   schema.Name(),
-							Schema: schema.Schema(),
-						},
-					}
-					if desc := schema.Description(); desc != "" {
-						params.ResponseFormat.OfJSONSchema.JSONSchema.Description = openai.String(desc)
-					}
-					if schema.Strict() {
-						params.ResponseFormat.OfJSONSchema.JSONSchema.Strict = openai.Bool(true)
-					}
-				} else {
-					// Fallback to generic JSON object format
-					param := shared.NewResponseFormatJSONObjectParam()
-					params.ResponseFormat.OfJSONObject = &param
-				}
-			}
-		}
-		for _, tl := range options.Tools {
-			switch tl := tl.(type) {
-			case *hostedtool.WebSearch:
-				if location, ok := tl.AdditionalProperties["user_location"]; ok {
-					if location, ok := location.(map[string]string); ok {
-						if city, ok := location["city"]; ok && city != "" {
-							params.WebSearchOptions.UserLocation.Approximate.City = openai.String(city)
-						}
-						if region, ok := location["region"]; ok && region != "" {
-							params.WebSearchOptions.UserLocation.Approximate.Region = openai.String(region)
-						}
-						if country, ok := location["country"]; ok && country != "" {
-							params.WebSearchOptions.UserLocation.Approximate.Country = openai.String(country)
-						}
-						if timezone, ok := location["timezone"]; ok && timezone != "" {
-							params.WebSearchOptions.UserLocation.Approximate.Timezone = openai.String(timezone)
-						}
-					}
-				}
-				if contextSize, ok := tl.AdditionalProperties["search_context_size"]; ok {
-					if contextSize, ok := contextSize.(string); ok && contextSize != "" {
-						params.WebSearchOptions.SearchContextSize = contextSize
-					}
-				}
-			case tool.FuncTool:
-				name, description := tl.Name(), tl.Description()
-				var funcParams map[string]any
-				switch schema := tl.Schema().(type) {
-				case map[string]any:
-					funcParams = schema
-				default:
-					if schema == nil {
-						break
-					}
-					data, err := json.Marshal(schema)
-					if err == nil {
-						err = json.Unmarshal(data, &funcParams)
-					}
-					if err != nil {
-						return openai.ChatCompletionNewParams{}, fmt.Errorf("failed to convert function tool schema to JSON format: %w", err)
-					}
-				}
-				params.Tools = append(params.Tools, openai.ChatCompletionToolUnionParam{
-					OfFunction: &openai.ChatCompletionFunctionToolParam{
-						Function: shared.FunctionDefinitionParam{
-							Name:        name,
-							Description: openai.String(description),
-							Parameters:  funcParams,
-						},
+		options.ResponseFormat = format
+	}
+	if options.ResponseFormat != nil {
+		switch options.ResponseFormat.Kind() {
+		case "json":
+			if schema, ok := options.ResponseFormat.(format.SchemaFormat); ok {
+				params.ResponseFormat.OfJSONSchema = &shared.ResponseFormatJSONSchemaParam{
+					JSONSchema: shared.ResponseFormatJSONSchemaJSONSchemaParam{
+						Name:   schema.Name(),
+						Schema: schema.Schema(),
 					},
-				})
+				}
+				if desc := schema.Description(); desc != "" {
+					params.ResponseFormat.OfJSONSchema.JSONSchema.Description = openai.String(desc)
+				}
+				if schema.Strict() {
+					params.ResponseFormat.OfJSONSchema.JSONSchema.Strict = openai.Bool(true)
+				}
+			} else {
+				// Fallback to generic JSON object format
+				param := shared.NewResponseFormatJSONObjectParam()
+				params.ResponseFormat.OfJSONObject = &param
 			}
 		}
-		if options.ToolMode != "" {
-			params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
-				OfAuto: openai.String(string(options.ToolMode)),
+	}
+	for _, tl := range options.Tools {
+		switch tl := tl.(type) {
+		case *hostedtool.WebSearch:
+			if location, ok := tl.AdditionalProperties["user_location"]; ok {
+				if location, ok := location.(map[string]string); ok {
+					if city, ok := location["city"]; ok && city != "" {
+						params.WebSearchOptions.UserLocation.Approximate.City = openai.String(city)
+					}
+					if region, ok := location["region"]; ok && region != "" {
+						params.WebSearchOptions.UserLocation.Approximate.Region = openai.String(region)
+					}
+					if country, ok := location["country"]; ok && country != "" {
+						params.WebSearchOptions.UserLocation.Approximate.Country = openai.String(country)
+					}
+					if timezone, ok := location["timezone"]; ok && timezone != "" {
+						params.WebSearchOptions.UserLocation.Approximate.Timezone = openai.String(timezone)
+					}
+				}
 			}
+			if contextSize, ok := tl.AdditionalProperties["search_context_size"]; ok {
+				if contextSize, ok := contextSize.(string); ok && contextSize != "" {
+					params.WebSearchOptions.SearchContextSize = contextSize
+				}
+			}
+		case tool.FuncTool:
+			name, description := tl.Name(), tl.Description()
+			var funcParams map[string]any
+			switch schema := tl.Schema().(type) {
+			case map[string]any:
+				funcParams = schema
+			default:
+				if schema == nil {
+					break
+				}
+				data, err := json.Marshal(schema)
+				if err == nil {
+					err = json.Unmarshal(data, &funcParams)
+				}
+				if err != nil {
+					return openai.ChatCompletionNewParams{}, fmt.Errorf("failed to convert function tool schema to JSON format: %w", err)
+				}
+			}
+			params.Tools = append(params.Tools, openai.ChatCompletionToolUnionParam{
+				OfFunction: &openai.ChatCompletionFunctionToolParam{
+					Function: shared.FunctionDefinitionParam{
+						Name:        name,
+						Description: openai.String(description),
+						Parameters:  funcParams,
+					},
+				},
+			})
+		}
+	}
+	if options.ToolMode != "" {
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String(string(options.ToolMode)),
 		}
 	}
 	for _, msg := range messages {

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -96,10 +96,23 @@ func NewChatAgentAzure(config ClientConfig, options *chatagent.Options) *chatage
 	return newChatAgent(true, config, options)
 }
 
+var _ format.Formatter = (*formatter)(nil)
+
+type formatter struct {
+}
+
+func (formatter) Format(v any) (format.Format, error) {
+	return jsonformat.ForType(reflect.TypeOf(v))
+}
+
+func (formatter) Unmarshal(data []byte, format format.Format, v any) error {
+	return jsonformat.Unmarshal(format.(*jsonformat.Format), data, v)
+}
+
 func (a *client) Capabilities() chatclient.Capabilities {
 	return chatclient.Capabilities{
 		Streaming:        true,
-		StructuredOutput: true,
+		StructuredOutput: formatter{},
 	}
 }
 
@@ -143,14 +156,6 @@ func (a *client) Response(ctx context.Context, options chatclient.ChatOptions, m
 			}
 			if !yield(update, nil) {
 				return
-			}
-
-			if options.StructuredOutput != nil {
-				if txt := update.String(); txt != "" {
-					if err := jsonformat.Unmarshal(options.ResponseFormat.(*jsonformat.Format), []byte(txt), options.StructuredOutput); err != nil {
-						yield(nil, err)
-					}
-				}
 			}
 		}
 	}
@@ -236,13 +241,6 @@ func (a *client) buildCompletionParams(options *chatclient.ChatOptions, messages
 	}
 	if options.MaxTokens.Valid() {
 		params.MaxTokens = openai.Int(int64(options.MaxTokens.MustValue()))
-	}
-	if options.ResponseFormat == nil && options.StructuredOutput != nil {
-		format, err := jsonformat.ForType(reflect.TypeOf(options.StructuredOutput))
-		if err != nil {
-			return params, err
-		}
-		options.ResponseFormat = format
 	}
 	if options.ResponseFormat != nil {
 		switch options.ResponseFormat.Kind() {

--- a/go/samples/getting_started/anthropic/chat_basic/anthropic_chat_basic.go
+++ b/go/samples/getting_started/anthropic/chat_basic/anthropic_chat_basic.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/anthropic"
-	"github.com/microsoft/agent-framework/go/message"
 )
 
 /*
@@ -17,26 +17,25 @@ interactions, showing both streaming and non-streaming responses.
 */
 
 func main() {
-	ag := anthropic.NewChatAgent(anthropic.ClientConfig{
+	a := anthropic.NewChatAgent(anthropic.ClientConfig{
 		Model:  "claude-sonnet-4-5",
 		APIKey: os.Getenv("ANTHROPIC_API_KEY"),
 	}, nil)
 
-	nonStreamingExample(ag, "What's the weather like in Seattle?")
-	streamingExample(ag, "What's the weather like in Portland, Oregon?")
+	nonStreamingExample(a, "What's the weather like in Seattle?")
+	streamingExample(a, "What's the weather like in Portland, Oregon?")
 }
 
-func nonStreamingExample(ag agent.Agent, query string) {
+func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(ag.Run(nil, message.NewText(query))))
+	fmt.Println("Result: ", must(agent.RunText(context.Background(), a, query)))
 }
 
-func streamingExample(ag agent.Agent, query string) {
+func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	stream := ag.RunStream(nil, message.NewText(query))
-	for update, err := range stream {
+	for update, err := range agent.RunTextStream(context.Background(), a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
+++ b/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/microsoft/agent-framework/go/agent"
-	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
 )
 
@@ -22,7 +22,7 @@ func main() {
 	// - AZURE_OPENAI_API_KEY
 	// - AZURE_OPENAI_ENDPOINT
 	// - AZURE_OPENAI_DEPLOYMENT_NAME
-	ag := openai.NewChatAgentAzure(openai.ClientConfig{
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
 		APIKey:     os.Getenv("AZURE_OPENAI_API_KEY"),         // or set directly
 		Endpoint:   os.Getenv("AZURE_OPENAI_ENDPOINT"),        // e.g., "https://your-resource.openai.azure.com/"
 		Model:      os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), // e.g., "gpt-4o"
@@ -30,34 +30,33 @@ func main() {
 	}, nil)
 
 	// Example 1: Tool WILL be called (weather-related query)
-	nonStreamingExample(ag, "What's the weather like in Seattle?")
+	nonStreamingExample(a, "What's the weather like in Seattle?")
 
 	// Example 2: Tool WILL be called (streaming)
-	streamingExample(ag, "What's the weather like in Portland?")
+	streamingExample(a, "What's the weather like in Portland?")
 
 	// Example 3: Tool will NOT be called (general conversation)
-	nonStreamingExample(ag, "Hello! How are you today?")
+	nonStreamingExample(a, "Hello! How are you today?")
 
 	// Example 4: Tool will NOT be called (unrelated question)
-	nonStreamingExample(ag, "What is the capital of France?")
+	nonStreamingExample(a, "What is the capital of France?")
 
 	// Example 5: Tool WILL be called (implicit weather request)
-	nonStreamingExample(ag, "Should I bring an umbrella in Boston today?")
+	nonStreamingExample(a, "Should I bring an umbrella in Boston today?")
 
 }
 
-func nonStreamingExample(ag agent.Agent, query string) {
+func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("\n=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Assistant: ", must(ag.Run(nil, message.NewText(query))))
+	fmt.Println("Assistant: ", must(agent.RunText(context.Background(), a, query)))
 }
 
-func streamingExample(ag agent.Agent, query string) {
+func streamingExample(a agent.Agent, query string) {
 	fmt.Println("\n=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
 	fmt.Print("Assistant: ")
-	stream := ag.RunStream(nil, message.NewText(query))
-	for update, err := range stream {
+	for update, err := range agent.RunTextStream(context.Background(), a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/go/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
+++ b/go/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
@@ -33,7 +33,7 @@ func main() {
 		},
 	})
 
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
 	}, &chatagent.Options{
 		Instructions: "You are a helpful assistant who responds in French.",
@@ -42,7 +42,7 @@ func main() {
 		},
 	})
 
-	fmt.Println(must(ag.RunText(nil, "What is the weather like in Amsterdam?")))
+	fmt.Println(must(agent.RunText(context.Background(), a, "What is the weather like in Amsterdam?")))
 
 }
 

--- a/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
+++ b/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/microsoft/agent-framework/go/agent"
-	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
 )
 
@@ -17,25 +17,25 @@ interactions, showing both streaming and non-streaming responses.
 */
 
 func main() {
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model:  "gpt-5-nano",
 		APIKey: os.Getenv("OPENAI_API_KEY"),
 	}, nil)
 
-	nonStreamingExample(ag, "What's the weather like in Seattle?")
-	streamingExample(ag, "What's the weather like in Portland, Oregon?")
+	nonStreamingExample(a, "What's the weather like in Seattle?")
+	streamingExample(a, "What's the weather like in Portland, Oregon?")
 }
 
-func nonStreamingExample(ag agent.Agent, query string) {
+func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(ag.Run(nil, message.NewText(query))))
+	fmt.Println("Result: ", must(agent.RunText(context.Background(), a, query)))
 }
 
-func streamingExample(ag agent.Agent, query string) {
+func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	stream := ag.RunStream(nil, message.NewText(query))
+	stream := agent.RunTextStream(context.Background(), a, query)
 	for update, err := range stream {
 		if err != nil {
 			fmt.Print(err)

--- a/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
+++ b/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent"
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
@@ -16,7 +18,7 @@ showing multi-modal content handling with text and images.
 */
 
 func main() {
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
 	}, &chatagent.Options{
 		Name:         "VisionAgent",
@@ -24,12 +26,13 @@ func main() {
 	})
 
 	fmt.Println("Result: ", must(
-		ag.Run(nil, &message.Message{Role: message.RoleUser, Contents: []message.Content{
+		agent.Run(context.Background(), a, agent.RunOptions{}, message.New(
 			&message.TextContent{Text: "Describe the content of this image."},
 			&message.URIContent{
 				URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
 				MediaType: "image/jpeg",
-			}}}),
+			},
+		)),
 	))
 }
 

--- a/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
+++ b/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent"
-	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
 	"github.com/microsoft/agent-framework/go/tool"
 )
@@ -18,7 +18,7 @@ for real-time information retrieval and current data access.
 */
 
 func main() {
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-search-preview",
 	}, &chatagent.Options{
 		Instructions: "You are a helpful weather agent.",
@@ -29,23 +29,22 @@ func main() {
 
 	const message = "What is the current weather? Do not ask for my current location."
 	if true {
-		nonStreamingExample(ag, message)
+		nonStreamingExample(a, message)
 	} else {
-		streamingExample(ag, message)
+		streamingExample(a, message)
 	}
 }
 
-func nonStreamingExample(ag agent.Agent, query string) {
+func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(ag.Run(nil, message.NewText(query))))
+	fmt.Println("Result: ", must(agent.RunText(context.Background(), a, query)))
 }
 
-func streamingExample(ag agent.Agent, query string) {
+func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	stream := ag.RunStream(nil, message.NewText(query))
-	for update, err := range stream {
+	for update, err := range agent.RunTextStream(context.Background(), a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
+++ b/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
@@ -15,32 +15,33 @@ import (
 )
 
 func main() {
-	var ag *chatagent.Agent
-	ag = openai.NewChatAgent(openai.ClientConfig{
+	var a *chatagent.Agent
+	a = openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
 	}, &chatagent.Options{
 		Instructions:       "You are a friendly assistant. Always address the user by their name.",
-		NewContextProvider: func() memory.ContextProvider { return &UserInfoMemory{Agent: ag} },
+		NewContextProvider: func() memory.ContextProvider { return &UserInfoMemory{Agent: a} },
 	})
 
 	fmt.Println(">> Use thread with blank memory")
 
-	ctx := &agent.RunContext{Thread: ag.NewThread()}
+	ctx := context.Background()
+	opts := agent.RunOptions{Thread: a.NewThread()}
 
-	fmt.Println(must(ag.Run(ctx, message.NewText("Hello, what is the square root of 9?"))))
+	fmt.Println(must(agent.Run(ctx, a, opts, message.NewText("Hello, what is the square root of 9?"))))
 
-	fmt.Println(must(ag.Run(ctx, message.NewText("My name is Ruaidhrí"))))
+	fmt.Println(must(agent.Run(ctx, a, opts, message.NewText("My name is Ruaidhrí"))))
 
-	fmt.Println(must(ag.Run(ctx, message.NewText("I am 20 years old"))))
+	fmt.Println(must(agent.Run(ctx, a, opts, message.NewText("I am 20 years old"))))
 
 	// We can serialize the thread. The serialized state will include the state of the memory component.
-	serializedThread := must(json.Marshal(ctx.Thread))
+	serializedThread := must(json.Marshal(opts.Thread))
 
 	fmt.Println(">> Use new thread with previously created memories")
 
-	deserializedThread := must(ag.UnmarshalThread(serializedThread))
+	deserializedThread := must(a.UnmarshalThread(serializedThread))
 
-	fmt.Println(must(ag.Run(&agent.RunContext{Thread: deserializedThread}, message.NewText("What is my name and age?"))))
+	fmt.Println(must(agent.Run(ctx, a, agent.RunOptions{Thread: deserializedThread}, message.NewText("What is my name and age?"))))
 }
 
 type UserInfo struct {
@@ -79,10 +80,8 @@ func (u *UserInfoMemory) Invoked(ctx *memory.InvokedContext) error {
 		return nil
 	}
 	// To avoid infinite loops, we mark re-entrancy in the context.
-	actx := &agent.RunContext{
-		Context: context.WithValue(ctx.Context, reentrantCtxKey{}, struct{}{}),
-	}
-	out, _, err := chatagent.RunFor[UserInfo](u.Agent, actx, append(ctx.RequestMessages,
+	ctx.Context = context.WithValue(ctx.Context, reentrantCtxKey{}, struct{}{})
+	out, _, err := agent.RunFor[UserInfo](ctx, u.Agent, agent.RunOptions{}, append(ctx.RequestMessages,
 		message.NewText("Extract the user's name and age from the message if present. If not present return empty values."),
 	)...)
 	if err != nil {

--- a/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
+++ b/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
@@ -42,7 +42,7 @@ func mcpToolsOnAgentLevel() {
 
 	// Create the OpenAI agent with MCP tools
 	// In Go, we configure tools as default options that will be used for all runs
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
 	}, &chatagent.Options{
 		Name:         "DocsAgent",
@@ -52,17 +52,19 @@ func mcpToolsOnAgentLevel() {
 		},
 	})
 
+	ctx := context.Background()
+
 	// First query - uses the tools defined at agent creation
 	const query1 = "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(ag.Name(), ": ", must(ag.RunText(nil, query1)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(ctx, a, query1)))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	const query2 = "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(ag.Name(), ": ", must(ag.RunText(nil, query2)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(ctx, a, query2)))
 }
 
 // mcpToolsOnRunLevel demonstrates MCP tools defined when running the agent.
@@ -77,33 +79,32 @@ func mcpToolsOnRunLevel() {
 	tools := must(mcptool.ListTools(context.Background(), session))
 
 	// Create the OpenAI agent
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
 	}, &chatagent.Options{
 		Name:         "DocsAgent",
 		Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
 	})
 
-	ctx := &agent.RunContext{
-		Options: &agent.RunOptions{
-			Options: &chatagent.ChatOptions{
-				Tools:    tools,
-				ToolMode: tool.ToolModeAuto,
-			},
+	ctx := context.Background()
+	opts := agent.RunOptions{
+		Options: &chatagent.ChatOptions{
+			Tools:    tools,
+			ToolMode: tool.ToolModeAuto,
 		},
 	}
 
 	// First query
 	query1 := "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, message.NewText(query1))))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.Run(ctx, a, opts, message.NewText(query1))))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	query2 := "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(ag.Name(), ": ", must(ag.Run(ctx, message.NewText(query2))))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.Run(ctx, a, opts, message.NewText(query2))))
 }
 
 // must is a helper to panic on error for samples.

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent"
 	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
@@ -22,7 +24,7 @@ type CityInfo struct {
 }
 
 func main() {
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
 	}, &chatagent.Options{
 		Name:         "CityAgent",
@@ -32,7 +34,7 @@ func main() {
 	const query = "Tell me about Paris, France"
 	fmt.Println("User: ", query)
 
-	city, resp, err := chatagent.RunFor[CityInfo](ag, nil, message.NewText(query))
+	city, resp, err := agent.RunFor[CityInfo](context.Background(), a, agent.RunOptions{}, message.NewText(query))
 	if err != nil {
 		panic(err)
 	}

--- a/go/samples/getting_started/openai/chat_with_thread/openai_chat_with_thread.go
+++ b/go/samples/getting_started/openai/chat_with_thread/openai_chat_with_thread.go
@@ -41,7 +41,7 @@ func main() {
 func exampleWithAutomaticThreadCreation() {
 	fmt.Println("=== Automatic Thread Creation Example ===")
 
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
 	}, &chatagent.Options{
 		Instructions: "You are a helpful weather agent.",
@@ -50,15 +50,17 @@ func exampleWithAutomaticThreadCreation() {
 		},
 	})
 
+	ctx := context.Background()
+
 	// First conversation - no thread provided, will be created automatically
 	query1 := "What's the weather like in Seattle?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(ag.Run(nil, message.NewText(query1))))
+	fmt.Println("Agent: ", must(agent.Run(ctx, a, agent.RunOptions{}, message.NewText(query1))))
 
 	// Second conversation - still no thread provided, will create another new thread
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(ag.Run(nil, message.NewText(query2))))
+	fmt.Println("Agent: ", must(agent.Run(ctx, a, agent.RunOptions{}, message.NewText(query2))))
 	fmt.Println("Note: Each call creates a separate thread, so the agent doesn't remember previous context.")
 	fmt.Println()
 }
@@ -69,7 +71,7 @@ func exampleWithThreadPersistence() {
 	fmt.Println("Using the same thread across multiple conversations to maintain context.")
 	fmt.Println()
 
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
 	}, &chatagent.Options{
 		ChatOptions: &chatagent.ChatOptions{
@@ -78,22 +80,23 @@ func exampleWithThreadPersistence() {
 	})
 
 	// Create a new thread that will be reused
-	thread := ag.NewThread()
+	ctx := context.Background()
+	options := agent.RunOptions{Thread: a.NewThread()}
 
 	// First conversation
 	query1 := "What's the weather like in Tokyo?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query1))))
+	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query1))))
 
 	// Second conversation using the same thread - maintains context
 	query2 := "How about London?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query2))))
+	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query2))))
 
 	// Third conversation - agent should remember both previous cities
 	query3 := "Which of the cities I asked about has better weather?"
 	fmt.Println("User: ", query3)
-	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query3))))
+	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query3))))
 	fmt.Println("Note: The agent remembers context from previous messages in the same thread.")
 	fmt.Println()
 }
@@ -102,7 +105,7 @@ func exampleWithThreadPersistence() {
 func exampleWithExistingThreadMessages() {
 	fmt.Println("=== Existing Thread Messages Example ===")
 
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
 	}, &chatagent.Options{
 		ChatOptions: &chatagent.ChatOptions{
@@ -111,11 +114,12 @@ func exampleWithExistingThreadMessages() {
 	})
 
 	// Start a conversation and build up message history
-	thread := ag.NewThread()
+	ctx := context.Background()
+	options := agent.RunOptions{Thread: a.NewThread()}
 
 	query1 := "What's the weather in Paris?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(ag.Run(&agent.RunContext{Thread: thread}, message.NewText(query1))))
+	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query1))))
 
 	fmt.Println("\n--- Continuing with the same thread in a new agent instance ---")
 
@@ -131,7 +135,7 @@ func exampleWithExistingThreadMessages() {
 	// Use the same thread object which contains the conversation history
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(newAgent.Run(&agent.RunContext{Thread: thread}, message.NewText(query2))))
+	fmt.Println("Agent: ", must(agent.Run(ctx, newAgent, agent.RunOptions{Thread: options.Thread}, message.NewText(query2))))
 	fmt.Println("Note: The agent continues the conversation using the thread message history.")
 	fmt.Println()
 }

--- a/go/samples/getting_started/openai/chat_with_tool/openai_chat_with_tool.go
+++ b/go/samples/getting_started/openai/chat_with_tool/openai_chat_with_tool.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"math/rand"
 
+	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent"
-	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
 	"github.com/microsoft/agent-framework/go/tool"
 	"github.com/microsoft/agent-framework/go/tool/functool"
@@ -28,7 +28,7 @@ var weatherTool = functool.MustNew(&functool.Func{
 })
 
 func main() {
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
 	}, &chatagent.Options{
 		Instructions: "You are a helpful weather agent.",
@@ -37,10 +37,9 @@ func main() {
 		},
 	})
 
-	fmt.Println(must(ag.RunText(nil, "What's the weather like in Amsterdam?")))
+	fmt.Println(must(agent.RunText(context.Background(), a, "What's the weather like in Amsterdam?")))
 
-	stream := ag.RunStream(nil, message.NewText("What is the weather like in Amsterdam?"))
-	for update, err := range stream {
+	for update, err := range agent.RunTextStream(context.Background(), a, "What is the weather like in Amsterdam?") {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/go/samples/getting_started/openai/chat_with_tool_with_approvals/openai_chat_with_tool_with_approvals.go
+++ b/go/samples/getting_started/openai/chat_with_tool_with_approvals/openai_chat_with_tool_with_approvals.go
@@ -22,7 +22,7 @@ var weatherTool = functool.MustNew(&functool.Func{
 })
 
 func main() {
-	ag := openai.NewChatAgent(openai.ClientConfig{
+	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
 	}, &chatagent.Options{
 		Instructions: "You are a helpful weather agent.",
@@ -31,11 +31,12 @@ func main() {
 		},
 	})
 
-	ctx := &agent.RunContext{
-		Thread: ag.NewThread(),
+	ctx := context.Background()
+	options := agent.RunOptions{
+		Thread: a.NewThread(),
 	}
 
-	resp := must(ag.RunText(ctx, "What's the weather like in Amsterdam?"))
+	resp := must(agent.Run(ctx, a, options, message.NewText("What's the weather like in Amsterdam?")))
 
 	var userResponses []message.Content
 	for req := range resp.UserInputRequests() {
@@ -54,7 +55,7 @@ func main() {
 	}
 
 	// Pass the user input responses back to the agent for further processing.
-	fmt.Println("Agent:", must(ag.Run(ctx, message.New(userResponses...))))
+	fmt.Println("Agent:", must(agent.Run(ctx, a, options, message.New(userResponses...))))
 }
 
 // must is a helper to panic on error for samples.

--- a/go/workflow/internal/execution/state.go
+++ b/go/workflow/internal/execution/state.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"maps"
 
+	"github.com/microsoft/agent-framework/go/internal/concurrent"
 	"github.com/microsoft/agent-framework/go/internal/hashmap"
 	"github.com/microsoft/agent-framework/go/workflow"
 	"github.com/microsoft/agent-framework/go/workflow/internal/checkpoint"
@@ -143,24 +144,24 @@ func (h updateKeyHasher) Equal(a, b UpdateKey) bool {
 // StateManager manages state for all executors in a workflow run.
 // A zero value is valid is ready to use.
 type StateManager struct {
-	scopes        hashmap.Map[workflow.ScopeID, *StateScope]
-	queuedUpdates hashmap.Map[UpdateKey, StateUpdate]
+	scopes        concurrent.HashMap[workflow.ScopeID, *StateScope]
+	queuedUpdates concurrent.HashMap[UpdateKey, StateUpdate]
 }
 
 func NewStateManager() StateManager {
 	return StateManager{
-		scopes:        *hashmap.NewMap[workflow.ScopeID, *StateScope](workflow.ScopeIDHasher),
-		queuedUpdates: *hashmap.NewMap[UpdateKey, StateUpdate](UpdateKeyHasher),
+		scopes:        *concurrent.NewHashMap[workflow.ScopeID, *StateScope](workflow.ScopeIDHasher),
+		queuedUpdates: *concurrent.NewHashMap[UpdateKey, StateUpdate](UpdateKeyHasher),
 	}
 }
 
 // getOrCreateScope gets or creates a state scope.
 func (sm *StateManager) getOrCreateScope(scopeID workflow.ScopeID) *StateScope {
-	if scope, ok := sm.scopes.At(scopeID); ok {
+	if scope, ok := sm.scopes.Load(scopeID); ok {
 		return scope
 	}
 	scope := NewStateScope(scopeID)
-	sm.scopes.Set(scopeID, scope)
+	sm.scopes.Swap(scopeID, scope)
 	return scope
 }
 
@@ -185,7 +186,7 @@ func (sm *StateManager) ClearState(executorID string, scopeName string) error {
 
 // ClearStateByID clears all state for the given scope ID.
 func (sm *StateManager) ClearStateByID(scopeID workflow.ScopeID) error {
-	scope, exists := sm.scopes.At(scopeID)
+	scope, exists := sm.scopes.Load(scopeID)
 	if !exists {
 		return nil
 	}
@@ -194,16 +195,16 @@ func (sm *StateManager) ClearStateByID(scopeID workflow.ScopeID) error {
 
 	// Mark existing updates as deletes
 	for updateKey := range sm.getUpdatesForScopeStrict(scopeID) {
-		update, _ := sm.queuedUpdates.At(updateKey)
+		update, _ := sm.queuedUpdates.Load(updateKey)
 		if !update.IsDelete {
-			sm.queuedUpdates.Set(updateKey, DeleteStateUpdate(update.Key))
+			sm.queuedUpdates.Swap(updateKey, DeleteStateUpdate(update.Key))
 		}
 		delete(keysToDelete, update.Key)
 	}
 
 	// Queue deletes for remaining keys
 	for key := range keysToDelete {
-		sm.queuedUpdates.Set(UpdateKey{ScopeID: scopeID, Key: key}, DeleteStateUpdate(key))
+		sm.queuedUpdates.Swap(UpdateKey{ScopeID: scopeID, Key: key}, DeleteStateUpdate(key))
 	}
 
 	return nil
@@ -212,7 +213,7 @@ func (sm *StateManager) ClearStateByID(scopeID workflow.ScopeID) error {
 // applyUnpublishedUpdates applies queued updates to a set of keys.
 func (sm *StateManager) applyUnpublishedUpdates(scopeID workflow.ScopeID, keys map[string]struct{}) map[string]struct{} {
 	for key := range sm.getUpdatesForScopeStrict(scopeID) {
-		update, _ := sm.queuedUpdates.At(key)
+		update, _ := sm.queuedUpdates.Load(key)
 		if update.IsDelete {
 			delete(keys, update.Key)
 		} else {
@@ -251,7 +252,7 @@ func (sm *StateManager) ReadStateByID(scopeID workflow.ScopeID, key string) (wor
 	stateKey := UpdateKey{ScopeID: scopeID, Key: key}
 
 	// Check queued updates first
-	if update, hasUpdate := sm.queuedUpdates.At(stateKey); hasUpdate {
+	if update, hasUpdate := sm.queuedUpdates.Load(stateKey); hasUpdate {
 		if update.IsDelete || update.Value == nil {
 			return workflow.PortableValue{}, false, nil
 		}
@@ -304,7 +305,7 @@ func (sm *StateManager) WriteStateByID(scopeID workflow.ScopeID, key string, val
 	}
 
 	stateKey := UpdateKey{ScopeID: scopeID, Key: key}
-	sm.queuedUpdates.Set(stateKey, UpdateStateUpdate(key, value))
+	sm.queuedUpdates.Swap(stateKey, UpdateStateUpdate(key, value))
 
 	return nil
 }
@@ -322,7 +323,7 @@ func (sm *StateManager) ClearStateKeyByID(scopeID workflow.ScopeID, key string) 
 	}
 
 	stateKey := UpdateKey{ScopeID: scopeID, Key: key}
-	sm.queuedUpdates.Set(stateKey, DeleteStateUpdate(key))
+	sm.queuedUpdates.Swap(stateKey, DeleteStateUpdate(key))
 
 	return nil
 }
@@ -333,11 +334,11 @@ func (sm *StateManager) PublishUpdates(tracer StepTracer) error {
 	updatesByScope := hashmap.NewMap[workflow.ScopeID, map[string][]StateUpdate](workflow.ScopeIDHasher)
 
 	for key, update := range sm.queuedUpdates.All() {
-		if _, ok := updatesByScope.At(key.ScopeID); !ok {
+		if _, ok := updatesByScope.Load(key.ScopeID); !ok {
 			updatesByScope.Set(key.ScopeID, make(map[string][]StateUpdate))
 		}
 
-		scopeUpdates, _ := updatesByScope.At(key.ScopeID)
+		scopeUpdates, _ := updatesByScope.Load(key.ScopeID)
 		scopeUpdates[key.Key] = append(scopeUpdates[key.Key], update)
 	}
 
@@ -361,7 +362,7 @@ func (sm *StateManager) PublishUpdates(tracer StepTracer) error {
 
 // ExportState exports all state for checkpointing.
 func (sm *StateManager) ExportState() (iter.Seq2[workflow.ScopeKey, workflow.PortableValue], error) {
-	if sm.queuedUpdates.Len() != 0 {
+	for range sm.queuedUpdates.Keys() {
 		return nil, fmt.Errorf("cannot export state while there are queued updates. Call PublishUpdates() first")
 	}
 
@@ -382,7 +383,7 @@ func (sm *StateManager) ExportState() (iter.Seq2[workflow.ScopeKey, workflow.Por
 
 // ImportState imports state from a checkpoint.
 func (sm *StateManager) ImportState(cp *checkpoint.Checkpoint) error {
-	if sm.queuedUpdates.Len() != 0 {
+	for range sm.queuedUpdates.Keys() {
 		return fmt.Errorf("cannot import state while there are queued updates. Call PublishUpdates() first")
 	}
 
@@ -390,10 +391,10 @@ func (sm *StateManager) ImportState(cp *checkpoint.Checkpoint) error {
 	sm.scopes.Clear()
 
 	for scopeKey, value := range cp.StateData.All() {
-		scope, ok := sm.scopes.At(scopeKey.ID)
+		scope, ok := sm.scopes.Load(scopeKey.ID)
 		if !ok {
 			scope = NewStateScope(scopeKey.ID)
-			sm.scopes.Set(scopeKey.ID, scope)
+			sm.scopes.Swap(scopeKey.ID, scope)
 		}
 		scope.ImportState(scopeKey.Key, value)
 	}


### PR DESCRIPTION
Refactor the `agent` package to be more idiomatic. The improvements in here are mostly taken from feedback form the last demo.

Notable changes:

- The `agent.Agent` interface has been simplified so it is easier to implement (see for example the A2A implementation).
- The `agent.Agent` callers are not expected to use an agent instance anymore, but a set of run functions defined in `agent`. This consolidates helper functions that where previously implemented on each agent implementation.
- The agent Run methods and functions no longer accepts an `agent.Context` (which has been removed). They now accept parameters that are easier to identify as a Go developer.