### PR TITLE
use optional parameters as inputs for agent runs

### DIFF
--- a/go/agent/a2aagent/a2a.go
+++ b/go/agent/a2aagent/a2a.go
@@ -81,20 +81,24 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return &thread, nil
 }
 
-func (a *Agent) Run(ctx context.Context, options agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		var thread *Thread
-		if options.Thread == nil {
+		if v, ok := agent.GetOption(agent.WithThread, options...); !ok {
 			thread = a.NewThread().(*Thread)
-			options.Thread = thread
-		} else if t, ok := options.Thread.(*Thread); ok {
+		} else if t, ok := v.(*Thread); ok {
 			thread = t
 		} else {
 			yield(nil, errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
 			return
 		}
+		ctx, ok := agent.GetOption(agent.WithContext, options...)
+		if !ok {
+			ctx = context.Background()
+		}
+		streaming, _ := agent.GetOption(agent.WithStreaming, options...)
 		var parts []a2a.Part
-		for _, msg := range messages {
+		for msg := range agent.GetOptions(agent.WithMessage, options...) {
 			parts = parts[:0] // reset parts slice
 			parts, err := contentsToParts(msg.Contents, parts)
 			if err != nil {
@@ -114,14 +118,14 @@ func (a *Agent) Run(ctx context.Context, options agent.RunOptions, messages ...*
 					ContextID:      thread.ContextID,
 				},
 			}
-			a.sendMsg(ctx, &options, params, yield)
+			a.sendMsg(ctx, thread, streaming, params, yield)
 		}
 	}
 }
 
-func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *a2a.MessageSendParams, yield func(*agent.RunResponseUpdate, error) bool) {
+func (a *Agent) sendMsg(ctx context.Context, thread *Thread, streaming bool, params *a2a.MessageSendParams, yield func(*agent.RunResponseUpdate, error) bool) {
 	var seq iter.Seq2[a2a.Event, error]
-	if options.Streaming.Or(false) {
+	if streaming {
 		seq = a.Client.SendStreamingMessage(ctx, params)
 	} else {
 		resp, err := a.Client.SendMessage(ctx, params)
@@ -130,7 +134,6 @@ func (a *Agent) sendMsg(ctx context.Context, options *agent.RunOptions, params *
 		}
 	}
 	id, name := a.iden.ID(), a.iden.Name()
-	thread := options.Thread.(*Thread)
 	for e, err := range seq {
 		if err != nil {
 			yield(nil, err)

--- a/go/agent/a2aagent/a2a_test.go
+++ b/go/agent/a2aagent/a2a_test.go
@@ -178,13 +178,13 @@ func TestRunAllowsNonUserRoleMessages(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}},
-		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}},
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}},
+	inputMessages := []agent.Option{
+		agent.WithMessage(&message.Message{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}}),
+		agent.WithMessage(&message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}}),
+		agent.WithMessage(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
 	}
 
-	_, err := agent.Run(t.Context(), a, agent.RunOptions{}, inputMessages...)
+	_, err := agent.Run(a, inputMessages...)
 	if err != nil {
 		t.Errorf("Run() error = %v, want nil", err)
 	}
@@ -203,11 +203,7 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Hello, world!"}}},
-	}
-
-	result, err := agent.Run(t.Context(), a, agent.RunOptions{}, inputMessages...)
+	result, err := agent.RunText(a, "Hello, world!")
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -280,12 +276,8 @@ func TestRunWithNewThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test message"}}},
-	}
-
 	thread := a.NewThread()
-	_, err := agent.Run(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...)
+	_, err := agent.RunText(a, "Test message", agent.WithThread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -304,13 +296,9 @@ func TestRunWithExistingThread(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test message"}}},
-	}
-
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	_, err := agent.Run(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...)
+	_, err := agent.RunText(a, "Test message", agent.WithThread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -336,13 +324,9 @@ func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test message"}}},
-	}
-
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	_, err := agent.Run(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...)
+	_, err := agent.RunText(a, "Test message", agent.WithThread(thread))
 	if err == nil {
 		t.Error("Run() error = nil, want error")
 	}
@@ -360,12 +344,8 @@ func TestRunStreamingAsyncWithValidUserMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Hello, streaming!"}}},
-	}
-
 	var updates []*agent.RunResponseUpdate
-	for update, err := range agent.RunStream(t.Context(), a, agent.RunOptions{}, inputMessages...) {
+	for update, err := range agent.RunTextStream(a, "Hello, streaming!") {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -444,13 +424,9 @@ func TestRunStreamingAsyncWithThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test streaming"}}},
-	}
-
 	thread := a.NewThread()
 
-	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...) {
+	for _, err := range agent.RunTextStream(a, "Test streaming", agent.WithThread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -472,13 +448,9 @@ func TestRunStreamingAsyncWithExistingThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test streaming"}}},
-	}
-
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...) {
+	for _, err := range agent.RunTextStream(a, "Test streaming", agent.WithThread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -506,12 +478,9 @@ func TestRunStreamingAsyncWithThreadHavingDifferentContextID(t *testing.T) {
 	a := newTestAgent(transport, nil)
 
 	thread := a.NewThreadWithContextID("existing-context-id")
-	inputMessages := []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test streaming"}}},
-	}
 
 	gotError := false
-	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{Thread: thread}, inputMessages...) {
+	for _, err := range agent.RunTextStream(a, "Test streaming", agent.WithThread(thread)) {
 		if err != nil {
 			gotError = true
 			break
@@ -535,13 +504,13 @@ func TestRunStreamingAsyncAllowsNonUserRoleMessages(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}},
-		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}},
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}},
+	inputMessages := []agent.Option{
+		agent.WithMessage(&message.Message{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}}),
+		agent.WithMessage(&message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}}),
+		agent.WithMessage(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
 	}
 
-	for _, err := range agent.RunStream(t.Context(), a, agent.RunOptions{}, inputMessages...) {
+	for _, err := range agent.RunStream(a, inputMessages...) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -553,8 +522,8 @@ func TestRunWithHostedFileContent(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, nil)
 
-	inputMessages := []*message.Message{
-		{
+	inputMessages := []agent.Option{
+		agent.WithMessage(&message.Message{
 			Role: message.RoleUser,
 			Contents: []message.Content{
 				&message.TextContent{Text: "Check this file:"},
@@ -563,10 +532,10 @@ func TestRunWithHostedFileContent(t *testing.T) {
 					MediaType: "application/pdf",
 				},
 			},
-		},
+		}),
 	}
 
-	_, err := agent.Run(t.Context(), a, agent.RunOptions{}, inputMessages...)
+	_, err := agent.Run(a, inputMessages...)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -15,18 +15,7 @@ import (
 	"github.com/microsoft/agent-framework/go/format"
 	"github.com/microsoft/agent-framework/go/memory"
 	"github.com/microsoft/agent-framework/go/message"
-	"github.com/microsoft/agent-framework/go/param"
 )
-
-type RunOptions struct {
-	Thread                   memory.Thread
-	Streaming                param.Opt[bool]
-	AllowBackgroundResponses param.Opt[bool]
-	ContinuationToken        any
-	ResponseFormat           format.Format
-
-	Options any
-}
 
 type Identity struct {
 	id          string
@@ -66,17 +55,18 @@ type Agent interface {
 	Identity() Identity
 	Capabilities() Capabilities
 
-	Run(ctx context.Context, options RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error]
+	Run(...Option) iter.Seq2[*RunResponseUpdate, error]
 
 	NewThread() memory.Thread
 	UnmarshalThread(data []byte) (memory.Thread, error)
 }
 
-func Run(ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) (*RunResponse, error) {
+// Run executes the agent with the given options and returns the response.
+func Run(a Agent, opts ...Option) (*RunResponse, error) {
 	resp := RunResponse{
 		AgentID: a.Identity().ID(),
 	}
-	for update, err := range run(ctx, a, options, messages...) {
+	for update, err := range run(a, opts...) {
 		if err != nil {
 			return nil, err
 		}
@@ -88,34 +78,37 @@ func Run(ctx context.Context, a Agent, options RunOptions, messages ...*message.
 	return &resp, nil
 }
 
-func RunStream(ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
-	options.Streaming = param.NewOpt(true)
-	return run(ctx, a, options, messages...)
-}
-
-func run(ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) iter.Seq2[*RunResponseUpdate, error] {
-	retErr := func(err error) iter.Seq2[*RunResponseUpdate, error] {
-		return func(yield func(*RunResponseUpdate, error) bool) {
-			yield(nil, err)
-		}
-	}
-	if a == nil {
-		return retErr(errors.New("agent cannot be nil"))
-	}
-	return a.Run(ctx, options, messages...)
+// RunStream executes the agent with the given options and returns a streaming sequence of response updates.
+func RunStream(a Agent, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
+	opts = append(opts, WithStreaming(true))
+	return run(a, opts...)
 }
 
 // RunText executes the agent with a single text message and returns the response.
-func RunText(ctx context.Context, a Agent, msg string) (*RunResponse, error) {
-	return Run(ctx, a, RunOptions{}, message.NewText(msg))
+func RunText(a Agent, msg string, opts ...Option) (*RunResponse, error) {
+	return Run(a, append(opts, WithMessage(message.NewText(msg)))...)
 }
 
-func RunTextStream(ctx context.Context, a Agent, msg string) iter.Seq2[*RunResponseUpdate, error] {
-	return RunStream(ctx, a, RunOptions{}, message.NewText(msg))
+// RunTextStream executes the agent with a single text message and returns a streaming sequence of response updates.
+func RunTextStream(a Agent, msg string, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
+	return RunStream(a, append(opts, WithMessage(message.NewText(msg)))...)
+}
+
+func run(a Agent, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
+	if a == nil {
+		return func(yield func(*RunResponseUpdate, error) bool) {
+			yield(nil, errors.New("agent cannot be nil"))
+		}
+	}
+	if _, ok := GetOption(WithContext, opts...); !ok {
+		// If no context is provided, use background.
+		opts = append(opts, WithContext(context.Background()))
+	}
+	return a.Run(opts...)
 }
 
 // RunFor executes the agent with the given messages and returns the result of type T.
-func RunFor[T any](ctx context.Context, a Agent, options RunOptions, messages ...*message.Message) (T, *RunResponse, error) {
+func RunFor[T any](a Agent, opts ...Option) (T, *RunResponse, error) {
 	var v T
 	formatter := a.Capabilities().StructuredOutput
 	if formatter == nil {
@@ -125,12 +118,12 @@ func RunFor[T any](ctx context.Context, a Agent, options RunOptions, messages ..
 	if err != nil {
 		return v, nil, err
 	}
-	options.ResponseFormat = format
-	resp, err := Run(ctx, a, options, messages...)
+	opts = append(opts, WithResponseFormat(format))
+	resp, err := Run(a, opts...)
 	if err != nil {
 		return v, resp, err
 	}
-	err = formatter.Unmarshal([]byte(resp.String()), options.ResponseFormat, &v)
+	err = formatter.Unmarshal([]byte(resp.String()), format, &v)
 	return v, resp, err
 }
 

--- a/go/agent/chatagent/chatagent.go
+++ b/go/agent/chatagent/chatagent.go
@@ -84,14 +84,14 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
 }
 
-func (a *Agent) Run(opts ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		client := a.Client
-		if fn, ok := agent.GetOption(WithNewClient, opts...); ok {
+		if fn, ok := agent.GetOption(WithNewClient, options...); ok {
 			// If we have a custom chat client factory, we should use it to create a new chat client with the transformed tools.
 			client = fn(client)
 		}
-		ctx, thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(opts)
+		ctx, thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(options)
 		if err != nil {
 			yield(nil, err)
 			return

--- a/go/agent/chatagent/chatagent.go
+++ b/go/agent/chatagent/chatagent.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"slices"
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent/chatclient"
 	"github.com/microsoft/agent-framework/go/memory"
 	"github.com/microsoft/agent-framework/go/message"
+	"github.com/microsoft/agent-framework/go/param"
 )
 
 type ChatOptions = chatclient.ChatOptions
@@ -82,10 +84,14 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
 }
 
-func (a *Agent) Run(ctx context.Context, options agent.RunOptions, messages ...*message.Message) iter.Seq2[*agent.RunResponseUpdate, error] {
-	client := applyRunOptionsTransformations(&options, a.Client)
+func (a *Agent) Run(opts ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
-		thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, &options, messages)
+		client := a.Client
+		if fn, ok := agent.GetOption(WithNewClient, opts...); ok {
+			// If we have a custom chat client factory, we should use it to create a new chat client with the transformed tools.
+			client = fn(client)
+		}
+		ctx, thread, opts, messages, ctxMessages, err := a.prepareThreadAndMessages(opts)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -184,29 +190,34 @@ func (a *Agent) updateThreadWithTypeAndConversationID(thread *Thread, convID str
 	return nil
 }
 
-func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.RunOptions, messages []*message.Message) (thread *Thread, opts ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
-	retError := func(e error) (*Thread, ChatOptions, []*message.Message, []*message.Message, error) {
-		return nil, ChatOptions{}, nil, nil, e
+func (a *Agent) prepareThreadAndMessages(options []agent.Option) (ctx context.Context, thread *Thread, opts ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
+	retError := func(e error) (context.Context, *Thread, ChatOptions, []*message.Message, []*message.Message, error) {
+		return nil, nil, ChatOptions{}, nil, nil, e
 	}
 	opts = a.createConfiguredChatOptions(options)
 	if v, ok := opts.AllowBackgroundResponses.Value(); ok && v && thread == nil {
 		return retError(errors.New("a thread must be provided when continuing a background response with a continuation token"))
 	}
-	if options.Thread != nil {
+	if v, ok := agent.GetOption(agent.WithThread, options...); ok {
 		var ok bool
-		thread, ok = options.Thread.(*Thread)
+		thread, ok = v.(*Thread)
 		if !ok {
 			return retError(errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
 		}
 	} else {
 		thread = a.newThread("")
 	}
+	messages := slices.Collect(agent.GetOptions(agent.WithMessage, options...))
 	if opts.ContinuationToken != nil {
 		if len(messages) > 0 {
 			return retError(errors.New("messages are not allowed when continuing a background response using a continuation token"))
 		}
 	}
-
+	var ok bool
+	ctx, ok = agent.GetOption(agent.WithContext, options...)
+	if !ok {
+		ctx = context.Background()
+	}
 	if opts.ContinuationToken == nil {
 		if thread.MessageStore != nil {
 			//  Add any existing messages from the thread to the messages to be sent to the chat client.
@@ -258,33 +269,31 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options *agent.Run
 	if thread.ConversationID != "" && opts.ConversationID != thread.ConversationID {
 		opts.ConversationID = thread.ConversationID
 	}
-	return thread, opts, msgsForClient, ctxMessages, nil
+	return ctx, thread, opts, msgsForClient, ctxMessages, nil
 }
 
-func (a *Agent) createConfiguredChatOptions(runOpts *agent.RunOptions) ChatOptions {
+func (a *Agent) createConfiguredChatOptions(options []agent.Option) ChatOptions {
 	var opts ChatOptions
 	// Try to get ChatOptions from RunOptions
-	if runOpts.Options != nil {
-		if v, ok := runOpts.Options.(*ChatOptions); ok {
-			opts = *v.Clone()
-		}
+	if v, ok := agent.GetOption(WithOptions, options...); ok {
+		opts = *v.Clone()
 	}
 	// Merge in Agent-level ChatOptions
 	if a.Options.ChatOptions != nil {
 		opts.Copy(a.Options.ChatOptions)
 	}
 	// Merge in RunOptions specific fields
-	opts.AllowBackgroundResponses = runOpts.AllowBackgroundResponses
-	opts.ContinuationToken = runOpts.ContinuationToken
-	opts.Streaming = runOpts.Streaming
-	opts.ResponseFormat = runOpts.ResponseFormat
-	return opts
-}
-
-func applyRunOptionsTransformations(opts *agent.RunOptions, client chatclient.Client) chatclient.Client {
-	if v, ok := opts.Options.(*RunOptions); ok && v.NewClient != nil {
-		// If we have a custom chat client factory, we should use it to create a new chat client with the transformed tools.
-		client = v.NewClient(client)
+	if v, ok := agent.GetOption(agent.WithAllowBackgroundResponses, options...); ok {
+		opts.AllowBackgroundResponses = param.NewOpt(v)
 	}
-	return client
+	if v, ok := agent.GetOption(agent.WithContinuationToken, options...); ok {
+		opts.ContinuationToken = v
+	}
+	if v, ok := agent.GetOption(agent.WithStreaming, options...); ok {
+		opts.Streaming = param.NewOpt(v)
+	}
+	if v, ok := agent.GetOption(agent.WithResponseFormat, options...); ok {
+		opts.ResponseFormat = v
+	}
+	return opts
 }

--- a/go/agent/chatagent/chatclient/funcinvoke_approval_test.go
+++ b/go/agent/chatagent/chatclient/funcinvoke_approval_test.go
@@ -4,7 +4,6 @@ package chatclient_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"iter"
 	"testing"
@@ -164,14 +163,14 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAllRequireApp
 			downstreamClientOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 				}},
 			}
 
 			expectedOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 				}},
 			}
 
@@ -202,14 +201,14 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequireApp
 	downstreamClientOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 	}
 
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 	}
 
@@ -256,14 +255,14 @@ func TestFunctionInvoking_AllFunctionCallsReplacedWithApprovalsWhenAnyRequestOrA
 			downstreamClientOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 				}},
 			}
 
 			expectedOutput := []*message.Message{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+					&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 				}},
 			}
 
@@ -286,11 +285,11 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 	}
 
@@ -299,7 +298,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -318,7 +317,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -350,13 +349,13 @@ func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExe
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
 		}},
 		{Role: message.RoleAssistant, ID: "resp2", Contents: []message.Content{
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
 		),
 		message.New(
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 	}
 
@@ -367,7 +366,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExe
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
 		}},
 		{Role: message.RoleAssistant, ID: "resp2", Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -385,7 +384,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesFromSeparateFCCMessagesAreExe
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
 		}},
 		{Role: message.RoleAssistant, ID: "resp2", Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -410,11 +409,11 @@ func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 	}
 
@@ -422,7 +421,7 @@ func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -439,7 +438,7 @@ func TestFunctionInvoking_RejectedApprovalResponsesAreFailed(t *testing.T) {
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -467,11 +466,11 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, ID: "resp1", Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: false, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 	}
 
@@ -479,7 +478,7 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -498,7 +497,7 @@ func TestFunctionInvoking_MixedApprovedAndRejectedApprovalResponsesAreExecutedAn
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Tool call invocation was rejected by user."},
@@ -526,11 +525,11 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 	}
 
@@ -538,7 +537,7 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -549,7 +548,7 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 	// Downstream client returns a new FunctionCallContent for Func2 with different arguments
 	downstreamClientOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":3}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":3}`},
 		}},
 	}
 
@@ -557,14 +556,14 @@ func TestFunctionInvoking_ApprovedInputsAreExecutedAndFunctionResultsAreConverte
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":3}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":3}`}},
 		}},
 	}
 
@@ -587,17 +586,17 @@ func TestFunctionInvoking_AlreadyExecutedApprovalsAreIgnored(t *testing.T) {
 		// Previous turn: approval requests
 		{Role: message.RoleAssistant, ID: "resp1", Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 		// Previous turn: approval responses
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 		// Previous turn: already executed - function calls
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		// Previous turn: already executed - function results
 		{Role: message.RoleTool, Contents: []message.Content{
@@ -619,7 +618,7 @@ func TestFunctionInvoking_AlreadyExecutedApprovalsAreIgnored(t *testing.T) {
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -678,7 +677,7 @@ func TestFunctionInvoking_MixedApprovalRequiredToolsWithNonApprovalRequiringFunc
 			// Round 1: Only Func2 is called (doesn't require approval, so it's executed immediately)
 			{
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 				}},
 			},
 			// Round 2: Final response after Func2 execution
@@ -693,7 +692,7 @@ func TestFunctionInvoking_MixedApprovalRequiredToolsWithNonApprovalRequiringFunc
 	// Expected output: Func2 call, result, and final response
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
@@ -721,7 +720,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExec
 		message.New(&message.TextContent{Text: "hello"}),
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 	}
 
@@ -729,7 +728,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExec
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -746,7 +745,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesWithoutApprovalRequestAreExec
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -775,7 +774,7 @@ func TestFunctionInvoking_FunctionCallContentIsNotPassedToDownstreamServiceWithS
 	input := []*message.Message{
 		message.New(
 			&message.FunctionApprovalResponseContent{ID: "callId1", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalResponseContent{ID: "callId2", Approved: true, FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		),
 	}
 
@@ -797,7 +796,7 @@ func TestFunctionInvoking_FunctionCallContentIsNotPassedToDownstreamServiceWithS
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -832,7 +831,7 @@ func TestFunctionInvoking_FunctionCallContentIsYieldedImmediatelyIfNoApprovalReq
 			{
 				{Role: message.RoleAssistant, Contents: []message.Content{
 					&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 				}},
 			},
 			// Round 2: After executing functions, downstream returns final response
@@ -848,7 +847,7 @@ func TestFunctionInvoking_FunctionCallContentIsYieldedImmediatelyIfNoApprovalReq
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -881,7 +880,7 @@ func TestFunctionInvoking_FunctionCallsAreBufferedUntilApprovalRequirementEncoun
 	downstreamClientOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 	}
 
@@ -889,7 +888,7 @@ func TestFunctionInvoking_FunctionCallsAreBufferedUntilApprovalRequirementEncoun
 	expectedOutput := []*message.Message{
 		{Role: message.RoleAssistant, Contents: []message.Content{
 			&message.FunctionApprovalRequestContent{ID: "callId1", FunctionCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
-			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)}},
+			&message.FunctionApprovalRequestContent{ID: "callId2", FunctionCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`}},
 		}},
 	}
 

--- a/go/agent/chatagent/chatclient/funcinvoke_test.go
+++ b/go/agent/chatagent/chatclient/funcinvoke_test.go
@@ -64,19 +64,19 @@ func TestFunctionInvoking_SupportsSingleFunctionCallPerRequest(t *testing.T) {
 	plan := []*message.Message{
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: json.RawMessage(`{}`)},
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
+			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: `{"i":43}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId3", Result: "Success: Function completed."},
@@ -131,9 +131,9 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 			plan := []*message.Message{
 				message.New(&message.TextContent{Text: "hello"}),
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: json.RawMessage(`{"i":null}`)},
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":34}`)},
-					&message.FunctionCallContent{CallID: "callId3", Name: "Func2", Arguments: json.RawMessage(`{"i":56}`)},
+					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{"i":null}`},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":34}`},
+					&message.FunctionCallContent{CallID: "callId3", Name: "Func2", Arguments: `{"i":56}`},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
@@ -141,8 +141,8 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 					&message.FunctionResultContent{CallID: "callId3", Result: "Result 2: 56"},
 				}},
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId4", Name: "Func2", Arguments: json.RawMessage(`{"i":78}`)},
-					&message.FunctionCallContent{CallID: "callId5", Name: "Func1", Arguments: json.RawMessage(`{"i":null}`)},
+					&message.FunctionCallContent{CallID: "callId4", Name: "Func2", Arguments: `{"i":78}`},
+					&message.FunctionCallContent{CallID: "callId5", Name: "Func1", Arguments: `{"i":null}`},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId4", Result: "Result 2: 78"},
@@ -385,19 +385,19 @@ func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 			plan := []*message.Message{
 				message.New(&message.TextContent{Text: "hello"}),
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: json.RawMessage(`{}`)},
+					&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 				}},
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+					&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 				}},
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
+					&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: `{"i":43}`},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId3", Result: "Success: Function completed."},
@@ -454,13 +454,13 @@ func TestFunctionInvoking_PrefersToolsProvidedByChatOptions(t *testing.T) {
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
+			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: `{"i":43}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId3", Result: "Success: Function completed."},
@@ -495,8 +495,8 @@ func TestFunctionInvoking_ParallelFunctionCallsMayBeInvokedConcurrently(t *testi
 	plan := []*message.Message{
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: `{"Arg":"hello"}`},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: `{"Arg":"world"}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
@@ -536,8 +536,8 @@ func TestFunctionInvoking_ConcurrentInvocationOfParallelCallsDisabledByDefault(t
 	plan := []*message.Message{
 		message.New(&message.TextContent{Text: "hello"}),
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: json.RawMessage(`{"Arg":"hello"}`)},
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: json.RawMessage(`{"Arg":"world"}`)},
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func", Arguments: `{"Arg":"hello"}`},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func", Arguments: `{"Arg":"world"}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId1", Result: "hellohello"},
@@ -714,7 +714,7 @@ func createFunctionCallIterationPlan(callIndex *int, shouldThrow ...bool) []*mes
 		assistantContents = append(assistantContents, &message.FunctionCallContent{
 			CallID:    callID,
 			Name:      "Func",
-			Arguments: json.RawMessage(arguments),
+			Arguments: string(arguments),
 		})
 
 		result := "Success"
@@ -839,13 +839,13 @@ func TestFunctionInvoking_KeepsFunctionCallingContent(t *testing.T) {
 			&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: json.RawMessage(`{"i":42}`)},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{"i":42}`},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{CallID: "callId2", Result: "Result 2: 42"},
 		}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: json.RawMessage(`{"i":43}`)},
+			&message.FunctionCallContent{CallID: "callId3", Name: "VoidReturn", Arguments: `{"i":43}`},
 			&message.TextContent{Text: "more"},
 		}},
 		{Role: message.RoleTool, Contents: []message.Content{
@@ -908,8 +908,8 @@ func TestFunctionInvoking_TerminateOnUnknownCalls(t *testing.T) {
 			fullPlan := []*message.Message{
 				message.New(&message.TextContent{Text: "hello"}),
 				{Role: message.RoleAssistant, Contents: []message.Content{
-					&message.FunctionCallContent{CallID: "callId1", Name: "UnknownFunc", Arguments: json.RawMessage(`{"i":1}`)},
-					&message.FunctionCallContent{CallID: "callId2", Name: "KnownFunc", Arguments: json.RawMessage(`{"i":2}`)},
+					&message.FunctionCallContent{CallID: "callId1", Name: "UnknownFunc", Arguments: `{"i":1}`},
+					&message.FunctionCallContent{CallID: "callId2", Name: "KnownFunc", Arguments: `{"i":2}`},
 				}},
 				{Role: message.RoleTool, Contents: []message.Content{
 					&message.FunctionResultContent{CallID: "callId1", Result: "Error: Requested function \"UnknownFunc\" not found."},

--- a/go/agent/chatagent/options.go
+++ b/go/agent/chatagent/options.go
@@ -5,6 +5,7 @@ package chatagent
 import (
 	"log/slog"
 
+	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent/chatclient"
 	"github.com/microsoft/agent-framework/go/memory"
 )
@@ -33,9 +34,30 @@ func (o *Options) Clone() *Options {
 	return &clone
 }
 
-// RunOptions contains options for agent execution.
-type RunOptions struct {
-	ChatOptions *ChatOptions
+type opts struct {
+	*ChatOptions
+}
 
+func (opts) AgentOption() {}
+
+func (o opts) Value() any {
+	return o.ChatOptions
+}
+
+func WithOptions(options *ChatOptions) agent.Option {
+	return opts{options}
+}
+
+type newClientOpts struct {
 	NewClient func(chatclient.Client) chatclient.Client
+}
+
+func (newClientOpts) AgentOption() {}
+
+func (o newClientOpts) Value() any {
+	return o.NewClient
+}
+
+func WithNewClient(newClient func(chatclient.Client) chatclient.Client) agent.Option {
+	return newClientOpts{newClient}
 }

--- a/go/agent/opts.go
+++ b/go/agent/opts.go
@@ -94,10 +94,7 @@ func GetOption[T any](setter func(T) Option, opts ...Option) (T, bool) {
 	for _, opt := range slices.Backward(opts) {
 		if reflect.TypeOf(opt) == setterType {
 			v, ok := opt.Value().(T)
-			if !ok {
-				panic("option type mismatch")
-			}
-			return v, true
+			return v, ok
 		}
 	}
 	return zero, false

--- a/go/agent/opts.go
+++ b/go/agent/opts.go
@@ -16,7 +16,7 @@ import (
 // An Option configures the behavior of an Agent during a Run.
 //
 // Each option must be implemented as its own distinct type.
-// [GetOption] and [GetOptions] uses the option's type
+// [GetOption] and [GetOptions] use the option's type
 // to uniquely identify each option.
 type Option interface {
 	AgentOption()

--- a/go/agent/opts.go
+++ b/go/agent/opts.go
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package agent
+
+import (
+	"context"
+	"iter"
+	"reflect"
+	"slices"
+
+	"github.com/microsoft/agent-framework/go/format"
+	"github.com/microsoft/agent-framework/go/memory"
+	"github.com/microsoft/agent-framework/go/message"
+)
+
+// An Option configures the behavior of an Agent during a Run.
+//
+// Each option must be implemented as its own distinct type.
+// [GetOption] and [GetOptions] uses the option's type
+// to uniquely identify each option.
+type Option interface {
+	AgentOption()
+	Value() any
+}
+
+type (
+	contextOpt           struct{ context.Context }
+	responseFormatOpt    struct{ format.Format }
+	threadOpt            struct{ memory.Thread }
+	continuationTokenOpt struct{ any }
+
+	messageOpt struct{ *message.Message }
+
+	streamingOpt                bool
+	allowBackgroundResponsesOpt bool
+)
+
+func (contextOpt) AgentOption()                  {}
+func (responseFormatOpt) AgentOption()           {}
+func (threadOpt) AgentOption()                   {}
+func (streamingOpt) AgentOption()                {}
+func (continuationTokenOpt) AgentOption()        {}
+func (allowBackgroundResponsesOpt) AgentOption() {}
+func (messageOpt) AgentOption()                  {}
+
+func (o contextOpt) Value() any                  { return o.Context }
+func (o responseFormatOpt) Value() any           { return o.Format }
+func (o threadOpt) Value() any                   { return o.Thread }
+func (o streamingOpt) Value() any                { return bool(o) }
+func (o continuationTokenOpt) Value() any        { return o.any }
+func (o allowBackgroundResponsesOpt) Value() any { return bool(o) }
+func (o messageOpt) Value() any                  { return o.Message }
+
+// WithContext sets the context to use during the agent run.
+func WithContext(context context.Context) Option {
+	return contextOpt{context}
+}
+
+// WithStreaming sets whether to use streaming responses during the agent run.
+func WithStreaming(streaming bool) Option {
+	return streamingOpt(streaming)
+}
+
+// WithResponseFormat sets the desired response format for the agent run.
+func WithResponseFormat(format format.Format) Option {
+	return responseFormatOpt{format}
+}
+
+// WithThread sets the thread to use during the agent run.
+func WithThread(thread memory.Thread) Option {
+	return threadOpt{thread}
+}
+
+// WithContinuationToken sets the continuation token for the agent run.
+func WithContinuationToken(token any) Option {
+	return continuationTokenOpt{token}
+}
+
+// WithAllowBackgroundResponses sets whether to allow background responses during the agent run.
+func WithAllowBackgroundResponses(allow bool) Option {
+	return allowBackgroundResponsesOpt(allow)
+}
+
+// WithMessage adds a message to the agent run.
+func WithMessage(message *message.Message) Option {
+	return messageOpt{message}
+}
+
+// GetOption returns the value stored in opts with the provided setter,
+// reporting whether the value is present.
+func GetOption[T any](setter func(T) Option, opts ...Option) (T, bool) {
+	var zero T
+	var setterType = reflect.TypeOf(setter(zero))
+	for _, opt := range slices.Backward(opts) {
+		if reflect.TypeOf(opt) == setterType {
+			v, ok := opt.Value().(T)
+			if !ok {
+				panic("option type mismatch")
+			}
+			return v, true
+		}
+	}
+	return zero, false
+}
+
+// GetOptions returns a sequence of all values stored in opts with the provided setter.
+func GetOptions[T any](setter func(T) Option, opts ...Option) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		var zero T
+		var setterType = reflect.TypeOf(setter(zero))
+		for _, opt := range opts {
+			if reflect.TypeOf(opt) == setterType {
+				v, ok := opt.Value().(T)
+				if !ok {
+					panic("option type mismatch")
+				}
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/go/agent/tool.go
+++ b/go/agent/tool.go
@@ -5,7 +5,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/microsoft/agent-framework/go/memory"
 	"github.com/microsoft/agent-framework/go/message"
@@ -59,21 +58,14 @@ func (t functool) ReturnSchema() any {
 	}
 }
 
-func (t functool) Call(ctx context.Context, args any) (any, error) {
+func (t functool) Call(ctx context.Context, args string) (any, error) {
 	var in struct {
 		Query string `json:"query"`
 	}
-	var raw json.RawMessage
-	if args == nil {
-		raw = json.RawMessage("{}")
-	} else {
-		var ok bool
-		raw, ok = args.(json.RawMessage)
-		if !ok {
-			return nil, fmt.Errorf("expected json.RawMessage arguments, got %T", args)
-		}
+	if args == "" {
+		args = "{}"
 	}
-	if err := json.Unmarshal(raw, &in); err != nil {
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return nil, err
 	}
 	resp, err := Run(t.agent, WithContext(ctx), WithThread(t.thread), WithMessage(message.NewText(in.Query)))

--- a/go/agent/tool.go
+++ b/go/agent/tool.go
@@ -76,10 +76,7 @@ func (t functool) Call(ctx context.Context, args any) (any, error) {
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return nil, err
 	}
-	resp, err := Run(ctx, t.agent, RunOptions{Thread: t.thread}, &message.Message{
-		Role:     message.RoleUser,
-		Contents: []message.Content{&message.TextContent{Text: in.Query}},
-	})
+	resp, err := Run(t.agent, WithContext(ctx), WithThread(t.thread), WithMessage(message.NewText(in.Query)))
 	if err != nil {
 		return "", err
 	}

--- a/go/agent/workflow.go
+++ b/go/agent/workflow.go
@@ -63,21 +63,26 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 	ex.Config = append(ex.Config, messageworkflow.NewExecutorConfig(&messageworkflow.Options{
 		StateKey: "agent_messages",
 		TakeTurnHandler: func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
-			if !token.EmitEventsOr(emitEvents) {
-				response, err := Run(ctx, a, RunOptions{Thread: ensureThread()}, messages...)
-				if err != nil {
-					return err
-				}
-				return ctx.SendMessage("", response.Messages)
+			emitEvents := token.EmitEventsOr(emitEvents)
+			options := make([]Option, 0, 2+len(messages))
+			options = append(options, WithContext(ctx))
+			options = append(options, WithThread(ensureThread()))
+			if emitEvents {
+				// Run the agent in streaming mode only when agent run update events are to be emitted.
+				options = append(options, WithStreaming(true))
 			}
-			// Run the agent in streaming mode only when agent run update events are to be emitted.
+			for _, msg := range messages {
+				options = append(options, WithMessage(msg))
+			}
 			var updates []*RunResponseUpdate
-			for update, err := range RunStream(ctx, a, RunOptions{Thread: ensureThread()}, messages...) {
+			for update, err := range RunStream(a, options...) {
 				if err != nil {
 					return err
 				}
-				if err := ctx.AddEvent(RunUpdateEvent{id, update}); err != nil {
-					return err
+				if emitEvents {
+					if err := ctx.AddEvent(RunUpdateEvent{id, update}); err != nil {
+						return err
+					}
 				}
 				updates = append(updates, update)
 			}

--- a/go/anthropic/chat.go
+++ b/go/anthropic/chat.go
@@ -125,9 +125,7 @@ func (a *client) Response(ctx context.Context, opts chatclient.ChatOptions, mess
 				indices := slices.Collect(maps.Keys(functions))
 				slices.Sort(indices)
 				for _, id := range indices {
-					fn := functions[id]
-					fn.Arguments = json.RawMessage(fn.Arguments.(string))
-					contents = append(contents, fn)
+					contents = append(contents, functions[id])
 				}
 			}
 
@@ -218,14 +216,10 @@ func (a *client) buildBlock(index int, v any, contents []message.Content, functi
 			},
 		})
 	case anthropic.ToolUseBlock:
-		var input any
-		if v.Input != nil {
-			input = v.Input
-		}
 		functions[index] = &message.FunctionCallContent{
 			CallID:    v.ID,
 			Name:      v.Name,
-			Arguments: input,
+			Arguments: string(v.Input),
 		}
 	}
 	return contents
@@ -242,11 +236,7 @@ func (a *client) buildDelta(index int, v any, contents []message.Content, functi
 		})
 	case anthropic.InputJSONDelta:
 		if fnContent, ok := functions[index]; ok {
-			if fnContent.Arguments == nil {
-				fnContent.Arguments = d.PartialJSON
-			} else {
-				fnContent.Arguments = fnContent.Arguments.(string) + d.PartialJSON
-			}
+			fnContent.Arguments += d.PartialJSON
 		}
 	case anthropic.ThinkingDelta:
 		contents = append(contents, &message.TextReasoningContent{
@@ -302,7 +292,7 @@ func (a *client) buildMessageParams(options *chatclient.ChatOptions, messages ..
 					properties = props
 				}
 				if reqs, ok := schema["required"]; ok {
-					if reqList, ok := reqs.([]interface{}); ok {
+					if reqList, ok := reqs.([]any); ok {
 						for _, r := range reqList {
 							if s, ok := r.(string); ok {
 								required = append(required, s)

--- a/go/message/content.go
+++ b/go/message/content.go
@@ -227,7 +227,7 @@ func (t ErrorContent) kind() contentKind { return "error" }
 type serializedFunctionCallContent struct {
 	ContentHeader
 
-	Arguments any
+	Arguments string
 	CallID    string
 	Error     string `json:",omitempty"`
 	Name      string `json:",omitempty"`
@@ -239,7 +239,7 @@ type serializedFunctionCallContent struct {
 type FunctionCallContent struct {
 	ContentHeader
 
-	Arguments any
+	Arguments string
 	CallID    string
 	Error     error // Error that occurred while mapping the original function call data to this object.
 	Name      string

--- a/go/message/content_test.go
+++ b/go/message/content_test.go
@@ -82,7 +82,7 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 		&message.TextContent{Text: "sample text"},
 		&message.TextReasoningContent{Text: "sample reasoning"},
 		&message.FunctionCallContent{
-			Arguments: map[string]any{"key": "value"},
+			Arguments: `{"key":"value"}`,
 		},
 		&message.FunctionResultContent{
 			CallID: "call-123",

--- a/go/message/message.go
+++ b/go/message/message.go
@@ -39,10 +39,7 @@ func New(contents ...Content) *Message {
 
 // NewText creates a new [Message] with text content.
 func NewText(text string) *Message {
-	return &Message{
-		Role:     RoleUser,
-		Contents: []Content{&TextContent{Text: text}},
-	}
+	return New(&TextContent{Text: text})
 }
 
 func (m *Message) String() string {

--- a/go/openai/chat.go
+++ b/go/openai/chat.go
@@ -136,7 +136,7 @@ func (a *client) Response(ctx context.Context, options chatclient.ChatOptions, m
 			contents = append(contents, &message.FunctionCallContent{
 				CallID:    tc.ID,
 				Name:      tc.Function.Name,
-				Arguments: json.RawMessage(tc.Function.Arguments),
+				Arguments: tc.Function.Arguments,
 			})
 		}
 		if choice.Message.Content != "" {
@@ -170,15 +170,10 @@ func (a *client) Response(ctx context.Context, options chatclient.ChatOptions, m
 			}
 			var contents []message.Content
 			if tc, ok := acc.JustFinishedToolCall(); ok {
-				args, err := unmarshalArgs(tc.Arguments)
-				if err != nil {
-					yield(nil, err)
-					return
-				}
 				contents = append(contents, &message.FunctionCallContent{
 					CallID:    tc.ID,
 					Name:      tc.Name,
-					Arguments: args,
+					Arguments: tc.Arguments,
 				})
 			}
 			var role message.Role
@@ -422,16 +417,12 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 					})
 				}
 			case *message.FunctionCallContent:
-				args, err := marshalArgs(c.Arguments)
-				if err != nil {
-					return nil, err
-				}
 				toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
 					OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
 						ID: c.CallID,
 						Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
 							Name:      c.Name,
-							Arguments: args,
+							Arguments: c.Arguments,
 						},
 					},
 				})
@@ -475,20 +466,4 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 	default:
 		panic("unknown message role: " + string(msg.Role))
 	}
-}
-
-func marshalArgs(args any) (string, error) {
-	data, err := json.Marshal(args)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
-func unmarshalArgs(data string) (any, error) {
-	var args any
-	if err := json.Unmarshal([]byte(data), &args); err != nil {
-		return nil, fmt.Errorf("can't unmarshal response args: %w", err)
-	}
-	return args, nil
 }

--- a/go/samples/getting_started/anthropic/chat_basic/anthropic_chat_basic.go
+++ b/go/samples/getting_started/anthropic/chat_basic/anthropic_chat_basic.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -29,13 +28,13 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(agent.RunText(context.Background(), a, query)))
+	fmt.Println("Result: ", must(agent.RunText(a, query)))
 }
 
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	for update, err := range agent.RunTextStream(context.Background(), a, query) {
+	for update, err := range agent.RunTextStream(a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
+++ b/go/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -49,14 +48,14 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("\n=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Assistant: ", must(agent.RunText(context.Background(), a, query)))
+	fmt.Println("Assistant: ", must(agent.RunText(a, query)))
 }
 
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("\n=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
 	fmt.Print("Assistant: ")
-	for update, err := range agent.RunTextStream(context.Background(), a, query) {
+	for update, err := range agent.RunTextStream(a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/go/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
+++ b/go/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
@@ -41,16 +41,9 @@ func main() {
 			Tools: []tool.Tool{agent.FuncTool(weatherAgent, nil)},
 		},
 	})
-
-	fmt.Println(must(agent.RunText(context.Background(), a, "What is the weather like in Amsterdam?")))
-
-}
-
-// must is a helper to panic on error for samples.
-// In production code, handle errors appropriately.
-func must[T any](resp T, err error) T {
+	resp, err := agent.RunText(a, "What is the weather like in Amsterdam?")
 	if err != nil {
 		panic(err)
 	}
-	return resp
+	fmt.Println(resp)
 }

--- a/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
+++ b/go/samples/getting_started/openai/chat_basic/openai_chat_basic.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -29,14 +28,17 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(agent.RunText(context.Background(), a, query)))
+	resp, err := agent.RunText(a, query)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Result: ", resp)
 }
 
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	stream := agent.RunTextStream(context.Background(), a, query)
-	for update, err := range stream {
+	for update, err := range agent.RunTextStream(a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break
@@ -44,13 +46,4 @@ func streamingExample(a agent.Agent, query string) {
 		fmt.Print(update)
 	}
 	fmt.Print("\n")
-}
-
-// must is a helper to panic on error for samples.
-// In production code, handle errors appropriately.
-func must[T any](resp T, err error) T {
-	if err != nil {
-		panic(err)
-	}
-	return resp
 }

--- a/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
+++ b/go/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -25,22 +24,15 @@ func main() {
 		Instructions: "You are a helpful agent that can analyze images.",
 	})
 
-	fmt.Println("Result: ", must(
-		agent.Run(context.Background(), a, agent.RunOptions{}, message.New(
-			&message.TextContent{Text: "Describe the content of this image."},
-			&message.URIContent{
-				URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
-				MediaType: "image/jpeg",
-			},
-		)),
-	))
-}
-
-// must is a helper to panic on error for samples.
-// In production code, handle errors appropriately.
-func must[T any](resp T, err error) T {
+	resp, err := agent.Run(a,
+		agent.WithMessage(message.NewText("Describe the content of this image.")),
+		agent.WithMessage(message.New(&message.URIContent{
+			URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+			MediaType: "image/jpeg",
+		})),
+	)
 	if err != nil {
 		panic(err)
 	}
-	return resp
+	fmt.Println(resp)
 }

--- a/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
+++ b/go/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -38,13 +37,17 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(agent.RunText(context.Background(), a, query)))
+	resp, err := agent.RunText(a, query)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(resp)
 }
 
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	for update, err := range agent.RunTextStream(context.Background(), a, query) {
+	for update, err := range agent.RunTextStream(a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break
@@ -52,13 +55,4 @@ func streamingExample(a agent.Agent, query string) {
 		fmt.Print(update)
 	}
 	fmt.Print("\n")
-}
-
-// must is a helper to panic on error for samples.
-// In production code, handle errors appropriately.
-func must[T any](resp T, err error) T {
-	if err != nil {
-		panic(err)
-	}
-	return resp
 }

--- a/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
+++ b/go/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
@@ -25,23 +25,22 @@ func main() {
 
 	fmt.Println(">> Use thread with blank memory")
 
-	ctx := context.Background()
-	opts := agent.RunOptions{Thread: a.NewThread()}
+	thread := a.NewThread()
 
-	fmt.Println(must(agent.Run(ctx, a, opts, message.NewText("Hello, what is the square root of 9?"))))
+	fmt.Println(must(agent.RunText(a, "Hello, what is the square root of 9?", agent.WithThread(thread))))
 
-	fmt.Println(must(agent.Run(ctx, a, opts, message.NewText("My name is Ruaidhrí"))))
+	fmt.Println(must(agent.RunText(a, "My name is Ruaidhrí", agent.WithThread(thread))))
 
-	fmt.Println(must(agent.Run(ctx, a, opts, message.NewText("I am 20 years old"))))
+	fmt.Println(must(agent.RunText(a, "I am 20 years old", agent.WithThread(thread))))
 
 	// We can serialize the thread. The serialized state will include the state of the memory component.
-	serializedThread := must(json.Marshal(opts.Thread))
+	serializedThread := must(json.Marshal(thread))
 
 	fmt.Println(">> Use new thread with previously created memories")
 
 	deserializedThread := must(a.UnmarshalThread(serializedThread))
 
-	fmt.Println(must(agent.Run(ctx, a, agent.RunOptions{Thread: deserializedThread}, message.NewText("What is my name and age?"))))
+	fmt.Println(must(agent.RunText(a, "What is my name and age?", agent.WithThread(deserializedThread))))
 }
 
 type UserInfo struct {
@@ -80,10 +79,13 @@ func (u *UserInfoMemory) Invoked(ctx *memory.InvokedContext) error {
 		return nil
 	}
 	// To avoid infinite loops, we mark re-entrancy in the context.
-	ctx.Context = context.WithValue(ctx.Context, reentrantCtxKey{}, struct{}{})
-	out, _, err := agent.RunFor[UserInfo](ctx, u.Agent, agent.RunOptions{}, append(ctx.RequestMessages,
-		message.NewText("Extract the user's name and age from the message if present. If not present return empty values."),
-	)...)
+	opts := []agent.Option{agent.WithContext(context.WithValue(ctx.Context, reentrantCtxKey{}, struct{}{}))}
+	for _, msg := range ctx.RequestMessages {
+		opts = append(opts, agent.WithMessage(msg))
+	}
+	opts = append(opts, agent.WithMessage(message.NewText("Extract the user's name and age from the message if present. If not present return empty values.")))
+	// We ask the agent to extract the user info from the conversation so far.
+	out, _, err := agent.RunFor[UserInfo](u.Agent, opts...)
 	if err != nil {
 		return err
 	}

--- a/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
+++ b/go/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent"
-	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
 	"github.com/microsoft/agent-framework/go/tool"
 	"github.com/microsoft/agent-framework/go/tool/mcptool"
@@ -52,19 +51,17 @@ func mcpToolsOnAgentLevel() {
 		},
 	})
 
-	ctx := context.Background()
-
 	// First query - uses the tools defined at agent creation
 	const query1 = "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(ctx, a, query1)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query1)))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	const query2 = "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(ctx, a, query2)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query2)))
 }
 
 // mcpToolsOnRunLevel demonstrates MCP tools defined when running the agent.
@@ -86,25 +83,22 @@ func mcpToolsOnRunLevel() {
 		Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
 	})
 
-	ctx := context.Background()
-	opts := agent.RunOptions{
-		Options: &chatagent.ChatOptions{
-			Tools:    tools,
-			ToolMode: tool.ToolModeAuto,
-		},
-	}
+	opts := chatagent.WithOptions(&chatagent.ChatOptions{
+		Tools:    tools,
+		ToolMode: tool.ToolModeAuto,
+	})
 
 	// First query
 	query1 := "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.Run(ctx, a, opts, message.NewText(query1))))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query1, opts)))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	query2 := "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.Run(ctx, a, opts, message.NewText(query2))))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query2, opts)))
 }
 
 // must is a helper to panic on error for samples.

--- a/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/go/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/agent"
@@ -34,7 +33,7 @@ func main() {
 	const query = "Tell me about Paris, France"
 	fmt.Println("User: ", query)
 
-	city, resp, err := agent.RunFor[CityInfo](context.Background(), a, agent.RunOptions{}, message.NewText(query))
+	city, resp, err := agent.RunFor[CityInfo](a, agent.WithMessage(message.NewText(query)))
 	if err != nil {
 		panic(err)
 	}

--- a/go/samples/getting_started/openai/chat_with_thread/openai_chat_with_thread.go
+++ b/go/samples/getting_started/openai/chat_with_thread/openai_chat_with_thread.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/microsoft/agent-framework/go/agent"
 	"github.com/microsoft/agent-framework/go/agent/chatagent"
-	"github.com/microsoft/agent-framework/go/message"
 	"github.com/microsoft/agent-framework/go/openai"
 	"github.com/microsoft/agent-framework/go/tool"
 	"github.com/microsoft/agent-framework/go/tool/functool"
@@ -50,17 +49,15 @@ func exampleWithAutomaticThreadCreation() {
 		},
 	})
 
-	ctx := context.Background()
-
 	// First conversation - no thread provided, will be created automatically
 	query1 := "What's the weather like in Seattle?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(agent.Run(ctx, a, agent.RunOptions{}, message.NewText(query1))))
+	fmt.Println("Agent: ", must(agent.RunText(a, query1)))
 
 	// Second conversation - still no thread provided, will create another new thread
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(agent.Run(ctx, a, agent.RunOptions{}, message.NewText(query2))))
+	fmt.Println("Agent: ", must(agent.RunText(a, query2)))
 	fmt.Println("Note: Each call creates a separate thread, so the agent doesn't remember previous context.")
 	fmt.Println()
 }
@@ -80,23 +77,22 @@ func exampleWithThreadPersistence() {
 	})
 
 	// Create a new thread that will be reused
-	ctx := context.Background()
-	options := agent.RunOptions{Thread: a.NewThread()}
+	thread := a.NewThread()
 
 	// First conversation
 	query1 := "What's the weather like in Tokyo?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query1))))
+	fmt.Println("Agent: ", must(agent.RunText(a, query1, agent.WithThread(thread))))
 
 	// Second conversation using the same thread - maintains context
 	query2 := "How about London?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query2))))
+	fmt.Println("Agent: ", must(agent.RunText(a, query2, agent.WithThread(thread))))
 
 	// Third conversation - agent should remember both previous cities
 	query3 := "Which of the cities I asked about has better weather?"
 	fmt.Println("User: ", query3)
-	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query3))))
+	fmt.Println("Agent: ", must(agent.RunText(a, query3, agent.WithThread(thread))))
 	fmt.Println("Note: The agent remembers context from previous messages in the same thread.")
 	fmt.Println()
 }
@@ -114,12 +110,11 @@ func exampleWithExistingThreadMessages() {
 	})
 
 	// Start a conversation and build up message history
-	ctx := context.Background()
-	options := agent.RunOptions{Thread: a.NewThread()}
+	thread := a.NewThread()
 
 	query1 := "What's the weather in Paris?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(agent.Run(ctx, a, options, message.NewText(query1))))
+	fmt.Println("Agent: ", must(agent.RunText(a, query1, agent.WithThread(thread))))
 
 	fmt.Println("\n--- Continuing with the same thread in a new agent instance ---")
 
@@ -135,7 +130,7 @@ func exampleWithExistingThreadMessages() {
 	// Use the same thread object which contains the conversation history
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(agent.Run(ctx, newAgent, agent.RunOptions{Thread: options.Thread}, message.NewText(query2))))
+	fmt.Println("Agent: ", must(agent.RunText(newAgent, query2, agent.WithThread(thread))))
 	fmt.Println("Note: The agent continues the conversation using the thread message history.")
 	fmt.Println()
 }

--- a/go/samples/getting_started/openai/chat_with_tool/openai_chat_with_tool.go
+++ b/go/samples/getting_started/openai/chat_with_tool/openai_chat_with_tool.go
@@ -37,22 +37,17 @@ func main() {
 		},
 	})
 
-	fmt.Println(must(agent.RunText(context.Background(), a, "What's the weather like in Amsterdam?")))
+	resp, err := agent.RunText(a, "What's the weather like in Amsterdam?")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(resp)
 
-	for update, err := range agent.RunTextStream(context.Background(), a, "What is the weather like in Amsterdam?") {
+	for update, err := range agent.RunTextStream(a, "What is the weather like in Amsterdam?") {
 		if err != nil {
 			fmt.Print(err)
 			break
 		}
 		fmt.Print(update)
 	}
-}
-
-// must is a helper to panic on error for samples.
-// In production code, handle errors appropriately.
-func must[T any](resp T, err error) T {
-	if err != nil {
-		panic(err)
-	}
-	return resp
 }

--- a/go/samples/getting_started/openai/chat_with_tool_with_approvals/openai_chat_with_tool_with_approvals.go
+++ b/go/samples/getting_started/openai/chat_with_tool_with_approvals/openai_chat_with_tool_with_approvals.go
@@ -31,12 +31,12 @@ func main() {
 		},
 	})
 
-	ctx := context.Background()
-	options := agent.RunOptions{
-		Thread: a.NewThread(),
-	}
+	thread := a.NewThread()
 
-	resp := must(agent.Run(ctx, a, options, message.NewText("What's the weather like in Amsterdam?")))
+	resp, err := agent.RunText(a, "What's the weather like in Amsterdam?", agent.WithThread(thread))
+	if err != nil {
+		panic(err)
+	}
 
 	var userResponses []message.Content
 	for req := range resp.UserInputRequests() {
@@ -55,14 +55,9 @@ func main() {
 	}
 
 	// Pass the user input responses back to the agent for further processing.
-	fmt.Println("Agent:", must(agent.Run(ctx, a, options, message.New(userResponses...))))
-}
-
-// must is a helper to panic on error for samples.
-// In production code, handle errors appropriately.
-func must[T any](resp T, err error) T {
+	resp, err = agent.Run(a, agent.WithMessage(message.New(userResponses...)), agent.WithThread(thread))
 	if err != nil {
 		panic(err)
 	}
-	return resp
+	fmt.Println("Agent:", resp)
 }

--- a/go/tool/functool/func.go
+++ b/go/tool/functool/func.go
@@ -4,7 +4,6 @@ package functool
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -28,7 +27,7 @@ type Func struct {
 // request or result: the params contain raw arguments, no input validation
 // is performed, and the result is returned to the user as-is, without any
 // validation of the output.
-type Handler func(_ context.Context, args json.RawMessage) (any, error)
+type Handler func(_ context.Context, args string) (any, error)
 
 // A HandlerFor handles a call to tools/call with typed arguments and results.
 //
@@ -64,18 +63,11 @@ func (t *Tool) ReturnSchema() any {
 	return t.Func.outputFormat.Schema()
 }
 
-func (t *Tool) Call(ctx context.Context, args any) (any, error) {
-	var raw json.RawMessage
-	if args == nil {
-		raw = json.RawMessage("{}")
-	} else {
-		var ok bool
-		raw, ok = args.(json.RawMessage)
-		if !ok {
-			return nil, fmt.Errorf("expected json.RawMessage arguments, got %T", args)
-		}
+func (t *Tool) Call(ctx context.Context, args string) (any, error) {
+	if args == "" {
+		args = "{}"
 	}
-	return t.Handler(ctx, raw)
+	return t.Handler(ctx, args)
 }
 
 func MustNew[In, Out any](fnp *Func, h HandlerFor[In, Out]) *Tool {
@@ -121,17 +113,17 @@ func New[In, Out any](fnp *Func, h HandlerFor[In, Out]) (*Tool, error) {
 		return nil, fmt.Errorf("resolving output schema: %w", err)
 	}
 
-	t.Handler = func(ctx context.Context, args json.RawMessage) (any, error) {
+	t.Handler = func(ctx context.Context, args string) (any, error) {
 		var in In
 		if t.Func.inputWrapped {
 			// Extract wrapped value.
 			var decodedArgs inputWrapper[In]
-			if err := jsonformat.Unmarshal(t.Func.inputFormat, args, &decodedArgs); err != nil {
+			if err := jsonformat.Unmarshal(t.Func.inputFormat, []byte(args), &decodedArgs); err != nil {
 				return nil, err
 			}
 			in = decodedArgs.Arg0
 		} else {
-			if err := jsonformat.Unmarshal(t.Func.inputFormat, args, &in); err != nil {
+			if err := jsonformat.Unmarshal(t.Func.inputFormat, []byte(args), &in); err != nil {
 				return nil, err
 			}
 		}

--- a/go/tool/functool/func_test.go
+++ b/go/tool/functool/func_test.go
@@ -4,7 +4,6 @@ package functool_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -78,7 +77,7 @@ func TestFuncTool_CallMissingArg0(t *testing.T) {
 	)
 
 	// Call without required arg0
-	_, err := tl.Call(t.Context(), json.RawMessage(`{}`))
+	_, err := tl.Call(t.Context(), `{}`)
 	if err == nil {
 		t.Error("expected error for missing arg0, got nil")
 	}
@@ -97,7 +96,7 @@ func TestFuncTool_CallStruct(t *testing.T) {
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), json.RawMessage(`{"v":"hello"}`))
+	ret, err := tl.Call(t.Context(), `{"v":"hello"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +115,7 @@ func TestFuncTool_CallString(t *testing.T) {
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), json.RawMessage(`{"arg0":"hello"}`))
+	ret, err := tl.Call(t.Context(), `{"arg0":"hello"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +134,7 @@ func TestFuncTool_CallNoArg(t *testing.T) {
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), nil)
+	ret, err := tl.Call(t.Context(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +153,7 @@ func TestFuncTool_CallNoRet(t *testing.T) {
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), nil)
+	ret, err := tl.Call(t.Context(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +179,7 @@ func TestFuncTool_CallError(t *testing.T) {
 		handler,
 	)
 
-	_, err := tl.Call(t.Context(), json.RawMessage(`{"value":"test"}`))
+	_, err := tl.Call(t.Context(), `{"value":"test"}`)
 	if err != expectedErr {
 		t.Errorf("expected error %v, got %v", expectedErr, err)
 	}

--- a/go/tool/mcptool/mcp.go
+++ b/go/tool/mcptool/mcp.go
@@ -7,6 +7,7 @@ package mcptool
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/microsoft/agent-framework/go/message"
@@ -111,11 +112,11 @@ func (w *mcpWrapper) ReturnSchema() any {
 }
 
 // Call implements the Func-like calling pattern for MCP tools.
-func (w *mcpWrapper) Call(ctx context.Context, args any) (any, error) {
+func (w *mcpWrapper) Call(ctx context.Context, args string) (any, error) {
 	// Call the MCP tool
 	result, err := w.session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      w.tool.Name,
-		Arguments: args,
+		Arguments: json.RawMessage(args),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("MCP tool call failed: %w", err)

--- a/go/tool/tool.go
+++ b/go/tool/tool.go
@@ -29,7 +29,7 @@ type FuncTool interface {
 	Schema() any
 	ReturnSchema() any
 
-	Call(ctx context.Context, args any) (any, error)
+	Call(ctx context.Context, args string) (any, error)
 }
 
 // ApprovalRequiredTool indicates that a tool requires user approval before invocation.


### PR DESCRIPTION
@griffinbird this PR is for you 💘.

An agent run can be configured in many ways, but all of the options are optional, even the input messages. Agent implementations and middlewares might also provide their own additional configuration, which should compose well when multiple layers are stacked.

.NET deals with this unlimited extensibility by using sub-classing and optional parameters with sane default values.

Go doesn't support these language constructs, so the current agent API is a bit cumbersome to use, even for the basic use-case of just wanting to pass a text message to the agent, with limited support for custom options.

```go
// Simple case
agent.RunText(context.Background(), a, message.NewText("hello world"))

// Simple case with context
agent.RunText(ctx, a, message.NewText("hello world"))

// With context, memory, and options
opts := agent.RunOptions{
  Thread: thread,
  Options: chatagent.ChatOptions{
    MaxTurns: 1
  },
  Options2: logmiddleware.Options{Logger: slog.New()} // Not supported!
}
agent.Run(ctx, a, opts, message.NewText("hello world"), message.NewText("bye world"))
```

This PR switches to a more ergonomic (but also more controversial) optional parameters approach. This provides all the flexibility that .NET has, with the major downside of making options a bit more complicated to discover (which is mitigated by using consistent naming conventions):

```go
// Simple case
agent.RunText(a, "hello world")

// Simple case with context
agent.RunText(a, "hello world", agent.WithContext(ctx))

// With context, memory, and options
agent.Run(a,
  agent.WithContext(ctx),
  agent.WithThread(thread),
  chatagent.WithOptions(&chatagent.ChatOptions{MaxTurns: 1}),
  logmiddleware.WithOptions(logmiddleware.Options{Logger: slog.New()}),
  agent.WithMessage(message.NewText("hello world")),
  agent.WithMessage(message.NewText("bye world")),
)
```

Check the samples to see how this new approach simplifies "real" code.

