### PR TITLE
Make context a required agent run parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Create a simple Azure Chat Agent that writes a haiku about the Microsoft Agent F
 
 ```go
 import (
+  "context"
 	"fmt"
 	"os"
 
@@ -93,7 +94,7 @@ func main() {
 		Model:      os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), // e.g., "gpt-4o"
 	}, nil)
 
-  resp, err := agent.RunText(a, "Write a haiku about the Microsoft Agent Framework")
+  resp, err := agent.RunText(context.Background(), a, "Write a haiku about the Microsoft Agent Framework")
   if err != nil {
     panic(err)
   }

--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -81,7 +81,7 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return &thread, nil
 }
 
-func (a *Agent) Run(options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		var thread *Thread
 		if v, ok := agent.GetOption(options, agent.WithThread); !ok {
@@ -91,10 +91,6 @@ func (a *Agent) Run(options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate,
 		} else {
 			yield(nil, errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
 			return
-		}
-		ctx, ok := agent.GetOption(options, agent.WithContext)
-		if !ok {
-			ctx = context.Background()
 		}
 		streaming, _ := agent.GetOption(options, agent.WithStreaming)
 		var parts []a2a.Part

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -184,7 +184,7 @@ func TestRunAllowsNonUserRoleMessages(t *testing.T) {
 		agent.WithMessage(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
 	}
 
-	_, err := agent.Run(a, inputMessages...)
+	_, err := agent.Run(t.Context(), a, inputMessages...)
 	if err != nil {
 		t.Errorf("Run() error = %v, want nil", err)
 	}
@@ -203,7 +203,7 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, nil)
 
-	result, err := agent.RunText(a, "Hello, world!")
+	result, err := agent.RunText(t.Context(), a, "Hello, world!")
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -277,7 +277,7 @@ func TestRunWithNewThread(t *testing.T) {
 	a := newTestAgent(transport, nil)
 
 	thread := a.NewThread()
-	_, err := agent.RunText(a, "Test message", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -298,7 +298,7 @@ func TestRunWithExistingThread(t *testing.T) {
 
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	_, err := agent.RunText(a, "Test message", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -326,7 +326,7 @@ func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
 
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	_, err := agent.RunText(a, "Test message", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(thread))
 	if err == nil {
 		t.Error("Run() error = nil, want error")
 	}
@@ -345,7 +345,7 @@ func TestRunStreamingAsyncWithValidUserMessage(t *testing.T) {
 	a := newTestAgent(transport, nil)
 
 	var updates []*agent.RunResponseUpdate
-	for update, err := range agent.RunTextStream(a, "Hello, streaming!") {
+	for update, err := range agent.RunTextStream(t.Context(), a, "Hello, streaming!") {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -426,7 +426,7 @@ func TestRunStreamingAsyncWithThread(t *testing.T) {
 
 	thread := a.NewThread()
 
-	for _, err := range agent.RunTextStream(a, "Test streaming", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agent.WithThread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -450,7 +450,7 @@ func TestRunStreamingAsyncWithExistingThread(t *testing.T) {
 
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	for _, err := range agent.RunTextStream(a, "Test streaming", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agent.WithThread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -480,7 +480,7 @@ func TestRunStreamingAsyncWithThreadHavingDifferentContextID(t *testing.T) {
 	thread := a.NewThreadWithContextID("existing-context-id")
 
 	gotError := false
-	for _, err := range agent.RunTextStream(a, "Test streaming", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agent.WithThread(thread)) {
 		if err != nil {
 			gotError = true
 			break
@@ -510,7 +510,7 @@ func TestRunStreamingAsyncAllowsNonUserRoleMessages(t *testing.T) {
 		agent.WithMessage(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
 	}
 
-	for _, err := range agent.RunStream(a, inputMessages...) {
+	for _, err := range agent.RunStream(t.Context(), a, inputMessages...) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -535,7 +535,7 @@ func TestRunWithHostedFileContent(t *testing.T) {
 		}),
 	}
 
-	_, err := agent.Run(a, inputMessages...)
+	_, err := agent.Run(t.Context(), a, inputMessages...)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -55,18 +55,18 @@ type Agent interface {
 	Identity() Identity
 	Capabilities() Capabilities
 
-	Run(...Option) iter.Seq2[*RunResponseUpdate, error]
+	Run(context.Context, ...Option) iter.Seq2[*RunResponseUpdate, error]
 
 	NewThread() memory.Thread
 	UnmarshalThread(data []byte) (memory.Thread, error)
 }
 
 // Run executes the agent with the given options and returns the response.
-func Run(a Agent, opts ...Option) (*RunResponse, error) {
+func Run(ctx context.Context, a Agent, opts ...Option) (*RunResponse, error) {
 	resp := RunResponse{
 		AgentID: a.Identity().ID(),
 	}
-	for update, err := range run(a, opts) {
+	for update, err := range run(ctx, a, opts) {
 		if err != nil {
 			return nil, err
 		}
@@ -79,40 +79,36 @@ func Run(a Agent, opts ...Option) (*RunResponse, error) {
 }
 
 // RunStream executes the agent with the given options and returns a streaming sequence of response updates.
-func RunStream(a Agent, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
+func RunStream(ctx context.Context, a Agent, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
 	opts = append(opts, WithStreaming(true))
-	return run(a, opts)
+	return run(ctx, a, opts)
 }
 
 // RunText executes the agent with a single text message and returns the response.
-func RunText(a Agent, msg string, opts ...Option) (*RunResponse, error) {
-	return Run(a, append(opts, WithMessage(message.NewText(msg)))...)
+func RunText(ctx context.Context, a Agent, msg string, opts ...Option) (*RunResponse, error) {
+	return Run(ctx, a, append(opts, WithMessage(message.NewText(msg)))...)
 }
 
 // RunTextStream executes the agent with a single text message and returns a streaming sequence of response updates.
-func RunTextStream(a Agent, msg string, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
-	return RunStream(a, append(opts, WithMessage(message.NewText(msg)))...)
+func RunTextStream(ctx context.Context, a Agent, msg string, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
+	return RunStream(ctx, a, append(opts, WithMessage(message.NewText(msg)))...)
 }
 
-func run(a Agent, opts []Option) iter.Seq2[*RunResponseUpdate, error] {
+func run(ctx context.Context, a Agent, opts []Option) iter.Seq2[*RunResponseUpdate, error] {
 	if a == nil {
 		return func(yield func(*RunResponseUpdate, error) bool) {
 			yield(nil, errors.New("agent cannot be nil"))
 		}
 	}
-	if _, ok := GetOption(opts, WithContext); !ok {
-		// If no context is provided, use background.
-		opts = append(opts, WithContext(context.Background()))
-	}
 	if _, ok := GetOption(opts, WithThread); !ok {
 		// If no thread is provided, create a new one.
 		opts = append(opts, WithThread(a.NewThread()))
 	}
-	return a.Run(opts...)
+	return a.Run(ctx, opts...)
 }
 
 // RunFor executes the agent with the given messages and returns the result of type T.
-func RunFor[T any](a Agent, opts ...Option) (T, *RunResponse, error) {
+func RunFor[T any](ctx context.Context, a Agent, opts ...Option) (T, *RunResponse, error) {
 	var v T
 	formatter := a.Capabilities().StructuredOutput
 	if formatter == nil {
@@ -123,7 +119,7 @@ func RunFor[T any](a Agent, opts ...Option) (T, *RunResponse, error) {
 		return v, nil, err
 	}
 	opts = append(opts, WithResponseFormat(format))
-	resp, err := Run(a, opts...)
+	resp, err := Run(ctx, a, opts...)
 	if err != nil {
 		return v, resp, err
 	}

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -84,14 +84,14 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
 }
 
-func (a *Agent) Run(options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		client := a.Client
 		if fn, ok := agent.GetOption(options, WithNewClient); ok {
 			// If we have a custom chat client factory, we should use it to create a new chat client with the transformed tools.
 			client = fn(client)
 		}
-		ctx, thread, opts, inputMsgs, messages, ctxMessages, err := a.prepareThreadAndMessages(options)
+		thread, opts, inputMsgs, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, options)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -190,9 +190,9 @@ func (a *Agent) updateThreadWithTypeAndConversationID(thread *Thread, convID str
 	return nil
 }
 
-func (a *Agent) prepareThreadAndMessages(options []agent.Option) (ctx context.Context, thread *Thread, opts ChatOptions, inputMsgs, msgsForClient, ctxMessages []*message.Message, err error) {
-	retError := func(e error) (context.Context, *Thread, ChatOptions, []*message.Message, []*message.Message, []*message.Message, error) {
-		return nil, nil, ChatOptions{}, nil, nil, nil, e
+func (a *Agent) prepareThreadAndMessages(ctx context.Context, options []agent.Option) (thread *Thread, opts ChatOptions, inputMsgs, msgsForClient, ctxMessages []*message.Message, err error) {
+	retError := func(e error) (*Thread, ChatOptions, []*message.Message, []*message.Message, []*message.Message, error) {
+		return nil, ChatOptions{}, nil, nil, nil, e
 	}
 	opts = a.createConfiguredChatOptions(options)
 	if v, ok := opts.AllowBackgroundResponses.Value(); ok && v && thread == nil {
@@ -212,11 +212,6 @@ func (a *Agent) prepareThreadAndMessages(options []agent.Option) (ctx context.Co
 		if len(inputMsgs) > 0 {
 			return retError(errors.New("messages are not allowed when continuing a background response using a continuation token"))
 		}
-	}
-	var ok bool
-	ctx, ok = agent.GetOption(options, agent.WithContext)
-	if !ok {
-		ctx = context.Background()
 	}
 	if opts.ContinuationToken == nil {
 		if thread.MessageStore != nil {
@@ -269,7 +264,7 @@ func (a *Agent) prepareThreadAndMessages(options []agent.Option) (ctx context.Co
 	if thread.ConversationID != "" && opts.ConversationID != thread.ConversationID {
 		opts.ConversationID = thread.ConversationID
 	}
-	return ctx, thread, opts, inputMsgs, msgsForClient, ctxMessages, nil
+	return thread, opts, inputMsgs, msgsForClient, ctxMessages, nil
 }
 
 func (a *Agent) createConfiguredChatOptions(options []agent.Option) ChatOptions {

--- a/agent/opts.go
+++ b/agent/opts.go
@@ -68,11 +68,6 @@ func WithToolMode(mode tool.ToolMode) Option {
 	return toolMode(mode)
 }
 
-// WithContext sets the context to use during the agent run.
-func WithContext(context context.Context) Option {
-	return contextOpt{context}
-}
-
 // WithStreaming sets whether to use streaming responses during the agent run.
 func WithStreaming(streaming bool) Option {
 	return streamingOpt(streaming)

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -68,7 +68,7 @@ func (t functool) Call(ctx context.Context, args string) (any, error) {
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return nil, err
 	}
-	resp, err := Run(t.agent, WithContext(ctx), WithThread(t.thread), WithMessage(message.NewText(in.Query)))
+	resp, err := Run(ctx, t.agent, WithThread(t.thread), WithMessage(message.NewText(in.Query)))
 	if err != nil {
 		return "", err
 	}

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -64,8 +64,7 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 		StateKey: "agent_messages",
 		TakeTurnHandler: func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
 			emitEvents := token.EmitEventsOr(emitEvents)
-			options := make([]Option, 0, 2+len(messages))
-			options = append(options, WithContext(ctx))
+			options := make([]Option, 0, 1+len(messages))
 			options = append(options, WithThread(ensureThread()))
 			if emitEvents {
 				// Run the agent in streaming mode only when agent run update events are to be emitted.
@@ -75,7 +74,7 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 				options = append(options, WithMessage(msg))
 			}
 			var updates []*RunResponseUpdate
-			for update, err := range RunStream(a, options...) {
+			for update, err := range RunStream(ctx, a, options...) {
 				if err != nil {
 					return err
 				}

--- a/samples/getting_started/anthropic/chat_basic/anthropic_chat_basic.go
+++ b/samples/getting_started/anthropic/chat_basic/anthropic_chat_basic.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -28,13 +29,13 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Result: ", must(agent.RunText(a, query)))
+	fmt.Println("Result: ", must(agent.RunText(context.Background(), a, query)))
 }
 
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	for update, err := range agent.RunTextStream(a, query) {
+	for update, err := range agent.RunTextStream(context.Background(), a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
+++ b/samples/getting_started/azure_openai/chat_basic/azure_chat_basic.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -48,14 +49,14 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("\n=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	fmt.Println("Assistant: ", must(agent.RunText(a, query)))
+	fmt.Println("Assistant: ", must(agent.RunText(context.Background(), a, query)))
 }
 
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("\n=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
 	fmt.Print("Assistant: ")
-	for update, err := range agent.RunTextStream(a, query) {
+	for update, err := range agent.RunTextStream(context.Background(), a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
+++ b/samples/getting_started/openai/chat_as_functool/openai_chat_as_functool.go
@@ -41,7 +41,7 @@ func main() {
 			Tools: []tool.Tool{agent.FuncTool(weatherAgent, nil)},
 		},
 	})
-	resp, err := agent.RunText(a, "What is the weather like in Amsterdam?")
+	resp, err := agent.RunText(context.Background(), a, "What is the weather like in Amsterdam?")
 	if err != nil {
 		panic(err)
 	}

--- a/samples/getting_started/openai/chat_basic/openai_chat_basic.go
+++ b/samples/getting_started/openai/chat_basic/openai_chat_basic.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -28,7 +29,7 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	resp, err := agent.RunText(a, query)
+	resp, err := agent.RunText(context.Background(), a, query)
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +39,7 @@ func nonStreamingExample(a agent.Agent, query string) {
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	for update, err := range agent.RunTextStream(a, query) {
+	for update, err := range agent.RunTextStream(context.Background(), a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
+++ b/samples/getting_started/openai/chat_image_analysis/openai_chat_image_analysis.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -24,7 +25,7 @@ func main() {
 		Instructions: "You are a helpful agent that can analyze images.",
 	})
 
-	resp, err := agent.Run(a,
+	resp, err := agent.Run(context.Background(), a,
 		agent.WithMessage(message.NewText("Describe the content of this image.")),
 		agent.WithMessage(message.New(&message.URIContent{
 			URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",

--- a/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
+++ b/samples/getting_started/openai/chat_web_search/openai_chat_web_search.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -37,7 +38,7 @@ func main() {
 func nonStreamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Non-streaming Response Example ===")
 	fmt.Println("User: ", query)
-	resp, err := agent.RunText(a, query)
+	resp, err := agent.RunText(context.Background(), a, query)
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +48,7 @@ func nonStreamingExample(a agent.Agent, query string) {
 func streamingExample(a agent.Agent, query string) {
 	fmt.Println("=== Streaming Response Example ===")
 	fmt.Println("User: ", query)
-	for update, err := range agent.RunTextStream(a, query) {
+	for update, err := range agent.RunTextStream(context.Background(), a, query) {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
+++ b/samples/getting_started/openai/chat_wit_memory/openai_chat_with_memory.go
@@ -27,11 +27,11 @@ func main() {
 
 	thread := a.NewThread()
 
-	fmt.Println(must(agent.RunText(a, "Hello, what is the square root of 9?", agent.WithThread(thread))))
+	fmt.Println(must(agent.RunText(context.Background(), a, "Hello, what is the square root of 9?", agent.WithThread(thread))))
 
-	fmt.Println(must(agent.RunText(a, "My name is Ruaidhrí", agent.WithThread(thread))))
+	fmt.Println(must(agent.RunText(context.Background(), a, "My name is Ruaidhrí", agent.WithThread(thread))))
 
-	fmt.Println(must(agent.RunText(a, "I am 20 years old", agent.WithThread(thread))))
+	fmt.Println(must(agent.RunText(context.Background(), a, "I am 20 years old", agent.WithThread(thread))))
 
 	// We can serialize the thread. The serialized state will include the state of the memory component.
 	serializedThread := must(json.Marshal(thread))
@@ -40,7 +40,7 @@ func main() {
 
 	deserializedThread := must(a.UnmarshalThread(serializedThread))
 
-	fmt.Println(must(agent.RunText(a, "What is my name and age?", agent.WithThread(deserializedThread))))
+	fmt.Println(must(agent.RunText(context.Background(), a, "What is my name and age?", agent.WithThread(deserializedThread))))
 }
 
 type UserInfo struct {
@@ -79,13 +79,14 @@ func (u *UserInfoMemory) Invoked(ctx *memory.InvokedContext) error {
 		return nil
 	}
 	// To avoid infinite loops, we mark re-entrancy in the context.
-	opts := []agent.Option{agent.WithContext(context.WithValue(ctx.Context, reentrantCtxKey{}, struct{}{}))}
+	ctx2 := context.WithValue(ctx.Context, reentrantCtxKey{}, struct{}{})
+	var opts []agent.Option
 	for _, msg := range ctx.RequestMessages {
 		opts = append(opts, agent.WithMessage(msg))
 	}
 	opts = append(opts, agent.WithMessage(message.NewText("Extract the user's name and age from the message if present. If not present return empty values.")))
 	// We ask the agent to extract the user info from the conversation so far.
-	out, _, err := agent.RunFor[UserInfo](u.Agent, opts...)
+	out, _, err := agent.RunFor[UserInfo](ctx2, u.Agent, opts...)
 	if err != nil {
 		return err
 	}

--- a/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
+++ b/samples/getting_started/openai/chat_with_local_mcp/openai_client_with_local_mcp.go
@@ -54,14 +54,14 @@ func mcpToolsOnAgentLevel() {
 	// First query - uses the tools defined at agent creation
 	const query1 = "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query1)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(context.Background(), a, query1)))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	const query2 = "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query2)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(context.Background(), a, query2)))
 }
 
 // mcpToolsOnRunLevel demonstrates MCP tools defined when running the agent.
@@ -91,14 +91,14 @@ func mcpToolsOnRunLevel() {
 	// First query
 	query1 := "How to create an Azure storage account using az cli?"
 	fmt.Println("User: ", query1)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query1, opts)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(context.Background(), a, query1, opts)))
 
 	fmt.Println("\n=======================================")
 
 	// Second query
 	query2 := "What is Microsoft Agent Framework?"
 	fmt.Println("User: ", query2)
-	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(a, query2, opts)))
+	fmt.Println(a.Identity().Name(), ": ", must(agent.RunText(context.Background(), a, query2, opts)))
 }
 
 // must is a helper to panic on error for samples.

--- a/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
+++ b/samples/getting_started/openai/chat_with_structured_output/openai_chat_with_structured_output.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -33,7 +34,7 @@ func main() {
 	const query = "Tell me about Paris, France"
 	fmt.Println("User: ", query)
 
-	city, resp, err := agent.RunFor[CityInfo](a, agent.WithMessage(message.NewText(query)))
+	city, resp, err := agent.RunFor[CityInfo](context.Background(), a, agent.WithMessage(message.NewText(query)))
 	if err != nil {
 		panic(err)
 	}

--- a/samples/getting_started/openai/chat_with_thread/openai_chat_with_thread.go
+++ b/samples/getting_started/openai/chat_with_thread/openai_chat_with_thread.go
@@ -52,12 +52,12 @@ func exampleWithAutomaticThreadCreation() {
 	// First conversation - no thread provided, will be created automatically
 	query1 := "What's the weather like in Seattle?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(agent.RunText(a, query1)))
+	fmt.Println("Agent: ", must(agent.RunText(context.Background(), a, query1)))
 
 	// Second conversation - still no thread provided, will create another new thread
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(agent.RunText(a, query2)))
+	fmt.Println("Agent: ", must(agent.RunText(context.Background(), a, query2)))
 	fmt.Println("Note: Each call creates a separate thread, so the agent doesn't remember previous context.")
 	fmt.Println()
 }
@@ -82,17 +82,17 @@ func exampleWithThreadPersistence() {
 	// First conversation
 	query1 := "What's the weather like in Tokyo?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(agent.RunText(a, query1, agent.WithThread(thread))))
+	fmt.Println("Agent: ", must(agent.RunText(context.Background(), a, query1, agent.WithThread(thread))))
 
 	// Second conversation using the same thread - maintains context
 	query2 := "How about London?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(agent.RunText(a, query2, agent.WithThread(thread))))
+	fmt.Println("Agent: ", must(agent.RunText(context.Background(), a, query2, agent.WithThread(thread))))
 
 	// Third conversation - agent should remember both previous cities
 	query3 := "Which of the cities I asked about has better weather?"
 	fmt.Println("User: ", query3)
-	fmt.Println("Agent: ", must(agent.RunText(a, query3, agent.WithThread(thread))))
+	fmt.Println("Agent: ", must(agent.RunText(context.Background(), a, query3, agent.WithThread(thread))))
 	fmt.Println("Note: The agent remembers context from previous messages in the same thread.")
 	fmt.Println()
 }
@@ -114,7 +114,7 @@ func exampleWithExistingThreadMessages() {
 
 	query1 := "What's the weather in Paris?"
 	fmt.Println("User: ", query1)
-	fmt.Println("Agent: ", must(agent.RunText(a, query1, agent.WithThread(thread))))
+	fmt.Println("Agent: ", must(agent.RunText(context.Background(), a, query1, agent.WithThread(thread))))
 
 	fmt.Println("\n--- Continuing with the same thread in a new agent instance ---")
 
@@ -130,7 +130,7 @@ func exampleWithExistingThreadMessages() {
 	// Use the same thread object which contains the conversation history
 	query2 := "What was the last city I asked about?"
 	fmt.Println("User: ", query2)
-	fmt.Println("Agent: ", must(agent.RunText(newAgent, query2, agent.WithThread(thread))))
+	fmt.Println("Agent: ", must(agent.RunText(context.Background(), newAgent, query2, agent.WithThread(thread))))
 	fmt.Println("Note: The agent continues the conversation using the thread message history.")
 	fmt.Println()
 }

--- a/samples/getting_started/openai/chat_with_tool/openai_chat_with_tool.go
+++ b/samples/getting_started/openai/chat_with_tool/openai_chat_with_tool.go
@@ -37,13 +37,13 @@ func main() {
 		},
 	})
 
-	resp, err := agent.RunText(a, "What's the weather like in Amsterdam?")
+	resp, err := agent.RunText(context.Background(), a, "What's the weather like in Amsterdam?")
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println(resp)
 
-	for update, err := range agent.RunTextStream(a, "What is the weather like in Amsterdam?") {
+	for update, err := range agent.RunTextStream(context.Background(), a, "What is the weather like in Amsterdam?") {
 		if err != nil {
 			fmt.Print(err)
 			break

--- a/samples/getting_started/openai/chat_with_tool_with_approvals/openai_chat_with_tool_with_approvals.go
+++ b/samples/getting_started/openai/chat_with_tool_with_approvals/openai_chat_with_tool_with_approvals.go
@@ -33,7 +33,7 @@ func main() {
 
 	thread := a.NewThread()
 
-	resp, err := agent.RunText(a, "What's the weather like in Amsterdam?", agent.WithThread(thread))
+	resp, err := agent.RunText(context.Background(), a, "What's the weather like in Amsterdam?", agent.WithThread(thread))
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	// Pass the user input responses back to the agent for further processing.
-	resp, err = agent.Run(a, agent.WithMessage(message.New(userResponses...)), agent.WithThread(thread))
+	resp, err = agent.Run(context.Background(), a, agent.WithMessage(message.New(userResponses...)), agent.WithThread(thread))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Having a `context.Context` as the first parameter for agent run functions rather than hiding it an an option feels more idiomatic. Also, production code (and arguably even testing code) should always pass a valid context to allow for short-circuiting I/O operations. We should make it more prominent so that people don't forget it.