### PR TITLE
Improve support for continuation token

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -80,6 +80,13 @@ func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*age
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		var thread *Thread
 		if v, ok := agent.GetOption(options, agent.WithThread); !ok {
+			// Aligning with other agent implementations that support background responses, where
+			// a thread is required for background responses to prevent inconsistent experience
+			// for callers if they forget to provide the thread for initial or follow-up runs.
+			if opts, ok := agent.GetOption(options, agent.WithAllowBackgroundResponses); ok && opts {
+				yield(nil, errors.New("a thread must be provided when AllowBackgroundResponses is enabled"))
+				return
+			}
 			thread = a.NewThread().(*Thread)
 		} else if t, ok := v.(*Thread); ok {
 			thread = t
@@ -88,6 +95,33 @@ func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*age
 			return
 		}
 		streaming, _ := agent.GetOption(options, agent.WithStreaming)
+		if token, ok := agent.GetOption(options, agent.WithContinuationToken); ok && token != nil {
+			if streaming {
+				// TODO: support resuming streaming responses using continuation tokens.
+				yield(nil, errors.New("reconnecting to task streams using continuation tokens is not supported yet"))
+				return
+			}
+			if _, ok := agent.GetOption(options, agent.WithMessage); ok {
+				yield(nil, errors.New("messages are not allowed when continuing a background response using a continuation token"))
+				return
+			}
+			taskID, ok := token.(a2a.TaskID)
+			if !ok {
+				yield(nil, fmt.Errorf("invalid continuation token type: expected %T but got %T", a2a.TaskID(""), token))
+				return
+			}
+			task, err := a.Client.GetTask(ctx, &a2a.TaskQueryParams{ID: taskID})
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if err := a.updateThreadContextID(thread, task.ContextID, string(task.ID)); err != nil {
+				yield(nil, err)
+				return
+			}
+			a.yieldTask(yield, task)
+			return
+		}
 		var parts []a2a.Part
 		for msg := range agent.GetOptions(options, agent.WithMessage) {
 			parts = parts[:0] // reset parts slice
@@ -124,48 +158,53 @@ func (a *Agent) sendMsg(ctx context.Context, thread *Thread, streaming bool, par
 			yield(resp, err)
 		}
 	}
-	id, name := a.iden.ID(), a.iden.Name()
 	for e, err := range seq {
 		if err != nil {
 			yield(nil, err)
 			return
 		}
+		if err := a.updateThreadContextID(thread, e.TaskInfo().ContextID, string(e.TaskInfo().TaskID)); err != nil {
+			yield(nil, err)
+			return
+		}
 		switch e := e.(type) {
 		case *a2a.Task:
-			if err := a.updateThreadContextID(thread, e.ContextID, string(e.ID)); err != nil {
+			if ok := a.yieldTask(yield, e); !ok {
+				return
+			}
+		case *a2a.TaskStatusUpdateEvent:
+			if !yield(&agent.RunResponseUpdate{
+				RawRepresentation:    e,
+				AdditionalProperties: e.Metadata,
+				AgentID:              a.iden.ID(),
+				MessageID:            string(e.TaskID),
+				ResponseID:           string(e.TaskID),
+				Role:                 message.RoleAssistant,
+				AuthorName:           a.iden.Name(),
+				CreatedAt:            time.Now(),
+			}, nil) {
+				return
+			}
+		case *a2a.TaskArtifactUpdateEvent:
+			contents, err := partsToContents(e.Artifact.Parts)
+			if err != nil {
 				yield(nil, err)
 				return
 			}
-			now := time.Now()
-			for _, artifact := range e.Artifacts {
-				contents, err := partsToContents(artifact.Parts)
-				if err != nil {
-					yield(nil, err)
-					return
-				}
-				timestamp := now
-				if e.Status.Timestamp != nil {
-					timestamp = *e.Status.Timestamp
-				}
-				if !yield(&agent.RunResponseUpdate{
-					RawRepresentation:    artifact,
-					AdditionalProperties: artifact.Metadata,
-					AgentID:              id,
-					MessageID:            string(artifact.ID),
-					ResponseID:           string(e.ID),
-					Contents:             contents,
-					Role:                 message.RoleAssistant,
-					CreatedAt:            timestamp,
-					AuthorName:           name,
-				}, nil) {
-					return
-				}
+			if !yield(&agent.RunResponseUpdate{
+				RawRepresentation:    e,
+				AdditionalProperties: e.Metadata,
+				AgentID:              a.iden.ID(),
+				MessageID:            string(e.Artifact.ID),
+				ResponseID:           string(e.TaskID),
+				Contents:             contents,
+				Role:                 message.RoleAssistant,
+				AuthorName:           a.iden.Name(),
+				CreatedAt:            time.Now(),
+			}, nil) {
+				return
 			}
 		case *a2a.Message:
-			if err := a.updateThreadContextID(thread, e.ContextID, ""); err != nil {
-				yield(nil, err)
-				return
-			}
 			contents, err := partsToContents(e.Parts)
 			if err != nil {
 				yield(nil, err)
@@ -178,12 +217,12 @@ func (a *Agent) sendMsg(ctx context.Context, thread *Thread, streaming bool, par
 			if !yield(&agent.RunResponseUpdate{
 				RawRepresentation:    e,
 				AdditionalProperties: e.Metadata,
-				AgentID:              id,
+				AgentID:              a.iden.ID(),
 				MessageID:            e.ID,
 				ResponseID:           e.ID,
 				Role:                 role,
 				Contents:             contents,
-				AuthorName:           name,
+				AuthorName:           a.iden.Name(),
 				CreatedAt:            time.Now(),
 			}, nil) {
 				return
@@ -193,6 +232,42 @@ func (a *Agent) sendMsg(ctx context.Context, thread *Thread, streaming bool, par
 			return
 		}
 	}
+}
+
+func (a *Agent) yieldTask(yield func(*agent.RunResponseUpdate, error) bool, task *a2a.Task) bool {
+	now := time.Now()
+	id, name := a.iden.ID(), a.iden.Name()
+	for _, artifact := range task.Artifacts {
+		contents, err := partsToContents(artifact.Parts)
+		if err != nil {
+			yield(nil, err)
+			return false
+		}
+		timestamp := now
+		if task.Status.Timestamp != nil {
+			timestamp = *task.Status.Timestamp
+		}
+		var continuationToken any
+		switch task.Status.State {
+		case a2a.TaskStateSubmitted, a2a.TaskStateWorking:
+			continuationToken = task.ID
+		}
+		if !yield(&agent.RunResponseUpdate{
+			RawRepresentation:    artifact,
+			AdditionalProperties: artifact.Metadata,
+			AgentID:              id,
+			MessageID:            string(artifact.ID),
+			ResponseID:           string(task.ID),
+			Contents:             contents,
+			ContinuationToken:    continuationToken,
+			Role:                 message.RoleAssistant,
+			CreatedAt:            timestamp,
+			AuthorName:           name,
+		}, nil) {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *Agent) updateThreadContextID(thread *Thread, contextID, taskID string) error {

--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -163,7 +163,8 @@ func (a *Agent) sendMsg(ctx context.Context, thread *Thread, streaming bool, par
 			yield(nil, err)
 			return
 		}
-		if err := a.updateThreadContextID(thread, e.TaskInfo().ContextID, string(e.TaskInfo().TaskID)); err != nil {
+		taskInfo := e.TaskInfo()
+		if err := a.updateThreadContextID(thread, taskInfo.ContextID, string(taskInfo.TaskID)); err != nil {
 			yield(nil, err)
 			return
 		}

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -19,7 +19,7 @@ import (
 type mockA2ATransport struct {
 	capturedMessageSendParams  *a2a.MessageSendParams
 	responseToReturn           a2a.SendMessageResult
-	streamingResponseToReturn  *a2a.Message // Use concrete type instead of interface
+	streamingResponseToReturn  a2a.Event
 	sendMessageCalled          bool
 	sendStreamingMessageCalled bool
 }
@@ -49,9 +49,26 @@ func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, params *a2a
 			Role:      a2a.MessageRoleAgent,
 			ContextID: params.Message.ContextID,
 		}
-	} else if responseToYield.ContextID == "" {
-		// If a response was provided but has no context ID, use the one from the request
-		responseToYield.ContextID = params.Message.ContextID
+	} else {
+		// Set context ID based on response type
+		switch resp := responseToYield.(type) {
+		case *a2a.Message:
+			if resp.ContextID == "" {
+				resp.ContextID = params.Message.ContextID
+			}
+		case *a2a.Task:
+			if resp.ContextID == "" {
+				resp.ContextID = params.Message.ContextID
+			}
+		case *a2a.TaskStatusUpdateEvent:
+			if resp.ContextID == "" {
+				resp.ContextID = params.Message.ContextID
+			}
+		case *a2a.TaskArtifactUpdateEvent:
+			if resp.ContextID == "" {
+				resp.ContextID = params.Message.ContextID
+			}
+		}
 	}
 	return func(yield func(a2a.Event, error) bool) {
 		yield(responseToYield, nil)
@@ -59,6 +76,11 @@ func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, params *a2a
 }
 
 func (m *mockA2ATransport) GetTask(ctx context.Context, params *a2a.TaskQueryParams) (*a2a.Task, error) {
+	if m.responseToReturn != nil {
+		if task, ok := m.responseToReturn.(*a2a.Task); ok {
+			return task, nil
+		}
+	}
 	return nil, errors.New("not implemented")
 }
 
@@ -332,8 +354,8 @@ func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 }
 
-// TestRunStreamingAsyncWithValidUserMessage tests streaming with valid user message
-func TestRunStreamingAsyncWithValidUserMessage(t *testing.T) {
+// TestRunStreamingWithValidUserMessage tests streaming with valid user message
+func TestRunStreamingWithValidUserMessage(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
@@ -412,8 +434,8 @@ func TestRunStreamingAsyncWithValidUserMessage(t *testing.T) {
 	}
 }
 
-// TestRunStreamingAsyncWithThread tests streaming with thread context ID update
-func TestRunStreamingAsyncWithThread(t *testing.T) {
+// TestRunStreamingWithThread tests streaming with thread context ID update
+func TestRunStreamingWithThread(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
@@ -441,8 +463,8 @@ func TestRunStreamingAsyncWithThread(t *testing.T) {
 	}
 }
 
-// TestRunStreamingAsyncWithExistingThread tests streaming with existing thread
-func TestRunStreamingAsyncWithExistingThread(t *testing.T) {
+// TestRunStreamingWithExistingThread tests streaming with existing thread
+func TestRunStreamingWithExistingThread(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{},
 	}
@@ -465,8 +487,8 @@ func TestRunStreamingAsyncWithExistingThread(t *testing.T) {
 	}
 }
 
-// TestRunStreamingAsyncWithThreadHavingDifferentContextID tests error on context ID mismatch in streaming
-func TestRunStreamingAsyncWithThreadHavingDifferentContextID(t *testing.T) {
+// TestRunStreamingWithThreadHavingDifferentContextID tests error on context ID mismatch in streaming
+func TestRunStreamingWithThreadHavingDifferentContextID(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
@@ -492,8 +514,8 @@ func TestRunStreamingAsyncWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 }
 
-// TestRunStreamingAsyncAllowsNonUserRoleMessages tests that streaming allows non-user messages
-func TestRunStreamingAsyncAllowsNonUserRoleMessages(t *testing.T) {
+// TestRunStreamingAllowsNonUserRoleMessages tests that streaming allows non-user messages
+func TestRunStreamingAllowsNonUserRoleMessages(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
@@ -566,4 +588,617 @@ func TestRunWithHostedFileContent(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestRunWithInvalidThreadType tests error when using invalid thread type
+func TestRunWithInvalidThreadType(t *testing.T) {
+	transport := &mockA2ATransport{}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	// Create a custom thread type that is not an a2aagent.Thread
+	invalidThread := &customAgentThread{}
+
+	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(invalidThread))
+	if err == nil {
+		t.Error("Run() error = nil, want error for invalid thread type")
+	}
+}
+
+// TestRunStreamingWithInvalidThreadType tests error when using invalid thread type in streaming
+func TestRunStreamingWithInvalidThreadType(t *testing.T) {
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.Message{
+			ID:   "stream-1",
+			Role: a2a.MessageRoleAgent,
+			Parts: []a2a.Part{
+				a2a.TextPart{Text: "Response"},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	// Create a custom thread type that is not an a2aagent.Thread
+	invalidThread := &customAgentThread{}
+
+	gotError := false
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agent.WithThread(invalidThread)) {
+		if err != nil {
+			gotError = true
+			break
+		}
+	}
+
+	if !gotError {
+		t.Error("RunStream() expected error for invalid thread type, got nil")
+	}
+}
+
+// TestRunWithContinuationTokenAndMessages tests error when both continuation token and messages are provided
+func TestRunWithContinuationTokenAndMessages(t *testing.T) {
+	transport := &mockA2ATransport{}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithContinuationToken(a2a.TaskID("task-123")))
+	if err == nil {
+		t.Error("Run() error = nil, want error when continuation token and messages are provided")
+	}
+}
+
+// TestRunWithContinuationToken tests that continuation token calls GetTask
+func TestRunWithContinuationToken(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-123"),
+			ContextID: "context-123",
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	_, err := agent.Run(t.Context(), a, agent.WithContinuationToken(a2a.TaskID("task-123")))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+}
+
+// TestRunWithTaskInThreadAndMessage tests that task ID is added as reference
+func TestRunWithTaskInThreadAndMessage(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Message{
+			ID:   "response-123",
+			Role: a2a.MessageRoleAgent,
+			Parts: []a2a.Part{
+				a2a.TextPart{Text: "Response to task"},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread().(*a2aagent.Thread)
+	thread.TaskID = "task-123"
+
+	_, err := agent.RunText(t.Context(), a, "Please make the background transparent", agent.WithThread(thread))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	capturedMsg := transport.capturedMessageSendParams.Message
+	if capturedMsg == nil {
+		t.Fatal("capturedMessageSendParams.Message is nil")
+	}
+	if len(capturedMsg.ReferenceTasks) == 0 {
+		t.Error("message.ReferenceTasks is empty, expected task-123")
+	} else if string(capturedMsg.ReferenceTasks[0]) != "task-123" {
+		t.Errorf("message.ReferenceTasks[0] = %q, want %q", capturedMsg.ReferenceTasks[0], "task-123")
+	}
+}
+
+// TestRunWithAgentTask tests that thread task ID is updated
+func TestRunWithAgentTask(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-456"),
+			ContextID: "context-789",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateSubmitted,
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread()
+
+	_, err := agent.RunText(t.Context(), a, "Start a task", agent.WithThread(thread))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	a2aThread, ok := thread.(*a2aagent.Thread)
+	if !ok {
+		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+	}
+	if a2aThread.TaskID != "task-456" {
+		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, "task-456")
+	}
+}
+
+// TestRunWithAgentTaskResponse tests task response conversion
+func TestRunWithAgentTaskResponse(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-789"),
+			ContextID: "context-456",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateSubmitted,
+			},
+			Artifacts: []*a2a.Artifact{
+				{
+					ID: a2a.ArtifactID("art-1"),
+					Parts: []a2a.Part{
+						a2a.TextPart{Text: "Artifact content"},
+					},
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread()
+
+	result, err := agent.RunText(t.Context(), a, "Start a long-running task", agent.WithThread(thread))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	if result == nil {
+		t.Fatal("result is nil")
+	}
+	if result.AgentID != a.Identity().ID() {
+		t.Errorf("result.AgentID = %q, want %q", result.AgentID, a.Identity().ID())
+	}
+	if result.ID != "task-789" {
+		t.Errorf("result.ID = %q, want %q", result.ID, "task-789")
+	}
+
+	if result.ContinuationToken == nil {
+		t.Error("result.ContinuationToken is nil, want non-nil for submitted task")
+	} else if token, ok := result.ContinuationToken.(a2a.TaskID); !ok {
+		t.Errorf("result.ContinuationToken type = %T, want a2a.TaskID", result.ContinuationToken)
+	} else if string(token) != "task-789" {
+		t.Errorf("continuation token = %q, want %q", token, "task-789")
+	}
+
+	a2aThread, ok := thread.(*a2aagent.Thread)
+	if !ok {
+		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+	}
+	if a2aThread.ContextID != "context-456" {
+		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, "context-456")
+	}
+	if a2aThread.TaskID != "task-789" {
+		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, "task-789")
+	}
+}
+
+// TestRunWithVariousTaskStates tests continuation token behavior for different task states
+func TestRunWithVariousTaskStates(t *testing.T) {
+	tests := []struct {
+		name                    string
+		state                   a2a.TaskState
+		expectContinuationToken bool
+	}{
+		{"Submitted", a2a.TaskStateSubmitted, true},
+		{"Working", a2a.TaskStateWorking, true},
+		{"Completed", a2a.TaskStateCompleted, false},
+		{"Failed", a2a.TaskStateFailed, false},
+		{"Canceled", a2a.TaskStateCanceled, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := &mockA2ATransport{
+				responseToReturn: &a2a.Task{
+					ID:        a2a.TaskID("task-123"),
+					ContextID: "context-123",
+					Status: a2a.TaskStatus{
+						State: tt.state,
+					},
+					Artifacts: []*a2a.Artifact{
+						{
+							ID:    a2a.ArtifactID("art-1"),
+							Parts: []a2a.Part{a2a.TextPart{Text: "Content"}},
+						},
+					},
+				},
+			}
+			a := newTestAgent(transport, a2aagent.Options{})
+
+			result, err := agent.RunText(t.Context(), a, "Test message")
+			if err != nil {
+				t.Fatalf("Run() error = %v, want nil", err)
+			}
+
+			if tt.expectContinuationToken {
+				if result.ContinuationToken == nil {
+					t.Error("result.ContinuationToken is nil, want non-nil")
+				}
+			} else {
+				if result.ContinuationToken != nil {
+					t.Errorf("result.ContinuationToken = %v, want nil", result.ContinuationToken)
+				}
+			}
+		})
+	}
+}
+
+// TestRunStreamingWithContinuationTokenAndMessages tests error in streaming mode
+func TestRunStreamingWithContinuationTokenAndMessages(t *testing.T) {
+	transport := &mockA2ATransport{}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	gotError := false
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agent.WithContinuationToken(a2a.TaskID("task-123"))) {
+		if err != nil {
+			gotError = true
+			break
+		}
+	}
+
+	if !gotError {
+		t.Error("RunStream() expected error when continuation token used with streaming, got nil")
+	}
+}
+
+// TestRunStreamingWithTaskInThreadAndMessage tests task reference in streaming
+func TestRunStreamingWithTaskInThreadAndMessage(t *testing.T) {
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.Message{
+			ID:   "response-123",
+			Role: a2a.MessageRoleAgent,
+			Parts: []a2a.Part{
+				a2a.TextPart{Text: "Response to task"},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread().(*a2aagent.Thread)
+	thread.TaskID = "task-123"
+
+	for _, err := range agent.RunTextStream(t.Context(), a, "Please make the background transparent", agent.WithThread(thread)) {
+		if err != nil {
+			t.Fatalf("RunStream() error = %v, want nil", err)
+		}
+	}
+
+	capturedMsg := transport.capturedMessageSendParams.Message
+	if capturedMsg == nil {
+		t.Fatal("capturedMessageSendParams.Message is nil")
+	}
+	if len(capturedMsg.ReferenceTasks) == 0 {
+		t.Error("message.ReferenceTasks is empty, expected task-123")
+	} else if string(capturedMsg.ReferenceTasks[0]) != "task-123" {
+		t.Errorf("message.ReferenceTasks[0] = %q, want %q", capturedMsg.ReferenceTasks[0], "task-123")
+	}
+}
+
+// TestRunStreamingWithAgentTaskUpdatesThread tests thread task ID update in streaming
+func TestRunStreamingWithAgentTaskUpdatesThread(t *testing.T) {
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-456"),
+			ContextID: "context-789",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateSubmitted,
+			},
+			Artifacts: []*a2a.Artifact{
+				{
+					ID:    a2a.ArtifactID("art-1"),
+					Parts: []a2a.Part{a2a.TextPart{Text: "Task content"}},
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread()
+
+	for _, err := range agent.RunTextStream(t.Context(), a, "Start a task", agent.WithThread(thread)) {
+		if err != nil {
+			t.Fatalf("RunStream() error = %v, want nil", err)
+		}
+	}
+
+	a2aThread, ok := thread.(*a2aagent.Thread)
+	if !ok {
+		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+	}
+	if a2aThread.TaskID != "task-456" {
+		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, "task-456")
+	}
+}
+
+// TestRunStreamingWithAgentMessage tests streaming message response
+func TestRunStreamingWithAgentMessage(t *testing.T) {
+	const messageID = "msg-123"
+	const contextID = "ctx-456"
+	const messageText = "Hello from agent!"
+
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.Message{
+			ID:        messageID,
+			Role:      a2a.MessageRoleAgent,
+			ContextID: contextID,
+			Parts: []a2a.Part{
+				a2a.TextPart{Text: messageText},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	var updates []*agent.RunResponseUpdate
+	for update, err := range agent.RunTextStream(t.Context(), a, "Test message") {
+		if err != nil {
+			t.Fatalf("RunStream() error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+
+	update := updates[0]
+	if update.Role != message.RoleAssistant {
+		t.Errorf("update.Role = %q, want %q", update.Role, message.RoleAssistant)
+	}
+	if update.MessageID != messageID {
+		t.Errorf("update.MessageID = %q, want %q", update.MessageID, messageID)
+	}
+	if update.ResponseID != messageID {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, messageID)
+	}
+	if update.AgentID != a.Identity().ID() {
+		t.Errorf("update.AgentID = %q, want %q", update.AgentID, a.Identity().ID())
+	}
+	if update.String() != messageText {
+		t.Errorf("update.String() = %q, want %q", update.String(), messageText)
+	}
+	if _, ok := update.RawRepresentation.(*a2a.Message); !ok {
+		t.Errorf("update.RawRepresentation type = %T, want *a2a.Message", update.RawRepresentation)
+	}
+}
+
+// TestRunStreamingWithAgentTaskYieldsUpdate tests streaming task response
+func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
+	const taskID = "task-789"
+	const contextID = "ctx-012"
+
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.Task{
+			ID:        a2a.TaskID(taskID),
+			ContextID: contextID,
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateSubmitted,
+			},
+			Artifacts: []*a2a.Artifact{
+				{
+					ID: a2a.ArtifactID("art-123"),
+					Parts: []a2a.Part{
+						a2a.TextPart{Text: "Task artifact content"},
+					},
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread()
+
+	var updates []*agent.RunResponseUpdate
+	for update, err := range agent.RunTextStream(t.Context(), a, "Start long-running task", agent.WithThread(thread)) {
+		if err != nil {
+			t.Fatalf("RunStream() error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+
+	update := updates[0]
+	if update.Role != message.RoleAssistant {
+		t.Errorf("update.Role = %q, want %q", update.Role, message.RoleAssistant)
+	}
+	if update.ResponseID != taskID {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
+	}
+	if update.AgentID != a.Identity().ID() {
+		t.Errorf("update.AgentID = %q, want %q", update.AgentID, a.Identity().ID())
+	}
+	if _, ok := update.RawRepresentation.(*a2a.Artifact); !ok {
+		t.Errorf("update.RawRepresentation type = %T, want *a2a.Artifact", update.RawRepresentation)
+	}
+
+	a2aThread, ok := thread.(*a2aagent.Thread)
+	if !ok {
+		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+	}
+	if a2aThread.ContextID != contextID {
+		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, contextID)
+	}
+	if a2aThread.TaskID != taskID {
+		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, taskID)
+	}
+}
+
+// TestRunStreamingWithTaskStatusUpdateEvent tests handling of TaskStatusUpdateEvent
+func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
+	const taskID = "task-status-123"
+	const contextID = "ctx-status-456"
+
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
+			TaskID:    a2a.TaskID(taskID),
+			ContextID: contextID,
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateWorking,
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread()
+
+	var updates []*agent.RunResponseUpdate
+	for update, err := range agent.RunTextStream(t.Context(), a, "Check task status", agent.WithThread(thread)) {
+		if err != nil {
+			t.Fatalf("RunStream() error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+
+	update := updates[0]
+	if update.Role != message.RoleAssistant {
+		t.Errorf("update.Role = %q, want %q", update.Role, message.RoleAssistant)
+	}
+	if update.ResponseID != taskID {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
+	}
+	if update.AgentID != a.Identity().ID() {
+		t.Errorf("update.AgentID = %q, want %q", update.AgentID, a.Identity().ID())
+	}
+	if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
+		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
+	}
+
+	a2aThread, ok := thread.(*a2aagent.Thread)
+	if !ok {
+		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+	}
+	if a2aThread.ContextID != contextID {
+		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, contextID)
+	}
+	if a2aThread.TaskID != taskID {
+		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, taskID)
+	}
+}
+
+// TestRunStreamingWithTaskArtifactUpdateEvent tests handling of TaskArtifactUpdateEvent
+func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
+	const taskID = "task-artifact-123"
+	const contextID = "ctx-artifact-456"
+	const artifactContent = "Task artifact data"
+
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.TaskArtifactUpdateEvent{
+			TaskID:    a2a.TaskID(taskID),
+			ContextID: contextID,
+			Artifact: &a2a.Artifact{
+				ID: a2a.ArtifactID("artifact-789"),
+				Parts: []a2a.Part{
+					a2a.TextPart{Text: artifactContent},
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	thread := a.NewThread()
+
+	var updates []*agent.RunResponseUpdate
+	for update, err := range agent.RunTextStream(t.Context(), a, "Process artifact", agent.WithThread(thread)) {
+		if err != nil {
+			t.Fatalf("RunStream() error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+
+	update := updates[0]
+	if update.Role != message.RoleAssistant {
+		t.Errorf("update.Role = %q, want %q", update.Role, message.RoleAssistant)
+	}
+	if update.ResponseID != taskID {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
+	}
+	if update.AgentID != a.Identity().ID() {
+		t.Errorf("update.AgentID = %q, want %q", update.AgentID, a.Identity().ID())
+	}
+	if _, ok := update.RawRepresentation.(*a2a.TaskArtifactUpdateEvent); !ok {
+		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskArtifactUpdateEvent", update.RawRepresentation)
+	}
+
+	if len(update.Contents) == 0 {
+		t.Error("update.Contents is empty, want non-empty")
+	}
+	if update.String() != artifactContent {
+		t.Errorf("update.String() = %q, want %q", update.String(), artifactContent)
+	}
+
+	a2aThread, ok := thread.(*a2aagent.Thread)
+	if !ok {
+		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+	}
+	if a2aThread.ContextID != contextID {
+		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, contextID)
+	}
+	if a2aThread.TaskID != taskID {
+		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, taskID)
+	}
+}
+
+// TestRunWithAllowBackgroundResponsesAndNoThread tests error when no thread provided
+func TestRunWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
+	transport := &mockA2ATransport{}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	// Call the agent's Run method directly (not the helper functions) to test the validation
+	gotError := false
+	for _, err := range a.Run(context.Background(), agent.WithMessage(message.NewText("Test message")), agent.WithAllowBackgroundResponses(true)) {
+		if err != nil {
+			gotError = true
+			break
+		}
+	}
+	if !gotError {
+		t.Error("Run() error = nil, want error when AllowBackgroundResponses is true without thread")
+	}
+}
+
+// TestRunStreamingWithAllowBackgroundResponsesAndNoThread tests error in streaming mode
+func TestRunStreamingWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
+	transport := &mockA2ATransport{}
+	a := newTestAgent(transport, a2aagent.Options{})
+
+	// Call the agent's Run method directly with streaming enabled
+	gotError := false
+	for _, err := range a.Run(context.Background(), agent.WithMessage(message.NewText("Test message")), agent.WithAllowBackgroundResponses(true), agent.WithStreaming(true)) {
+		if err != nil {
+			gotError = true
+			break
+		}
+	}
+
+	if !gotError {
+		t.Error("RunStream() expected error when AllowBackgroundResponses is true without thread, got nil")
+	}
+}
+
+// customAgentThread is a custom agent thread for testing invalid thread type scenario
+type customAgentThread struct{}
+
+func (c *customAgentThread) ID() string {
+	return "custom-thread-id"
+}
+
+func (c *customAgentThread) MessagesReceived(ctx context.Context, messages ...*message.Message) error {
+	return nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -179,7 +179,12 @@ func processUpdate(r *RunResponse, update *RunResponseUpdate) {
 	if r.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(r.CreatedAt)) {
 		r.CreatedAt = update.CreatedAt
 	}
-	r.ContinuationToken = cmp.Or(update.ContinuationToken, r.ContinuationToken)
+	// If the update provides a nil ContinuationToken, clear it; otherwise, use the update's value.
+	if update.ContinuationToken == nil {
+		r.ContinuationToken = nil
+	} else {
+		r.ContinuationToken = update.ContinuationToken
+	}
 	if update.AdditionalProperties != nil {
 		if r.AdditionalProperties == nil {
 			r.AdditionalProperties = make(map[string]any)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -179,6 +179,7 @@ func processUpdate(r *RunResponse, update *RunResponseUpdate) {
 	if r.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(r.CreatedAt)) {
 		r.CreatedAt = update.CreatedAt
 	}
+	r.ContinuationToken = cmp.Or(update.ContinuationToken, r.ContinuationToken)
 	if update.AdditionalProperties != nil {
 		if r.AdditionalProperties == nil {
 			r.AdditionalProperties = make(map[string]any)
@@ -205,6 +206,7 @@ type RunResponse struct {
 	AdditionalProperties map[string]any
 	ID                   string
 	AgentID              string
+	ContinuationToken    any
 	CreatedAt            time.Time
 	Usage                *message.UsageDetails
 	Messages             []*message.Message
@@ -247,6 +249,7 @@ type RunResponseUpdate struct {
 	ResponseID           string
 	AuthorName           string
 	Role                 message.Role
+	ContinuationToken    any
 	CreatedAt            time.Time
 	Contents             []message.Content
 }

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -91,6 +91,10 @@ func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*age
 			yield(nil, err)
 			return
 		}
+		if err := validateStreamResumptionAllowed(opts.ContinuationToken, thread); err != nil {
+			yield(nil, err)
+			return
+		}
 		var updates []*chatclient.ChatResponseUpdate
 		for update, err := range client.Response(ctx, opts, messages...) {
 			if err != nil {
@@ -108,6 +112,7 @@ func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*age
 					ResponseID:           update.ResponseID,
 					CreatedAt:            update.CreatedAt,
 					Role:                 update.Role,
+					ContinuationToken:    update.ContinuationToken,
 					Contents:             update.Contents,
 					RawRepresentation:    update.RawRepresentation,
 					AdditionalProperties: update.AdditionalProperties,
@@ -207,6 +212,9 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options []agent.Op
 		if len(inputMsgs) > 0 {
 			return retError(errors.New("messages are not allowed when continuing a background response using a continuation token"))
 		}
+		if thread.ConversationID == "" && thread.MessageStore == nil {
+			return retError(errors.New("continuation tokens are not allowed to be used for initial runs"))
+		}
 	}
 	if opts.ContinuationToken == nil {
 		if thread.MessageStore != nil {
@@ -260,6 +268,23 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options []agent.Op
 		opts.ConversationID = thread.ConversationID
 	}
 	return thread, opts, inputMsgs, msgsForClient, ctxMessages, nil
+}
+
+func validateStreamResumptionAllowed(continuationToken any, thread *Thread) error {
+	if continuationToken == nil {
+		return nil
+	}
+	// Streaming resumption is only supported with chat history managed by the agent service because, currently, there's no good solution
+	// to collect updates received in failed runs and pass them to the last successful run so it can store them to the message store.
+	if thread.ConversationID == "" {
+		return errors.New("streaming resumption is only supported when chat history is stored and managed by the underlying service")
+	}
+	// Similarly, streaming resumption is not supported when a context provider is used because, currently, there's no good solution
+	// to collect updates received in failed runs and pass them to the last successful run so it can notify the context provider of the updates.
+	if thread.ContextProvider != nil {
+		return errors.New("using context provider with streaming resumption is not supported")
+	}
+	return nil
 }
 
 func (a *Agent) createConfiguredChatOptions(options []agent.Option) ChatOptions {

--- a/agent/chatagent/chatclient/chatclient.go
+++ b/agent/chatagent/chatclient/chatclient.go
@@ -36,6 +36,7 @@ type ChatResponseUpdate struct {
 	ModelID              string
 	ResponseID           string
 	Role                 message.Role
+	ContinuationToken    any
 	CreatedAt            time.Time
 	RawRepresentation    any
 	Contents             []message.Content

--- a/agent/opts.go
+++ b/agent/opts.go
@@ -83,12 +83,35 @@ func WithThread(thread memory.Thread) Option {
 	return threadOpt{thread}
 }
 
-// WithContinuationToken sets the continuation token for the agent run.
+// WithContinuationToken sets the continuation token for resuming and getting the result
+// of the agent response identified by this token.
+//
+// This token is used for background responses that can be activated via [WithAllowBackgroundResponses]
+// if the agent supports them. Streamed background responses, such as those returned by default by [RunStream],
+// can be resumed if interrupted. This means that a continuation token obtained from the [RunResponseUpdate] continuation token
+// of an update just before the interruption occurred can be passed to this function to resume the stream from
+// the point of interruption. Non-streamed background responses, such as those returned by [Run], can be polled for
+// completion by obtaining the token from the [RunResponse] continuation token.
 func WithContinuationToken(token any) Option {
 	return continuationTokenOpt{token}
 }
 
 // WithAllowBackgroundResponses sets whether to allow background responses during the agent run.
+//
+// Background responses allow running long-running operations or tasks asynchronously in the background that can be resumed
+// by streaming APIs and polled for completion by non-streaming APIs.
+//
+// When this property is set to true, non-streaming APIs may start a background operation and return an initial
+// response with a continuation token. Subsequent calls to the same API should be made in a polling manner with
+// the continuation token to get the final result of the operation.
+//
+// When this property is set to true, streaming APIs may also start a background operation and begin streaming
+// response updates until the operation is completed. If the streaming connection is interrupted, the
+// continuation token obtained from the last update that has one should be supplied to a subsequent call to the same streaming API
+// to resume the stream from the point of interruption and continue receiving updates until the operation is completed.
+//
+// This property only takes effect if the implementation it's used with supports background responses.
+// If the implementation does not support background responses, this property will be ignored.
 func WithAllowBackgroundResponses(allow bool) Option {
 	return allowBackgroundResponsesOpt(allow)
 }


### PR DESCRIPTION
Continuation tokens were not supported by the A2A agents, fix that. Also, add some validations related to continuation tokens to the Chat agent.

While here, handle some missing A2A event types.