### PR TITLE
Move agent options to agentopt

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -16,6 +16,7 @@ import (
 	"github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2aclient"
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
 )
@@ -76,14 +77,14 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return &thread, nil
 }
 
-func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, options ...agentopt.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		var thread *Thread
-		if v, ok := agent.GetOption(options, agent.WithThread); !ok {
+		if v, ok := agentopt.Get(options, agentopt.Thread); !ok {
 			// Aligning with other agent implementations that support background responses, where
 			// a thread is required for background responses to prevent inconsistent experience
 			// for callers if they forget to provide the thread for initial or follow-up runs.
-			if opts, ok := agent.GetOption(options, agent.WithAllowBackgroundResponses); ok && opts {
+			if opts, ok := agentopt.Get(options, agentopt.AllowBackgroundResponses); ok && opts {
 				yield(nil, errors.New("a thread must be provided when AllowBackgroundResponses is enabled"))
 				return
 			}
@@ -94,14 +95,14 @@ func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*age
 			yield(nil, errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
 			return
 		}
-		streaming, _ := agent.GetOption(options, agent.WithStreaming)
-		if token, ok := agent.GetOption(options, agent.WithContinuationToken); ok && token != nil {
+		streaming, _ := agentopt.Get(options, agentopt.Streaming)
+		if token, ok := agentopt.Get(options, agentopt.ContinuationToken); ok && token != nil {
 			if streaming {
 				// TODO: support resuming streaming responses using continuation tokens.
 				yield(nil, errors.New("reconnecting to task streams using continuation tokens is not supported yet"))
 				return
 			}
-			if _, ok := agent.GetOption(options, agent.WithMessage); ok {
+			if _, ok := agentopt.Get(options, agentopt.Message); ok {
 				yield(nil, errors.New("messages are not allowed when continuing a background response using a continuation token"))
 				return
 			}
@@ -123,7 +124,7 @@ func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*age
 			return
 		}
 		var parts []a2a.Part
-		for msg := range agent.GetOptions(options, agent.WithMessage) {
+		for msg := range agentopt.All(options, agentopt.Message) {
 			parts = parts[:0] // reset parts slice
 			parts, err := contentsToParts(msg.Contents, parts)
 			if err != nil {

--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -95,7 +95,7 @@ func (a *Agent) Run(ctx context.Context, options ...agentopt.Option) iter.Seq2[*
 			yield(nil, errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
 			return
 		}
-		streaming, _ := agentopt.Get(options, agentopt.Streaming)
+		streaming, _ := agentopt.Get(options, agentopt.Stream)
 		if token, ok := agentopt.Get(options, agentopt.ContinuationToken); ok && token != nil {
 			if streaming {
 				// TODO: support resuming streaming responses using continuation tokens.

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -282,8 +282,8 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	if result.Messages[0].Role != message.RoleAssistant {
 		t.Errorf("result.Messages[0].Role = %q, want %q", result.Messages[0].Role, message.RoleAssistant)
 	}
-	if result.Messages[0].Text() != "Hello! How can I help you today?" {
-		t.Errorf("result.Messages[0].Text() = %q, want %q", result.Messages[0].Text(), "Hello! How can I help you today?")
+	if result.Messages[0].String() != "Hello! How can I help you today?" {
+		t.Errorf("result.Messages[0].String() = %q, want %q", result.Messages[0].String(), "Hello! How can I help you today?")
 	}
 }
 

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/a2aproject/a2a-go/a2aclient"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/a2aagent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -200,10 +201,10 @@ func TestRunAllowsNonUserRoleMessages(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	inputMessages := []agent.Option{
-		agent.WithMessage(&message.Message{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}}),
-		agent.WithMessage(&message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}}),
-		agent.WithMessage(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
+	inputMessages := []agentopt.Option{
+		agentopt.Message(&message.Message{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}}),
+		agentopt.Message(&message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}}),
+		agentopt.Message(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
 	}
 
 	_, err := agent.Run(t.Context(), a, inputMessages...)
@@ -299,7 +300,7 @@ func TestRunWithNewThread(t *testing.T) {
 	a := newTestAgent(transport, a2aagent.Options{})
 
 	thread := a.NewThread()
-	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -320,7 +321,7 @@ func TestRunWithExistingThread(t *testing.T) {
 
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -348,7 +349,7 @@ func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
 
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
 	if err == nil {
 		t.Error("Run() error = nil, want error")
 	}
@@ -448,7 +449,7 @@ func TestRunStreamingWithThread(t *testing.T) {
 
 	thread := a.NewThread()
 
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -472,7 +473,7 @@ func TestRunStreamingWithExistingThread(t *testing.T) {
 
 	thread := a.NewThreadWithContextID("existing-context-id")
 
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -502,7 +503,7 @@ func TestRunStreamingWithThreadHavingDifferentContextID(t *testing.T) {
 	thread := a.NewThreadWithContextID("existing-context-id")
 
 	gotError := false
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
 		if err != nil {
 			gotError = true
 			break
@@ -526,10 +527,10 @@ func TestRunStreamingAllowsNonUserRoleMessages(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	inputMessages := []agent.Option{
-		agent.WithMessage(&message.Message{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}}),
-		agent.WithMessage(&message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}}),
-		agent.WithMessage(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
+	inputMessages := []agentopt.Option{
+		agentopt.Message(&message.Message{Role: message.RoleSystem, Contents: []message.Content{&message.TextContent{Text: "I am a system message"}}}),
+		agentopt.Message(&message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "I am an assistant message"}}}),
+		agentopt.Message(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Valid user message"}}}),
 	}
 
 	for _, err := range agent.RunStream(t.Context(), a, inputMessages...) {
@@ -544,8 +545,8 @@ func TestRunWithHostedFileContent(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	inputMessages := []agent.Option{
-		agent.WithMessage(&message.Message{
+	inputMessages := []agentopt.Option{
+		agentopt.Message(&message.Message{
 			Role: message.RoleUser,
 			Contents: []message.Content{
 				&message.TextContent{Text: "Check this file:"},
@@ -598,7 +599,7 @@ func TestRunWithInvalidThreadType(t *testing.T) {
 	// Create a custom thread type that is not an a2aagent.Thread
 	invalidThread := &customAgentThread{}
 
-	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithThread(invalidThread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(invalidThread))
 	if err == nil {
 		t.Error("Run() error = nil, want error for invalid thread type")
 	}
@@ -621,7 +622,7 @@ func TestRunStreamingWithInvalidThreadType(t *testing.T) {
 	invalidThread := &customAgentThread{}
 
 	gotError := false
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agent.WithThread(invalidThread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agentopt.Thread(invalidThread)) {
 		if err != nil {
 			gotError = true
 			break
@@ -638,7 +639,7 @@ func TestRunWithContinuationTokenAndMessages(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	_, err := agent.RunText(t.Context(), a, "Test message", agent.WithContinuationToken(a2a.TaskID("task-123")))
+	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.ContinuationToken(a2a.TaskID("task-123")))
 	if err == nil {
 		t.Error("Run() error = nil, want error when continuation token and messages are provided")
 	}
@@ -654,7 +655,7 @@ func TestRunWithContinuationToken(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	_, err := agent.Run(t.Context(), a, agent.WithContinuationToken(a2a.TaskID("task-123")))
+	_, err := agent.Run(t.Context(), a, agentopt.ContinuationToken(a2a.TaskID("task-123")))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -676,7 +677,7 @@ func TestRunWithTaskInThreadAndMessage(t *testing.T) {
 	thread := a.NewThread().(*a2aagent.Thread)
 	thread.TaskID = "task-123"
 
-	_, err := agent.RunText(t.Context(), a, "Please make the background transparent", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Please make the background transparent", agentopt.Thread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -707,7 +708,7 @@ func TestRunWithAgentTask(t *testing.T) {
 
 	thread := a.NewThread()
 
-	_, err := agent.RunText(t.Context(), a, "Start a task", agent.WithThread(thread))
+	_, err := agent.RunText(t.Context(), a, "Start a task", agentopt.Thread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -744,7 +745,7 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 
 	thread := a.NewThread()
 
-	result, err := agent.RunText(t.Context(), a, "Start a long-running task", agent.WithThread(thread))
+	result, err := agent.RunText(t.Context(), a, "Start a long-running task", agentopt.Thread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -836,7 +837,7 @@ func TestRunStreamingWithContinuationTokenAndMessages(t *testing.T) {
 	a := newTestAgent(transport, a2aagent.Options{})
 
 	gotError := false
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agent.WithContinuationToken(a2a.TaskID("task-123"))) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agentopt.ContinuationToken(a2a.TaskID("task-123"))) {
 		if err != nil {
 			gotError = true
 			break
@@ -864,7 +865,7 @@ func TestRunStreamingWithTaskInThreadAndMessage(t *testing.T) {
 	thread := a.NewThread().(*a2aagent.Thread)
 	thread.TaskID = "task-123"
 
-	for _, err := range agent.RunTextStream(t.Context(), a, "Please make the background transparent", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Please make the background transparent", agentopt.Thread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -902,7 +903,7 @@ func TestRunStreamingWithAgentTaskUpdatesThread(t *testing.T) {
 
 	thread := a.NewThread()
 
-	for _, err := range agent.RunTextStream(t.Context(), a, "Start a task", agent.WithThread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Start a task", agentopt.Thread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -995,7 +996,7 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 	thread := a.NewThread()
 
 	var updates []*agent.RunResponseUpdate
-	for update, err := range agent.RunTextStream(t.Context(), a, "Start long-running task", agent.WithThread(thread)) {
+	for update, err := range agent.RunTextStream(t.Context(), a, "Start long-running task", agentopt.Thread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -1051,7 +1052,7 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 	thread := a.NewThread()
 
 	var updates []*agent.RunResponseUpdate
-	for update, err := range agent.RunTextStream(t.Context(), a, "Check task status", agent.WithThread(thread)) {
+	for update, err := range agent.RunTextStream(t.Context(), a, "Check task status", agentopt.Thread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -1111,7 +1112,7 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	thread := a.NewThread()
 
 	var updates []*agent.RunResponseUpdate
-	for update, err := range agent.RunTextStream(t.Context(), a, "Process artifact", agent.WithThread(thread)) {
+	for update, err := range agent.RunTextStream(t.Context(), a, "Process artifact", agentopt.Thread(thread)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -1162,7 +1163,7 @@ func TestRunWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
 
 	// Call the agent's Run method directly (not the helper functions) to test the validation
 	gotError := false
-	for _, err := range a.Run(context.Background(), agent.WithMessage(message.NewText("Test message")), agent.WithAllowBackgroundResponses(true)) {
+	for _, err := range a.Run(context.Background(), agentopt.Message(message.NewText("Test message")), agentopt.AllowBackgroundResponses(true)) {
 		if err != nil {
 			gotError = true
 			break
@@ -1180,7 +1181,7 @@ func TestRunStreamingWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
 
 	// Call the agent's Run method directly with streaming enabled
 	gotError := false
-	for _, err := range a.Run(context.Background(), agent.WithMessage(message.NewText("Test message")), agent.WithAllowBackgroundResponses(true), agent.WithStreaming(true)) {
+	for _, err := range a.Run(context.Background(), agentopt.Message(message.NewText("Test message")), agentopt.AllowBackgroundResponses(true), agentopt.Streaming(true)) {
 		if err != nil {
 			gotError = true
 			break

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -1181,7 +1181,7 @@ func TestRunStreamingWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
 
 	// Call the agent's Run method directly with streaming enabled
 	gotError := false
-	for _, err := range a.Run(context.Background(), agentopt.Message(message.NewText("Test message")), agentopt.AllowBackgroundResponses(true), agentopt.Streaming(true)) {
+	for _, err := range a.Run(context.Background(), agentopt.Message(message.NewText("Test message")), agentopt.AllowBackgroundResponses(true), agentopt.Stream(true)) {
 		if err != nil {
 			gotError = true
 			break

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/format"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
@@ -64,11 +65,11 @@ type Agent interface {
 }
 
 type Runner interface {
-	Run(ctx context.Context, options ...Option) iter.Seq2[*RunResponseUpdate, error]
+	Run(ctx context.Context, options ...agentopt.Option) iter.Seq2[*RunResponseUpdate, error]
 }
 
 type Middleware interface {
-	Run(ctx context.Context, next Runner, options ...Option) iter.Seq2[*RunResponseUpdate, error]
+	Run(ctx context.Context, next Runner, options ...agentopt.Option) iter.Seq2[*RunResponseUpdate, error]
 }
 
 func NewMessagesFromUpdates(updates []*RunResponseUpdate) []*message.Message {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -148,16 +148,7 @@ func processUpdate(r *RunResponse, update *RunResponseUpdate) {
 		msg.CreatedAt = update.CreatedAt
 	}
 	for _, content := range update.Contents {
-		switch c := content.(type) {
-		case *message.UsageContent:
-			// Usage content is treated specially and propagated to the response's Usage.
-			if r.Usage == nil {
-				r.Usage = new(message.UsageDetails)
-			}
-			r.Usage.Add(c.Details)
-		default:
-			msg.Contents = append(msg.Contents, content)
-		}
+		msg.Contents = append(msg.Contents, content)
 	}
 	// Other members on a ChatResponseUpdate map to members of the ChatResponse.
 	// Update the response object with those, preferring the values from later updates.
@@ -199,7 +190,6 @@ type RunResponse struct {
 	AgentID              string
 	ContinuationToken    any
 	CreatedAt            time.Time
-	Usage                *message.UsageDetails
 	Messages             []*message.Message
 }
 
@@ -214,6 +204,14 @@ func (r *RunResponse) String() string {
 		}
 	}
 	return sb.String()
+}
+
+func (r *RunResponse) Usage() message.UsageDetails {
+	var usage message.UsageDetails
+	for _, msg := range r.Messages {
+		usage.Add(msg.Usage())
+	}
+	return usage
 }
 
 func (r *RunResponse) UserInputRequests() iter.Seq[message.Content] {

--- a/agent/agentopt/agentopt.go
+++ b/agent/agentopt/agentopt.go
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package agent
+package agentopt
 
 import (
 	"iter"
@@ -16,7 +16,7 @@ import (
 // An Option configures the behavior of an Agent during a Run.
 //
 // Each option must be implemented as its own distinct type.
-// [GetOption] and [GetOptions] use the option's type
+// [Get] and [All] use the option's type
 // to uniquely identify each option.
 type Option interface {
 	AgentOption()
@@ -28,9 +28,8 @@ type (
 	threadOpt            struct{ memory.Thread }
 	continuationTokenOpt struct{ any }
 
-	messageOpt    struct{ *message.Message }
-	toolOpt       struct{ tool.Tool }
-	middlewareOpt struct{ Middleware }
+	messageOpt struct{ *message.Message }
+	toolOpt    struct{ tool.Tool }
 
 	toolModeOpt                 tool.ToolMode
 	streamingOpt                bool
@@ -45,7 +44,6 @@ func (allowBackgroundResponsesOpt) AgentOption() {}
 func (messageOpt) AgentOption()                  {}
 func (toolOpt) AgentOption()                     {}
 func (toolModeOpt) AgentOption()                 {}
-func (middlewareOpt) AgentOption()               {}
 
 func (o responseFormatOpt) Value() any           { return o.Format }
 func (o threadOpt) Value() any                   { return o.Thread }
@@ -55,52 +53,46 @@ func (o allowBackgroundResponsesOpt) Value() any { return bool(o) }
 func (o messageOpt) Value() any                  { return o.Message }
 func (o toolModeOpt) Value() any                 { return tool.ToolMode(o) }
 func (o toolOpt) Value() any                     { return o.Tool }
-func (o middlewareOpt) Value() any               { return Middleware(o) }
 
-// WithMiddleware adds a middleware to the agent run.
-func WithMiddleware(mw Middleware) Option {
-	return middlewareOpt{mw}
-}
-
-// WithTool adds a tool to the agent run.
-func WithTool(tool tool.Tool) Option {
+// Tool adds a tool to the agent run.
+func Tool(tool tool.Tool) Option {
 	return toolOpt{tool}
 }
 
-// WithToolMode sets the tool mode for the agent run.
-func WithToolMode(mode tool.ToolMode) Option {
+// ToolMode sets the tool mode for the agent run.
+func ToolMode(mode tool.ToolMode) Option {
 	return toolModeOpt(mode)
 }
 
-// WithStreaming sets whether to use streaming responses during the agent run.
-func WithStreaming(streaming bool) Option {
+// Streaming sets whether to use streaming responses during the agent run.
+func Streaming(streaming bool) Option {
 	return streamingOpt(streaming)
 }
 
-// WithResponseFormat sets the desired response format for the agent run.
-func WithResponseFormat(format format.Format) Option {
+// ResponseFormat sets the desired response format for the agent run.
+func ResponseFormat(format format.Format) Option {
 	return responseFormatOpt{format}
 }
 
-// WithThread sets the thread to use during the agent run.
-func WithThread(thread memory.Thread) Option {
+// Thread sets the thread to use during the agent run.
+func Thread(thread memory.Thread) Option {
 	return threadOpt{thread}
 }
 
-// WithContinuationToken sets the continuation token for resuming and getting the result
+// ContinuationToken sets the continuation token for resuming and getting the result
 // of the agent response identified by this token.
 //
-// This token is used for background responses that can be activated via [WithAllowBackgroundResponses]
+// This token is used for background responses that can be activated via [AllowBackgroundResponses]
 // if the agent supports them. Streamed background responses, such as those returned by default by [RunStream],
 // can be resumed if interrupted. This means that a continuation token obtained from the [RunResponseUpdate] continuation token
 // of an update just before the interruption occurred can be passed to this function to resume the stream from
 // the point of interruption. Non-streamed background responses, such as those returned by [Run], can be polled for
 // completion by obtaining the token from the [RunResponse] continuation token.
-func WithContinuationToken(token any) Option {
+func ContinuationToken(token any) Option {
 	return continuationTokenOpt{token}
 }
 
-// WithAllowBackgroundResponses sets whether to allow background responses during the agent run.
+// AllowBackgroundResponses sets whether to allow background responses during the agent run.
 //
 // Background responses allow running long-running operations or tasks asynchronously in the background that can be resumed
 // by streaming APIs and polled for completion by non-streaming APIs.
@@ -116,18 +108,18 @@ func WithContinuationToken(token any) Option {
 //
 // This property only takes effect if the implementation it's used with supports background responses.
 // If the implementation does not support background responses, this property will be ignored.
-func WithAllowBackgroundResponses(allow bool) Option {
+func AllowBackgroundResponses(allow bool) Option {
 	return allowBackgroundResponsesOpt(allow)
 }
 
-// WithMessage adds a message to the agent run.
-func WithMessage(message *message.Message) Option {
+// Message adds a message to the agent run.
+func Message(message *message.Message) Option {
 	return messageOpt{message}
 }
 
-// GetOption returns the value stored in opts with the provided setter,
+// Get returns the value stored in opts with the provided setter,
 // reporting whether the value is present.
-func GetOption[T any](opts []Option, setter func(T) Option) (T, bool) {
+func Get[T any](opts []Option, setter func(T) Option) (T, bool) {
 	var zero T
 	var setterType = reflect.TypeOf(setter(zero))
 	for _, opt := range slices.Backward(opts) {
@@ -139,7 +131,7 @@ func GetOption[T any](opts []Option, setter func(T) Option) (T, bool) {
 	return zero, false
 }
 
-func DeleteOption[T any](opts []Option, setter func(T) Option) []Option {
+func Delete[T any](opts []Option, setter func(T) Option) []Option {
 	var zero T
 	var setterType = reflect.TypeOf(setter(zero))
 	return slices.DeleteFunc(opts, func(opt Option) bool {
@@ -147,8 +139,8 @@ func DeleteOption[T any](opts []Option, setter func(T) Option) []Option {
 	})
 }
 
-// GetOptions returns a sequence of all values stored in opts with the provided setter.
-func GetOptions[T any](opts []Option, setter func(T) Option) iter.Seq[T] {
+// All returns a sequence of all values stored in opts with the provided setter.
+func All[T any](opts []Option, setter func(T) Option) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		var zero T
 		var setterType = reflect.TypeOf(setter(zero))

--- a/agent/agentopt/agentopt.go
+++ b/agent/agentopt/agentopt.go
@@ -32,13 +32,13 @@ type (
 	toolOpt    struct{ tool.Tool }
 
 	toolModeOpt                 tool.ToolMode
-	streamingOpt                bool
+	streamOpt                   bool
 	allowBackgroundResponsesOpt bool
 )
 
 func (responseFormatOpt) AgentOption()           {}
 func (threadOpt) AgentOption()                   {}
-func (streamingOpt) AgentOption()                {}
+func (streamOpt) AgentOption()                   {}
 func (continuationTokenOpt) AgentOption()        {}
 func (allowBackgroundResponsesOpt) AgentOption() {}
 func (messageOpt) AgentOption()                  {}
@@ -47,7 +47,7 @@ func (toolModeOpt) AgentOption()                 {}
 
 func (o responseFormatOpt) Value() any           { return o.Format }
 func (o threadOpt) Value() any                   { return o.Thread }
-func (o streamingOpt) Value() any                { return bool(o) }
+func (o streamOpt) Value() any                   { return bool(o) }
 func (o continuationTokenOpt) Value() any        { return o.any }
 func (o allowBackgroundResponsesOpt) Value() any { return bool(o) }
 func (o messageOpt) Value() any                  { return o.Message }
@@ -64,9 +64,9 @@ func ToolMode(mode tool.ToolMode) Option {
 	return toolModeOpt(mode)
 }
 
-// Streaming sets whether to use streaming responses during the agent run.
-func Streaming(streaming bool) Option {
-	return streamingOpt(streaming)
+// Stream sets whether to use streaming responses during the agent run.
+func Stream(stream bool) Option {
+	return streamOpt(stream)
 }
 
 // ResponseFormat sets the desired response format for the agent run.

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -7,12 +7,13 @@ import (
 	"iter"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
 type Turn struct {
-	Callbacks []func(context.Context, ...agent.Option)
+	Callbacks []func(context.Context, ...agentopt.Option)
 	Responses []Response
 }
 
@@ -20,7 +21,7 @@ type ResponseBuilder struct {
 	turns []Turn
 }
 
-func NewResponseBuilder(firstTurnCallbacks ...func(ctx context.Context, opts ...agent.Option)) *ResponseBuilder {
+func NewResponseBuilder(firstTurnCallbacks ...func(ctx context.Context, opts ...agentopt.Option)) *ResponseBuilder {
 	return &ResponseBuilder{
 		turns: []Turn{{
 			Responses: []Response{},
@@ -29,7 +30,7 @@ func NewResponseBuilder(firstTurnCallbacks ...func(ctx context.Context, opts ...
 	}
 }
 
-func (rb *ResponseBuilder) NewTurn(callbacks ...func(ctx context.Context, opts ...agent.Option)) *ResponseBuilder {
+func (rb *ResponseBuilder) NewTurn(callbacks ...func(ctx context.Context, opts ...agentopt.Option)) *ResponseBuilder {
 	rb.turns = append(rb.turns, Turn{
 		Callbacks: callbacks,
 		Responses: []Response{},
@@ -104,7 +105,7 @@ func (a *Agent) Capabilities() agent.Capabilities {
 	return a.Caps
 }
 
-func (a *Agent) Run(ctx context.Context, opts ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, opts ...agentopt.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		defer func() { a.currentTurn++ }()
 		if a.currentTurn >= len(a.Responses) {
@@ -160,7 +161,7 @@ func (m *Middleware) Called() bool {
 	return m.called
 }
 
-func (m *Middleware) Run(ctx context.Context, next agent.Runner, opts ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (m *Middleware) Run(ctx context.Context, next agent.Runner, opts ...agentopt.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	m.called = true
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		defer func() { m.currentTurn++ }()
@@ -194,7 +195,7 @@ type Runner struct {
 	currentTurn int
 }
 
-func (r *Runner) Run(ctx context.Context, opts ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (r *Runner) Run(ctx context.Context, opts ...agentopt.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		defer func() { r.currentTurn++ }()
 		if r.currentTurn >= len(r.Responses) {

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -309,7 +309,7 @@ func (a *Agent) createConfiguredChatOptions(options []agentopt.Option) ChatOptio
 	if v, ok := agentopt.Get(options, agentopt.ContinuationToken); ok {
 		opts.ContinuationToken = v
 	}
-	if v, ok := agentopt.Get(options, agentopt.Streaming); ok {
+	if v, ok := agentopt.Get(options, agentopt.Stream); ok {
 		opts.Streaming = param.NewOpt(v)
 	}
 	if v, ok := agentopt.Get(options, agentopt.ResponseFormat); ok {

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent/chatclient"
 	"github.com/microsoft/agent-framework-go/agent/middleware/autocall"
 	"github.com/microsoft/agent-framework-go/memory"
@@ -83,10 +84,10 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
 }
 
-func (a *Agent) Run(ctx context.Context, options ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, options ...agentopt.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
 		client := a.Client
-		if fn, ok := agent.GetOption(options, WithNewClient); ok {
+		if fn, ok := agentopt.Get(options, WithNewClient); ok {
 			// If we have a custom chat client factory, we should use it to create a new chat client with the transformed tools.
 			client = fn(client)
 		}
@@ -194,7 +195,7 @@ func (a *Agent) updateThreadWithTypeAndConversationID(thread *Thread, convID str
 	return nil
 }
 
-func (a *Agent) prepareThreadAndMessages(ctx context.Context, options []agent.Option) (thread *Thread, opts ChatOptions, inputMsgs, msgsForClient, ctxMessages []*message.Message, err error) {
+func (a *Agent) prepareThreadAndMessages(ctx context.Context, options []agentopt.Option) (thread *Thread, opts ChatOptions, inputMsgs, msgsForClient, ctxMessages []*message.Message, err error) {
 	retError := func(e error) (*Thread, ChatOptions, []*message.Message, []*message.Message, []*message.Message, error) {
 		return nil, ChatOptions{}, nil, nil, nil, e
 	}
@@ -202,7 +203,7 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options []agent.Op
 	if v, ok := opts.AllowBackgroundResponses.Value(); ok && v && thread == nil {
 		return retError(errors.New("a thread must be provided when continuing a background response with a continuation token"))
 	}
-	if v, ok := agent.GetOption(options, agent.WithThread); ok {
+	if v, ok := agentopt.Get(options, agentopt.Thread); ok {
 		var ok bool
 		thread, ok = v.(*Thread)
 		if !ok {
@@ -211,7 +212,7 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, options []agent.Op
 	} else {
 		thread = a.newThread("")
 	}
-	inputMsgs = slices.Collect(agent.GetOptions(options, agent.WithMessage))
+	inputMsgs = slices.Collect(agentopt.All(options, agentopt.Message))
 	if opts.ContinuationToken != nil {
 		if len(inputMsgs) > 0 {
 			return retError(errors.New("messages are not allowed when continuing a background response using a continuation token"))
@@ -291,10 +292,10 @@ func validateStreamResumptionAllowed(continuationToken any, thread *Thread) erro
 	return nil
 }
 
-func (a *Agent) createConfiguredChatOptions(options []agent.Option) ChatOptions {
+func (a *Agent) createConfiguredChatOptions(options []agentopt.Option) ChatOptions {
 	var opts ChatOptions
 	// Try to get ChatOptions from RunOptions
-	if v, ok := agent.GetOption(options, WithOptions); ok {
+	if v, ok := agentopt.Get(options, WithOptions); ok {
 		opts = *v.Clone()
 	}
 	// Merge in Agent-level ChatOptions
@@ -302,16 +303,16 @@ func (a *Agent) createConfiguredChatOptions(options []agent.Option) ChatOptions 
 		opts.Copy(a.Options.ChatOptions)
 	}
 	// Merge in RunOptions specific fields
-	if v, ok := agent.GetOption(options, agent.WithAllowBackgroundResponses); ok {
+	if v, ok := agentopt.Get(options, agentopt.AllowBackgroundResponses); ok {
 		opts.AllowBackgroundResponses = param.NewOpt(v)
 	}
-	if v, ok := agent.GetOption(options, agent.WithContinuationToken); ok {
+	if v, ok := agentopt.Get(options, agentopt.ContinuationToken); ok {
 		opts.ContinuationToken = v
 	}
-	if v, ok := agent.GetOption(options, agent.WithStreaming); ok {
+	if v, ok := agentopt.Get(options, agentopt.Streaming); ok {
 		opts.Streaming = param.NewOpt(v)
 	}
-	if v, ok := agent.GetOption(options, agent.WithResponseFormat); ok {
+	if v, ok := agentopt.Get(options, agentopt.ResponseFormat); ok {
 		opts.ResponseFormat = v
 	}
 	return opts

--- a/agent/chatagent/options.go
+++ b/agent/chatagent/options.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent/chatclient"
 	"github.com/microsoft/agent-framework-go/memory"
 )
@@ -45,7 +46,7 @@ func (o opts) Value() any {
 	return o.ChatOptions
 }
 
-func WithOptions(options *ChatOptions) agent.Option {
+func WithOptions(options *ChatOptions) agentopt.Option {
 	return opts{options}
 }
 
@@ -59,6 +60,6 @@ func (o newClientOpts) Value() any {
 	return o.NewClient
 }
 
-func WithNewClient(newClient func(chatclient.Client) chatclient.Client) agent.Option {
+func WithNewClient(newClient func(chatclient.Client) chatclient.Client) agentopt.Option {
 	return newClientOpts{newClient}
 }

--- a/agent/middleware/autocall/autocall.go
+++ b/agent/middleware/autocall/autocall.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/param"
 	"github.com/microsoft/agent-framework-go/tool"
@@ -44,9 +45,9 @@ func New(options Options) agent.Middleware {
 	return ac
 }
 
-func (f *autocall) Run(ctx context.Context, next agent.Runner, opts ...agent.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
+func (f *autocall) Run(ctx context.Context, next agent.Runner, opts ...agentopt.Option) iter.Seq2[*agent.RunResponseUpdate, error] {
 	return func(yield func(*agent.RunResponseUpdate, error) bool) {
-		tools, requiresApproval := f.createToolsMap(agent.GetOptions(opts, agent.WithTool))
+		tools, requiresApproval := f.createToolsMap(agentopt.All(opts, agentopt.Tool))
 
 		// This is a synthetic ID since we're generating the tool messages instead of getting them from
 		// the underlying provider. When emitting the streamed chunks, it's perfectly valid for us to
@@ -55,7 +56,7 @@ func (f *autocall) Run(ctx context.Context, next agent.Runner, opts ...agent.Opt
 		// but there's no benefit to doing so.
 		toolMsgID := f.NewID()
 		var errCount int
-		if messages := slices.Collect(agent.GetOptions(opts, agent.WithMessage)); hasAnyApprovalContent(messages) {
+		if messages := slices.Collect(agentopt.All(opts, agentopt.Message)); hasAnyApprovalContent(messages) {
 			// We also need a synthetic ID for the function call content for approved function calls
 			// where we don't know what the original message id of the function call was.
 			funcCallFallbackMsgID := f.NewID()
@@ -93,11 +94,11 @@ func (f *autocall) Run(ctx context.Context, next agent.Runner, opts ...agent.Opt
 				}
 			}
 			// Remove all existing message options
-			opts = agent.DeleteOption(opts, agent.WithMessage)
+			opts = agentopt.Delete(opts, agentopt.Message)
 
 			// Add all accumulated messages
 			for _, msg := range messages {
-				opts = append(opts, agent.WithMessage(msg))
+				opts = append(opts, agentopt.Message(msg))
 			}
 		}
 		// At this point, we've fully handled all approval responses that were part of the original messages,
@@ -137,7 +138,7 @@ func (f *autocall) Run(ctx context.Context, next agent.Runner, opts ...agent.Opt
 				// or the first time we get an FCC that requires approval. At that point, we can yield all of the updates buffered thus far
 				// and anything further, replacing FCCs with approval if any required it, or yielding them as is.
 				if requiresApproval && approvalRequiredFunctions == nil && len(functionCallContents) > 0 {
-					for tl := range agent.GetOptions(opts, agent.WithTool) {
+					for tl := range agentopt.All(opts, agentopt.Tool) {
 						if tl, ok := tl.(tool.ApprovalRequiredTool); ok {
 							approvalRequiredFunctions = append(approvalRequiredFunctions, tl)
 						}
@@ -264,23 +265,23 @@ func convertToolResultMsgToUpdate(msg *message.Message, msgID string) *agent.Run
 	}
 }
 
-func updateOptionsForNextIteration(opts []agent.Option, msg *message.Message) []agent.Option {
+func updateOptionsForNextIteration(opts []agentopt.Option, msg *message.Message) []agentopt.Option {
 	// Remove all existing message options
-	opts = agent.DeleteOption(opts, agent.WithMessage)
+	opts = agentopt.Delete(opts, agentopt.Message)
 
 	// Add the new message
-	opts = append(opts, agent.WithMessage(msg))
+	opts = append(opts, agentopt.Message(msg))
 
-	if v, ok := agent.GetOption(opts, agent.WithToolMode); ok && v == tool.ToolModeRequired {
+	if v, ok := agentopt.Get(opts, agentopt.ToolMode); ok && v == tool.ToolModeRequired {
 		// We have to reset the tool mode to be non-required after the first iteration,
 		// as otherwise we'll be in an infinite loop.
-		opts = append(opts, agent.WithToolMode(tool.ToolModeAuto))
+		opts = append(opts, agentopt.ToolMode(tool.ToolModeAuto))
 	}
 	// Reset the continuation token of a background response operation
 	// to signal the inner client to handle function call result rather
 	// than getting the result of the operation.
-	if _, ok := agent.GetOption(opts, agent.WithContinuationToken); ok {
-		opts = append(opts, agent.WithContinuationToken(nil))
+	if _, ok := agentopt.Get(opts, agentopt.ContinuationToken); ok {
+		opts = append(opts, agentopt.ContinuationToken(nil))
 	}
 	return opts
 }

--- a/agent/middleware/autocall/autocall_approval_test.go
+++ b/agent/middleware/autocall/autocall_approval_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/agenttest"
 	"github.com/microsoft/agent-framework-go/agent/middleware/autocall"
 	"github.com/microsoft/agent-framework-go/message"
@@ -16,9 +17,9 @@ import (
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
-func expectedMessages(t *testing.T, expected ...*message.Message) func(context.Context, ...agent.Option) {
-	return func(ctx context.Context, opts ...agent.Option) {
-		got := slices.Collect(agent.GetOptions(opts, agent.WithMessage))
+func expectedMessages(t *testing.T, expected ...*message.Message) func(context.Context, ...agentopt.Option) {
+	return func(ctx context.Context, opts ...agentopt.Option) {
+		got := slices.Collect(agentopt.All(opts, agentopt.Message))
 		if err := agenttest.MessagesEqual(expected, got); err != nil {
 			t.Errorf("Messages not equal: %v", err)
 		}
@@ -30,7 +31,7 @@ func invokeAndAssertApproval(t *testing.T, tools []tool.Tool, input []*message.M
 	downstreamAgentOutput []*agent.RunResponseUpdate, expectedOutput []*agent.RunResponseUpdate,
 	expectedDownstreamAgentInput []*message.Message, additionalTools []tool.Tool) {
 
-	var cb func(context.Context, ...agent.Option)
+	var cb func(context.Context, ...agentopt.Option)
 	if expectedDownstreamAgentInput != nil {
 		cb = expectedMessages(t, expectedDownstreamAgentInput...)
 	}
@@ -61,12 +62,12 @@ func invokeAndAssertApprovalWithAgent(t *testing.T, runner agent.Runner,
 	ctx := t.Context()
 
 	// Build options
-	opts := []agent.Option{}
+	opts := []agentopt.Option{}
 	for _, msg := range input {
-		opts = append(opts, agent.WithMessage(msg))
+		opts = append(opts, agentopt.Message(msg))
 	}
 	for _, tool := range tools {
-		opts = append(opts, agent.WithTool(tool))
+		opts = append(opts, agentopt.Tool(tool))
 	}
 
 	// Collect all streaming updates into messages
@@ -89,12 +90,12 @@ func expectApprovalError(t *testing.T, tools []tool.Tool, input []*message.Messa
 	ctx := t.Context()
 
 	// Build options
-	opts := []agent.Option{}
+	opts := []agentopt.Option{}
 	for _, msg := range input {
-		opts = append(opts, agent.WithMessage(msg))
+		opts = append(opts, agentopt.Message(msg))
 	}
 	for _, tool := range tools {
-		opts = append(opts, agent.WithTool(tool))
+		opts = append(opts, agentopt.Tool(tool))
 	}
 
 	var lastErr error

--- a/agent/middleware/autocall/autocall_test.go
+++ b/agent/middleware/autocall/autocall_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/agenttest"
 	"github.com/microsoft/agent-framework-go/agent/middleware/autocall"
 	"github.com/microsoft/agent-framework-go/message"
@@ -180,9 +181,9 @@ func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, e
 	initialMessages := []*message.Message{plan[0]}
 
 	// Build options
-	opts := []agent.Option{agent.WithMessage(initialMessages[0])}
+	opts := []agentopt.Option{agentopt.Message(initialMessages[0])}
 	for _, tool := range tools {
-		opts = append(opts, agent.WithTool(tool))
+		opts = append(opts, agentopt.Tool(tool))
 	}
 
 	// Collect all updates
@@ -635,9 +636,9 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 			initialMessages := []*message.Message{plan[0]}
 
 			// Build options
-			opts := []agent.Option{agent.WithMessage(initialMessages[0])}
+			opts := []agentopt.Option{agentopt.Message(initialMessages[0])}
 			for _, tool := range tools {
-				opts = append(opts, agent.WithTool(tool))
+				opts = append(opts, agentopt.Tool(tool))
 			}
 
 			var streamErr error
@@ -748,9 +749,9 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 				Responses: rb.Build(),
 			}
 
-			opts := []agent.Option{agent.WithMessage(plan[0])}
+			opts := []agentopt.Option{agentopt.Message(plan[0])}
 			for _, tool := range tools {
-				opts = append(opts, agent.WithTool(tool))
+				opts = append(opts, agentopt.Tool(tool))
 			}
 
 			var streamErr error
@@ -965,9 +966,9 @@ func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 			Build(),
 	}
 
-	opts := []agent.Option{agent.WithMessage(messages[0])}
+	opts := []agentopt.Option{agentopt.Message(messages[0])}
 	for _, tool := range tools {
-		opts = append(opts, agent.WithTool(tool))
+		opts = append(opts, agentopt.Tool(tool))
 	}
 
 	var updates []*agent.RunResponseUpdate

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -9,11 +9,12 @@ import (
 	"iter"
 	"slices"
 
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
 // Run executes the agent with the given options and returns the response.
-func Run(ctx context.Context, a Agent, opts ...Option) (*RunResponse, error) {
+func Run(ctx context.Context, a Agent, opts ...agentopt.Option) (*RunResponse, error) {
 	resp := RunResponse{
 		AgentID: a.Identity().ID(),
 	}
@@ -30,23 +31,23 @@ func Run(ctx context.Context, a Agent, opts ...Option) (*RunResponse, error) {
 }
 
 // RunStream executes the agent with the given options and returns a streaming sequence of response updates.
-func RunStream(ctx context.Context, a Agent, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
-	opts = append(opts, WithStreaming(true))
+func RunStream(ctx context.Context, a Agent, opts ...agentopt.Option) iter.Seq2[*RunResponseUpdate, error] {
+	opts = append(opts, agentopt.Streaming(true))
 	return run(ctx, a, opts)
 }
 
 // RunText executes the agent with a single text message and returns the response.
-func RunText(ctx context.Context, a Agent, msg string, opts ...Option) (*RunResponse, error) {
-	return Run(ctx, a, append(opts, WithMessage(message.NewText(msg)))...)
+func RunText(ctx context.Context, a Agent, msg string, opts ...agentopt.Option) (*RunResponse, error) {
+	return Run(ctx, a, append(opts, agentopt.Message(message.NewText(msg)))...)
 }
 
 // RunTextStream executes the agent with a single text message and returns a streaming sequence of response updates.
-func RunTextStream(ctx context.Context, a Agent, msg string, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
-	return RunStream(ctx, a, append(opts, WithMessage(message.NewText(msg)))...)
+func RunTextStream(ctx context.Context, a Agent, msg string, opts ...agentopt.Option) iter.Seq2[*RunResponseUpdate, error] {
+	return RunStream(ctx, a, append(opts, agentopt.Message(message.NewText(msg)))...)
 }
 
 // RunFor executes the agent with the given messages and returns the result of type T.
-func RunFor[T any](ctx context.Context, a Agent, opts ...Option) (T, *RunResponse, error) {
+func RunFor[T any](ctx context.Context, a Agent, opts ...agentopt.Option) (T, *RunResponse, error) {
 	var v T
 	formatter := a.Capabilities().StructuredOutput
 	if formatter == nil {
@@ -56,7 +57,7 @@ func RunFor[T any](ctx context.Context, a Agent, opts ...Option) (T, *RunRespons
 	if err != nil {
 		return v, nil, err
 	}
-	opts = append(opts, WithResponseFormat(format))
+	opts = append(opts, agentopt.ResponseFormat(format))
 	resp, err := Run(ctx, a, opts...)
 	if err != nil {
 		return v, resp, err
@@ -70,7 +71,7 @@ type agentRunner struct {
 	agent Agent
 }
 
-func (ar agentRunner) Run(ctx context.Context, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
+func (ar agentRunner) Run(ctx context.Context, opts ...agentopt.Option) iter.Seq2[*RunResponseUpdate, error] {
 	return func(yield func(*RunResponseUpdate, error) bool) {
 		iden := ar.agent.Identity()
 		id, name := iden.ID(), iden.Name()
@@ -101,26 +102,25 @@ type middlewareRunner struct {
 	next Runner
 }
 
-func (mr middlewareRunner) Run(ctx context.Context, opts ...Option) iter.Seq2[*RunResponseUpdate, error] {
+func (mr middlewareRunner) Run(ctx context.Context, opts ...agentopt.Option) iter.Seq2[*RunResponseUpdate, error] {
 	return mr.Middleware.Run(ctx, mr.next, opts...)
 }
 
-func run(ctx context.Context, a Agent, opts []Option) iter.Seq2[*RunResponseUpdate, error] {
+func run(ctx context.Context, a Agent, opts []agentopt.Option) iter.Seq2[*RunResponseUpdate, error] {
 	// If no thread is provided, create a new one.
-	if _, ok := GetOption(opts, WithThread); !ok {
-		opts = append(opts, WithThread(a.NewThread()))
+	if _, ok := agentopt.Get(opts, agentopt.Thread); !ok {
+		opts = append(opts, agentopt.Thread(a.NewThread()))
 	}
 
 	caps := a.Capabilities()
 
 	// Collect tools from agent capabilities.
 	for _, t := range caps.Tools {
-		opts = append(opts, WithTool(t))
+		opts = append(opts, agentopt.Tool(t))
 	}
 
 	// Collect all middlewares and add the agent's Run method as the final middleware.
 	middlewares := slices.Clone(caps.Middlewares)
-	middlewares = append(middlewares, slices.Collect(GetOptions(opts, WithMiddleware))...)
 
 	// Chain the middlewares together.
 	var chain Runner = agentRunner{agent: a}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -32,7 +32,7 @@ func Run(ctx context.Context, a Agent, opts ...agentopt.Option) (*RunResponse, e
 
 // RunStream executes the agent with the given options and returns a streaming sequence of response updates.
 func RunStream(ctx context.Context, a Agent, opts ...agentopt.Option) iter.Seq2[*RunResponseUpdate, error] {
-	opts = append(opts, agentopt.Streaming(true))
+	opts = append(opts, agentopt.Stream(true))
 	return run(ctx, a, opts)
 }
 

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -517,7 +517,7 @@ func TestRunStream_BasicExecution(t *testing.T) {
 		Responses: agenttest.NewResponseBuilder(
 			func(ctx context.Context, opts ...agentopt.Option) {
 				// Verify streaming option is set
-				streaming, ok := agentopt.Get(opts, agentopt.Streaming)
+				streaming, ok := agentopt.Get(opts, agentopt.Stream)
 				if !ok || !streaming {
 					t.Fatal("streaming not enabled")
 				}
@@ -651,7 +651,7 @@ func TestRunTextStream_BasicExecution(t *testing.T) {
 		Responses: agenttest.NewResponseBuilder(
 			func(ctx context.Context, opts ...agentopt.Option) {
 				// Verify streaming is enabled
-				streaming, ok := agentopt.Get(opts, agentopt.Streaming)
+				streaming, ok := agentopt.Get(opts, agentopt.Stream)
 				if !ok || !streaming {
 					t.Fatal("streaming not enabled")
 				}

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -168,20 +168,18 @@ func TestRun_UsageTracking(t *testing.T) {
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	if resp.Usage == nil {
-		t.Fatal("expected usage details, got nil")
+	usage := resp.Usage()
+
+	if usage.InputTokenCount != 10 {
+		t.Errorf("expected input tokens 10, got %d", usage.InputTokenCount)
 	}
 
-	if resp.Usage.InputTokenCount != 10 {
-		t.Errorf("expected input tokens 10, got %d", resp.Usage.InputTokenCount)
+	if usage.OutputTokenCount != 20 {
+		t.Errorf("expected output tokens 20, got %d", usage.OutputTokenCount)
 	}
 
-	if resp.Usage.OutputTokenCount != 20 {
-		t.Errorf("expected output tokens 20, got %d", resp.Usage.OutputTokenCount)
-	}
-
-	if resp.Usage.TotalTokenCount != 30 {
-		t.Errorf("expected total tokens 30, got %d", resp.Usage.TotalTokenCount)
+	if usage.TotalTokenCount != 30 {
+		t.Errorf("expected total tokens 30, got %d", usage.TotalTokenCount)
 	}
 }
 

--- a/agent/runner_test.go
+++ b/agent/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/agenttest"
 	"github.com/microsoft/agent-framework-go/format"
 	"github.com/microsoft/agent-framework-go/memory"
@@ -249,68 +250,6 @@ func TestRun_ResponseMetadata(t *testing.T) {
 	}
 }
 
-func TestRun_WithMiddleware(t *testing.T) {
-	ctx := t.Context()
-	mw := &agenttest.Middleware{}
-
-	a := &agenttest.Agent{
-		Responses: agenttest.NewResponseBuilder().
-			AddText("Response").
-			Build(),
-	}
-
-	_, err := agent.Run(ctx, a, agent.WithMiddleware(mw))
-	if err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
-
-	if !mw.Called() {
-		t.Error("expected middleware to be invoked")
-	}
-}
-
-func TestRun_MiddlewareOrder(t *testing.T) {
-	ctx := t.Context()
-
-	mw1 := &agenttest.Middleware{
-		PreResponses: agenttest.NewResponseBuilder().
-			AddText("mw1-before ").
-			Build(),
-		PostResponses: agenttest.NewResponseBuilder().
-			AddText("mw1-after").
-			Build(),
-	}
-
-	mw2 := &agenttest.Middleware{
-		PreResponses: agenttest.NewResponseBuilder().
-			AddText("mw2-before ").
-			Build(),
-		PostResponses: agenttest.NewResponseBuilder().
-			AddText("mw2-after ").
-			Build(),
-	}
-
-	a := &agenttest.Agent{
-		Responses: agenttest.NewResponseBuilder().
-			Add(&agent.RunResponseUpdate{
-				Contents: []message.Content{
-					&message.TextContent{Text: "Response "},
-				},
-			}).
-			Build(),
-	}
-
-	resp, err := agent.Run(ctx, a, agent.WithMiddleware(mw1), agent.WithMiddleware(mw2))
-	if err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
-	want := "mw1-before mw2-before Response mw2-after mw1-after"
-	got := resp.String()
-	if got != want {
-		t.Errorf("expected response %q, got %q", want, got)
-	}
-}
-
 func TestRun_AgentCapabilitiesMiddleware(t *testing.T) {
 	ctx := t.Context()
 	capsMw := &agenttest.Middleware{}
@@ -345,8 +284,8 @@ func TestRun_AgentCapabilitiesTools(t *testing.T) {
 			Tools: []tool.Tool{testTool},
 		},
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
-				for tool := range agent.GetOptions(opts, agent.WithTool) {
+			func(ctx context.Context, opts ...agentopt.Option) {
+				for tool := range agentopt.All(opts, agentopt.Tool) {
 					receivedTools = append(receivedTools, tool.Name())
 				}
 			}).
@@ -460,8 +399,8 @@ func TestRun_ThreadCreation(t *testing.T) {
 			return agenttest.NewThread()
 		},
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
-				thread, ok := agent.GetOption(opts, agent.WithThread)
+			func(ctx context.Context, opts ...agentopt.Option) {
+				thread, ok := agentopt.Get(opts, agentopt.Thread)
 				if !ok || thread == nil {
 					t.Error("no thread provided")
 				}
@@ -491,8 +430,8 @@ func TestRun_ProvidedThread(t *testing.T) {
 			return agenttest.NewThread()
 		},
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
-				thread, ok := agent.GetOption(opts, agent.WithThread)
+			func(ctx context.Context, opts ...agentopt.Option) {
+				thread, ok := agentopt.Get(opts, agentopt.Thread)
 				if !ok {
 					t.Fatal("no thread provided")
 				}
@@ -509,7 +448,7 @@ func TestRun_ProvidedThread(t *testing.T) {
 			Build(),
 	}
 
-	_, err := agent.Run(ctx, a, agent.WithThread(providedThread))
+	_, err := agent.Run(ctx, a, agentopt.Thread(providedThread))
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
 	}
@@ -578,9 +517,9 @@ func TestRunStream_BasicExecution(t *testing.T) {
 
 	a := &agenttest.Agent{
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
+			func(ctx context.Context, opts ...agentopt.Option) {
 				// Verify streaming option is set
-				streaming, ok := agent.GetOption(opts, agent.WithStreaming)
+				streaming, ok := agentopt.Get(opts, agentopt.Streaming)
 				if !ok || !streaming {
 					t.Fatal("streaming not enabled")
 				}
@@ -644,10 +583,10 @@ func TestRunText_BasicExecution(t *testing.T) {
 
 	a := &agenttest.Agent{
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
+			func(ctx context.Context, opts ...agentopt.Option) {
 				// Verify message option is set with correct text
 				hasMessage := false
-				for msg := range agent.GetOptions(opts, agent.WithMessage) {
+				for msg := range agentopt.All(opts, agentopt.Message) {
 					if len(msg.Contents) > 0 {
 						if tc, ok := msg.Contents[0].(*message.TextContent); ok {
 							if tc.Text == "Hello" {
@@ -680,10 +619,10 @@ func TestRunText_WithAdditionalOptions(t *testing.T) {
 
 	a := &agenttest.Agent{
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
+			func(ctx context.Context, opts ...agentopt.Option) {
 				// Verify both message and thread are present
-				_, hasMessage := agent.GetOption(opts, agent.WithMessage)
-				thread, hasThread := agent.GetOption(opts, agent.WithThread)
+				_, hasMessage := agentopt.Get(opts, agentopt.Message)
+				thread, hasThread := agentopt.Get(opts, agentopt.Thread)
 
 				if !hasMessage {
 					t.Fatal("message not found")
@@ -699,7 +638,7 @@ func TestRunText_WithAdditionalOptions(t *testing.T) {
 			Build(),
 	}
 
-	_, err := agent.RunText(ctx, a, "Test", agent.WithThread(providedThread))
+	_, err := agent.RunText(ctx, a, "Test", agentopt.Thread(providedThread))
 	if err != nil {
 		t.Fatalf("RunText failed: %v", err)
 	}
@@ -712,14 +651,14 @@ func TestRunTextStream_BasicExecution(t *testing.T) {
 
 	a := &agenttest.Agent{
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
+			func(ctx context.Context, opts ...agentopt.Option) {
 				// Verify streaming is enabled
-				streaming, ok := agent.GetOption(opts, agent.WithStreaming)
+				streaming, ok := agentopt.Get(opts, agentopt.Streaming)
 				if !ok || !streaming {
 					t.Fatal("streaming not enabled")
 				}
 				// Verify message is present
-				_, hasMessage := agent.GetOption(opts, agent.WithMessage)
+				_, hasMessage := agentopt.Get(opts, agentopt.Message)
 				if !hasMessage {
 					t.Fatal("message not found")
 				}
@@ -792,9 +731,9 @@ func TestRunFor_BasicExecution(t *testing.T) {
 			StructuredOutput: formatter,
 		},
 		Responses: agenttest.NewResponseBuilder(
-			func(ctx context.Context, opts ...agent.Option) {
+			func(ctx context.Context, opts ...agentopt.Option) {
 				// Verify response format is set
-				_, hasFormat := agent.GetOption(opts, agent.WithResponseFormat)
+				_, hasFormat := agentopt.Get(opts, agentopt.ResponseFormat)
 				if !hasFormat {
 					t.Fatal("response format not set")
 				}

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
@@ -68,7 +69,7 @@ func (t functool) Call(ctx context.Context, args string) (any, error) {
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return nil, err
 	}
-	resp, err := Run(ctx, t.agent, WithThread(t.thread), WithMessage(message.NewText(in.Query)))
+	resp, err := Run(ctx, t.agent, agentopt.Thread(t.thread), agentopt.Message(message.NewText(in.Query)))
 	if err != nil {
 		return "", err
 	}

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -69,7 +69,7 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 			options = append(options, agentopt.Thread(ensureThread()))
 			if emitEvents {
 				// Run the agent in streaming mode only when agent run update events are to be emitted.
-				options = append(options, agentopt.Streaming(true))
+				options = append(options, agentopt.Stream(true))
 			}
 			for _, msg := range messages {
 				options = append(options, agentopt.Message(msg))

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/message/messageworkflow"
@@ -64,14 +65,14 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 		StateKey: "agent_messages",
 		TakeTurnHandler: func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
 			emitEvents := token.EmitEventsOr(emitEvents)
-			options := make([]Option, 0, 1+len(messages))
-			options = append(options, WithThread(ensureThread()))
+			options := make([]agentopt.Option, 0, 1+len(messages))
+			options = append(options, agentopt.Thread(ensureThread()))
 			if emitEvents {
 				// Run the agent in streaming mode only when agent run update events are to be emitted.
-				options = append(options, WithStreaming(true))
+				options = append(options, agentopt.Streaming(true))
 			}
 			for _, msg := range messages {
-				options = append(options, WithMessage(msg))
+				options = append(options, agentopt.Message(msg))
 			}
 			var updates []*RunResponseUpdate
 			for update, err := range RunStream(ctx, a, options...) {

--- a/examples/getting_started/agent/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/agent/step02_multiturn_conversation/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/openai"
 )
@@ -25,18 +26,18 @@ func main() {
 
 	// Invoke the agent with a multi-turn conversation, where the context is preserved in the thread object.
 	thread := a.NewThread()
-	fmt.Println(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agent.WithThread(thread)))
-	fmt.Println(agent.RunText(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agent.WithThread(thread)))
+	fmt.Println(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
+	fmt.Println(agent.RunText(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Thread(thread)))
 
 	// Invoke the agent with a multi-turn conversation and streaming, where the context is preserved in the thread object.
 	thread2 := a.NewThread()
-	for update, err := range agent.RunTextStream(ctx, a, "Tell me a joke about a pirate.", agent.WithThread(thread2)) {
+	for update, err := range agent.RunTextStream(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread2)) {
 		if err != nil {
 			panic(err)
 		}
 		fmt.Println(update)
 	}
-	for update, err := range agent.RunTextStream(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agent.WithThread(thread2)) {
+	for update, err := range agent.RunTextStream(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Thread(thread2)) {
 		if err != nil {
 			panic(err)
 		}

--- a/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/agent/chatagent/chatclient"
 	"github.com/microsoft/agent-framework-go/message"
@@ -43,7 +44,7 @@ func main() {
 
 	// Call the agent and check if there are any user input requests to handle.
 	thread := a.NewThread()
-	resp, err := agent.RunText(ctx, a, "What is the weather like in Amsterdam?", agent.WithThread(thread))
+	resp, err := agent.RunText(ctx, a, "What is the weather like in Amsterdam?", agentopt.Thread(thread))
 	if err != nil {
 		panic(err)
 	}
@@ -65,5 +66,5 @@ func main() {
 	}
 
 	// Pass the user input responses back to the agent for further processing.
-	fmt.Println(agent.Run(ctx, a, agent.WithMessage(message.New(userResponses...)), agent.WithThread(thread)))
+	fmt.Println(agent.Run(ctx, a, agentopt.Message(message.New(userResponses...)), agentopt.Thread(thread)))
 }

--- a/examples/getting_started/agent/step05_structured_output/main.go
+++ b/examples/getting_started/agent/step05_structured_output/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/agent/chatagent/chatclient"
 	"github.com/microsoft/agent-framework-go/format/jsonformat"
@@ -34,7 +35,7 @@ func main() {
 	ctx := context.Background()
 
 	// Set PersonInfo as the type parameter of RunFor method to specify the expected structured output from the agent and invoke the agent with some unstructured input.
-	person, _, err := agent.RunFor[PersonInfo](ctx, a, agent.WithMessage(message.NewText("Please provide information about John Smith, who is a 35-year-old software engineer.")))
+	person, _, err := agent.RunFor[PersonInfo](ctx, a, agentopt.Message(message.NewText("Please provide information about John Smith, who is a 35-year-old software engineer.")))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/openai"
 )
@@ -31,7 +32,7 @@ func main() {
 	thread := a.NewThread()
 
 	// Run the agent with a new thread.
-	fmt.Println(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agent.WithThread(thread)))
+	fmt.Println(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
 
 	// Serialize the thread state to JSON, so it can be stored for later use.
 	serializedThread, err := json.Marshal(thread)
@@ -62,5 +63,5 @@ func main() {
 	}
 
 	// Run the agent again with the resumed thread.
-	fmt.Println(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agent.WithThread(resumedThread)))
+	fmt.Println(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Thread(resumedThread)))
 }

--- a/examples/getting_started/agent/step07_3rdparty_thread_storage/main.go
+++ b/examples/getting_started/agent/step07_3rdparty_thread_storage/main.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
@@ -46,7 +47,7 @@ func main() {
 	thread := a.NewThread()
 
 	// Run the agent with the thread that stores conversation history in the disk store.
-	fmt.Println(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agent.WithThread(thread)))
+	fmt.Println(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
 
 	// Serialize the thread state, so it can be stored for later use.
 	// Since the chat history is stored in the disk store, the serialized thread
@@ -68,7 +69,7 @@ func main() {
 	}
 
 	// Run the agent with the thread that stores conversation history in the vector store a second time.
-	fmt.Println(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agent.WithThread(resumedThread)))
+	fmt.Println(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Thread(resumedThread)))
 }
 
 type fsMessageStore struct {

--- a/examples/getting_started/agent/step11_using_images/main.go
+++ b/examples/getting_started/agent/step11_using_images/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/openai"
@@ -32,7 +33,7 @@ func main() {
 		},
 	)
 
-	for resp, err := range agent.RunStream(ctx, a, agent.WithMessage(msg)) {
+	for resp, err := range agent.RunStream(ctx, a, agentopt.Message(msg)) {
 		if err != nil {
 			panic(err)
 		}

--- a/message/content.go
+++ b/message/content.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"maps"
 	"reflect"
 	"slices"
@@ -68,6 +69,39 @@ func (cs *Contents) UnmarshalJSON(data []byte) error {
 	var err error
 	*cs, err = jsonx.UnmarshalDiscriminatedUnionSlice[Content](data, supportedContents)
 	return err
+}
+
+// Text returns the first text content in the response, or empty string.
+func (cs Contents) Text() string {
+	for _, c := range cs {
+		if textContent, ok := c.(*TextContent); ok {
+			return textContent.Text
+		}
+	}
+	return ""
+}
+
+func (cs Contents) Usage() UsageDetails {
+	var usage UsageDetails
+	for _, c := range cs {
+		if usageContent, ok := c.(*UsageContent); ok {
+			usage.Add(usageContent.Details)
+		}
+	}
+	return usage
+}
+
+func (cs Contents) UserInputRequests() iter.Seq[Content] {
+	return func(yield func(Content) bool) {
+		for _, c := range cs {
+			switch c := c.(type) {
+			case *FunctionApprovalRequestContent:
+				if !yield(c) {
+					return
+				}
+			}
+		}
+	}
 }
 
 // TextContent represents plain text content.

--- a/message/message.go
+++ b/message/message.go
@@ -2,7 +2,9 @@
 
 package message
 
-import "time"
+import (
+	"time"
+)
 
 // Role represents the role of a message sender in a conversation.
 type Role string
@@ -24,9 +26,11 @@ type Message struct {
 	Contents             Contents
 	Role                 Role
 	ID                   string
+	AuthorID             string    `json:",omitzero"`
 	AuthorName           string    `json:",omitzero"`
 	CreatedAt            time.Time `json:",omitzero"`
-	RawRepresentation    any       `json:",omitzero"`
+	ContinuationToken    any       `json:",omitzero"`
+	RawRepresentation    any       `json:"-"`
 }
 
 // New creates a new [Message] with the given role and contents.
@@ -43,20 +47,17 @@ func NewText(text string) *Message {
 }
 
 func (m *Message) String() string {
-	return m.Text()
+	return m.Contents.Text()
 }
 
-// Text returns the first text content in the response, or empty string.
-func (m *Message) Text() string {
-	if m == nil {
-		return ""
-	}
+func (m *Message) Usage() UsageDetails {
+	var usage UsageDetails
 	for _, c := range m.Contents {
-		if textContent, ok := c.(*TextContent); ok {
-			return textContent.Text
+		if usageContent, ok := c.(*UsageContent); ok {
+			usage.Add(usageContent.Details)
 		}
 	}
-	return ""
+	return usage
 }
 
 // Clone creates a shallow copy of the message.

--- a/samples/getting_started/azure_openai/agent/agent_step02_multiturn_conversation/multiturn_agent_test.go
+++ b/samples/getting_started/azure_openai/agent/agent_step02_multiturn_conversation/multiturn_agent_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/openai"
@@ -131,7 +132,7 @@ func runWithThread(ag agent.Agent, thread memory.Thread, query string) {
 		colorGray, timestamp(), colorReset,
 		colorBlue, colorBold, colorReset)
 
-	resp, err := agent.RunText(ctx, ag, query, agent.WithThread(thread))
+	resp, err := agent.RunText(ctx, ag, query, agentopt.Thread(thread))
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -151,7 +152,7 @@ func runStreamWithThread(ag agent.Agent, thread memory.Thread, query string) {
 		colorGray, timestamp(), colorReset,
 		colorBlue, colorBold, colorReset)
 
-	for update, err := range agent.RunTextStream(ctx, ag, query, agent.WithThread(thread)) {
+	for update, err := range agent.RunTextStream(ctx, ag, query, agentopt.Thread(thread)) {
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
 			return

--- a/samples/getting_started/azure_openai/agent/agent_step04_using_function_tools_approval/function_tools_approval_test.go
+++ b/samples/getting_started/azure_openai/agent/agent_step04_using_function_tools_approval/function_tools_approval_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
@@ -138,7 +139,7 @@ func runWithApproval(ag agent.Agent, thread memory.Thread, query string, simulat
 		colorGreen, colorBold, colorReset, query)
 
 	// Run the agent - this may return approval requests instead of a final answer
-	resp, err := agent.RunText(ctx, ag, query, agent.WithThread(thread))
+	resp, err := agent.RunText(ctx, ag, query, agentopt.Thread(thread))
 	if err != nil {
 		fmt.Printf("%s❌ Error: %v%s\n", colorRed, err, colorReset)
 		return
@@ -180,8 +181,8 @@ func runWithApproval(ag agent.Agent, thread memory.Thread, query string, simulat
 			colorBlue, colorBold, colorReset)
 
 		resp, err = agent.Run(ctx, ag,
-			agent.WithMessage(message.New(userResponses...)),
-			agent.WithThread(thread))
+			agentopt.Message(message.New(userResponses...)),
+			agentopt.Thread(thread))
 		if err != nil {
 			fmt.Printf("\n%s❌ Error: %v%s\n", colorRed, err, colorReset)
 			return

--- a/samples/getting_started/openai/chat_cli/openai_chat_cli.go
+++ b/samples/getting_started/openai/chat_cli/openai_chat_cli.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/openai"
@@ -104,7 +105,7 @@ func runChatLoop(ag agent.Agent, thread memory.Thread) {
 		fmt.Print("Assistant: ")
 
 		hasError := false
-		for update, err := range agent.RunTextStream(ctx, ag, userInput, agent.WithThread(thread)) {
+		for update, err := range agent.RunTextStream(ctx, ag, userInput, agentopt.Thread(thread)) {
 			if err != nil {
 				fmt.Printf("\n❌ Error: %v\n", err)
 				hasError = true

--- a/samples/getting_started/openai/chat_cli_enhanced/openai_chat_cli_enhanced.go
+++ b/samples/getting_started/openai/chat_cli_enhanced/openai_chat_cli_enhanced.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/openai"
@@ -139,7 +140,7 @@ func runChatLoop(ag agent.Agent, thread memory.Thread) {
 			colorBlue, colorBold, colorReset)
 
 		hasError := false
-		for update, err := range agent.RunTextStream(ctx, ag, userInput, agent.WithThread(thread)) {
+		for update, err := range agent.RunTextStream(ctx, ag, userInput, agentopt.Thread(thread)) {
 			if err != nil {
 				fmt.Printf("\n%s❌ Error: %v%s\n", colorRed, err, colorReset)
 				hasError = true


### PR DESCRIPTION
Having all agent options in the `agent/agentopt` package makes them more discoverable. Also, we can drop the `With` prefix, as the package name is enough.