### PR TITLE
fix: initialise ChatOptions in NewAgent to prevent nil pointer panic

### DIFF
--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -31,6 +31,9 @@ type Agent struct {
 
 // NewAgent creates a new chat agent with the given chat client and options.
 func NewAgent(client chatclient.Client, options Options) *Agent {
+	if options.ChatOptions == nil {
+		options.ChatOptions = &ChatOptions{}
+	}
 	return &Agent{
 		Client:  client,
 		Options: options,


### PR DESCRIPTION
### Summary
Fixes a nil pointer panic when creating an agent without explicitly setting ChatOptions, calling Capabilities() causes panic.

### Problem
When using chatgentOptions without providing ChatOptions, calling Capabilities() causes a panic.

```Go
a := openai.NewChatAgent(openai.ClientConfig{
    Model: "gpt-4o-mini",
}, chatagent.Options{
    Instructions: "You are good at telling jokes.",
    Name:         "Joker",
})

// PANIC: runtime error: invalid memory address or nil pointer dereference
// at agent/chatagent/chatagent.go:57 (a.Options.ChatOptions.Tools)
```

### Solution
Intialise ChatOptions in NewAgent if not provided:

```Go
func NewAgent(client chatclient.Client, options Options) *Agent {
    if options.ChatOptions == nil {
        options.ChatOptions = &ChatOptions{}
    }
    // ...
}
```
I believe this is following pattern already used in Middlewares.

### Testing
Verifed all examples in examples/getting_started_agent/steps* run without nil pointer errors.