### PR TITLE
Support passing options to Agent.NewThread

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -30,6 +30,15 @@ type Options struct {
 	Logger      *slog.Logger
 }
 
+type contextIDOpt struct{ string }
+
+func (contextIDOpt) NewThreadOption() {}
+func (o contextIDOpt) Value() any     { return o.string }
+
+func WithContextID(id string) agentopt.NewThreadOption {
+	return contextIDOpt{id}
+}
+
 var _ agent.Agent = (*Agent)(nil)
 
 type Agent struct {
@@ -54,11 +63,8 @@ func (a *Agent) Identity() agent.Identity {
 	return a.iden
 }
 
-func (a *Agent) NewThread() memory.Thread {
-	return &Thread{}
-}
-
-func (a *Agent) NewThreadWithContextID(contextID string) *Thread {
+func (a *Agent) NewThread(ctx context.Context, options ...agentopt.NewThreadOption) memory.Thread {
+	contextID, _ := agentopt.Get(options, WithContextID)
 	return &Thread{
 		ContextID: contextID,
 	}
@@ -72,7 +78,7 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return &thread, nil
 }
 
-func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		var thread *Thread
 		if v, ok := agentopt.Get(options, agentopt.Thread); !ok {
@@ -83,7 +89,7 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 				yield(nil, errors.New("a thread must be provided when AllowBackgroundResponses is enabled"))
 				return
 			}
-			thread = a.NewThread().(*Thread)
+			thread = a.NewThread(ctx).(*Thread)
 		} else if t, ok := v.(*Thread); ok {
 			thread = t
 		} else {

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -296,7 +296,7 @@ func TestRunWithNewThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
@@ -316,7 +316,7 @@ func TestRunWithExistingThread(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThreadWithContextID("existing-context-id")
+	thread := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
 
 	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
 	if err != nil {
@@ -344,7 +344,7 @@ func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThreadWithContextID("existing-context-id")
+	thread := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
 
 	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
 	if err == nil {
@@ -444,7 +444,7 @@ func TestRunStreamingWithThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 
 	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
 		if err != nil {
@@ -468,7 +468,7 @@ func TestRunStreamingWithExistingThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThreadWithContextID("existing-context-id")
+	thread := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
 
 	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
 		if err != nil {
@@ -497,7 +497,7 @@ func TestRunStreamingWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThreadWithContextID("existing-context-id")
+	thread := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
 
 	gotError := false
 	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
@@ -671,7 +671,7 @@ func TestRunWithTaskInThreadAndMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread().(*a2aagent.Thread)
+	thread := a.NewThread(t.Context()).(*a2aagent.Thread)
 	thread.TaskID = "task-123"
 
 	_, err := agent.RunText(t.Context(), a, "Please make the background transparent", agentopt.Thread(thread))
@@ -703,7 +703,7 @@ func TestRunWithAgentTask(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 
 	_, err := agent.RunText(t.Context(), a, "Start a task", agentopt.Thread(thread))
 	if err != nil {
@@ -740,7 +740,7 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 
 	result, err := agent.RunText(t.Context(), a, "Start a long-running task", agentopt.Thread(thread))
 	if err != nil {
@@ -859,7 +859,7 @@ func TestRunStreamingWithTaskInThreadAndMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread().(*a2aagent.Thread)
+	thread := a.NewThread(t.Context()).(*a2aagent.Thread)
 	thread.TaskID = "task-123"
 
 	for _, err := range agent.RunTextStream(t.Context(), a, "Please make the background transparent", agentopt.Thread(thread)) {
@@ -898,7 +898,7 @@ func TestRunStreamingWithAgentTaskUpdatesThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 
 	for _, err := range agent.RunTextStream(t.Context(), a, "Start a task", agentopt.Thread(thread)) {
 		if err != nil {
@@ -990,7 +990,7 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 
 	var updates []*message.ResponseUpdate
 	for update, err := range agent.RunTextStream(t.Context(), a, "Start long-running task", agentopt.Thread(thread)) {
@@ -1046,7 +1046,7 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 
 	var updates []*message.ResponseUpdate
 	for update, err := range agent.RunTextStream(t.Context(), a, "Check task status", agentopt.Thread(thread)) {
@@ -1106,7 +1106,7 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread := a.NewThread()
+	thread := a.NewThread(t.Context())
 
 	var updates []*message.ResponseUpdate
 	for update, err := range agent.RunTextStream(t.Context(), a, "Process artifact", agentopt.Thread(thread)) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -44,14 +44,14 @@ func (iden Identity) Description() string {
 type Agent interface {
 	Identity() Identity
 
-	Run(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error]
+	Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 
-	NewThread() memory.Thread
+	NewThread(ctx context.Context, options ...agentopt.NewThreadOption) memory.Thread
 	UnmarshalThread(data []byte) (memory.Thread, error)
 }
 
 type StructuredOutputAgent interface {
 	Agent
 
-	RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error]
+	RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }

--- a/agent/agentopt/agentopt.go
+++ b/agent/agentopt/agentopt.go
@@ -21,7 +21,7 @@ type Option interface {
 	Value() any
 }
 
-// An RunOption configures the behavior of an Agent during a Run.
+// A RunOption configures the behavior of an Agent during a Run.
 type RunOption interface {
 	Option
 

--- a/agent/agentopt/agentopt.go
+++ b/agent/agentopt/agentopt.go
@@ -12,14 +12,27 @@ import (
 	"github.com/microsoft/agent-framework-go/tool"
 )
 
-// An Option configures the behavior of an Agent during a Run.
+// An Option is a configuration option for an Agent.
 //
 // Each option must be implemented as its own distinct type.
 // [Get] and [All] use the option's type
 // to uniquely identify each option.
 type Option interface {
-	AgentOption()
 	Value() any
+}
+
+// An RunOption configures the behavior of an Agent during a Run.
+type RunOption interface {
+	Option
+
+	RunOption()
+}
+
+// A NewThreadOption configures the behavior of a new Thread created by an Agent.
+type NewThreadOption interface {
+	Option
+
+	NewThreadOption()
 }
 
 type (
@@ -34,13 +47,13 @@ type (
 	allowBackgroundResponsesOpt bool
 )
 
-func (responseFormatOpt) AgentOption()           {}
-func (threadOpt) AgentOption()                   {}
-func (streamOpt) AgentOption()                   {}
-func (continuationTokenOpt) AgentOption()        {}
-func (allowBackgroundResponsesOpt) AgentOption() {}
-func (toolOpt) AgentOption()                     {}
-func (toolModeOpt) AgentOption()                 {}
+func (responseFormatOpt) RunOption()           {}
+func (threadOpt) RunOption()                   {}
+func (streamOpt) RunOption()                   {}
+func (continuationTokenOpt) RunOption()        {}
+func (allowBackgroundResponsesOpt) RunOption() {}
+func (toolOpt) RunOption()                     {}
+func (toolModeOpt) RunOption()                 {}
 
 func (o responseFormatOpt) Value() any           { return o.Format }
 func (o threadOpt) Value() any                   { return o.Thread }
@@ -51,27 +64,27 @@ func (o toolModeOpt) Value() any                 { return tool.ToolMode(o) }
 func (o toolOpt) Value() any                     { return o.Tool }
 
 // Tool adds a tool to the agent run.
-func Tool(tool tool.Tool) Option {
+func Tool(tool tool.Tool) RunOption {
 	return toolOpt{tool}
 }
 
 // ToolMode sets the tool mode for the agent run.
-func ToolMode(mode tool.ToolMode) Option {
+func ToolMode(mode tool.ToolMode) RunOption {
 	return toolModeOpt(mode)
 }
 
 // Stream sets whether to use streaming responses during the agent run.
-func Stream(stream bool) Option {
+func Stream(stream bool) RunOption {
 	return streamOpt(stream)
 }
 
 // ResponseFormat sets the desired response format for the agent run.
-func ResponseFormat(format format.Format) Option {
+func ResponseFormat(format format.Format) RunOption {
 	return responseFormatOpt{format}
 }
 
 // Thread sets the thread to use during the agent run.
-func Thread(thread memory.Thread) Option {
+func Thread(thread memory.Thread) RunOption {
 	return threadOpt{thread}
 }
 
@@ -84,7 +97,7 @@ func Thread(thread memory.Thread) Option {
 // of an update just before the interruption occurred can be passed to this function to resume the stream from
 // the point of interruption. Non-streamed background responses, such as those returned by [Run], can be polled for
 // completion by obtaining the token from the [RunResponse] continuation token.
-func ContinuationToken(token any) Option {
+func ContinuationToken(token any) RunOption {
 	return continuationTokenOpt{token}
 }
 
@@ -104,13 +117,13 @@ func ContinuationToken(token any) Option {
 //
 // This property only takes effect if the implementation it's used with supports background responses.
 // If the implementation does not support background responses, this property will be ignored.
-func AllowBackgroundResponses(allow bool) Option {
+func AllowBackgroundResponses(allow bool) RunOption {
 	return allowBackgroundResponsesOpt(allow)
 }
 
 // Get returns the value stored in opts with the provided setter,
 // reporting whether the value is present.
-func Get[T any](opts []Option, setter func(T) Option) (T, bool) {
+func Get[T any, O Option](opts []O, setter func(T) O) (T, bool) {
 	var zero T
 	var setterType = reflect.TypeOf(setter(zero))
 	for _, opt := range slices.Backward(opts) {
@@ -122,16 +135,8 @@ func Get[T any](opts []Option, setter func(T) Option) (T, bool) {
 	return zero, false
 }
 
-func Delete[T any](opts []Option, setter func(T) Option) []Option {
-	var zero T
-	var setterType = reflect.TypeOf(setter(zero))
-	return slices.DeleteFunc(opts, func(opt Option) bool {
-		return reflect.TypeOf(opt) == setterType
-	})
-}
-
 // All returns a sequence of all values stored in opts with the provided setter.
-func All[T any](opts []Option, setter func(T) Option) iter.Seq[T] {
+func All[T any](opts []RunOption, setter func(T) RunOption) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		var zero T
 		var setterType = reflect.TypeOf(setter(zero))

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Turn struct {
-	Callbacks []func(context.Context, []*message.Message, ...agentopt.Option)
+	Callbacks []func(context.Context, []*message.Message, ...agentopt.RunOption)
 	Responses []Response
 }
 
@@ -22,7 +22,7 @@ type ResponseBuilder struct {
 	turns []Turn
 }
 
-func NewResponseBuilder(firstTurnCallbacks ...func(ctx context.Context, messages []*message.Message, opts ...agentopt.Option)) *ResponseBuilder {
+func NewResponseBuilder(firstTurnCallbacks ...func(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption)) *ResponseBuilder {
 	return &ResponseBuilder{
 		turns: []Turn{{
 			Responses: []Response{},
@@ -31,7 +31,7 @@ func NewResponseBuilder(firstTurnCallbacks ...func(ctx context.Context, messages
 	}
 }
 
-func (rb *ResponseBuilder) NewTurn(callbacks ...func(ctx context.Context, messages []*message.Message, opts ...agentopt.Option)) *ResponseBuilder {
+func (rb *ResponseBuilder) NewTurn(callbacks ...func(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption)) *ResponseBuilder {
 	rb.turns = append(rb.turns, Turn{
 		Callbacks: callbacks,
 		Responses: []Response{},
@@ -86,9 +86,11 @@ type Response struct {
 	Error    error
 }
 
+var _ agent.Agent = (*Agent)(nil)
+
 type Agent struct {
 	Iden          agent.Identity
-	NewThreadFunc func() memory.Thread
+	NewThreadFunc func(context.Context, ...agentopt.NewThreadOption) memory.Thread
 	Responses     []Turn
 
 	currentTurn int
@@ -101,7 +103,7 @@ func (a *Agent) Identity() agent.Identity {
 	return a.Iden
 }
 
-func (a *Agent) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { a.currentTurn++ }()
 		if a.currentTurn >= len(a.Responses) {
@@ -119,9 +121,9 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, opts ...ag
 	}
 }
 
-func (a *Agent) NewThread() memory.Thread {
+func (a *Agent) NewThread(ctx context.Context, opts ...agentopt.NewThreadOption) memory.Thread {
 	if a.NewThreadFunc != nil {
-		return a.NewThreadFunc()
+		return a.NewThreadFunc(ctx, opts...)
 	}
 	return &Thread{}
 }
@@ -157,7 +159,7 @@ func (m *Middleware) Called() bool {
 	return m.called
 }
 
-func (m *Middleware) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (m *Middleware) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	m.called = true
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { m.currentTurn++ }()
@@ -191,7 +193,7 @@ type Runner struct {
 	currentTurn int
 }
 
-func (r *Runner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (r *Runner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { r.currentTurn++ }()
 		if r.currentTurn >= len(r.Responses) {

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -52,17 +52,10 @@ func (a *Agent) Instructions() string {
 	return a.Options.Instructions
 }
 
-func (a *Agent) NewThread() memory.Thread {
-	return a.newThread("")
-}
-
-func (a *Agent) NewThreadWithConversationID(conversationID string) *Thread {
-	return a.newThread(conversationID)
-}
-
-func (a *Agent) newThread(conversationID string) *Thread {
+func (a *Agent) NewThread(ctx context.Context, opts ...agentopt.NewThreadOption) memory.Thread {
+	convID, _ := agentopt.Get(opts, WithConversationID)
 	thread := &Thread{
-		ConversationID: conversationID,
+		ConversationID: convID,
 	}
 	if a.Options.NewContextProvider != nil {
 		thread.ContextProvider = a.Options.NewContextProvider()
@@ -74,19 +67,19 @@ func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
 	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
 }
 
-func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	if a.Options.ChatOptions != nil {
 		for _, tl := range a.Options.ChatOptions.Tools {
 			options = append(options, agentopt.Tool(tl))
 		}
 	}
 	if _, ok := agentopt.Get(options, agentopt.Thread); !ok {
-		options = append(options, agentopt.Thread(a.NewThread()))
+		options = append(options, agentopt.Thread(a.NewThread(ctx)))
 	}
 	return middleware.RunChain(ctx, a.run, a.Options.Middlewares, messages, options...)
 }
 
-func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		formatter := a.Client.Capabilities().StructuredOutput
 		if formatter == nil {
@@ -115,7 +108,7 @@ func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, o
 	}
 }
 
-func (a *Agent) run(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *Agent) run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		originalMessages := messages
 		client := a.Client
@@ -227,7 +220,7 @@ func (a *Agent) updateThreadWithTypeAndConversationID(thread *Thread, convID str
 	return nil
 }
 
-func (a *Agent) prepareThreadAndMessages(ctx context.Context, messages []*message.Message, options []agentopt.Option) (thread *Thread, opts ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
+func (a *Agent) prepareThreadAndMessages(ctx context.Context, messages []*message.Message, options []agentopt.RunOption) (thread *Thread, opts ChatOptions, msgsForClient, ctxMessages []*message.Message, err error) {
 	retError := func(e error) (*Thread, ChatOptions, []*message.Message, []*message.Message, error) {
 		return nil, ChatOptions{}, nil, nil, e
 	}
@@ -324,7 +317,7 @@ func validateStreamResumptionAllowed(continuationToken any, thread *Thread) erro
 	return nil
 }
 
-func (a *Agent) createConfiguredChatOptions(options []agentopt.Option) ChatOptions {
+func (a *Agent) createConfiguredChatOptions(options []agentopt.RunOption) ChatOptions {
 	var opts ChatOptions
 	// Try to get ChatOptions from RunOptions
 	if v, ok := agentopt.Get(options, WithOptions); ok {

--- a/agent/chatagent/options.go
+++ b/agent/chatagent/options.go
@@ -42,13 +42,13 @@ type opts struct {
 	*ChatOptions
 }
 
-func (opts) AgentOption() {}
+func (opts) RunOption() {}
 
 func (o opts) Value() any {
 	return o.ChatOptions
 }
 
-func WithOptions(options *ChatOptions) agentopt.Option {
+func WithOptions(options *ChatOptions) agentopt.RunOption {
 	return opts{options}
 }
 
@@ -56,12 +56,22 @@ type newClientOpts struct {
 	NewClient func(chatclient.Client) chatclient.Client
 }
 
-func (newClientOpts) AgentOption() {}
+func (newClientOpts) RunOption() {}
 
 func (o newClientOpts) Value() any {
 	return o.NewClient
 }
 
-func WithNewClient(newClient func(chatclient.Client) chatclient.Client) agentopt.Option {
+func WithNewClient(newClient func(chatclient.Client) chatclient.Client) agentopt.RunOption {
 	return newClientOpts{newClient}
+}
+
+type conversationIDOpt string
+
+func (conversationIDOpt) NewThreadOption() {}
+
+func (o conversationIDOpt) Value() any { return string(o) }
+
+func WithConversationID(conversationID string) agentopt.NewThreadOption {
+	return conversationIDOpt(conversationID)
 }

--- a/agent/middleware/autocall/autocall.go
+++ b/agent/middleware/autocall/autocall.go
@@ -45,7 +45,7 @@ func New(options Options) middleware.Middleware {
 	return ac
 }
 
-func (f *autocall) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (f *autocall) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		tools, requiresApproval := f.createToolsMap(agentopt.All(opts, agentopt.Tool))
 
@@ -260,7 +260,7 @@ func convertToolResultMsgToUpdate(msg *message.Message, msgID string) *message.R
 	}
 }
 
-func updateOptionsForNextIteration(opts []agentopt.Option) []agentopt.Option {
+func updateOptionsForNextIteration(opts []agentopt.RunOption) []agentopt.RunOption {
 	if v, ok := agentopt.Get(opts, agentopt.ToolMode); ok && v == tool.ToolModeRequired {
 		// We have to reset the tool mode to be non-required after the first iteration,
 		// as otherwise we'll be in an infinite loop.

--- a/agent/middleware/autocall/autocall_approval_test.go
+++ b/agent/middleware/autocall/autocall_approval_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
-func expectedMessages(t *testing.T, expected ...*message.Message) func(context.Context, []*message.Message, ...agentopt.Option) {
-	return func(ctx context.Context, messages []*message.Message, opts ...agentopt.Option) {
+func expectedMessages(t *testing.T, expected ...*message.Message) func(context.Context, []*message.Message, ...agentopt.RunOption) {
+	return func(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) {
 		if err := agenttest.MessagesEqual(expected, messages); err != nil {
 			t.Errorf("Messages not equal: %v", err)
 		}
@@ -29,7 +29,7 @@ func invokeAndAssertApproval(t *testing.T, tools []tool.Tool, input []*message.M
 	downstreamAgentOutput []*message.ResponseUpdate, expectedOutput []*message.ResponseUpdate,
 	expectedDownstreamAgentInput []*message.Message, additionalTools []tool.Tool) {
 
-	var cb func(context.Context, []*message.Message, ...agentopt.Option)
+	var cb func(context.Context, []*message.Message, ...agentopt.RunOption)
 	if expectedDownstreamAgentInput != nil {
 		cb = expectedMessages(t, expectedDownstreamAgentInput...)
 	}
@@ -60,7 +60,7 @@ func invokeAndAssertApprovalWithAgent(t *testing.T, next middleware.RunFunc,
 	ctx := t.Context()
 
 	// Build options
-	var opts []agentopt.Option
+	var opts []agentopt.RunOption
 	for _, tool := range tools {
 		opts = append(opts, agentopt.Tool(tool))
 	}
@@ -85,7 +85,7 @@ func expectApprovalError(t *testing.T, tools []tool.Tool, input []*message.Messa
 	ctx := t.Context()
 
 	// Build options
-	var opts []agentopt.Option
+	var opts []agentopt.RunOption
 	for _, tool := range tools {
 		opts = append(opts, agentopt.Tool(tool))
 	}

--- a/agent/middleware/autocall/autocall_test.go
+++ b/agent/middleware/autocall/autocall_test.go
@@ -180,7 +180,7 @@ func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, e
 	initialMessages := []*message.Message{plan[0]}
 
 	// Build options
-	var opts []agentopt.Option
+	var opts []agentopt.RunOption
 	for _, tool := range tools {
 		opts = append(opts, agentopt.Tool(tool))
 	}
@@ -632,7 +632,7 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 			initialMessages := []*message.Message{plan[0]}
 
 			// Build options
-			var opts []agentopt.Option
+			var opts []agentopt.RunOption
 			for _, tool := range tools {
 				opts = append(opts, agentopt.Tool(tool))
 			}
@@ -748,7 +748,7 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 			initialMessages := []*message.Message{plan[0]}
 
 			// Build options
-			var opts []agentopt.Option
+			var opts []agentopt.RunOption
 			for _, tool := range tools {
 				opts = append(opts, agentopt.Tool(tool))
 			}
@@ -966,7 +966,7 @@ func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 	}
 
 	initialMessages := []*message.Message{messages[0]}
-	var opts []agentopt.Option
+	var opts []agentopt.RunOption
 	for _, tool := range tools {
 		opts = append(opts, agentopt.Tool(tool))
 	}

--- a/agent/middleware/middleware.go
+++ b/agent/middleware/middleware.go
@@ -11,14 +11,14 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-type RunFunc func(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error]
+type RunFunc func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 
 type Middleware interface {
-	Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error]
+	Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
 
 // RunChain applies the given middlewares around the given RunFunc.
-func RunChain(ctx context.Context, fn RunFunc, middlewares []Middleware, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func RunChain(ctx context.Context, fn RunFunc, middlewares []Middleware, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	// Chain the middlewares together.
 	for _, mw := range slices.Backward(middlewares) {
 		fn = middlewareRunner{
@@ -34,6 +34,6 @@ type middlewareRunner struct {
 	next RunFunc
 }
 
-func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return mr.Middleware.Run(ctx, mr.next, messages, opts...)
 }

--- a/agent/middleware/middleware_test.go
+++ b/agent/middleware/middleware_test.go
@@ -14,7 +14,7 @@ import (
 func TestChain(t *testing.T) {
 	t.Run("empty middleware chain", func(t *testing.T) {
 		called := false
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			called = true
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -32,7 +32,7 @@ func TestChain(t *testing.T) {
 	t.Run("single middleware", func(t *testing.T) {
 		order := []string{}
 
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			order = append(order, "base")
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -63,7 +63,7 @@ func TestChain(t *testing.T) {
 	t.Run("multiple middlewares", func(t *testing.T) {
 		order := []string{}
 
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			order = append(order, "base")
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -105,9 +105,9 @@ func TestChain(t *testing.T) {
 	})
 
 	t.Run("middleware can modify options", func(t *testing.T) {
-		receivedOpts := []agentopt.Option{}
+		receivedOpts := []agentopt.RunOption{}
 
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			receivedOpts = options
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -116,7 +116,7 @@ func TestChain(t *testing.T) {
 		mw := &testMiddleware{
 			name:  "mw1",
 			onRun: func(name string) {},
-			modifyOpts: func(opts []agentopt.Option) []agentopt.Option {
+			modifyOpts: func(opts []agentopt.RunOption) []agentopt.RunOption {
 				return append(opts, additionalOpt)
 			},
 		}
@@ -139,7 +139,7 @@ func TestChain(t *testing.T) {
 	})
 
 	t.Run("middleware can intercept and modify sequence", func(t *testing.T) {
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			return func(yield func(*message.ResponseUpdate, error) bool) {
 				if !yield(&message.ResponseUpdate{}, nil) {
 					return
@@ -171,7 +171,7 @@ func TestChain(t *testing.T) {
 		key := contextKey("test")
 
 		var capturedCtx context.Context
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			capturedCtx = ctx
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -199,10 +199,10 @@ func TestChain(t *testing.T) {
 type testMiddleware struct {
 	name       string
 	onRun      func(string)
-	modifyOpts func([]agentopt.Option) []agentopt.Option
+	modifyOpts func([]agentopt.RunOption) []agentopt.RunOption
 }
 
-func (tm *testMiddleware) Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (tm *testMiddleware) Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	tm.onRun(tm.name)
 
 	opts := options
@@ -218,7 +218,7 @@ type interceptMiddleware struct {
 	interceptCount int
 }
 
-func (im *interceptMiddleware) Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (im *interceptMiddleware) Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		count := 0
 		for update, err := range next(ctx, messages, options...) {
@@ -238,7 +238,7 @@ type testOption struct {
 	value string
 }
 
-func (to *testOption) AgentOption() {}
+func (to *testOption) RunOption() {}
 
 func (to *testOption) Value() any {
 	return to.value

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Run executes the agent with the given options and returns the response.
-func Run(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.Option) (*message.Response, error) {
+func Run(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) (*message.Response, error) {
 	var resp message.Response
 	for update, err := range a.Run(ctx, messages, opts...) {
 		if err != nil {
@@ -25,43 +25,43 @@ func Run(ctx context.Context, a Agent, messages []*message.Message, opts ...agen
 }
 
 // RunText executes the agent with a single text message and returns the response.
-func RunText(ctx context.Context, a Agent, msg string, opts ...agentopt.Option) (*message.Response, error) {
+func RunText(ctx context.Context, a Agent, msg string, opts ...agentopt.RunOption) (*message.Response, error) {
 	return Run(ctx, a, []*message.Message{message.NewText(msg)}, opts...)
 }
 
 // RunMessage executes the agent with a single message and returns the response.
-func RunMessage(ctx context.Context, a Agent, msg *message.Message, opts ...agentopt.Option) (*message.Response, error) {
+func RunMessage(ctx context.Context, a Agent, msg *message.Message, opts ...agentopt.RunOption) (*message.Response, error) {
 	return Run(ctx, a, []*message.Message{msg}, opts...)
 }
 
 // RunStream executes the agent with the given options and returns a streaming sequence of response updates.
-func RunStream(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func RunStream(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	opts = append(opts, agentopt.Stream(true))
 	return a.Run(ctx, messages, opts...)
 }
 
 // RunTextStream executes the agent with a single text message and returns a streaming sequence of response updates.
-func RunTextStream(ctx context.Context, a Agent, msg string, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func RunTextStream(ctx context.Context, a Agent, msg string, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return RunStream(ctx, a, []*message.Message{message.NewText(msg)}, opts...)
 }
 
 // RunMessageStream executes the agent with a single message and returns a streaming sequence of response updates.
-func RunMessageStream(ctx context.Context, a Agent, msg *message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func RunMessageStream(ctx context.Context, a Agent, msg *message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return RunStream(ctx, a, []*message.Message{msg}, opts...)
 }
 
 // RunTextFor executes the agent with a single text message and returns the result of type T.
-func RunTextFor[T any](ctx context.Context, a Agent, msg string, opts ...agentopt.Option) (T, error) {
+func RunTextFor[T any](ctx context.Context, a Agent, msg string, opts ...agentopt.RunOption) (T, error) {
 	return RunFor[T](ctx, a, []*message.Message{message.NewText(msg)}, opts...)
 }
 
 // RunMessageFor executes the agent with a single message and returns the result of type T.
-func RunMessageFor[T any](ctx context.Context, a Agent, msg *message.Message, opts ...agentopt.Option) (T, error) {
+func RunMessageFor[T any](ctx context.Context, a Agent, msg *message.Message, opts ...agentopt.RunOption) (T, error) {
 	return RunFor[T](ctx, a, []*message.Message{msg}, opts...)
 }
 
 // RunFor executes the agent with the given messages and returns the result of type T.
-func RunFor[T any](ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.Option) (T, error) {
+func RunFor[T any](ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) (T, error) {
 	var v T
 	if a, ok := a.(StructuredOutputAgent); ok {
 		for _, err := range a.RunOf(ctx, &v, messages, opts...) {

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 
@@ -16,9 +17,9 @@ import (
 func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 	var thread memory.Thread
 	var threadStateKey string
-	ensureThread := func() memory.Thread {
+	ensureThread := func(ctx context.Context) memory.Thread {
 		if thread == nil {
-			thread = a.NewThread()
+			thread = a.NewThread(ctx)
 		}
 		threadStateKey = reflect.ValueOf(thread).String()
 		return thread
@@ -56,8 +57,8 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 		StateKey: "agent_messages",
 		TakeTurnHandler: func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
 			emitEvents := token.EmitEventsOr(emitEvents)
-			options := make([]agentopt.Option, 0, 1+len(messages))
-			options = append(options, agentopt.Thread(ensureThread()))
+			options := make([]agentopt.RunOption, 0, 1+len(messages))
+			options = append(options, agentopt.Thread(ensureThread(ctx)))
 			if emitEvents {
 				// Run the agent in streaming mode only when agent run update events are to be emitted.
 				options = append(options, agentopt.Stream(true))

--- a/examples/chat_cli/main.go
+++ b/examples/chat_cli/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
-	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/openai"
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
@@ -40,13 +39,13 @@ func main() {
 		},
 	})
 
-	// Create a thread to maintain conversation history
-	thread := a.NewThread()
-
-	runChatLoop(context.Background(), a, thread)
+	runChatLoop(context.Background(), a)
 }
 
-func runChatLoop(ctx context.Context, a agent.Agent, thread memory.Thread) {
+func runChatLoop(ctx context.Context, a agent.Agent) {
+	// Create a thread to maintain conversation history
+	thread := a.NewThread(ctx)
+
 	scanner := bufio.NewScanner(os.Stdin)
 
 	for {
@@ -72,7 +71,7 @@ func runChatLoop(ctx context.Context, a agent.Agent, thread memory.Thread) {
 		}
 
 		if userInput == "clear" {
-			thread = a.NewThread()
+			thread = a.NewThread(ctx)
 			fmt.Print("\n✨ Conversation cleared!\n\n")
 			continue
 		}

--- a/examples/getting_started/agent/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/agent/step02_multiturn_conversation/main.go
@@ -31,12 +31,12 @@ func main() {
 	ctx := context.Background()
 
 	// Invoke the agent with a multi-turn conversation, where the context is preserved in the thread object.
-	thread := a.NewThread()
+	thread := a.NewThread(ctx)
 	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
 	demo.Response(agent.RunText(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Thread(thread)))
 
 	// Invoke the agent with a multi-turn conversation and streaming, where the context is preserved in the thread object.
-	thread2 := a.NewThread()
+	thread2 := a.NewThread(ctx)
 	for update, err := range agent.RunTextStream(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread2)) {
 		demo.Response(update, err)
 	}

--- a/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
@@ -47,7 +47,7 @@ func main() {
 	ctx := context.Background()
 
 	// Call the agent and check if there are any user input requests to handle.
-	thread := a.NewThread()
+	thread := a.NewThread(ctx)
 	resp, err := agent.RunText(ctx, a, "What is the weather like in Amsterdam?", agentopt.Thread(thread))
 	if err != nil {
 		panic(err)

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -35,7 +35,7 @@ func main() {
 	ctx := context.Background()
 
 	// Start a new thread for the agent conversation.
-	thread := a.NewThread()
+	thread := a.NewThread(ctx)
 
 	// Run the agent with a new thread.
 	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))

--- a/examples/getting_started/agent/step07_3rdparty_thread_storage/main.go
+++ b/examples/getting_started/agent/step07_3rdparty_thread_storage/main.go
@@ -50,7 +50,7 @@ func main() {
 	ctx := context.Background()
 
 	// Start a new thread for the agent conversation.
-	thread := a.NewThread()
+	thread := a.NewThread(ctx)
 
 	// Run the agent with the thread that stores conversation history in the disk store.
 	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))

--- a/examples/internal/demo/demo.go
+++ b/examples/internal/demo/demo.go
@@ -43,7 +43,7 @@ func NewLogger(name, description string, metadata ...string) middleware.Middlewa
 	return &logger{}
 }
 
-func (mw *logger) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+func (mw *logger) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		mw.n++
 		fmt.Printf("===== Run %d =====\n\n", mw.n)


### PR DESCRIPTION
Some agent implementations (like the existing a2aagent and chatagent) allow customizing threads based on previous conversations. There is currently no good way to generalize this use-case other than agent implementations providing their own `NewThread` variants. This makes it difficult to built provider-agnostic code calling `agent.NewThread`.

This PR modifies the `Agent.NewThread` method to accept a slice of the (new) `agentopt.NewThreadOption` interface. For now there is no provider-agnostic option that implements it, but the a2aagent and chatagent do provide one each.