### PR TITLE
Add logging middleware

### DIFF
--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -7,38 +7,76 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"log/slog"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/agent/middleware/autocall"
+	"github.com/microsoft/agent-framework-go/agent/middleware/logger"
+	"github.com/microsoft/agent-framework-go/format"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
 )
+
+type Config struct {
+	ID          string
+	Name        string
+	Description string
+
+	Instructions string
+
+	Logger           *slog.Logger
+	LogSensitiveData bool
+
+	FormatOfFn  func(v any) (format.Format, error)
+	UnmarshalFn func(format format.Format, data []byte, v any) error
+
+	DisableFuncAutoCall bool
+	Middlewares         []middleware.Middleware
+
+	RunOptions []agentopt.RunOption
+
+	NewMessageStore    func() memory.MessageStore
+	NewContextProvider func() memory.ContextProvider
+}
+
+func (o *Config) Clone() *Config {
+	if o == nil {
+		return nil
+	}
+	clone := *o
+	clone.Middlewares = slices.Clone(o.Middlewares)
+	clone.RunOptions = slices.Clone(o.RunOptions)
+	return &clone
+}
 
 type RunFunc func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 
 var _ agent.Agent = (*Agent)(nil)
 
 type Agent struct {
-	RunFn   RunFunc
-	Options Options
-
-	iden agent.Identity
+	runFn  RunFunc
+	config Config
+	iden   agent.Identity
 }
 
 // NewAgent creates a new chat agent with the given chat client and options.
-func NewAgent(runfn RunFunc, options Options) *Agent {
-	opts := *options.Clone()
+func NewAgent(runfn RunFunc, cfg Config) *Agent {
+	opts := *cfg.Clone()
 	if !opts.DisableFuncAutoCall {
 		opts.Middlewares = append(opts.Middlewares,
-			autocall.New(autocall.Options{}),
+			autocall.New(autocall.Config{
+				Logger:           opts.Logger,
+				LogSensitiveData: opts.LogSensitiveData,
+			}),
 		)
 	}
 	return &Agent{
-		RunFn:   runfn,
-		Options: opts,
-		iden:    agent.NewIdentity(options.ID, options.Name, options.Description),
+		runFn:  runfn,
+		config: opts,
+		iden:   agent.NewIdentity(cfg.ID, cfg.Name, cfg.Description),
 	}
 }
 
@@ -47,7 +85,7 @@ func (a *Agent) Identity() agent.Identity {
 }
 
 func (a *Agent) Instructions() string {
-	return a.Options.Instructions
+	return a.config.Instructions
 }
 
 func (a *Agent) NewThread(ctx context.Context, opts ...agentopt.NewThreadOption) memory.Thread {
@@ -55,32 +93,33 @@ func (a *Agent) NewThread(ctx context.Context, opts ...agentopt.NewThreadOption)
 	thread := &Thread{
 		ConversationID: convID,
 	}
-	if a.Options.NewContextProvider != nil {
-		thread.ContextProvider = a.Options.NewContextProvider()
+	if a.config.NewContextProvider != nil {
+		thread.ContextProvider = a.config.NewContextProvider()
 	}
 	return thread
 }
 
 func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
-	return newThreadFromJSON(data, a.Options.NewMessageStore, a.Options.NewContextProvider)
+	return newThreadFromJSON(data, a.config.NewMessageStore, a.config.NewContextProvider)
 }
 
 func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	// Prepend options from agent configuration.
-	options = append(a.Options.RunOptions, options...)
+	options = append(a.config.RunOptions, options...)
 	if _, ok := agentopt.Get(options, agentopt.Thread); !ok {
 		options = append(options, agentopt.Thread(a.NewThread(ctx)))
 	}
-	return middleware.RunChain(ctx, a.run, a.Options.Middlewares, messages, options...)
+	ctx = logger.WithAgentContext(ctx, a.iden.ID(), a.iden.Name())
+	return middleware.RunChain(ctx, a.run, a.config.Middlewares, messages, options...)
 }
 
 func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
-		if a.Options.FormatOfFn == nil || a.Options.UnmarshalFn == nil {
+		if a.config.FormatOfFn == nil || a.config.UnmarshalFn == nil {
 			yield(nil, errors.New("agent does not support structured output"))
 			return
 		}
-		format, err := a.Options.FormatOfFn(v)
+		format, err := a.config.FormatOfFn(v)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -94,7 +133,7 @@ func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, o
 			}
 			data = append(data, update.String()...)
 		}
-		if err := a.Options.UnmarshalFn(format, data, v); err != nil {
+		if err := a.config.UnmarshalFn(format, data, v); err != nil {
 			yield(nil, err)
 			return
 		}
@@ -115,7 +154,7 @@ func (a *Agent) run(ctx context.Context, messages []*message.Message, options ..
 			return
 		}
 		var resp message.Response
-		for update, err := range a.RunFn(ctx, messages, options...) {
+		for update, err := range a.runFn(ctx, messages, options...) {
 			if err != nil {
 				a.notifyContextProviderOfFailure(ctx, thread, err, messages, ctxMessages)
 				yield(nil, err)
@@ -141,10 +180,10 @@ func (a *Agent) run(ctx context.Context, messages []*message.Message, options ..
 			}
 		}
 		resp.Coalesce()
-		if thread.ConversationID == "" && thread.MessageStore == nil && a.Options.NewMessageStore != nil {
+		if thread.ConversationID == "" && thread.MessageStore == nil && a.config.NewMessageStore != nil {
 			// If we don't have a conversation ID then we must be managing the message store ourselves.
 			// If we don't have a message store yet and we have a factory, use it to create a new one.
-			thread.MessageStore = a.Options.NewMessageStore()
+			thread.MessageStore = a.config.NewMessageStore()
 		}
 		// Only notify the thread of new messages if the response was successful to avoid inconsistent message state in the thread.
 		if err := thread.MessagesReceived(ctx, append(originalMessages, append(ctxMessages, resp.Messages...)...)...); err != nil {

--- a/agent/chatagent/config.go
+++ b/agent/chatagent/config.go
@@ -3,44 +3,8 @@
 package chatagent
 
 import (
-	"log/slog"
-	"slices"
-
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
-	"github.com/microsoft/agent-framework-go/agent/middleware"
-	"github.com/microsoft/agent-framework-go/format"
-	"github.com/microsoft/agent-framework-go/memory"
 )
-
-type Options struct {
-	ID          string
-	Name        string
-	Description string
-
-	Instructions string
-	Logger       *slog.Logger
-
-	FormatOfFn  func(v any) (format.Format, error)
-	UnmarshalFn func(format format.Format, data []byte, v any) error
-
-	DisableFuncAutoCall bool
-	Middlewares         []middleware.Middleware
-
-	RunOptions []agentopt.RunOption
-
-	NewMessageStore    func() memory.MessageStore
-	NewContextProvider func() memory.ContextProvider
-}
-
-func (o *Options) Clone() *Options {
-	if o == nil {
-		return nil
-	}
-	clone := *o
-	clone.Middlewares = slices.Clone(o.Middlewares)
-	clone.RunOptions = slices.Clone(o.RunOptions)
-	return &clone
-}
 
 type (
 	conversationIDOpt         string

--- a/agent/middleware/autocall/autocall.go
+++ b/agent/middleware/autocall/autocall.go
@@ -12,16 +12,19 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/internal/slogx"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 )
 
-type Options struct {
+type Config struct {
 	Logger                             *slog.Logger
+	LogSensitiveData                   bool
 	AdditionalTools                    []tool.Tool
 	IncludeDetailedErrors              bool
 	TerminateOnUnknownCalls            bool
@@ -32,14 +35,35 @@ type Options struct {
 }
 
 type autocall struct {
-	Options
+	logger                             slogx.Logger
+	additionalTools                    []tool.Tool
+	includeDetailedErrors              bool
+	terminateOnUnknownCalls            bool
+	allowConcurrentInvocations         bool
+	maximumConsecutiveErrorsPerRequest int
+	maximumIterationsPerRequest        int
+	newID                              func() string
 }
 
 // New creates a new function-invoking chat client that wraps the provided client.
-func New(options Options) middleware.Middleware {
-	ac := &autocall{options}
-	if ac.NewID == nil {
-		ac.NewID = uuid.NewString
+func New(cfg Config) middleware.Middleware {
+	if cfg.NewID == nil {
+		cfg.NewID = uuid.NewString
+	}
+	ac := &autocall{
+		logger: slogx.Logger{
+			Logger:        cfg.Logger,
+			SensitiveData: cfg.LogSensitiveData,
+			Type:          slogx.TypeMiddleware,
+			Name:          "autocall",
+		},
+		additionalTools:                    cfg.AdditionalTools,
+		includeDetailedErrors:              cfg.IncludeDetailedErrors,
+		terminateOnUnknownCalls:            cfg.TerminateOnUnknownCalls,
+		allowConcurrentInvocations:         cfg.AllowConcurrentInvocations,
+		maximumConsecutiveErrorsPerRequest: cfg.MaximumConsecutiveErrorsPerRequest,
+		maximumIterationsPerRequest:        cmp.Or(cfg.MaximumIterationsPerRequest, 40),
+		newID:                              cfg.NewID,
 	}
 	return ac
 }
@@ -53,13 +77,13 @@ func (f *autocall) Run(ctx context.Context, next middleware.RunFunc, messages []
 		// use the same message ID for all of them within a given iteration, as this is a single logical
 		// message with multiple content items. We could also use different message IDs per tool content,
 		// but there's no benefit to doing so.
-		toolMsgID := f.NewID()
+		toolMsgID := f.newID()
 		var errCount int
 		if hasAnyApprovalContent(messages) {
 			messages = slices.Clone(messages)
 			// We also need a synthetic ID for the function call content for approved function calls
 			// where we don't know what the original message id of the function call was.
-			funcCallFallbackMsgID := f.NewID()
+			funcCallFallbackMsgID := f.newID()
 
 			// A previous turn may have translated FunctionCallContents from the inner client into approval requests sent back to the caller,
 			// for any functions that were actually ApprovalRequiredFunctions. If the incoming chat messages include responses to those
@@ -136,7 +160,7 @@ func (f *autocall) Run(ctx context.Context, next middleware.RunFunc, messages []
 							approvalRequiredFunctions = append(approvalRequiredFunctions, tl)
 						}
 					}
-					for _, tl := range f.AdditionalTools {
+					for _, tl := range f.additionalTools {
 						if tl, ok := tl.(tool.ApprovalRequiredTool); ok {
 							approvalRequiredFunctions = append(approvalRequiredFunctions, tl)
 						}
@@ -182,7 +206,7 @@ func (f *autocall) Run(ctx context.Context, next middleware.RunFunc, messages []
 			}
 			// If there's nothing more to do, break out of the loop and allow the handling at the
 			// end to configure the response with aggregated data from previous requests.
-			if i >= f.maximumIterationsPerRequest() || hasApprovalRequiringFcc || f.shouldTerminateLoopBasedOnHandleableFunctions(functionCallContents, tools) {
+			if i >= f.maximumIterationsPerRequest || hasApprovalRequiringFcc || f.shouldTerminateLoopBasedOnHandleableFunctions(functionCallContents, tools) {
 				break
 			}
 
@@ -283,7 +307,7 @@ func (f *autocall) shouldTerminateLoopBasedOnHandleableFunctions(funcCalls []*me
 		// There are functions to call but we have no tools, so we can't handle them.
 		// If we're configured to terminate on unknown call requests, do so now.
 		// Otherwise, processFunctionCalls will handle it by creating a NotFound response message.
-		return f.TerminateOnUnknownCalls
+		return f.terminateOnUnknownCalls
 	}
 	// At this point, we have both function call requests and some tools.
 	// Look up each function.
@@ -293,7 +317,7 @@ func (f *autocall) shouldTerminateLoopBasedOnHandleableFunctions(funcCalls []*me
 			// The tool couldn't be found. If we're configured to terminate on unknown call requests,
 			// break out of the loop now. Otherwise, processFunctionCalls will handle it by
 			// creating a NotFound response message.
-			if f.TerminateOnUnknownCalls {
+			if f.terminateOnUnknownCalls {
 				return true
 			}
 			continue
@@ -305,13 +329,6 @@ func (f *autocall) shouldTerminateLoopBasedOnHandleableFunctions(funcCalls []*me
 		}
 	}
 	return false
-}
-
-func (f *autocall) maximumIterationsPerRequest() int {
-	if f.MaximumIterationsPerRequest == 0 {
-		return 40
-	}
-	return f.MaximumIterationsPerRequest
 }
 
 func (f *autocall) createToolsMap(tools iter.Seq[tool.Tool]) (mtools map[string]tool.Tool, anyRequiredApproval bool) {
@@ -326,7 +343,7 @@ func (f *autocall) createToolsMap(tools iter.Seq[tool.Tool]) (mtools map[string]
 			}
 		}
 	}
-	for _, t := range f.AdditionalTools {
+	for _, t := range f.additionalTools {
 		fn(t)
 	}
 	for t := range tools {
@@ -375,7 +392,7 @@ func (f *autocall) processFunctionCalls(ctx context.Context, tools map[string]to
 	}
 	// Process all functions. If there's more than one and concurrent invocation is enabled, do so in parallel.
 	results := make([]message.Content, len(funcCalls))
-	if len(funcCalls) > 1 && f.AllowConcurrentInvocations {
+	if len(funcCalls) > 1 && f.allowConcurrentInvocations {
 		// Rather than awaiting each function before invoking the next, invoke all of them
 		// and then await all of them. We avoid forcibly introducing parallelism via Task.Run,
 		// but if a function invocation completes asynchronously, its processing can overlap
@@ -406,7 +423,7 @@ func (f *autocall) processFunctionCalls(ctx context.Context, tools map[string]to
 	// Update consecutive error count
 	if len(errs) > 0 {
 		errCount++
-		if errCount > f.MaximumConsecutiveErrorsPerRequest {
+		if errCount > f.maximumConsecutiveErrorsPerRequest {
 			return nil, errCount, errors.Join(errs...)
 		}
 	} else {
@@ -430,6 +447,8 @@ func (f *autocall) processFunctionCall(ctx context.Context, tools map[string]too
 			nil,
 		)
 	}
+	f.logger.Debug(ctx, "calling function", "funcName", funcCall.Name, slogx.SensitiveData("arguments", funcCall.Arguments))
+	start := time.Now()
 	var result any
 	var err error
 	func() {
@@ -444,6 +463,14 @@ func (f *autocall) processFunctionCall(ctx context.Context, tools map[string]too
 		}()
 		result, err = tl.Call(ctx, funcCall.Arguments)
 	}()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			f.logger.Debug(ctx, "call canceled", "funcName", funcCall.Name)
+		} else {
+			f.logger.Error(ctx, "call failed", "funcName", funcCall.Name, "error", err)
+		}
+	}
+	f.logger.Debug(ctx, "function call completed", "funcName", funcCall.Name, "duration", time.Since(start), slogx.SensitiveData("result", result))
 
 	return f.createFunctionResult(funcCall.CallID, result, err)
 }
@@ -457,7 +484,7 @@ func (f *autocall) createFunctionResult(callID string, result any, err error) *m
 
 	// Format errors into Result string for the LLM to see
 	if err != nil {
-		if f.IncludeDetailedErrors {
+		if f.includeDetailedErrors {
 			result = fmt.Sprintf("Error: Function failed. Exception: %v", err)
 		} else {
 			result = "Error: Function failed."

--- a/agent/middleware/autocall/autocall_approval_test.go
+++ b/agent/middleware/autocall/autocall_approval_test.go
@@ -50,7 +50,7 @@ func invokeAndAssertApprovalWithAgent(t *testing.T, next middleware.RunFunc,
 	tools []tool.Tool, input []*message.Message,
 	expectedOutput []*message.ResponseUpdate, additionalTools []tool.Tool) {
 
-	autocallOptions := autocall.Options{
+	autocallOptions := autocall.Config{
 		NewID: func() string { return "" },
 	}
 	if additionalTools != nil {
@@ -91,7 +91,7 @@ func expectApprovalError(t *testing.T, tools []tool.Tool, input []*message.Messa
 	}
 
 	var lastErr error
-	for _, err := range autocall.New(autocall.Options{}).Run(ctx, runner.Run, input, opts...) {
+	for _, err := range autocall.New(autocall.Config{}).Run(ctx, runner.Run, input, opts...) {
 		if err != nil {
 			lastErr = err
 			break

--- a/agent/middleware/autocall/autocall_log_test.go
+++ b/agent/middleware/autocall/autocall_log_test.go
@@ -1,0 +1,375 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package autocall_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/microsoft/agent-framework-go/agent/middleware/autocall"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/tool"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+)
+
+// TestAutocall_LogsSuccessfulFunctionCall tests that successful function calls are logged
+func TestAutocall_LogsSuccessfulFunctionCall(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "TestFunc"},
+			func(ctx context.Context, args struct{}) (string, error) {
+				return "Success", nil
+			}),
+	}
+
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "TestFunc", Arguments: `{}`},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "Success"},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
+
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{
+		Logger: log,
+	})
+
+	// Assert logs contain expected entries
+	output := buf.String()
+	if !strings.Contains(output, "calling function") {
+		t.Errorf("expected log to contain 'calling function', got: %s", output)
+	}
+	if !strings.Contains(output, "funcName=TestFunc") {
+		t.Errorf("expected log to contain 'funcName=TestFunc', got: %s", output)
+	}
+	if !strings.Contains(output, "function call completed") {
+		t.Errorf("expected log to contain 'function call completed', got: %s", output)
+	}
+	if !strings.Contains(output, "duration") {
+		t.Errorf("expected log to contain 'duration', got: %s", output)
+	}
+}
+
+// TestAutocall_LogsSensitiveData tests that sensitive data is logged when enabled
+func TestAutocall_LogsSensitiveData(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	type TestArgs struct {
+		Value string `json:"value"`
+	}
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "TestFunc"},
+			func(ctx context.Context, args TestArgs) (string, error) {
+				return "Result: " + args.Value, nil
+			}),
+	}
+
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "TestFunc", Arguments: `{"value":"secretdata"}`},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "Result: secretdata"},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
+
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{
+		Logger:           log,
+		LogSensitiveData: true,
+	})
+
+	// Assert logs contain sensitive data
+	output := buf.String()
+	if !strings.Contains(output, "arguments") {
+		t.Errorf("expected log to contain 'arguments', got: %s", output)
+	}
+	if !strings.Contains(output, "secretdata") {
+		t.Errorf("expected log to contain 'secretdata', got: %s", output)
+	}
+	if !strings.Contains(output, "result") {
+		t.Errorf("expected log to contain 'result', got: %s", output)
+	}
+	if !strings.Contains(output, "Result: secretdata") {
+		t.Errorf("expected log to contain result value, got: %s", output)
+	}
+}
+
+// TestAutocall_DoesNotLogSensitiveDataByDefault tests that sensitive data is not logged by default
+func TestAutocall_DoesNotLogSensitiveDataByDefault(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	type TestArgs struct {
+		Value string `json:"value"`
+	}
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "TestFunc"},
+			func(ctx context.Context, args TestArgs) (string, error) {
+				return "Result: " + args.Value, nil
+			}),
+	}
+
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "TestFunc", Arguments: `{"value":"secretdata"}`},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "Result: secretdata"},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
+
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{
+		Logger:           log,
+		LogSensitiveData: false,
+	})
+
+	// Assert logs DO NOT contain sensitive data
+	output := buf.String()
+	if strings.Contains(output, "arguments") {
+		t.Errorf("expected log to NOT contain 'arguments', got: %s", output)
+	}
+	if strings.Contains(output, "secretdata") {
+		t.Errorf("expected log to NOT contain 'secretdata', got: %s", output)
+	}
+	if strings.Contains(output, "result") {
+		t.Errorf("expected log to NOT contain 'result', got: %s", output)
+	}
+	// Function name should still be logged
+	if !strings.Contains(output, "funcName=TestFunc") {
+		t.Errorf("expected log to contain 'funcName=TestFunc', got: %s", output)
+	}
+}
+
+// TestAutocall_LogsFailedFunctionCall tests that failed function calls are logged
+func TestAutocall_LogsFailedFunctionCall(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "FailingFunc"},
+			func(ctx context.Context, args struct{}) (string, error) {
+				return "", errors.New("something went wrong")
+			}),
+	}
+
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "FailingFunc", Arguments: `{}`},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Function failed.", Error: fmt.Errorf("something went wrong")},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
+
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{
+		Logger:                             log,
+		MaximumConsecutiveErrorsPerRequest: 3,
+	})
+
+	// Assert logs contain error information
+	output := buf.String()
+	if !strings.Contains(output, "call failed") {
+		t.Errorf("expected log to contain 'call failed', got: %s", output)
+	}
+	if !strings.Contains(output, "funcName=FailingFunc") {
+		t.Errorf("expected log to contain 'funcName=FailingFunc', got: %s", output)
+	}
+	if !strings.Contains(output, "error") {
+		t.Errorf("expected log to contain 'error', got: %s", output)
+	}
+	if !strings.Contains(output, "something went wrong") {
+		t.Errorf("expected log to contain error message, got: %s", output)
+	}
+}
+
+// TestAutocall_LogsCanceledFunctionCall tests that canceled function calls are logged
+func TestAutocall_LogsCanceledFunctionCall(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "CancelableFunc"},
+			func(ctx context.Context, args struct{}) (string, error) {
+				return "", context.Canceled
+			}),
+	}
+
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "CancelableFunc", Arguments: `{}`},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "Error: Function failed.", Error: context.Canceled},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
+
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{
+		Logger:                             log,
+		MaximumConsecutiveErrorsPerRequest: 3,
+	})
+
+	// Assert logs contain cancellation information
+	output := buf.String()
+	if !strings.Contains(output, "call canceled") {
+		t.Errorf("expected log to contain 'call canceled', got: %s", output)
+	}
+	if !strings.Contains(output, "funcName=CancelableFunc") {
+		t.Errorf("expected log to contain 'funcName=CancelableFunc', got: %s", output)
+	}
+}
+
+// TestAutocall_LogsMultipleFunctionCalls tests that multiple function calls are all logged
+func TestAutocall_LogsMultipleFunctionCalls(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "Func1"},
+			func(ctx context.Context, args struct{}) (string, error) {
+				return "Result1", nil
+			}),
+		functool.MustNew(&functool.Func{Name: "Func2"},
+			func(ctx context.Context, args struct{}) (string, error) {
+				return "Result2", nil
+			}),
+	}
+
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`},
+			&message.FunctionCallContent{CallID: "callId2", Name: "Func2", Arguments: `{}`},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "Result1"},
+			&message.FunctionResultContent{CallID: "callId2", Result: "Result2"},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
+
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{
+		Logger:                     log,
+		AllowConcurrentInvocations: false,
+	})
+
+	// Assert logs contain both function calls
+	output := buf.String()
+	func1Calls := strings.Count(output, "funcName=Func1")
+	func2Calls := strings.Count(output, "funcName=Func2")
+
+	// Each function should appear twice: once in "calling function" and once in "function call completed"
+	if func1Calls < 2 {
+		t.Errorf("expected at least 2 log entries for Func1, got %d. Output: %s", func1Calls, output)
+	}
+	if func2Calls < 2 {
+		t.Errorf("expected at least 2 log entries for Func2, got %d. Output: %s", func2Calls, output)
+	}
+}
+
+// TestAutocall_LoggingWithConcurrentInvocations tests logging with concurrent function calls
+func TestAutocall_LoggingWithConcurrentInvocations(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "SlowFunc1"},
+			func(ctx context.Context, args struct{}) (string, error) {
+				time.Sleep(10 * time.Millisecond)
+				return "Result1", nil
+			}),
+		functool.MustNew(&functool.Func{Name: "SlowFunc2"},
+			func(ctx context.Context, args struct{}) (string, error) {
+				time.Sleep(10 * time.Millisecond)
+				return "Result2", nil
+			}),
+	}
+
+	plan := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.FunctionCallContent{CallID: "callId1", Name: "SlowFunc1", Arguments: `{}`},
+			&message.FunctionCallContent{CallID: "callId2", Name: "SlowFunc2", Arguments: `{}`},
+		}},
+		{Role: message.RoleTool, Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "callId1", Result: "Result1"},
+			&message.FunctionResultContent{CallID: "callId2", Result: "Result2"},
+		}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "done"},
+		}},
+	}
+
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{
+		Logger:                     log,
+		AllowConcurrentInvocations: true,
+	})
+
+	// Assert logs contain both function calls
+	output := buf.String()
+	if !strings.Contains(output, "funcName=SlowFunc1") {
+		t.Errorf("expected log to contain SlowFunc1, got: %s", output)
+	}
+	if !strings.Contains(output, "funcName=SlowFunc2") {
+		t.Errorf("expected log to contain SlowFunc2, got: %s", output)
+	}
+	// Verify completion logs
+	completionLogs := strings.Count(output, "function call completed")
+	if completionLogs < 2 {
+		t.Errorf("expected at least 2 'function call completed' logs, got %d", completionLogs)
+	}
+}

--- a/agent/middleware/autocall/autocall_test.go
+++ b/agent/middleware/autocall/autocall_test.go
@@ -66,7 +66,7 @@ func TestFunctionInvoking_SupportsSingleFunctionCallPerRequest(t *testing.T) {
 		}},
 	}
 
-	invokeAndAssert(t, tools, plan, nil, autocall.Options{})
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{})
 }
 
 func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) {
@@ -131,7 +131,7 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 				}},
 			}
 
-			autocallOptions := autocall.Options{
+			autocallOptions := autocall.Config{
 				AllowConcurrentInvocations: tt.allowConcurrentInvocations,
 			}
 
@@ -145,7 +145,7 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 // Returns the final chat history.
 // Plan should start with the initial user message and contain all expected messages.
 // autocallOptions can be nil to use default settings.
-func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, expected []*message.Message, autocallOptions autocall.Options) []*message.Message {
+func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, expected []*message.Message, autocallOptions autocall.Config) []*message.Message {
 	t.Helper()
 
 	if len(plan) == 0 {
@@ -241,7 +241,7 @@ func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 				}
 			}
 
-			autocallOptions := autocall.Options{
+			autocallOptions := autocall.Config{
 				AdditionalTools: []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "Func1"},
 						func(ctx context.Context, args Func1Args) (string, error) {
@@ -301,7 +301,7 @@ func TestFunctionInvoking_PrefersToolsProvidedByOptions(t *testing.T) {
 			}),
 	}
 
-	autocallOptions := autocall.Options{
+	autocallOptions := autocall.Config{
 		AdditionalTools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func1"},
 				func(ctx context.Context, args struct{}) (string, error) {
@@ -379,7 +379,7 @@ func TestFunctionInvoking_ParallelFunctionCallsMayBeInvokedConcurrently(t *testi
 		}},
 	}
 
-	autocallOptions := autocall.Options{
+	autocallOptions := autocall.Config{
 		AllowConcurrentInvocations: true,
 	}
 
@@ -418,7 +418,7 @@ func TestFunctionInvoking_ConcurrentInvocationOfParallelCallsDisabledByDefault(t
 		}},
 	}
 
-	invokeAndAssert(t, tools, plan, nil, autocall.Options{})
+	invokeAndAssert(t, tools, plan, nil, autocall.Config{})
 }
 
 // TestFunctionInvoking_ContinuesWithSuccessfulCallsUntilMaximumIterations tests MaximumIterationsPerRequest
@@ -456,7 +456,7 @@ func TestFunctionInvoking_ContinuesWithSuccessfulCallsUntilMaximumIterations(t *
 	// The loop runs maxIterations times, each time adding assistant+tool, then stops with one more assistant message
 	expectedPlan := plan[:maxIterations*2+2]
 
-	autocallOptions := autocall.Options{
+	autocallOptions := autocall.Config{
 		MaximumIterationsPerRequest: maxIterations,
 	}
 
@@ -516,7 +516,7 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 			// Any more failures will exceed the limit (should throw)
 			plan = append(plan, createFunctionCallIterationPlan(&callIndex, true, true)...)
 
-			autocallOptions := autocall.Options{
+			autocallOptions := autocall.Config{
 				MaximumConsecutiveErrorsPerRequest: 2,
 				AllowConcurrentInvocations:         tt.allowConcurrentInvocations,
 			}
@@ -633,7 +633,7 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 			}
 			plan = append(plan, createFunctionCallIterationPlan(&callIndex, true)...)
 
-			autocallOptions := autocall.Options{
+			autocallOptions := autocall.Config{
 				MaximumConsecutiveErrorsPerRequest: 0,
 				AllowConcurrentInvocations:         tt.allowConcurrentInvocations,
 			}
@@ -730,7 +730,7 @@ func TestFunctionInvoking_KeepsFunctionCallingContent(t *testing.T) {
 		}},
 	}
 
-	finalChat := invokeAndAssert(t, tools, plan, nil, autocall.Options{})
+	finalChat := invokeAndAssert(t, tools, plan, nil, autocall.Config{})
 	validateFunctionContent(t, finalChat)
 }
 
@@ -773,7 +773,7 @@ func TestFunctionInvoking_TerminateOnUnknownCalls(t *testing.T) {
 					}),
 			}
 
-			autocallOptions := autocall.Options{
+			autocallOptions := autocall.Config{
 				TerminateOnUnknownCalls: tt.terminateOnUnknownCalls,
 			}
 
@@ -837,7 +837,7 @@ func TestFunctionInvoking_ExceptionDetailsOnlyReportedWhenRequested(t *testing.T
 				}},
 			}
 
-			autocallOptions := autocall.Options{
+			autocallOptions := autocall.Config{
 				MaximumConsecutiveErrorsPerRequest: 3,
 				IncludeDetailedErrors:              tt.detailedErrors,
 			}
@@ -886,7 +886,7 @@ func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 	}
 
 	var resp message.Response
-	for update, err := range autocall.New(autocall.Options{}).Run(t.Context(), runner.Run, initialMessages, opts...) {
+	for update, err := range autocall.New(autocall.Config{}).Run(t.Context(), runner.Run, initialMessages, opts...) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/agent/middleware/logger/logger.go
+++ b/agent/middleware/logger/logger.go
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package logger
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"log/slog"
+	"time"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/internal/slogx"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+type agentContextKey struct{}
+
+type agentContext struct {
+	ID   string
+	Name string
+}
+
+func WithAgentContext(ctx context.Context, id, name string) context.Context {
+	return context.WithValue(ctx, agentContextKey{}, agentContext{id, name})
+}
+
+type Config struct {
+	Logger        *slog.Logger
+	SensitiveData bool
+}
+
+func New(cfg Config) middleware.Middleware {
+	return &logger{l: slogx.Logger{
+		Logger:        cfg.Logger,
+		SensitiveData: cfg.SensitiveData,
+		Type:          slogx.TypeMiddleware,
+		Name:          "logger",
+	}}
+}
+
+type logger struct {
+	l slogx.Logger
+}
+
+func (l *logger) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	return func(yield func(*message.ResponseUpdate, error) bool) {
+		start := time.Now()
+		l.log(ctx, slog.LevelDebug, "run invoked", slogx.SensitiveData("messages", messages), slogx.SensitiveData("opts", opts))
+		for update, err := range next(ctx, messages, opts...) {
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					l.log(ctx, slog.LevelDebug, "run canceled", "error", err)
+				} else {
+					l.log(ctx, slog.LevelError, "run failed", "error", err)
+				}
+			} else if l.l.SensitiveData {
+				l.log(ctx, slog.LevelDebug, "run received update", slogx.SensitiveData("update", update))
+			}
+			if !yield(update, err) {
+				return
+			}
+		}
+		l.log(ctx, slog.LevelDebug, "run completed", "duration", time.Since(start).String())
+	}
+}
+
+func (l *logger) log(ctx context.Context, level slog.Level, msg string, args ...any) {
+	agentCtx := ctx.Value(agentContextKey{})
+	if agentCtx != nil {
+		ac := agentCtx.(agentContext)
+		args = append(args, "agentID", ac.ID)
+		if ac.Name != "" {
+			args = append(args, "agentName", ac.Name)
+		}
+	}
+	l.l.Log(ctx, level, msg, args...)
+}

--- a/agent/middleware/logger/logger_test.go
+++ b/agent/middleware/logger/logger_test.go
@@ -1,0 +1,424 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"iter"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/agent/middleware/logger"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+func TestLogger_Run_LogsDebugMessage(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	mw := logger.New(logger.Config{Logger: log})
+
+	// Create a simple next function
+	nextCalled := false
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		nextCalled = true
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
+		}
+	}
+
+	// Run the middleware
+	ctx := context.Background()
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := mw.Run(ctx, next, messages)
+	for range seq {
+	}
+
+	// Assert next was called
+	if !nextCalled {
+		t.Error("expected next function to be called")
+	}
+
+	// Assert logs were written
+	output := buf.String()
+	if !strings.Contains(output, "run invoked") {
+		t.Errorf("expected log to contain 'run invoked', got: %s", output)
+	}
+	if !strings.Contains(output, "run completed") {
+		t.Errorf("expected log to contain 'run completed', got: %s", output)
+	}
+}
+
+func TestLogger_Run_LogsTraceWithDetails(t *testing.T) {
+	// Create a logger with trace level enabled
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	mw := logger.New(logger.Config{Logger: log, SensitiveData: true})
+
+	// Create a simple next function
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
+		}
+	}
+
+	// Run the middleware
+	ctx := context.Background()
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := mw.Run(ctx, next, messages)
+	for range seq {
+	}
+
+	// Assert trace logs include details
+	output := buf.String()
+	if !strings.Contains(output, "run invoked") {
+		t.Errorf("expected log to contain 'run invoked', got: %s", output)
+	}
+	if !strings.Contains(output, "messages") {
+		t.Errorf("expected log to contain 'messages' field, got: %s", output)
+	}
+	if !strings.Contains(output, "run received update") {
+		t.Errorf("expected log to contain 'run received update', got: %s", output)
+	}
+	if !strings.Contains(output, "run completed") {
+		t.Errorf("expected log to contain 'run completed', got: %s", output)
+	}
+}
+
+func TestLogger_Run_LogsErrors(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	mw := logger.New(logger.Config{Logger: log})
+
+	// Create a next function that returns an error
+	expectedError := errors.New("test error")
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(nil, expectedError)
+		}
+	}
+
+	// Run the middleware
+	ctx := context.Background()
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := mw.Run(ctx, next, messages)
+	var receivedError error
+	for _, err := range seq {
+		if err != nil {
+			receivedError = err
+		}
+	}
+
+	// Assert error was received
+	if receivedError != expectedError {
+		t.Errorf("expected error %v, got %v", expectedError, receivedError)
+	}
+
+	// Assert error was logged
+	output := buf.String()
+	if !strings.Contains(output, "run failed") {
+		t.Errorf("expected log to contain 'run failed', got: %s", output)
+	}
+	if !strings.Contains(output, "test error") {
+		t.Errorf("expected log to contain error message 'test error', got: %s", output)
+	}
+}
+
+func TestLogger_Run_HandlesMultipleUpdates(t *testing.T) {
+	// Create a logger with trace level enabled
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	mw := logger.New(logger.Config{Logger: log, SensitiveData: true})
+
+	// Create a next function that yields multiple updates
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			if !yield(&message.ResponseUpdate{MessageID: "test-1"}, nil) {
+				return
+			}
+			if !yield(&message.ResponseUpdate{MessageID: "test-2"}, nil) {
+				return
+			}
+			yield(&message.ResponseUpdate{MessageID: "test-3"}, nil)
+		}
+	}
+
+	// Run the middleware
+	ctx := context.Background()
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := mw.Run(ctx, next, messages)
+	updateCount := 0
+	for range seq {
+		updateCount++
+	}
+
+	// Assert all updates were received
+	if updateCount != 3 {
+		t.Errorf("expected 3 updates, got %d", updateCount)
+	}
+
+	// Assert trace logs show multiple updates
+	output := buf.String()
+	updateLogs := strings.Count(output, "run received update")
+	if updateLogs != 3 {
+		t.Errorf("expected 3 'run received update' logs, got %d", updateLogs)
+	}
+}
+
+func TestLogger_Run_EarlyTermination(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	mw := logger.New(logger.Config{Logger: log})
+
+	// Create a next function that yields multiple updates
+	yieldCount := 0
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			for i := 0; i < 5; i++ {
+				yieldCount++
+				if !yield(&message.ResponseUpdate{MessageID: "test"}, nil) {
+					return
+				}
+			}
+		}
+	}
+
+	// Run the middleware but stop early
+	ctx := context.Background()
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := mw.Run(ctx, next, messages)
+	consumedCount := 0
+	for range seq {
+		consumedCount++
+		if consumedCount >= 2 {
+			break
+		}
+	}
+
+	// Assert only 2 updates were consumed
+	if consumedCount != 2 {
+		t.Errorf("expected to consume 2 updates, got %d", consumedCount)
+	}
+
+	// Assert that next function stopped after consumer stopped
+	if yieldCount != 2 {
+		t.Errorf("expected next to yield 2 times (stopped early), got %d", yieldCount)
+	}
+}
+
+func TestLogger_Run_PropagatesContext(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	mw := logger.New(logger.Config{Logger: log})
+
+	// Create a next function that checks context
+	type contextKey string
+	key := contextKey("test-key")
+	var receivedCtx context.Context
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		receivedCtx = ctx
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
+		}
+	}
+
+	// Run the middleware with a context value
+	ctx := context.WithValue(context.Background(), key, "test-value")
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := mw.Run(ctx, next, messages)
+	for range seq {
+	}
+
+	// Assert context was propagated
+	if receivedCtx == nil {
+		t.Fatal("context was not propagated")
+	}
+	if receivedCtx.Value(key) != "test-value" {
+		t.Errorf("expected context value 'test-value', got %v", receivedCtx.Value(key))
+	}
+}
+
+func TestLogger_Run_WorksInMiddlewareChain(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	loggerMw := logger.New(logger.Config{Logger: log})
+
+	// Create another test middleware
+	var order []string
+	testMw := &testMiddleware{
+		name: "test-mw",
+		onRun: func(name string) {
+			order = append(order, name)
+		},
+	}
+
+	// Base function
+	baseFn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		order = append(order, "base")
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
+		}
+	}
+
+	// Run the middleware chain
+	ctx := context.Background()
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := middleware.RunChain(ctx, baseFn, []middleware.Middleware{loggerMw, testMw}, messages)
+	for range seq {
+	}
+
+	// Assert execution order
+	expected := []string{"test-mw", "base"}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d calls, got %d", len(expected), len(order))
+	}
+	for i, v := range expected {
+		if order[i] != v {
+			t.Errorf("expected order[%d] to be %s, got %s", i, v, order[i])
+		}
+	}
+
+	// Assert logs were written
+	output := buf.String()
+	if !strings.Contains(output, "run invoked") {
+		t.Errorf("expected log to contain 'Run invoked', got: %s", output)
+	}
+	if !strings.Contains(output, "run completed") {
+		t.Errorf("expected log to contain 'Run completed', got: %s", output)
+	}
+}
+
+func TestLogger_Run_ContextCanceled(t *testing.T) {
+	// Create a logger that writes to a buffer
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create logger middleware
+	mw := logger.New(logger.Config{Logger: log})
+
+	// Create a next function that checks for context cancellation
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			// Yield first update
+			if !yield(&message.ResponseUpdate{MessageID: "test-1"}, nil) {
+				return
+			}
+			// Check if context is canceled
+			select {
+			case <-ctx.Done():
+				yield(nil, ctx.Err())
+				return
+			default:
+			}
+			// Yield second update
+			yield(&message.ResponseUpdate{MessageID: "test-2"}, nil)
+		}
+	}
+
+	// Create a cancelable context and cancel it immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	messages := []*message.Message{
+		message.New(&message.TextContent{Text: "test message"}),
+	}
+
+	seq := mw.Run(ctx, next, messages)
+	var receivedError error
+	updateCount := 0
+	for _, err := range seq {
+		if err != nil {
+			receivedError = err
+		} else {
+			updateCount++
+		}
+	}
+
+	// Assert we got the context canceled error
+	if receivedError != context.Canceled {
+		t.Errorf("expected context.Canceled error, got %v", receivedError)
+	}
+
+	// Assert logs were written
+	output := buf.String()
+	if !strings.Contains(output, "run invoked") {
+		t.Errorf("expected log to contain 'run invoked', got: %s", output)
+	}
+	if !strings.Contains(output, "run canceled") {
+		t.Errorf("expected log to contain 'run canceled', got: %s", output)
+	}
+	if !strings.Contains(output, "context canceled") {
+		t.Errorf("expected log to contain 'context canceled', got: %s", output)
+	}
+}
+
+// testMiddleware is a test implementation of Middleware
+type testMiddleware struct {
+	name  string
+	onRun func(string)
+}
+
+func (tm *testMiddleware) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	tm.onRun(tm.name)
+	return next(ctx, messages, options...)
+}

--- a/anthropic/chat.go
+++ b/anthropic/chat.go
@@ -32,7 +32,7 @@ type ClientConfig struct {
 	BaseURL string // Optional, defaults to Anthropic API
 }
 
-func NewChatAgent(config ClientConfig, options chatagent.Options) *chatagent.Agent {
+func NewChatAgent(config ClientConfig, options chatagent.Config) *chatagent.Agent {
 	opts := []option.RequestOption{}
 	if config.APIKey != "" {
 		opts = append(opts, option.WithAPIKey(config.APIKey))

--- a/examples/chat_cli/main.go
+++ b/examples/chat_cli/main.go
@@ -31,7 +31,7 @@ var weatherTool = functool.MustNew(&functool.Func{
 func main() {
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are a helpful assistant with access to weather information. Be concise and friendly.",
 		RunOptions: []agentopt.RunOption{
 			agentopt.Tool(weatherTool),

--- a/examples/getting_started/agent/step01_running/main.go
+++ b/examples/getting_started/agent/step01_running/main.go
@@ -21,7 +21,7 @@ var logger = demo.NewLogger(
 func main() {
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/agent/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/agent/step02_multiturn_conversation/main.go
@@ -22,7 +22,7 @@ var logger = demo.NewLogger(
 func main() {
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/agent/step03_using_function_tools/main.go
+++ b/examples/getting_started/agent/step03_using_function_tools/main.go
@@ -32,7 +32,7 @@ func main() {
 	// Create the agent, and provide the function tool to the agent.
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are a helpful assistant",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
 		RunOptions: []agentopt.RunOption{

--- a/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
@@ -35,7 +35,7 @@ func main() {
 	// Note that we are wrapping the function tool with tool.ApprovalRequiredFunc to require user approval before invoking it.
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are a helpful assistant",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
 		RunOptions: []agentopt.RunOption{

--- a/examples/getting_started/agent/step05_structured_output/main.go
+++ b/examples/getting_started/agent/step05_structured_output/main.go
@@ -31,7 +31,7 @@ type PersonInfo struct {
 func main() {
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are a helpful assistant.",
 		Name:         "HelpfulAssistant",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
@@ -54,7 +54,7 @@ func main() {
 	// Create the agent with the specified name, instructions, and expected structured output the agent should produce.
 	a = openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are a helpful assistant.",
 		Name:         "HelpfulAssistant",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -26,7 +26,7 @@ func main() {
 	// Create the agent.
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/agent/step07_3rdparty_thread_storage/main.go
+++ b/examples/getting_started/agent/step07_3rdparty_thread_storage/main.go
@@ -38,7 +38,7 @@ func main() {
 	// Create the agent with a custom message store that persists messages to disk.
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/agent/step11_using_images/main.go
+++ b/examples/getting_started/agent/step11_using_images/main.go
@@ -23,7 +23,7 @@ func main() {
 	// Create the agent.
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are a helpful agent that can analyze images.",
 		Name:         "VisionAgent",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/agent/step12_as_function_tool/main.go
+++ b/examples/getting_started/agent/step12_as_function_tool/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Create the agent and provide the function tool.
 	weatherAgent := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You answer questions about the weather.",
 		Name:         "WeatherAgent",
 		Description:  "An agent that answers questions about the weather.",
@@ -47,7 +47,7 @@ func main() {
 	// Create the main agent, and provide the weather agent as a function tool.
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are a helpful assistant who responds in French.",
 		RunOptions: []agentopt.RunOption{
 			agentopt.Tool(agent.FuncTool(weatherAgent, nil)),

--- a/examples/getting_started/anthropic/step01_running/main.go
+++ b/examples/getting_started/anthropic/step01_running/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Create Anthropic agent
 	a := anthropic.NewChatAgent(anthropic.ClientConfig{
 		Model: "claude-sonnet-4-5",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/azure_openai/step01_running/main.go
+++ b/examples/getting_started/azure_openai/step01_running/main.go
@@ -26,7 +26,7 @@ func main() {
 	a := openai.NewChatAgentAzure(openai.ClientConfig{
 		Model:      deployment,
 		APIVersion: "2025-01-01-preview",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/mcp/agent_mcp_server/main.go
+++ b/examples/getting_started/mcp/agent_mcp_server/main.go
@@ -48,7 +48,7 @@ func main() {
 	// In Go, we configure tools as default options that will be used for all runs
 	a := openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-4o-mini",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Name:         "DocsAgent",
 		Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
 		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions

--- a/examples/getting_started/workflows/foundational/3_agents/main.go
+++ b/examples/getting_started/workflows/foundational/3_agents/main.go
@@ -57,7 +57,7 @@ func main() {
 func newAgent(language string) agent.Agent {
 	return openai.NewChatAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
-	}, chatagent.Options{
+	}, chatagent.Config{
 		Instructions: fmt.Sprintf("You are a helpful assistant who translates text to %s.", language),
 	})
 }

--- a/internal/slogx/slogx.go
+++ b/internal/slogx/slogx.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package slogx
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+)
+
+type Type int
+
+const (
+	TypeNone Type = iota
+	TypeMiddleware
+)
+
+type sensitiveData struct {
+	any
+}
+
+func SensitiveData(key string, value any) slog.Attr {
+	return slog.Any(key, sensitiveData{value})
+}
+
+type Logger struct {
+	Logger        *slog.Logger
+	Type          Type
+	Name          string
+	SensitiveData bool
+}
+
+func (l *Logger) Debug(ctx context.Context, msg string, args ...any) {
+	l.Log(ctx, slog.LevelDebug, msg, args...)
+}
+
+func (l *Logger) Info(ctx context.Context, msg string, args ...any) {
+	l.Log(ctx, slog.LevelInfo, msg, args...)
+}
+
+func (l *Logger) Warn(ctx context.Context, msg string, args ...any) {
+	l.Log(ctx, slog.LevelWarn, msg, args...)
+}
+
+func (l *Logger) Error(ctx context.Context, msg string, args ...any) {
+	l.Log(ctx, slog.LevelError, msg, args...)
+}
+
+func (l *Logger) Log(ctx context.Context, level slog.Level, msg string, args ...any) {
+	if l.Logger == nil {
+		return
+	}
+	if !l.Logger.Enabled(ctx, level) {
+		return
+	}
+	switch l.Type {
+	case TypeMiddleware:
+		args = append(args, "middleware", l.Name)
+	}
+	if !l.SensitiveData {
+		args = slices.DeleteFunc(args, func(v any) bool {
+			if v, ok := v.(slog.Attr); ok {
+				_, isSensitive := v.Value.Any().(sensitiveData)
+				return isSensitive
+			}
+			return false
+		})
+	}
+	l.Logger.Log(ctx, level, msg, args...)
+}

--- a/openai/chat.go
+++ b/openai/chat.go
@@ -60,7 +60,7 @@ type ClientConfig struct {
 	APIVersion string
 }
 
-func newChatAgent(isAzure bool, config ClientConfig, options chatagent.Options) *chatagent.Agent {
+func newChatAgent(isAzure bool, config ClientConfig, options chatagent.Config) *chatagent.Agent {
 	ops := make([]option.RequestOption, 0, 2)
 	if isAzure {
 		if config.Endpoint != "" {
@@ -97,12 +97,12 @@ func newChatAgent(isAzure bool, config ClientConfig, options chatagent.Options) 
 	return chatagent.NewAgent(c.run, options)
 }
 
-func NewChatAgent(config ClientConfig, options chatagent.Options) *chatagent.Agent {
+func NewChatAgent(config ClientConfig, options chatagent.Config) *chatagent.Agent {
 	return newChatAgent(false, config, options)
 }
 
 // NewChatAgentAzure creates a new [Agent].
-func NewChatAgentAzure(config ClientConfig, options chatagent.Options) *chatagent.Agent {
+func NewChatAgentAzure(config ClientConfig, options chatagent.Config) *chatagent.Agent {
 	return newChatAgent(true, config, options)
 }
 

--- a/openai/chat_test.go
+++ b/openai/chat_test.go
@@ -62,7 +62,7 @@ func newTestServer(t *testing.T, input string, output string) *httptest.Server {
 func newTestClient(server *httptest.Server) agent.Agent {
 	return openai.NewChatAgent(
 		openai.ClientConfig{Model: "gpt-4o-mini", Endpoint: server.URL},
-		chatagent.Options{DisableFuncAutoCall: true},
+		chatagent.Config{DisableFuncAutoCall: true},
 	)
 }
 


### PR DESCRIPTION
Add `middleware/logging` and also add log instrumentation to `agent/chatagent` and to `middleware/autocall`.

While here, rename some `Option` structs to `Config`, which is more idiomatic.

