### PR TITLE
Pass agent to middlewares

### DIFF
--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -159,7 +159,7 @@ func (m *Middleware) Called() bool {
 	return m.called
 }
 
-func (m *Middleware) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (m *Middleware) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	m.called = true
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { m.currentTurn++ }()
@@ -171,7 +171,7 @@ func (m *Middleware) Run(ctx context.Context, next middleware.RunFunc, messages 
 				}
 			}
 		}
-		for update, err := range next(ctx, messages, opts...) {
+		for update, err := range next(ctx, a, messages, opts...) {
 			if !yield(update, err) {
 				return
 			}
@@ -193,7 +193,7 @@ type Runner struct {
 	currentTurn int
 }
 
-func (r *Runner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (r *Runner) Run(ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { r.currentTurn++ }()
 		if r.currentTurn >= len(r.Responses) {

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -14,7 +14,6 @@ import (
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/agent/middleware/autocall"
-	"github.com/microsoft/agent-framework-go/agent/middleware/logger"
 	"github.com/microsoft/agent-framework-go/format"
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
@@ -109,8 +108,7 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 	if _, ok := agentopt.Get(options, agentopt.Thread); !ok {
 		options = append(options, agentopt.Thread(a.NewThread(ctx)))
 	}
-	ctx = logger.WithAgentContext(ctx, a.iden.ID(), a.iden.Name())
-	return middleware.RunChain(ctx, a.run, a.config.Middlewares, messages, options...)
+	return middleware.RunChain(ctx, a.run, a.config.Middlewares, a, messages, options...)
 }
 
 func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
@@ -140,7 +138,7 @@ func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, o
 	}
 }
 
-func (a *Agent) run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		originalMessages := messages
 		thread, options, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, originalMessages, options)

--- a/agent/middleware/autocall/autocall.go
+++ b/agent/middleware/autocall/autocall.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/internal/slogx"
@@ -68,7 +69,7 @@ func New(cfg Config) middleware.Middleware {
 	return ac
 }
 
-func (f *autocall) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (f *autocall) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		tools, requiresApproval := f.createToolsMap(agentopt.All(opts, agentopt.Tool))
 
@@ -129,7 +130,7 @@ func (f *autocall) Run(ctx context.Context, next middleware.RunFunc, messages []
 			functionCallContents = functionCallContents[:0]
 			var hasApprovalRequiringFcc bool
 			var lastApprovalCheckedFCCIdx, lastYieldedUpdateIdx int
-			for update, err := range next(ctx, messages, opts...) {
+			for update, err := range next(ctx, a, messages, opts...) {
 				if err != nil {
 					yield(nil, err)
 					return

--- a/agent/middleware/autocall/autocall_approval_test.go
+++ b/agent/middleware/autocall/autocall_approval_test.go
@@ -67,7 +67,7 @@ func invokeAndAssertApprovalWithAgent(t *testing.T, next middleware.RunFunc,
 
 	// Collect all streaming updates into messages
 	var updates []*message.ResponseUpdate
-	for update, err := range autocall.New(autocallOptions).Run(ctx, next, input, opts...) {
+	for update, err := range autocall.New(autocallOptions).Run(next, ctx, nil, input, opts...) {
 		if err != nil {
 			t.Fatalf("StreamingResponse failed: %v", err)
 		}
@@ -91,7 +91,7 @@ func expectApprovalError(t *testing.T, tools []tool.Tool, input []*message.Messa
 	}
 
 	var lastErr error
-	for _, err := range autocall.New(autocall.Config{}).Run(ctx, runner.Run, input, opts...) {
+	for _, err := range autocall.New(autocall.Config{}).Run(runner.Run, ctx, nil, input, opts...) {
 		if err != nil {
 			lastErr = err
 			break

--- a/agent/middleware/autocall/autocall_test.go
+++ b/agent/middleware/autocall/autocall_test.go
@@ -191,7 +191,7 @@ func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, e
 
 	// Collect all updates
 	var resp message.Response
-	for update, err := range autocall.New(autocallOptions).Run(t.Context(), runner.Run, initialMessages, opts...) {
+	for update, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
 		if err != nil {
 			t.Fatalf("unexpected error during streaming: %v", err)
 		}
@@ -551,7 +551,7 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 			}
 
 			var streamErr error
-			for _, err := range autocall.New(autocallOptions).Run(t.Context(), runner.Run, initialMessages, opts...) {
+			for _, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
 				if err != nil {
 					streamErr = err
 					break
@@ -667,7 +667,7 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 			}
 
 			var streamErr error
-			for _, err := range autocall.New(autocallOptions).Run(t.Context(), runner.Run, initialMessages, opts...) {
+			for _, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
 				if err != nil {
 					streamErr = err
 					break
@@ -886,7 +886,7 @@ func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 	}
 
 	var resp message.Response
-	for update, err := range autocall.New(autocall.Config{}).Run(t.Context(), runner.Run, initialMessages, opts...) {
+	for update, err := range autocall.New(autocall.Config{}).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/agent/middleware/logger/logger.go
+++ b/agent/middleware/logger/logger.go
@@ -9,22 +9,12 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/internal/slogx"
 	"github.com/microsoft/agent-framework-go/message"
 )
-
-type agentContextKey struct{}
-
-type agentContext struct {
-	ID   string
-	Name string
-}
-
-func WithAgentContext(ctx context.Context, id, name string) context.Context {
-	return context.WithValue(ctx, agentContextKey{}, agentContext{id, name})
-}
 
 type Config struct {
 	Logger        *slog.Logger
@@ -44,35 +34,33 @@ type logger struct {
 	l slogx.Logger
 }
 
-func (l *logger) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (l *logger) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		start := time.Now()
-		l.log(ctx, slog.LevelDebug, "run invoked", slogx.SensitiveData("messages", messages), slogx.SensitiveData("opts", opts))
-		for update, err := range next(ctx, messages, opts...) {
+		l.log(ctx, a, slog.LevelDebug, "run invoked", slogx.SensitiveData("messages", messages), slogx.SensitiveData("opts", opts))
+		for update, err := range next(ctx, a, messages, opts...) {
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
-					l.log(ctx, slog.LevelDebug, "run canceled", "error", err)
+					l.log(ctx, a, slog.LevelDebug, "run canceled", "error", err)
 				} else {
-					l.log(ctx, slog.LevelError, "run failed", "error", err)
+					l.log(ctx, a, slog.LevelError, "run failed", "error", err)
 				}
 			} else if l.l.SensitiveData {
-				l.log(ctx, slog.LevelDebug, "run received update", slogx.SensitiveData("update", update))
+				l.log(ctx, a, slog.LevelDebug, "run received update", slogx.SensitiveData("update", update))
 			}
 			if !yield(update, err) {
 				return
 			}
 		}
-		l.log(ctx, slog.LevelDebug, "run completed", "duration", time.Since(start).String())
+		l.log(ctx, a, slog.LevelDebug, "run completed", "duration", time.Since(start).String())
 	}
 }
 
-func (l *logger) log(ctx context.Context, level slog.Level, msg string, args ...any) {
-	agentCtx := ctx.Value(agentContextKey{})
-	if agentCtx != nil {
-		ac := agentCtx.(agentContext)
-		args = append(args, "agentID", ac.ID)
-		if ac.Name != "" {
-			args = append(args, "agentName", ac.Name)
+func (l *logger) log(ctx context.Context, a agent.Agent, level slog.Level, msg string, args ...any) {
+	if a != nil {
+		args = append(args, "agentID", a.Identity().ID())
+		if a.Identity().Name() != "" {
+			args = append(args, "agentName", a.Identity().Name())
 		}
 	}
 	l.l.Log(ctx, level, msg, args...)

--- a/agent/middleware/logger/logger_test.go
+++ b/agent/middleware/logger/logger_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/agent/middleware/logger"
@@ -29,7 +30,7 @@ func TestLogger_Run_LogsDebugMessage(t *testing.T) {
 
 	// Create a simple next function
 	nextCalled := false
-	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		nextCalled = true
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
@@ -42,7 +43,7 @@ func TestLogger_Run_LogsDebugMessage(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(ctx, next, messages)
+	seq := mw.Run(next, ctx, nil, messages)
 	for range seq {
 	}
 
@@ -72,7 +73,7 @@ func TestLogger_Run_LogsTraceWithDetails(t *testing.T) {
 	mw := logger.New(logger.Config{Logger: log, SensitiveData: true})
 
 	// Create a simple next function
-	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
 		}
@@ -84,7 +85,7 @@ func TestLogger_Run_LogsTraceWithDetails(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(ctx, next, messages)
+	seq := mw.Run(next, ctx, nil, messages)
 	for range seq {
 	}
 
@@ -116,7 +117,7 @@ func TestLogger_Run_LogsErrors(t *testing.T) {
 
 	// Create a next function that returns an error
 	expectedError := errors.New("test error")
-	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(nil, expectedError)
 		}
@@ -128,7 +129,7 @@ func TestLogger_Run_LogsErrors(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(ctx, next, messages)
+	seq := mw.Run(next, ctx, nil, messages)
 	var receivedError error
 	for _, err := range seq {
 		if err != nil {
@@ -162,7 +163,7 @@ func TestLogger_Run_HandlesMultipleUpdates(t *testing.T) {
 	mw := logger.New(logger.Config{Logger: log, SensitiveData: true})
 
 	// Create a next function that yields multiple updates
-	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			if !yield(&message.ResponseUpdate{MessageID: "test-1"}, nil) {
 				return
@@ -180,7 +181,7 @@ func TestLogger_Run_HandlesMultipleUpdates(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(ctx, next, messages)
+	seq := mw.Run(next, ctx, nil, messages)
 	updateCount := 0
 	for range seq {
 		updateCount++
@@ -211,7 +212,7 @@ func TestLogger_Run_EarlyTermination(t *testing.T) {
 
 	// Create a next function that yields multiple updates
 	yieldCount := 0
-	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			for i := 0; i < 5; i++ {
 				yieldCount++
@@ -228,7 +229,7 @@ func TestLogger_Run_EarlyTermination(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(ctx, next, messages)
+	seq := mw.Run(next, ctx, nil, messages)
 	consumedCount := 0
 	for range seq {
 		consumedCount++
@@ -262,7 +263,7 @@ func TestLogger_Run_PropagatesContext(t *testing.T) {
 	type contextKey string
 	key := contextKey("test-key")
 	var receivedCtx context.Context
-	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		receivedCtx = ctx
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
@@ -275,7 +276,7 @@ func TestLogger_Run_PropagatesContext(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(ctx, next, messages)
+	seq := mw.Run(next, ctx, nil, messages)
 	for range seq {
 	}
 
@@ -308,7 +309,7 @@ func TestLogger_Run_WorksInMiddlewareChain(t *testing.T) {
 	}
 
 	// Base function
-	baseFn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	baseFn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		order = append(order, "base")
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
@@ -321,7 +322,7 @@ func TestLogger_Run_WorksInMiddlewareChain(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := middleware.RunChain(ctx, baseFn, []middleware.Middleware{loggerMw, testMw}, messages)
+	seq := middleware.RunChain(ctx, baseFn, []middleware.Middleware{loggerMw, testMw}, nil, messages)
 	for range seq {
 	}
 
@@ -357,7 +358,7 @@ func TestLogger_Run_ContextCanceled(t *testing.T) {
 	mw := logger.New(logger.Config{Logger: log})
 
 	// Create a next function that checks for context cancellation
-	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			// Yield first update
 			if !yield(&message.ResponseUpdate{MessageID: "test-1"}, nil) {
@@ -383,7 +384,7 @@ func TestLogger_Run_ContextCanceled(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(ctx, next, messages)
+	seq := mw.Run(next, ctx, nil, messages)
 	var receivedError error
 	updateCount := 0
 	for _, err := range seq {
@@ -418,7 +419,7 @@ type testMiddleware struct {
 	onRun func(string)
 }
 
-func (tm *testMiddleware) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (tm *testMiddleware) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	tm.onRun(tm.name)
-	return next(ctx, messages, options...)
+	return next(ctx, nil, messages, options...)
 }

--- a/agent/middleware/middleware.go
+++ b/agent/middleware/middleware.go
@@ -7,18 +7,25 @@ import (
 	"iter"
 	"slices"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-type RunFunc func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+type RunFunc func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 
 type Middleware interface {
-	Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+	Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+}
+
+type Func func(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+
+func (mf Func) Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	return mf(next, ctx, a, messages, options...)
 }
 
 // RunChain applies the given middlewares around the given RunFunc.
-func RunChain(ctx context.Context, fn RunFunc, middlewares []Middleware, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func RunChain(ctx context.Context, fn RunFunc, middlewares []Middleware, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	// Chain the middlewares together.
 	for _, mw := range slices.Backward(middlewares) {
 		fn = middlewareRunner{
@@ -26,7 +33,7 @@ func RunChain(ctx context.Context, fn RunFunc, middlewares []Middleware, message
 			next:       fn,
 		}.Run
 	}
-	return fn(ctx, messages, options...)
+	return fn(ctx, a, messages, options...)
 }
 
 type middlewareRunner struct {
@@ -34,6 +41,6 @@ type middlewareRunner struct {
 	next RunFunc
 }
 
-func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-	return mr.Middleware.Run(ctx, mr.next, messages, opts...)
+func (mr middlewareRunner) Run(ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	return mr.Middleware.Run(mr.next, ctx, a, messages, opts...)
 }

--- a/agent/middleware/middleware_test.go
+++ b/agent/middleware/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"testing"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
 )
@@ -14,13 +15,13 @@ import (
 func TestChain(t *testing.T) {
 	t.Run("empty middleware chain", func(t *testing.T) {
 		called := false
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			called = true
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{}, []*message.Message{})
+		seq := RunChain(ctx, fn, []Middleware{}, nil, []*message.Message{})
 		for range seq {
 		}
 
@@ -32,7 +33,7 @@ func TestChain(t *testing.T) {
 	t.Run("single middleware", func(t *testing.T) {
 		order := []string{}
 
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			order = append(order, "base")
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -45,7 +46,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw}, []*message.Message{})
+		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{})
 		for range seq {
 		}
 
@@ -63,7 +64,7 @@ func TestChain(t *testing.T) {
 	t.Run("multiple middlewares", func(t *testing.T) {
 		order := []string{}
 
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			order = append(order, "base")
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -88,7 +89,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw1, mw2, mw3}, []*message.Message{})
+		seq := RunChain(ctx, fn, []Middleware{mw1, mw2, mw3}, nil, []*message.Message{})
 		for range seq {
 		}
 
@@ -107,7 +108,7 @@ func TestChain(t *testing.T) {
 	t.Run("middleware can modify options", func(t *testing.T) {
 		receivedOpts := []agentopt.RunOption{}
 
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			receivedOpts = options
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -123,7 +124,7 @@ func TestChain(t *testing.T) {
 
 		initialOpt := &testOption{value: "initial"}
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw}, []*message.Message{}, initialOpt)
+		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{}, initialOpt)
 		for range seq {
 		}
 
@@ -139,7 +140,7 @@ func TestChain(t *testing.T) {
 	})
 
 	t.Run("middleware can intercept and modify sequence", func(t *testing.T) {
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			return func(yield func(*message.ResponseUpdate, error) bool) {
 				if !yield(&message.ResponseUpdate{}, nil) {
 					return
@@ -153,7 +154,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw}, []*message.Message{})
+		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{})
 
 		count := 0
 		for range seq {
@@ -171,7 +172,7 @@ func TestChain(t *testing.T) {
 		key := contextKey("test")
 
 		var capturedCtx context.Context
-		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			capturedCtx = ctx
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -182,7 +183,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.WithValue(context.Background(), key, "value")
-		seq := RunChain(ctx, fn, []Middleware{mw}, []*message.Message{})
+		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{})
 		for range seq {
 		}
 
@@ -202,7 +203,7 @@ type testMiddleware struct {
 	modifyOpts func([]agentopt.RunOption) []agentopt.RunOption
 }
 
-func (tm *testMiddleware) Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (tm *testMiddleware) Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	tm.onRun(tm.name)
 
 	opts := options
@@ -210,7 +211,7 @@ func (tm *testMiddleware) Run(ctx context.Context, next RunFunc, messages []*mes
 		opts = tm.modifyOpts(options)
 	}
 
-	return next(ctx, messages, opts...)
+	return next(ctx, a, messages, opts...)
 }
 
 // interceptMiddleware intercepts and limits the number of updates
@@ -218,10 +219,10 @@ type interceptMiddleware struct {
 	interceptCount int
 }
 
-func (im *interceptMiddleware) Run(ctx context.Context, next RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (im *interceptMiddleware) Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		count := 0
-		for update, err := range next(ctx, messages, options...) {
+		for update, err := range next(ctx, a, messages, options...) {
 			if count >= im.interceptCount {
 				return
 			}

--- a/examples/getting_started/agent/step14_middleware/main.go
+++ b/examples/getting_started/agent/step14_middleware/main.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to create and use an Agent as a function tool.
+
+package main
+
+import (
+	"context"
+	"iter"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/openai"
+)
+
+var logger = demo.NewLogger(
+	"Agent As Function Tool",
+	"Demonstrates how to create and use an Agent as a function tool.",
+	"Model", "gpt-4o-mini",
+)
+
+func main() {
+	a := openai.NewChatAgent(openai.ClientConfig{
+		Model: "gpt-5-nano",
+	}, chatagent.Config{
+		Instructions: "You are an AI assistant that helps people find information.",
+		Middlewares:  []middleware.Middleware{logger, middleware.Func(guardrailsMiddleware)},
+	})
+
+	demo.Response(agent.RunText(context.Background(), a, "Tell me something that contains the word harmful."))
+}
+
+// guardrailsMiddleware enforces guardrails by redacting certain keywords from input and output messages.
+func guardrailsMiddleware(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	redact := func(contents message.Contents) message.Contents {
+		// Simple redaction logic for demonstration purposes.
+		for _, c := range contents {
+			switch content := c.(type) {
+			case *message.TextContent:
+				content.Text = strings.ReplaceAll(content.Text, "harmful", "[REDACTED: Forbidden content]")
+			}
+		}
+		return contents
+	}
+	return func(yield func(*message.ResponseUpdate, error) bool) {
+		// Redact keywords from input messages
+		for _, msg := range messages {
+			msg.Contents = redact(msg.Contents)
+		}
+		// Call the next middleware/agent in the chain.
+		for update, err := range next(ctx, a, messages, opts...) {
+			if err == nil && update != nil {
+				// Redact keywords from output messages
+				update.Contents = redact(update.Contents)
+			}
+			if !yield(update, err) {
+				return
+			}
+		}
+	}
+}

--- a/examples/getting_started/agent/step14_middleware/main.go
+++ b/examples/getting_started/agent/step14_middleware/main.go
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-// This sample shows how to create and use an Agent as a function tool.
-
 package main
 
 import (
@@ -19,8 +17,8 @@ import (
 )
 
 var logger = demo.NewLogger(
-	"Agent As Function Tool",
-	"Demonstrates how to create and use an Agent as a function tool.",
+	"Custom Middleware",
+	"Demonstrates an agent with custom middleware to enforce guardrails.",
 	"Model", "gpt-4o-mini",
 )
 

--- a/examples/internal/demo/demo.go
+++ b/examples/internal/demo/demo.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"strings"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/message"
@@ -43,7 +44,7 @@ func NewLogger(name, description string, metadata ...string) middleware.Middlewa
 	return &logger{}
 }
 
-func (mw *logger) Run(ctx context.Context, next middleware.RunFunc, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (mw *logger) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		mw.n++
 		fmt.Printf("===== Run %d =====\n\n", mw.n)
@@ -53,7 +54,7 @@ func (mw *logger) Run(ctx context.Context, next middleware.RunFunc, messages []*
 			}
 		}
 		first := true
-		for update, err := range next(ctx, messages, opts...) {
+		for update, err := range next(ctx, a, messages, opts...) {
 			if err == nil && update.String() != "" {
 				if first {
 					assistant()


### PR DESCRIPTION
Some middlewares might need the caller agent for logging or executing additional functionality. Pass it as a middleware paramter.

While here, add a a custom middleware example.