### PR TITLE
memory.Thread interface should only require encoding.BinaryMarshaler

### DIFF
--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -1227,6 +1227,6 @@ func (c *customAgentThread) ID() string {
 	return "custom-thread-id"
 }
 
-func (c *customAgentThread) MessagesReceived(ctx context.Context, messages ...*message.Message) error {
-	return nil
+func (c *customAgentThread) MarshalBinary() (data []byte, err error) {
+	return []byte("{}"), nil
 }

--- a/agent/a2aagent/thread.go
+++ b/agent/a2aagent/thread.go
@@ -2,11 +2,7 @@
 
 package a2aagent
 
-import (
-	"context"
-
-	"github.com/microsoft/agent-framework-go/message"
-)
+import "encoding/json"
 
 // Thread represents a thread identified by a service-managed identifier.
 type Thread struct {
@@ -14,8 +10,6 @@ type Thread struct {
 	TaskID    string
 }
 
-func (t *Thread) MessagesReceived(ctx context.Context, messages ...*message.Message) error {
-	// The thread messages are stored in the service there is nothing to do here,
-	// since invoking the service should already update the thread.
-	return nil
+func (t *Thread) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(t)
 }

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -4,6 +4,7 @@ package agenttest
 
 import (
 	"context"
+	"encoding/json"
 	"iter"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -141,9 +142,8 @@ func NewThread() *Thread {
 	return &Thread{}
 }
 
-func (t *Thread) MessagesReceived(ctx context.Context, messages ...*message.Message) error {
-	t.messages = append(t.messages, messages...)
-	return nil
+func (t *Thread) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(t.messages)
 }
 
 // Middleware is a test implementation of the Middleware interface

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -190,7 +190,7 @@ func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Mess
 			thread.MessageStore = a.config.NewMessageStore()
 		}
 		// Only notify the thread of new messages if the response was successful to avoid inconsistent message state in the thread.
-		if err := thread.MessagesReceived(ctx, append(originalMessages, append(ctxMessages, resp.Messages...)...)...); err != nil {
+		if err := thread.messagesReceived(ctx, append(originalMessages, append(ctxMessages, resp.Messages...)...)...); err != nil {
 			yield(nil, err)
 			return
 		}

--- a/agent/chatagent/thread.go
+++ b/agent/chatagent/thread.go
@@ -50,7 +50,11 @@ func newThreadFromJSON(data []byte, newMessageStore func() memory.MessageStore, 
 	return thread, nil
 }
 
-func (t *Thread) MessagesReceived(ctx context.Context, messages ...*message.Message) error {
+func (t *Thread) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(t)
+}
+
+func (t *Thread) messagesReceived(ctx context.Context, messages ...*message.Message) error {
 	if t.ConversationID != "" {
 		// If the thread messages are stored in the service
 		// there is nothing to do here, since invoking the

--- a/agent/memory/thread.go
+++ b/agent/memory/thread.go
@@ -2,11 +2,7 @@
 
 package memory
 
-import (
-	"context"
-
-	"github.com/microsoft/agent-framework-go/message"
-)
+import "encoding"
 
 // Thread contains the state of a specific conversation with an agent which may include:
 //
@@ -29,6 +25,5 @@ import (
 // To support conversations that may need to survive application restarts or separate service requests,
 // a Thread can be serialized and deserialized, so that it can be saved in a persistent store.
 type Thread interface {
-	// MessagesReceived adds messages to the thread.
-	MessagesReceived(ctx context.Context, messages ...*message.Message) error
+	encoding.BinaryMarshaler
 }

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"reflect"
 
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
@@ -34,7 +33,7 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 					if thread == nil {
 						return nil
 					}
-					data, err := json.Marshal(thread)
+					data, err := thread.MarshalBinary()
 					if err != nil {
 						return err
 					}

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 
@@ -44,7 +43,7 @@ func main() {
 	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
 
 	// Serialize the thread state to JSON, so it can be stored for later use.
-	serializedThread, err := json.Marshal(thread)
+	serializedThread, err := thread.MarshalBinary()
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -42,7 +42,7 @@ func main() {
 	// Run the agent with a new thread.
 	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
 
-	// Serialize the thread state to JSON, so it can be stored for later use.
+	// Serialize the thread state so it can be stored for later use.
 	serializedThread, err := thread.MarshalBinary()
 	if err != nil {
 		demo.Panic(err)


### PR DESCRIPTION
.NET's `AgentThread` interface only requires the `Serialize` method. We were only requiring a `MessagesReceived` method.

Our approach doesn't make a lot of sense because some agents might not keep track of the messages. For those threads than do, they can still define their own method for doing so.

The .NET `Serialize` method only supports JSON for now, but their might overload the function signature to support other encodings. The safest approach to port it to Go is to make the `agent.Thread` implement the [encoding.BinaryMarshaler](https://pkg.go.dev/encoding#BinaryMarshaler) interface. This way each implementation can decide how to better encode itself.