### PR TITLE
rename memory.Thread to memory.Session

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -32,10 +32,10 @@ type Options struct {
 
 type contextIDOpt struct{ string }
 
-func (contextIDOpt) NewThreadOption() {}
-func (o contextIDOpt) Value() any     { return o.string }
+func (contextIDOpt) NewSessionOption() {}
+func (o contextIDOpt) Value() any      { return o.string }
 
-func WithContextID(id string) agentopt.NewThreadOption {
+func WithContextID(id string) agentopt.NewSessionOption {
 	return contextIDOpt{id}
 }
 
@@ -63,42 +63,42 @@ func (a *Agent) Identity() agent.Identity {
 	return a.iden
 }
 
-func (a *Agent) NewThread(ctx context.Context, options ...agentopt.NewThreadOption) (memory.Thread, error) {
+func (a *Agent) NewSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
 	contextID, _ := agentopt.Get(options, WithContextID)
-	return &Thread{
+	return &Session{
 		ContextID: contextID,
 	}, nil
 }
 
-func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
-	var thread Thread
-	if err := json.Unmarshal(data, &thread); err != nil {
+func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
 		return nil, err
 	}
-	return &thread, nil
+	return &session, nil
 }
 
 func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
-		var thread *Thread
-		if v, ok := agentopt.Get(options, agentopt.Thread); !ok {
+		var session *Session
+		if v, ok := agentopt.Get(options, agentopt.Session); !ok {
 			// Aligning with other agent implementations that support background responses, where
-			// a thread is required for background responses to prevent inconsistent experience
-			// for callers if they forget to provide the thread for initial or follow-up runs.
+			// a session is required for background responses to prevent inconsistent experience
+			// for callers if they forget to provide the session for initial or follow-up runs.
 			if opts, ok := agentopt.Get(options, agentopt.AllowBackgroundResponses); ok && opts {
-				yield(nil, errors.New("a thread must be provided when AllowBackgroundResponses is enabled"))
+				yield(nil, errors.New("a session must be provided when AllowBackgroundResponses is enabled"))
 				return
 			}
-			t, err := a.NewThread(ctx)
+			s, err := a.NewSession(ctx)
 			if err != nil {
 				yield(nil, err)
 				return
 			}
-			thread = t.(*Thread)
-		} else if t, ok := v.(*Thread); ok {
-			thread = t
+			session = s.(*Session)
+		} else if s, ok := v.(*Session); ok {
+			session = s
 		} else {
-			yield(nil, errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
+			yield(nil, errors.New("the provided session is not compatible with the agent, only sessions created by the agent can be used"))
 			return
 		}
 		stream, _ := agentopt.Get(options, agentopt.Stream)
@@ -117,7 +117,7 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 				yield(nil, err)
 				return
 			}
-			if err := a.updateThreadContextID(thread, task.ContextID, string(task.ID)); err != nil {
+			if err := a.updateSessionContextID(session, task.ContextID, string(task.ID)); err != nil {
 				yield(nil, err)
 				return
 			}
@@ -133,8 +133,8 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 				return
 			}
 			var taskIDs []a2a.TaskID
-			if thread.TaskID != "" {
-				taskIDs = append(taskIDs, a2a.TaskID(thread.TaskID))
+			if session.TaskID != "" {
+				taskIDs = append(taskIDs, a2a.TaskID(session.TaskID))
 			}
 			params := &a2a.MessageSendParams{
 				Message: &a2a.Message{
@@ -142,15 +142,15 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 					Role:           a2a.MessageRoleUser,
 					Parts:          parts,
 					ReferenceTasks: taskIDs,
-					ContextID:      thread.ContextID,
+					ContextID:      session.ContextID,
 				},
 			}
-			a.sendMsg(ctx, thread, stream, params, yield)
+			a.sendMsg(ctx, session, stream, params, yield)
 		}
 	}
 }
 
-func (a *Agent) sendMsg(ctx context.Context, thread *Thread, streaming bool, params *a2a.MessageSendParams, yield func(*message.ResponseUpdate, error) bool) {
+func (a *Agent) sendMsg(ctx context.Context, session *Session, streaming bool, params *a2a.MessageSendParams, yield func(*message.ResponseUpdate, error) bool) {
 	var seq iter.Seq2[a2a.Event, error]
 	if streaming {
 		seq = a.Client.SendStreamingMessage(ctx, params)
@@ -166,7 +166,7 @@ func (a *Agent) sendMsg(ctx context.Context, thread *Thread, streaming bool, par
 			return
 		}
 		taskInfo := e.TaskInfo()
-		if err := a.updateThreadContextID(thread, taskInfo.ContextID, string(taskInfo.TaskID)); err != nil {
+		if err := a.updateSessionContextID(session, taskInfo.ContextID, string(taskInfo.TaskID)); err != nil {
 			yield(nil, err)
 			return
 		}
@@ -275,17 +275,17 @@ func (a *Agent) yieldTask(yield func(*message.ResponseUpdate, error) bool, task 
 	return true
 }
 
-func (a *Agent) updateThreadContextID(thread *Thread, contextID, taskID string) error {
-	if thread == nil {
+func (a *Agent) updateSessionContextID(session *Session, contextID, taskID string) error {
+	if session == nil {
 		return nil
 	}
 	// Surface cases where the A2A agent responds with a response that
-	// has a different context ID than the thread's context ID.
-	if thread.ContextID != "" && thread.ContextID != contextID {
-		return fmt.Errorf("mismatched context ID: thread has %q but A2A response has %q", thread.ContextID, contextID)
+	// has a different context ID than the session's context ID.
+	if session.ContextID != "" && session.ContextID != contextID {
+		return fmt.Errorf("mismatched context ID: session has %q but A2A response has %q", session.ContextID, contextID)
 	}
-	thread.ContextID = contextID
-	thread.TaskID = taskID
+	session.ContextID = contextID
+	session.TaskID = taskID
 	return nil
 }
 

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -284,8 +284,8 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	}
 }
 
-// TestRunWithNewThread tests that new thread updates context ID
-func TestRunWithNewThread(t *testing.T) {
+// TestRunWithNewSession tests that new session updates context ID
+func TestRunWithNewSession(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Message{
 			ID:        "response-123",
@@ -296,35 +296,35 @@ func TestRunWithNewThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
+	_, err = agent.RunText(t.Context(), a, "Test message", agentopt.Session(session))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.ContextID != "new-context-id" {
-		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, "new-context-id")
+	if a2aSession.ContextID != "new-context-id" {
+		t.Errorf("session.ContextID = %q, want %q", a2aSession.ContextID, "new-context-id")
 	}
 }
 
-// TestRunWithExistingThread tests that existing thread context ID is used
-func TestRunWithExistingThread(t *testing.T) {
+// TestRunWithExistingSession tests that existing session context ID is used
+func TestRunWithExistingSession(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
+	_, err = agent.RunText(t.Context(), a, "Test message", agentopt.Session(session))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -338,8 +338,8 @@ func TestRunWithExistingThread(t *testing.T) {
 	}
 }
 
-// TestRunWithThreadHavingDifferentContextID tests error when context ID mismatch
-func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
+// TestRunWithSessionHavingDifferentContextID tests error when context ID mismatch
+func TestRunWithSessionHavingDifferentContextID(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Message{
 			ID:        "response-123",
@@ -350,12 +350,12 @@ func TestRunWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = agent.RunText(t.Context(), a, "Test message", agentopt.Thread(thread))
+	_, err = agent.RunText(t.Context(), a, "Test message", agentopt.Session(session))
 	if err == nil {
 		t.Error("Run() error = nil, want error")
 	}
@@ -441,8 +441,8 @@ func TestRunStreamingWithValidUserMessage(t *testing.T) {
 	}
 }
 
-// TestRunStreamingWithThread tests streaming with thread context ID update
-func TestRunStreamingWithThread(t *testing.T) {
+// TestRunStreamingWithSession tests streaming with session context ID update
+func TestRunStreamingWithSession(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
@@ -453,38 +453,38 @@ func TestRunStreamingWithThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Session(session)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.ContextID != "new-stream-context" {
-		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, "new-stream-context")
+	if a2aSession.ContextID != "new-stream-context" {
+		t.Errorf("session.ContextID = %q, want %q", a2aSession.ContextID, "new-stream-context")
 	}
 }
 
-// TestRunStreamingWithExistingThread tests streaming with existing thread
-func TestRunStreamingWithExistingThread(t *testing.T) {
+// TestRunStreamingWithExistingSession tests streaming with existing session
+func TestRunStreamingWithExistingSession(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{},
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Session(session)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -499,8 +499,8 @@ func TestRunStreamingWithExistingThread(t *testing.T) {
 	}
 }
 
-// TestRunStreamingWithThreadHavingDifferentContextID tests error on context ID mismatch in streaming
-func TestRunStreamingWithThreadHavingDifferentContextID(t *testing.T) {
+// TestRunStreamingWithSessionHavingDifferentContextID tests error on context ID mismatch in streaming
+func TestRunStreamingWithSessionHavingDifferentContextID(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
@@ -511,13 +511,13 @@ func TestRunStreamingWithThreadHavingDifferentContextID(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	gotError := false
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Thread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test streaming", agentopt.Session(session)) {
 		if err != nil {
 			gotError = true
 			break
@@ -605,22 +605,22 @@ func TestRunWithHostedFileContent(t *testing.T) {
 	}
 }
 
-// TestRunWithInvalidThreadType tests error when using invalid thread type
-func TestRunWithInvalidThreadType(t *testing.T) {
+// TestRunWithInvalidSessionType tests error when using invalid session type
+func TestRunWithInvalidSessionType(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	// Create a custom thread type that is not an a2aagent.Thread
-	invalidThread := &customAgentThread{}
+	// Create a custom session type that is not an a2aagent.Session
+	invalidSession := &customAgentSession{}
 
-	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Thread(invalidThread))
+	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Session(invalidSession))
 	if err == nil {
-		t.Error("Run() error = nil, want error for invalid thread type")
+		t.Error("Run() error = nil, want error for invalid session type")
 	}
 }
 
-// TestRunStreamingWithInvalidThreadType tests error when using invalid thread type in streaming
-func TestRunStreamingWithInvalidThreadType(t *testing.T) {
+// TestRunStreamingWithInvalidSessionType tests error when using invalid session type in streaming
+func TestRunStreamingWithInvalidSessionType(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:   "stream-1",
@@ -632,11 +632,11 @@ func TestRunStreamingWithInvalidThreadType(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	// Create a custom thread type that is not an a2aagent.Thread
-	invalidThread := &customAgentThread{}
+	// Create a custom session type that is not an a2aagent.Session
+	invalidSession := &customAgentSession{}
 
 	gotError := false
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agentopt.Thread(invalidThread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agentopt.Session(invalidSession)) {
 		if err != nil {
 			gotError = true
 			break
@@ -644,7 +644,7 @@ func TestRunStreamingWithInvalidThreadType(t *testing.T) {
 	}
 
 	if !gotError {
-		t.Error("RunStream() expected error for invalid thread type, got nil")
+		t.Error("RunStream() expected error for invalid session type, got nil")
 	}
 }
 
@@ -675,8 +675,8 @@ func TestRunWithContinuationToken(t *testing.T) {
 	}
 }
 
-// TestRunWithTaskInThreadAndMessage tests that task ID is added as reference
-func TestRunWithTaskInThreadAndMessage(t *testing.T) {
+// TestRunWithTaskInSessionAndMessage tests that task ID is added as reference
+func TestRunWithTaskInSessionAndMessage(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Message{
 			ID:   "response-123",
@@ -688,13 +688,13 @@ func TestRunWithTaskInThreadAndMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	thread.(*a2aagent.Thread).TaskID = "task-123"
+	session.(*a2aagent.Session).TaskID = "task-123"
 
-	_, err = agent.RunText(t.Context(), a, "Please make the background transparent", agentopt.Thread(thread))
+	_, err = agent.RunText(t.Context(), a, "Please make the background transparent", agentopt.Session(session))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -710,7 +710,7 @@ func TestRunWithTaskInThreadAndMessage(t *testing.T) {
 	}
 }
 
-// TestRunWithAgentTask tests that thread task ID is updated
+// TestRunWithAgentTask tests that session task ID is updated
 func TestRunWithAgentTask(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Task{
@@ -723,22 +723,22 @@ func TestRunWithAgentTask(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = agent.RunText(t.Context(), a, "Start a task", agentopt.Thread(thread))
+	_, err = agent.RunText(t.Context(), a, "Start a task", agentopt.Session(session))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.TaskID != "task-456" {
-		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, "task-456")
+	if a2aSession.TaskID != "task-456" {
+		t.Errorf("session.TaskID = %q, want %q", a2aSession.TaskID, "task-456")
 	}
 }
 
@@ -763,12 +763,12 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := agent.RunText(t.Context(), a, "Start a long-running task", agentopt.Thread(thread))
+	result, err := agent.RunText(t.Context(), a, "Start a long-running task", agentopt.Session(session))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -791,15 +791,15 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 		t.Errorf("continuation token = %q, want %q", result.ContinuationToken, "task-789")
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.ContextID != "context-456" {
-		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, "context-456")
+	if a2aSession.ContextID != "context-456" {
+		t.Errorf("session.ContextID = %q, want %q", a2aSession.ContextID, "context-456")
 	}
-	if a2aThread.TaskID != "task-789" {
-		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, "task-789")
+	if a2aSession.TaskID != "task-789" {
+		t.Errorf("session.TaskID = %q, want %q", a2aSession.TaskID, "task-789")
 	}
 }
 
@@ -868,8 +868,8 @@ func TestRunStreamingWithContinuationTokenAndMessages(t *testing.T) {
 	}
 }
 
-// TestRunStreamingWithTaskInThreadAndMessage tests task reference in streaming
-func TestRunStreamingWithTaskInThreadAndMessage(t *testing.T) {
+// TestRunStreamingWithTaskInSessionAndMessage tests task reference in streaming
+func TestRunStreamingWithTaskInSessionAndMessage(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
 			ID:   "response-123",
@@ -881,13 +881,13 @@ func TestRunStreamingWithTaskInThreadAndMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	thread.(*a2aagent.Thread).TaskID = "task-123"
+	session.(*a2aagent.Session).TaskID = "task-123"
 
-	for _, err := range agent.RunTextStream(t.Context(), a, "Please make the background transparent", agentopt.Thread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Please make the background transparent", agentopt.Session(session)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -904,8 +904,8 @@ func TestRunStreamingWithTaskInThreadAndMessage(t *testing.T) {
 	}
 }
 
-// TestRunStreamingWithAgentTaskUpdatesThread tests thread task ID update in streaming
-func TestRunStreamingWithAgentTaskUpdatesThread(t *testing.T) {
+// TestRunStreamingWithAgentTaskUpdatesSession tests session task ID update in streaming
+func TestRunStreamingWithAgentTaskUpdatesSession(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Task{
 			ID:        a2a.TaskID("task-456"),
@@ -923,23 +923,23 @@ func TestRunStreamingWithAgentTaskUpdatesThread(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, err := range agent.RunTextStream(t.Context(), a, "Start a task", agentopt.Thread(thread)) {
+	for _, err := range agent.RunTextStream(t.Context(), a, "Start a task", agentopt.Session(session)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.TaskID != "task-456" {
-		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, "task-456")
+	if a2aSession.TaskID != "task-456" {
+		t.Errorf("session.TaskID = %q, want %q", a2aSession.TaskID, "task-456")
 	}
 }
 
@@ -1018,13 +1018,13 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var updates []*message.ResponseUpdate
-	for update, err := range agent.RunTextStream(t.Context(), a, "Start long-running task", agentopt.Thread(thread)) {
+	for update, err := range agent.RunTextStream(t.Context(), a, "Start long-running task", agentopt.Session(session)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -1049,15 +1049,15 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.Task", update.RawRepresentation)
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.ContextID != contextID {
-		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, contextID)
+	if a2aSession.ContextID != contextID {
+		t.Errorf("session.ContextID = %q, want %q", a2aSession.ContextID, contextID)
 	}
-	if a2aThread.TaskID != taskID {
-		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, taskID)
+	if a2aSession.TaskID != taskID {
+		t.Errorf("session.TaskID = %q, want %q", a2aSession.TaskID, taskID)
 	}
 }
 
@@ -1077,13 +1077,13 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var updates []*message.ResponseUpdate
-	for update, err := range agent.RunTextStream(t.Context(), a, "Check task status", agentopt.Thread(thread)) {
+	for update, err := range agent.RunTextStream(t.Context(), a, "Check task status", agentopt.Session(session)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -1108,15 +1108,15 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.ContextID != contextID {
-		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, contextID)
+	if a2aSession.ContextID != contextID {
+		t.Errorf("session.ContextID = %q, want %q", a2aSession.ContextID, contextID)
 	}
-	if a2aThread.TaskID != taskID {
-		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, taskID)
+	if a2aSession.TaskID != taskID {
+		t.Errorf("session.TaskID = %q, want %q", a2aSession.TaskID, taskID)
 	}
 }
 
@@ -1140,13 +1140,13 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	thread, err := a.NewThread(t.Context())
+	session, err := a.NewSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var updates []*message.ResponseUpdate
-	for update, err := range agent.RunTextStream(t.Context(), a, "Process artifact", agentopt.Thread(thread)) {
+	for update, err := range agent.RunTextStream(t.Context(), a, "Process artifact", agentopt.Session(session)) {
 		if err != nil {
 			t.Fatalf("RunStream() error = %v, want nil", err)
 		}
@@ -1178,31 +1178,31 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 		t.Errorf("update.String() = %q, want %q", update.String(), artifactContent)
 	}
 
-	a2aThread, ok := thread.(*a2aagent.Thread)
+	a2aSession, ok := session.(*a2aagent.Session)
 	if !ok {
-		t.Fatalf("thread type = %T, want *a2aagent.Thread", thread)
+		t.Fatalf("session type = %T, want *a2aagent.Session", session)
 	}
-	if a2aThread.ContextID != contextID {
-		t.Errorf("thread.ContextID = %q, want %q", a2aThread.ContextID, contextID)
+	if a2aSession.ContextID != contextID {
+		t.Errorf("session.ContextID = %q, want %q", a2aSession.ContextID, contextID)
 	}
-	if a2aThread.TaskID != taskID {
-		t.Errorf("thread.TaskID = %q, want %q", a2aThread.TaskID, taskID)
+	if a2aSession.TaskID != taskID {
+		t.Errorf("session.TaskID = %q, want %q", a2aSession.TaskID, taskID)
 	}
 }
 
-// TestRunWithAllowBackgroundResponsesAndNoThread tests error when no thread provided
-func TestRunWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
+// TestRunWithAllowBackgroundResponsesAndNoSession tests error when no session provided
+func TestRunWithAllowBackgroundResponsesAndNoSession(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
 	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.AllowBackgroundResponses(true))
 	if err == nil {
-		t.Error("Run() error = nil, want error when AllowBackgroundResponses is true without thread")
+		t.Error("Run() error = nil, want error when AllowBackgroundResponses is true without session")
 	}
 }
 
-// TestRunStreamingWithAllowBackgroundResponsesAndNoThread tests error in streaming mode
-func TestRunStreamingWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
+// TestRunStreamingWithAllowBackgroundResponsesAndNoSession tests error in streaming mode
+func TestRunStreamingWithAllowBackgroundResponsesAndNoSession(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
@@ -1216,17 +1216,17 @@ func TestRunStreamingWithAllowBackgroundResponsesAndNoThread(t *testing.T) {
 	}
 
 	if !gotError {
-		t.Error("RunStream() expected error when AllowBackgroundResponses is true without thread, got nil")
+		t.Error("RunStream() expected error when AllowBackgroundResponses is true without session, got nil")
 	}
 }
 
-// customAgentThread is a custom agent thread for testing invalid thread type scenario
-type customAgentThread struct{}
+// customAgentSession is a custom agent session for testing invalid session type scenario
+type customAgentSession struct{}
 
-func (c *customAgentThread) ID() string {
-	return "custom-thread-id"
+func (c *customAgentSession) ID() string {
+	return "custom-session-id"
 }
 
-func (c *customAgentThread) MarshalBinary() (data []byte, err error) {
+func (c *customAgentSession) MarshalBinary() (data []byte, err error) {
 	return []byte("{}"), nil
 }

--- a/agent/a2aagent/thread.go
+++ b/agent/a2aagent/thread.go
@@ -4,12 +4,12 @@ package a2aagent
 
 import "encoding/json"
 
-// Thread represents a thread identified by a service-managed identifier.
-type Thread struct {
+// Session represents a session identified by a service-managed identifier.
+type Session struct {
 	ContextID string
 	TaskID    string
 }
 
-func (t *Thread) MarshalBinary() (data []byte, err error) {
+func (t *Session) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(t)
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -46,8 +46,8 @@ type Agent interface {
 
 	Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 
-	NewThread(ctx context.Context, options ...agentopt.NewThreadOption) (memory.Thread, error)
-	UnmarshalThread(data []byte) (memory.Thread, error)
+	NewSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error)
+	UnmarshalSession(data []byte) (memory.Session, error)
 }
 
 type StructuredOutputAgent interface {

--- a/agent/agentopt/agentopt.go
+++ b/agent/agentopt/agentopt.go
@@ -28,16 +28,16 @@ type RunOption interface {
 	RunOption()
 }
 
-// A NewThreadOption configures the behavior of a new Thread created by an Agent.
-type NewThreadOption interface {
+// A NewSessionOption configures the behavior of a new Session created by an Agent.
+type NewSessionOption interface {
 	Option
 
-	NewThreadOption()
+	NewSessionOption()
 }
 
 type (
 	responseFormatOpt    struct{ format.Format }
-	threadOpt            struct{ memory.Thread }
+	sessionOpt           struct{ memory.Session }
 	continuationTokenOpt string
 
 	toolOpt struct{ tool.Tool }
@@ -48,7 +48,7 @@ type (
 )
 
 func (responseFormatOpt) RunOption()           {}
-func (threadOpt) RunOption()                   {}
+func (sessionOpt) RunOption()                  {}
 func (streamOpt) RunOption()                   {}
 func (continuationTokenOpt) RunOption()        {}
 func (allowBackgroundResponsesOpt) RunOption() {}
@@ -56,7 +56,7 @@ func (toolOpt) RunOption()                     {}
 func (toolModeOpt) RunOption()                 {}
 
 func (o responseFormatOpt) Value() any           { return o.Format }
-func (o threadOpt) Value() any                   { return o.Thread }
+func (o sessionOpt) Value() any                  { return o.Session }
 func (o streamOpt) Value() any                   { return bool(o) }
 func (o continuationTokenOpt) Value() any        { return string(o) }
 func (o allowBackgroundResponsesOpt) Value() any { return bool(o) }
@@ -83,9 +83,9 @@ func ResponseFormat(format format.Format) RunOption {
 	return responseFormatOpt{format}
 }
 
-// Thread sets the thread to use during the agent run.
-func Thread(thread memory.Thread) RunOption {
-	return threadOpt{thread}
+// Session sets the session to use during the agent run.
+func Session(session memory.Session) RunOption {
+	return sessionOpt{session}
 }
 
 // ContinuationToken sets the continuation token for resuming and getting the result

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -90,9 +90,9 @@ type Response struct {
 var _ agent.Agent = (*Agent)(nil)
 
 type Agent struct {
-	Iden          agent.Identity
-	NewThreadFunc func(context.Context, ...agentopt.NewThreadOption) (memory.Thread, error)
-	Responses     []Turn
+	Iden           agent.Identity
+	NewSessionFunc func(context.Context, ...agentopt.NewSessionOption) (memory.Session, error)
+	Responses      []Turn
 
 	currentTurn int
 }
@@ -122,27 +122,27 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, opts ...ag
 	}
 }
 
-func (a *Agent) NewThread(ctx context.Context, opts ...agentopt.NewThreadOption) (memory.Thread, error) {
-	if a.NewThreadFunc != nil {
-		return a.NewThreadFunc(ctx, opts...)
+func (a *Agent) NewSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
+	if a.NewSessionFunc != nil {
+		return a.NewSessionFunc(ctx, opts...)
 	}
-	return &Thread{}, nil
+	return &Session{}, nil
 }
 
-func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
-	return &Thread{}, nil
+func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
+	return &Session{}, nil
 }
 
-// Thread is a test implementation of the Thread interface
-type Thread struct {
+// Session is a test implementation of the Session interface
+type Session struct {
 	messages []*message.Message
 }
 
-func NewThread() *Thread {
-	return &Thread{}
+func NewSession() *Session {
+	return &Session{}
 }
 
-func (t *Thread) MarshalBinary() (data []byte, err error) {
+func (t *Session) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(t.messages)
 }
 

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -87,32 +87,32 @@ func (a *Agent) Instructions() string {
 	return a.config.Instructions
 }
 
-func (a *Agent) NewThread(ctx context.Context, opts ...agentopt.NewThreadOption) (memory.Thread, error) {
+func (a *Agent) NewSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
 	convID, _ := agentopt.Get(opts, ConversationID)
-	thread := &Thread{
+	session := &Session{
 		ConversationID: convID,
 	}
 	if a.config.NewContextProvider != nil {
-		thread.ContextProvider = a.config.NewContextProvider()
+		session.ContextProvider = a.config.NewContextProvider()
 	}
-	return thread, nil
+	return session, nil
 }
 
-func (a *Agent) UnmarshalThread(data []byte) (memory.Thread, error) {
-	return newThreadFromJSON(data, a.config.NewMessageStore, a.config.NewContextProvider)
+func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
+	return newSessionFromJSON(data, a.config.NewMessageStore, a.config.NewContextProvider)
 }
 
 func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	// Prepend options from agent configuration.
 	options = append(a.config.RunOptions, options...)
-	if _, ok := agentopt.Get(options, agentopt.Thread); !ok {
-		thread, err := a.NewThread(ctx)
+	if _, ok := agentopt.Get(options, agentopt.Session); !ok {
+		session, err := a.NewSession(ctx)
 		if err != nil {
 			return func(yield func(*message.ResponseUpdate, error) bool) {
 				yield(nil, err)
 			}
 		}
-		options = append(options, agentopt.Thread(thread))
+		options = append(options, agentopt.Session(session))
 	}
 	return middleware.RunChain(ctx, a.run, a.config.Middlewares, a, messages, options...)
 }
@@ -147,20 +147,20 @@ func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, o
 func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		originalMessages := messages
-		thread, options, messages, ctxMessages, err := a.prepareThreadAndMessages(ctx, originalMessages, options)
+		session, options, messages, ctxMessages, err := a.prepareSessionAndMessages(ctx, originalMessages, options)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 		contToken, _ := agentopt.Get(options, agentopt.ContinuationToken)
-		if err := validateStreamResumptionAllowed(contToken, thread); err != nil {
+		if err := validateStreamResumptionAllowed(contToken, session); err != nil {
 			yield(nil, err)
 			return
 		}
 		var resp message.Response
 		for update, err := range a.runFn(ctx, messages, options...) {
 			if err != nil {
-				a.notifyContextProviderOfFailure(ctx, thread, err, messages, ctxMessages)
+				a.notifyContextProviderOfFailure(ctx, session, err, messages, ctxMessages)
 				yield(nil, err)
 				return
 			}
@@ -184,29 +184,29 @@ func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Mess
 			}
 		}
 		resp.Coalesce()
-		if thread.ConversationID == "" && thread.MessageStore == nil && a.config.NewMessageStore != nil {
+		if session.ConversationID == "" && session.MessageStore == nil && a.config.NewMessageStore != nil {
 			// If we don't have a conversation ID then we must be managing the message store ourselves.
 			// If we don't have a message store yet and we have a factory, use it to create a new one.
-			thread.MessageStore = a.config.NewMessageStore()
+			session.MessageStore = a.config.NewMessageStore()
 		}
-		// Only notify the thread of new messages if the response was successful to avoid inconsistent message state in the thread.
-		if err := thread.messagesReceived(ctx, append(originalMessages, append(ctxMessages, resp.Messages...)...)...); err != nil {
+		// Only notify the session of new messages if the response was successful to avoid inconsistent message state in the session.
+		if err := session.messagesReceived(ctx, append(originalMessages, append(ctxMessages, resp.Messages...)...)...); err != nil {
 			yield(nil, err)
 			return
 		}
 		// Notify the ContextProvider of all new messages.
-		if err := a.notifyContextProviderOfSuccess(ctx, thread, messages, ctxMessages, resp.Messages); err != nil {
+		if err := a.notifyContextProviderOfSuccess(ctx, session, messages, ctxMessages, resp.Messages); err != nil {
 			yield(nil, err)
 			return
 		}
 	}
 }
 
-func (a *Agent) notifyContextProviderOfSuccess(ctx context.Context, thread *Thread, messages, contextProviderMessages, respMessages []*message.Message) error {
-	if thread.ContextProvider == nil {
+func (a *Agent) notifyContextProviderOfSuccess(ctx context.Context, session *Session, messages, contextProviderMessages, respMessages []*message.Message) error {
+	if session.ContextProvider == nil {
 		return nil
 	}
-	return thread.ContextProvider.Invoked(&memory.InvokedContext{
+	return session.ContextProvider.Invoked(&memory.InvokedContext{
 		Context:                 ctx,
 		RequestMessages:         messages,
 		ContextProviderMessages: contextProviderMessages,
@@ -214,11 +214,11 @@ func (a *Agent) notifyContextProviderOfSuccess(ctx context.Context, thread *Thre
 	})
 }
 
-func (a *Agent) notifyContextProviderOfFailure(ctx context.Context, thread *Thread, err error, messages, contextProviderMessages []*message.Message) error {
-	if thread.ContextProvider == nil {
+func (a *Agent) notifyContextProviderOfFailure(ctx context.Context, session *Session, err error, messages, contextProviderMessages []*message.Message) error {
+	if session.ContextProvider == nil {
 		return nil
 	}
-	return thread.ContextProvider.Invoked(&memory.InvokedContext{
+	return session.ContextProvider.Invoked(&memory.InvokedContext{
 		Context:                 ctx,
 		Error:                   err,
 		RequestMessages:         messages,
@@ -226,29 +226,29 @@ func (a *Agent) notifyContextProviderOfFailure(ctx context.Context, thread *Thre
 	})
 }
 
-func (a *Agent) prepareThreadAndMessages(ctx context.Context, messages []*message.Message, options []agentopt.RunOption) (thread *Thread, opts []agentopt.RunOption, msgsForClient, ctxMessages []*message.Message, err error) {
-	retError := func(e error) (*Thread, []agentopt.RunOption, []*message.Message, []*message.Message, error) {
+func (a *Agent) prepareSessionAndMessages(ctx context.Context, messages []*message.Message, options []agentopt.RunOption) (session *Session, opts []agentopt.RunOption, msgsForClient, ctxMessages []*message.Message, err error) {
+	retError := func(e error) (*Session, []agentopt.RunOption, []*message.Message, []*message.Message, error) {
 		return nil, nil, nil, nil, e
 	}
-	if v, ok := agentopt.Get(options, agentopt.Thread); ok {
+	if v, ok := agentopt.Get(options, agentopt.Session); ok {
 		var ok bool
-		thread, ok = v.(*Thread)
+		session, ok = v.(*Session)
 		if !ok {
-			return retError(errors.New("the provided thread is not compatible with the agent, only threads created by the agent can be used"))
+			return retError(errors.New("the provided session is not compatible with the agent, only sessions created by the agent can be used"))
 		}
 	} else {
-		// This should never happen because we ensure a thread is always provided in Run.
-		panic("nil thread")
+		// This should never happen because we ensure a session is always provided in Run.
+		panic("nil session")
 	}
-	// Now check if AllowBackgroundResponses requires a thread
-	if v, ok := agentopt.Get(options, agentopt.AllowBackgroundResponses); ok && v && thread == nil {
-		return retError(errors.New("a thread must be provided when continuing a background response with a continuation token"))
+	// Now check if AllowBackgroundResponses requires a session
+	if v, ok := agentopt.Get(options, agentopt.AllowBackgroundResponses); ok && v && session == nil {
+		return retError(errors.New("a session must be provided when continuing a background response with a continuation token"))
 	}
 	if v, ok := agentopt.Get(options, agentopt.ContinuationToken); ok && v != "" {
 		if len(messages) > 0 {
 			return retError(errors.New("messages are not allowed when continuing a background response using a continuation token"))
 		}
-		if thread.ConversationID == "" && thread.MessageStore == nil {
+		if session.ConversationID == "" && session.MessageStore == nil {
 			return retError(errors.New("continuation tokens are not allowed to be used for initial runs"))
 		}
 	}
@@ -264,19 +264,19 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, messages []*messag
 		})
 	}
 	if v, ok := agentopt.Get(options, agentopt.ContinuationToken); !ok || v == "" {
-		if thread.MessageStore != nil {
-			//  Add any existing messages from the thread to the messages to be sent to the chat client.
-			for msg, err := range thread.MessageStore.All(ctx) {
+		if session.MessageStore != nil {
+			//  Add any existing messages from the session to the messages to be sent to the chat client.
+			for msg, err := range session.MessageStore.All(ctx) {
 				if err != nil {
 					return retError(err)
 				}
 				msgsForClient = append(msgsForClient, msg)
 			}
 		}
-		if thread.ContextProvider != nil {
+		if session.ContextProvider != nil {
 			// If we have a ContextProvider, we should get context from it, and update our
 			// messages and options with the additional context.
-			ctxData, err := thread.ContextProvider.Invoking(&memory.InvokingContext{
+			ctxData, err := session.ContextProvider.Invoking(&memory.InvokingContext{
 				Context:  ctx,
 				Messages: messages,
 			})
@@ -301,24 +301,24 @@ func (a *Agent) prepareThreadAndMessages(ctx context.Context, messages []*messag
 				}
 			}
 		}
-		// Add the input messages to the end of thread messages.
+		// Add the input messages to the end of session messages.
 		msgsForClient = append(msgsForClient, messages...)
 	}
-	return thread, options, msgsForClient, ctxMessages, nil
+	return session, options, msgsForClient, ctxMessages, nil
 }
 
-func validateStreamResumptionAllowed(continuationToken string, thread *Thread) error {
+func validateStreamResumptionAllowed(continuationToken string, session *Session) error {
 	if continuationToken == "" {
 		return nil
 	}
 	// Streaming resumption is only supported with chat history managed by the agent service because, currently, there's no good solution
 	// to collect updates received in failed runs and pass them to the last successful run so it can store them to the message store.
-	if thread.ConversationID == "" {
+	if session.ConversationID == "" {
 		return errors.New("streaming resumption is only supported when chat history is stored and managed by the underlying service")
 	}
 	// Similarly, streaming resumption is not supported when a context provider is used because, currently, there's no good solution
 	// to collect updates received in failed runs and pass them to the last successful run so it can notify the context provider of the updates.
-	if thread.ContextProvider != nil {
+	if session.ContextProvider != nil {
 		return errors.New("using context provider with streaming resumption is not supported")
 	}
 	return nil

--- a/agent/chatagent/config.go
+++ b/agent/chatagent/config.go
@@ -19,7 +19,7 @@ type (
 	modelOpt                  string
 )
 
-func (conversationIDOpt) NewThreadOption() {}
+func (conversationIDOpt) NewSessionOption() {}
 
 func (temperatureOpt) RunOption()            {}
 func (topPOpt) RunOption()                   {}
@@ -42,7 +42,7 @@ func (o allowMultipleToolCallsOpt) Value() any { return bool(o) }
 func (o stopSequenceOpt) Value() any           { return []string(o) }
 func (o modelOpt) Value() any                  { return string(o) }
 
-func ConversationID(conversationID string) agentopt.NewThreadOption {
+func ConversationID(conversationID string) agentopt.NewSessionOption {
 	return conversationIDOpt(conversationID)
 }
 

--- a/agent/chatagent/thread.go
+++ b/agent/chatagent/thread.go
@@ -10,15 +10,15 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-var _ memory.Thread = (*Thread)(nil)
+var _ memory.Session = (*Session)(nil)
 
-type Thread struct {
+type Session struct {
 	ConversationID  string
 	MessageStore    memory.MessageStore
 	ContextProvider memory.ContextProvider
 }
 
-func newThreadFromJSON(data []byte, newMessageStore func() memory.MessageStore, newContextProvider func() memory.ContextProvider) (*Thread, error) {
+func newSessionFromJSON(data []byte, newMessageStore func() memory.MessageStore, newContextProvider func() memory.ContextProvider) (*Session, error) {
 	var tmp struct {
 		ConversationID  string
 		MessageStore    json.RawMessage // delay unmarshaling until we know the ConversationID is empty
@@ -30,35 +30,35 @@ func newThreadFromJSON(data []byte, newMessageStore func() memory.MessageStore, 
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return nil, err
 	}
-	thread := &Thread{
+	session := &Session{
 		ConversationID:  tmp.ConversationID,
 		ContextProvider: tmp.ContextProvider,
 	}
 	if tmp.ConversationID != "" {
 		// Since we have an ID, we should not have a chat message store and we can return here.
-		return thread, nil
+		return session, nil
 	}
 
 	if newMessageStore != nil {
-		thread.MessageStore = newMessageStore()
+		session.MessageStore = newMessageStore()
 	} else {
-		thread.MessageStore = &memory.InMemoryMessageStore{}
+		session.MessageStore = &memory.InMemoryMessageStore{}
 	}
-	if err := json.Unmarshal(tmp.MessageStore, thread.MessageStore); err != nil {
+	if err := json.Unmarshal(tmp.MessageStore, session.MessageStore); err != nil {
 		return nil, err
 	}
-	return thread, nil
+	return session, nil
 }
 
-func (t *Thread) MarshalBinary() (data []byte, err error) {
+func (t *Session) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(t)
 }
 
-func (t *Thread) messagesReceived(ctx context.Context, messages ...*message.Message) error {
+func (t *Session) messagesReceived(ctx context.Context, messages ...*message.Message) error {
 	if t.ConversationID != "" {
-		// If the thread messages are stored in the service
+		// If the session messages are stored in the service
 		// there is nothing to do here, since invoking the
-		// service should already update the thread.
+		// service should already update the session.
 		return nil
 	}
 	if t.MessageStore == nil {

--- a/agent/memory/session.go
+++ b/agent/memory/session.go
@@ -4,26 +4,26 @@ package memory
 
 import "encoding"
 
-// Thread contains the state of a specific conversation with an agent which may include:
+// Session contains the state of a specific conversation with an agent which may include:
 //
 //   - Conversation history or a reference to externally stored conversation history.
 //   - Memories or a reference to externally stored memories.
 //   - Any other state that the agent needs to persist across runs for a conversation.
 //
-// A Thread may also have behaviors attached to it that may include:
+// A Session may also have behaviors attached to it that may include:
 //
 //   - Customized storage of state.
 //   - Data extraction from and injection into a conversation.
 //   - Chat history reduction, e.g. where messages needs to be summarized or truncated to reduce the size.
 //
-// A Thread is always constructed by an [agent.Agent] so that the [agent.Agent] can attach any necessary behaviors to the Thread.
-// See the [agent.Agent.NewThread] and [agent.Agent.UnmarshalThread] methods for more information.
+// A Session is always constructed by an [agent.Agent] so that the [agent.Agent] can attach any necessary behaviors to the Session.
+// See the [agent.Agent.NewSession] and [agent.Agent.UnmarshalSession] methods for more information.
 //
-// Because of these behaviors, a Thread may not be reusable across different agents, since each agent may add different
-// behaviors to the Thread it creates.
+// Because of these behaviors, a Session may not be reusable across different agents, since each agent may add different
+// behaviors to the Session it creates.
 //
 // To support conversations that may need to survive application restarts or separate service requests,
-// a Thread can be serialized and deserialized, so that it can be saved in a persistent store.
-type Thread interface {
+// a Session can be serialized and deserialized, so that it can be saved in a persistent store.
+type Session interface {
 	encoding.BinaryMarshaler
 }

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -12,14 +12,14 @@ import (
 )
 
 // FuncTool creates a function tool that invokes the given agent.
-// The provided thread is used for the agent's context during invocations,
-// or nil to create a new thread for each invocation.
-func FuncTool(agent Agent, thread memory.Thread) tool.FuncTool {
+// The provided session is used for the agent's context during invocations,
+// or nil to create a new session for each invocation.
+func FuncTool(agent Agent, session memory.Session) tool.FuncTool {
 	iden := agent.Identity()
 	return functool{
 		name:        iden.Name(),
 		description: iden.Description(),
-		thread:      thread,
+		session:     session,
 		agent:       agent,
 	}
 }
@@ -27,7 +27,7 @@ func FuncTool(agent Agent, thread memory.Thread) tool.FuncTool {
 type functool struct {
 	name        string
 	description string
-	thread      memory.Thread
+	session     memory.Session
 	agent       Agent
 }
 
@@ -68,7 +68,7 @@ func (t functool) Call(ctx context.Context, args string) (any, error) {
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return nil, err
 	}
-	resp, err := RunText(ctx, t.agent, in.Query, agentopt.Thread(t.thread))
+	resp, err := RunText(ctx, t.agent, in.Query, agentopt.Session(t.session))
 	if err != nil {
 		return "", err
 	}

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -14,15 +14,15 @@ import (
 )
 
 func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
-	var thread memory.Thread
-	var threadStateKey string
-	ensureThread := func(ctx context.Context) (memory.Thread, error) {
+	var session memory.Session
+	var sessionStateKey string
+	ensureSession := func(ctx context.Context) (memory.Session, error) {
 		var err error
-		if thread == nil {
-			thread, err = a.NewThread(ctx)
+		if session == nil {
+			session, err = a.NewSession(ctx)
 		}
-		threadStateKey = reflect.ValueOf(thread).String()
-		return thread, err
+		sessionStateKey = reflect.ValueOf(session).String()
+		return session, err
 	}
 	id := agentDescriptiveID(a)
 	ex := &workflow.Executor{
@@ -30,24 +30,24 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 		Config: []*workflow.ExecutorConfig{
 			{
 				OnCheckpoint: func(wctx *workflow.Context) error {
-					if thread == nil {
+					if session == nil {
 						return nil
 					}
-					data, err := thread.MarshalBinary()
+					data, err := session.MarshalBinary()
 					if err != nil {
 						return err
 					}
-					return wctx.QueueStateUpdate(threadStateKey, "", data)
+					return wctx.QueueStateUpdate(sessionStateKey, "", data)
 				},
 				OnCheckpointRestored: func(wctx *workflow.Context) error {
-					data, err := wctx.ReadState(threadStateKey, "")
+					data, err := wctx.ReadState(sessionStateKey, "")
 					if err != nil {
 						return err
 					}
 					if data == nil {
 						return nil
 					}
-					thread, err = a.UnmarshalThread(data.([]byte))
+					session, err = a.UnmarshalSession(data.([]byte))
 					return err
 				},
 			},
@@ -58,11 +58,11 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 		TakeTurnHandler: func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
 			emitEvents := token.EmitEventsOr(emitEvents)
 			options := make([]agentopt.RunOption, 0, 1+len(messages))
-			thread, err := ensureThread(ctx)
+			session, err := ensureSession(ctx)
 			if err != nil {
 				return err
 			}
-			options = append(options, agentopt.Thread(thread))
+			options = append(options, agentopt.Session(session))
 			if emitEvents {
 				// Run the agent in streaming mode only when agent run update events are to be emitted.
 				options = append(options, agentopt.Stream(true))

--- a/examples/chat_cli/main.go
+++ b/examples/chat_cli/main.go
@@ -42,8 +42,8 @@ func main() {
 }
 
 func runChatLoop(ctx context.Context, a agent.Agent) {
-	// Create a thread to maintain conversation history
-	thread, err := a.NewThread(ctx)
+	// Create a session to maintain conversation history
+	session, err := a.NewSession(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +73,7 @@ func runChatLoop(ctx context.Context, a agent.Agent) {
 		}
 
 		if userInput == "clear" {
-			thread, err = a.NewThread(ctx)
+			session, err = a.NewSession(ctx)
 			if err != nil {
 				panic(err)
 			}
@@ -85,7 +85,7 @@ func runChatLoop(ctx context.Context, a agent.Agent) {
 		fmt.Print("Assistant: ")
 
 		hasError := false
-		for update, err := range agent.RunTextStream(ctx, a, userInput, agentopt.Thread(thread)) {
+		for update, err := range agent.RunTextStream(ctx, a, userInput, agentopt.Session(session)) {
 			if err != nil {
 				fmt.Printf("\n❌ Error: %v\n", err)
 				hasError = true

--- a/examples/getting_started/agent/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/agent/step02_multiturn_conversation/main.go
@@ -15,7 +15,7 @@ import (
 
 var logger = demo.NewLogger(
 	"Multi-Turn Conversation",
-	"Demonstrates how to preserve conversation context with threads.",
+	"Demonstrates how to preserve conversation context with sessions.",
 	"Model", "gpt-4o-mini",
 )
 
@@ -30,23 +30,23 @@ func main() {
 
 	ctx := context.Background()
 
-	// Invoke the agent with a multi-turn conversation, where the context is preserved in the thread object.
-	thread, err := a.NewThread(ctx)
+	// Invoke the agent with a multi-turn conversation, where the context is preserved in the session object.
+	session, err := a.NewSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}
-	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
-	demo.Response(agent.RunText(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Thread(thread)))
+	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Session(session)))
+	demo.Response(agent.RunText(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Session(session)))
 
-	// Invoke the agent with a multi-turn conversation and streaming, where the context is preserved in the thread object.
-	thread2, err := a.NewThread(ctx)
+	// Invoke the agent with a multi-turn conversation and streaming, where the context is preserved in the session object.
+	session2, err := a.NewSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}
-	for update, err := range agent.RunTextStream(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread2)) {
+	for update, err := range agent.RunTextStream(ctx, a, "Tell me a joke about a pirate.", agentopt.Session(session2)) {
 		demo.Response(update, err)
 	}
-	for update, err := range agent.RunTextStream(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Thread(thread2)) {
+	for update, err := range agent.RunTextStream(ctx, a, "Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Session(session2)) {
 		demo.Response(update, err)
 	}
 }

--- a/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
@@ -46,11 +46,11 @@ func main() {
 	ctx := context.Background()
 
 	// Call the agent and check if there are any user input requests to handle.
-	thread, err := a.NewThread(ctx)
+	session, err := a.NewSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}
-	resp, err := agent.RunText(ctx, a, "What is the weather like in Amsterdam?", agentopt.Thread(thread))
+	resp, err := agent.RunText(ctx, a, "What is the weather like in Amsterdam?", agentopt.Session(session))
 	if err != nil {
 		panic(err)
 	}
@@ -75,5 +75,5 @@ func main() {
 		return
 	}
 	// Pass the user input responses back to the agent for further processing.
-	demo.Response(agent.RunMessage(ctx, a, message.New(userResponses...), agentopt.Thread(thread)))
+	demo.Response(agent.RunMessage(ctx, a, message.New(userResponses...), agentopt.Session(session)))
 }

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -33,43 +33,43 @@ func main() {
 
 	ctx := context.Background()
 
-	// Start a new thread for the agent conversation.
-	thread, err := a.NewThread(ctx)
+	// Start a new session for the agent conversation.
+	session, err := a.NewSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}
 
-	// Run the agent with a new thread.
-	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
+	// Run the agent with a new session.
+	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Session(session)))
 
-	// Serialize the thread state so it can be stored for later use.
-	serializedThread, err := thread.MarshalBinary()
+	// Serialize the session state so it can be stored for later use.
+	serializedSession, err := session.MarshalBinary()
 	if err != nil {
 		demo.Panic(err)
 	}
 
-	// Save the serialized thread to a temporary file (for demonstration purposes).
-	tmpDir, err := os.MkdirTemp("", "agent_thread")
+	// Save the serialized session to a temporary file (for demonstration purposes).
+	tmpDir, err := os.MkdirTemp("", "agent_session")
 	if err != nil {
 		demo.Panic(err)
 	}
-	tmpPath := filepath.Join(tmpDir, "thread.json")
-	if err := os.WriteFile(tmpPath, serializedThread, 0644); err != nil {
+	tmpPath := filepath.Join(tmpDir, "session.json")
+	if err := os.WriteFile(tmpPath, serializedSession, 0644); err != nil {
 		demo.Panic(err)
 	}
 
-	// Load the serialized thread from the temporary file (for demonstration purposes).
+	// Load the serialized session from the temporary file (for demonstration purposes).
 	loadedData, err := os.ReadFile(tmpPath)
 	if err != nil {
 		demo.Panic(err)
 	}
 
-	// Deserialize the thread state after loading from storage.
-	resumedThread, err := a.UnmarshalThread(loadedData)
+	// Deserialize the session state after loading from storage.
+	resumedSession, err := a.UnmarshalSession(loadedData)
 	if err != nil {
 		demo.Panic(err)
 	}
 
-	// Run the agent again with the resumed thread.
-	demo.Response(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Thread(resumedThread)))
+	// Run the agent again with the resumed session.
+	demo.Response(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Session(resumedSession)))
 }

--- a/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
+++ b/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 var logger = demo.NewLogger(
-	"3rd-Party Thread Storage",
+	"3rd-Party Session Storage",
 	"Demonstrates how to use a custom message store to persist conversation history to disk.",
 	"Model", "gpt-4o-mini",
 )
@@ -50,13 +50,13 @@ func main() {
 	ctx := context.Background()
 
 	// Start a new thread for the agent conversation.
-	thread, err := a.NewThread(ctx)
+	thread, err := a.NewSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}
 
 	// Run the agent with the thread that stores conversation history in the disk store.
-	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Thread(thread)))
+	demo.Response(agent.RunText(ctx, a, "Tell me a joke about a pirate.", agentopt.Session(thread)))
 
 	// Serialize the thread state, so it can be stored for later use.
 	// Since the chat history is stored in the disk store, the serialized thread
@@ -72,13 +72,13 @@ func main() {
 	// and loaded again later.
 
 	// Deserialize the thread state after loading from storage.
-	resumedThread, err := a.UnmarshalThread(serializedThread)
+	resumedThread, err := a.UnmarshalSession(serializedThread)
 	if err != nil {
 		demo.Panic(err)
 	}
 
 	// Run the agent with the thread that stores conversation history in the vector store a second time.
-	demo.Response(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Thread(resumedThread)))
+	demo.Response(agent.RunText(ctx, a, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Session(resumedThread)))
 }
 
 type fsMessageStore struct {

--- a/examples/getting_started/agent/step17_background_responses/main.go
+++ b/examples/getting_started/agent/step17_background_responses/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	ctx := context.Background()
 
-	thread, err := a.NewThread(ctx)
+	session, err := a.NewSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -37,7 +37,7 @@ func main() {
 	// Start the initial run.
 	resp, err := agent.RunText(ctx, a,
 		"Write a very long novel about otters in space.",
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 		agentopt.AllowBackgroundResponses(true))
 
 	demo.Response(resp, err)
@@ -49,7 +49,7 @@ func main() {
 
 		// Continue with the token.
 		resp, err = agent.Run(ctx, a, nil,
-			agentopt.Thread(thread),
+			agentopt.Session(session),
 			agentopt.AllowBackgroundResponses(true),
 			agentopt.ContinuationToken(resp.ContinuationToken),
 		)

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -94,22 +94,22 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		stream, _ := agentopt.Get(options, agentopt.Stream)
 
-		// Get thread for conversation ID management
-		var thread *chatagent.Thread
+		// Get session for conversation ID management
+		var session *chatagent.Session
 		var keepConversationID bool // true if we should keep the conversation ID unchanged (it's a "conv_" ID)
-		if t, ok := agentopt.Get(options, agentopt.Thread); ok && t != nil {
-			if typedThread, ok := t.(*chatagent.Thread); ok {
-				thread = typedThread
+		if t, ok := agentopt.Get(options, agentopt.Session); ok && t != nil {
+			if typedSession, ok := t.(*chatagent.Session); ok {
+				session = typedSession
 				// If the conversation ID starts with "conv_", we should keep it unchanged.
 				// Otherwise, we'll update it to the new response ID.
-				keepConversationID = thread.ConversationID != "" && strings.HasPrefix(thread.ConversationID, "conv_")
+				keepConversationID = session.ConversationID != "" && strings.HasPrefix(session.ConversationID, "conv_")
 			}
 		}
 
 		// Helper to update conversation ID after response completes
 		updateConversationID := func(responseID string) {
-			if thread != nil && !keepConversationID && responseID != "" {
-				thread.ConversationID = responseID
+			if session != nil && !keepConversationID && responseID != "" {
+				session.ConversationID = responseID
 			}
 		}
 
@@ -242,20 +242,20 @@ func responsesBuildCompletionParams(model string, messages []*message.Message, o
 	if v, ok := agentopt.Get(opts, agentopt.AllowBackgroundResponses); ok {
 		params.Background = openai.Bool(v)
 	}
-	if thread, ok := agentopt.Get(opts, agentopt.Thread); ok && thread != nil {
-		typedThread, ok := thread.(*chatagent.Thread)
+	if session, ok := agentopt.Get(opts, agentopt.Session); ok && session != nil {
+		typedSession, ok := session.(*chatagent.Session)
 		if !ok {
-			return responses.ResponseNewParams{}, fmt.Errorf("invalid thread type: %T", thread)
+			return responses.ResponseNewParams{}, fmt.Errorf("invalid session type: %T", session)
 		}
-		if typedThread.ConversationID != "" {
+		if typedSession.ConversationID != "" {
 			// Technically, OpenAI's IDs are opaque. However, by convention conversation IDs start with "conv_" and
 			// we can use that to disambiguate whether we're looking at a conversation ID or a response ID.
-			if strings.HasPrefix(typedThread.ConversationID, "conv_") {
+			if strings.HasPrefix(typedSession.ConversationID, "conv_") {
 				params.Conversation = responses.ResponseNewParamsConversationUnion{
-					OfString: openai.String(typedThread.ConversationID),
+					OfString: openai.String(typedSession.ConversationID),
 				}
 			} else {
-				params.PreviousResponseID = openai.String(typedThread.ConversationID)
+				params.PreviousResponseID = openai.String(typedSession.ConversationID)
 			}
 		}
 	}

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -3744,7 +3744,7 @@ func TestResponsesConversationId_AsResponseId_NonStreaming(t *testing.T) {
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	thread, err := a.NewThread(context.Background(), chatagent.ConversationID("resp_12345"))
+	session, err := a.NewSession(context.Background(), chatagent.ConversationID("resp_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3752,17 +3752,17 @@ func TestResponsesConversationId_AsResponseId_NonStreaming(t *testing.T) {
 	_, err = agent.RunText(context.Background(), a, "hello",
 		chatagent.MaxOutputTokens(20),
 		chatagent.Temperature(0.5),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	)
 
 	if err != nil {
 		t.Fatalf("RunText() error = %v", err)
 	}
 
-	// After the call, thread.ConversationID should be updated to the new response ID
-	chatThread := thread.(*chatagent.Thread)
-	if chatThread.ConversationID != "resp_67890" {
-		t.Errorf("expected ConversationId resp_67890, got %s", chatThread.ConversationID)
+	// After the call, session.ConversationID should be updated to the new response ID
+	chatSession := session.(*chatagent.Session)
+	if chatSession.ConversationID != "resp_67890" {
+		t.Errorf("expected ConversationId resp_67890, got %s", chatSession.ConversationID)
 	}
 }
 
@@ -3810,7 +3810,7 @@ func TestResponsesConversationId_AsConversationId_NonStreaming(t *testing.T) {
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	thread, err := a.NewThread(context.Background(), chatagent.ConversationID("conv_12345"))
+	session, err := a.NewSession(context.Background(), chatagent.ConversationID("conv_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3818,7 +3818,7 @@ func TestResponsesConversationId_AsConversationId_NonStreaming(t *testing.T) {
 	_, err = agent.RunText(context.Background(), a, "hello",
 		chatagent.MaxOutputTokens(20),
 		chatagent.Temperature(0.5),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	)
 
 	if err != nil {
@@ -3826,9 +3826,9 @@ func TestResponsesConversationId_AsConversationId_NonStreaming(t *testing.T) {
 	}
 
 	// When using a conversation ID, it should remain unchanged
-	chatThread := thread.(*chatagent.Thread)
-	if chatThread.ConversationID != "conv_12345" {
-		t.Errorf("expected ConversationId conv_12345, got %s", chatThread.ConversationID)
+	chatSession := session.(*chatagent.Session)
+	if chatSession.ConversationID != "conv_12345" {
+		t.Errorf("expected ConversationId conv_12345, got %s", chatSession.ConversationID)
 	}
 }
 
@@ -3881,7 +3881,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	thread, err := a.NewThread(context.Background(), chatagent.ConversationID("resp_12345"))
+	session, err := a.NewSession(context.Background(), chatagent.ConversationID("resp_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3890,7 +3890,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 	for update, err := range agent.RunTextStream(context.Background(), a, "hello",
 		chatagent.MaxOutputTokens(20),
 		chatagent.Temperature(0.5),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	) {
 		if err != nil {
 			t.Fatalf("RunTextStream() error = %v", err)
@@ -3904,9 +3904,9 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 		}
 	}
 
-	chatThread := thread.(*chatagent.Thread)
-	if chatThread.ConversationID != "resp_67890" {
-		t.Errorf("expected ConversationId resp_67890, got %s", chatThread.ConversationID)
+	chatSession := session.(*chatagent.Session)
+	if chatSession.ConversationID != "resp_67890" {
+		t.Errorf("expected ConversationId resp_67890, got %s", chatSession.ConversationID)
 	}
 }
 
@@ -3959,7 +3959,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	thread, err := a.NewThread(context.Background(), chatagent.ConversationID("conv_12345"))
+	session, err := a.NewSession(context.Background(), chatagent.ConversationID("conv_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3968,7 +3968,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 	for update, err := range agent.RunTextStream(context.Background(), a, "hello",
 		chatagent.MaxOutputTokens(20),
 		chatagent.Temperature(0.5),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	) {
 		if err != nil {
 			t.Fatalf("RunTextStream() error = %v", err)
@@ -3982,9 +3982,9 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 		}
 	}
 
-	chatThread := thread.(*chatagent.Thread)
-	if chatThread.ConversationID != "conv_12345" {
-		t.Errorf("expected ConversationId conv_12345, got %s", chatThread.ConversationID)
+	chatSession := session.(*chatagent.Session)
+	if chatSession.ConversationID != "conv_12345" {
+		t.Errorf("expected ConversationId conv_12345, got %s", chatSession.ConversationID)
 	}
 }
 
@@ -4019,7 +4019,7 @@ func TestResponsesBackgroundResponses_FirstCall(t *testing.T) {
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	thread, err := a.NewThread(context.Background())
+	session, err := a.NewSession(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4028,7 +4028,7 @@ func TestResponsesBackgroundResponses_FirstCall(t *testing.T) {
 		chatagent.MaxOutputTokens(20),
 		chatagent.Temperature(0.5),
 		agentopt.AllowBackgroundResponses(true),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	)
 	if err != nil {
 		t.Fatalf("RunText() error = %v", err)
@@ -4102,8 +4102,8 @@ func testResponsesBackgroundPolling(t *testing.T, status string) {
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	// Create thread with ConversationID to simulate a previous call (polling scenario)
-	thread, err := a.NewThread(context.Background(), chatagent.ConversationID("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8"))
+	// Create session with ConversationID to simulate a previous call (polling scenario)
+	session, err := a.NewSession(context.Background(), chatagent.ConversationID("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4118,7 +4118,7 @@ func testResponsesBackgroundPolling(t *testing.T, status string) {
 	resp, err := agent.Run(context.Background(), a, nil,
 		agentopt.ContinuationToken(string(ctJSON)),
 		agentopt.AllowBackgroundResponses(true),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	)
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -4233,7 +4233,7 @@ data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_6
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-2024-08-06")
-	thread, err := a.NewThread(context.Background())
+	session, err := a.NewSession(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4242,7 +4242,7 @@ data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_6
 	var allText strings.Builder
 	for update, err := range agent.RunTextStream(context.Background(), a, "hello",
 		agentopt.AllowBackgroundResponses(true),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	) {
 		if err != nil {
 			t.Fatalf("RunTextStream() error = %v", err)
@@ -4343,8 +4343,8 @@ data: {"type":"response.completed","sequence_number":17,"response":{"truncation"
 	// Emulating resumption of the stream after receiving the first 9 updates that provided the text "Hello! How can I"
 	token := `{"response_id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","sequence_number":9}`
 
-	// Create thread with ConversationID to allow continuation
-	thread := &chatagent.Thread{
+	// Create session with ConversationID to allow continuation
+	session := &chatagent.Session{
 		ConversationID: "resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b",
 	}
 
@@ -4353,7 +4353,7 @@ data: {"type":"response.completed","sequence_number":17,"response":{"truncation"
 		agentopt.AllowBackgroundResponses(true),
 		agentopt.ContinuationToken(token),
 		agentopt.Stream(true),
-		agentopt.Thread(thread),
+		agentopt.Session(session),
 	) {
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)


### PR DESCRIPTION
.NET sdk renamed AgentThread to AgentSession in https://github.com/microsoft/agent-framework/pull/3430. We should follow suit.