### PR TITLE
Forbid external Agent implementations

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -39,38 +39,38 @@ func WithContextID(id string) agentopt.NewSessionOption {
 	return contextIDOpt{id}
 }
 
-var _ agent.Agent = (*Agent)(nil)
-
-type Agent struct {
+type a2aagent struct {
 	Client  *a2aclient.Client
 	Options Options
-
-	iden agent.Identity
 }
 
-func NewAgent(client *a2aclient.Client, options Options) *Agent {
+func NewAgent(client *a2aclient.Client, options Options) agent.Agent {
 	if client == nil {
 		panic("client cannot be nil")
 	}
-	return &Agent{
+	a := &a2aagent{
 		Client:  client,
 		Options: options,
-		iden:    agent.NewIdentity(options.ID, options.Name, options.Description),
 	}
+	return agent.New(agent.Config{
+		ID:          options.ID,
+		Name:        options.Name,
+		Description: options.Description,
+
+		NewSession:       a.newSession,
+		UnmarshalSession: a.unmarshalSession,
+		Run:              a.run,
+	})
 }
 
-func (a *Agent) Identity() agent.Identity {
-	return a.iden
-}
-
-func (a *Agent) NewSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
+func (a *a2aagent) newSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
 	contextID, _ := agentopt.Get(options, WithContextID)
 	return &Session{
 		ContextID: contextID,
 	}, nil
 }
 
-func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
+func (a *a2aagent) unmarshalSession(data []byte) (memory.Session, error) {
 	var session Session
 	if err := json.Unmarshal(data, &session); err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
 	return &session, nil
 }
 
-func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		var session *Session
 		if v, ok := agentopt.Get(options, agentopt.Session); !ok {
@@ -89,7 +89,7 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 				yield(nil, errors.New("a session must be provided when AllowBackgroundResponses is enabled"))
 				return
 			}
-			s, err := a.NewSession(ctx)
+			s, err := a.newSession(ctx)
 			if err != nil {
 				yield(nil, err)
 				return
@@ -117,11 +117,11 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 				yield(nil, err)
 				return
 			}
-			if err := a.updateSessionContextID(session, task.ContextID, string(task.ID)); err != nil {
+			if err := updateSessionContextID(session, task.ContextID, string(task.ID)); err != nil {
 				yield(nil, err)
 				return
 			}
-			a.yieldTask(yield, task)
+			yieldTask(yield, task)
 			return
 		}
 		var parts []a2a.Part
@@ -145,45 +145,43 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 					ContextID:      session.ContextID,
 				},
 			}
-			a.sendMsg(ctx, session, stream, params, yield)
+			var seq iter.Seq2[a2a.Event, error]
+			if stream {
+				seq = a.Client.SendStreamingMessage(ctx, params)
+			} else {
+				resp, err := a.Client.SendMessage(ctx, params)
+				seq = func(yield func(a2a.Event, error) bool) {
+					yield(resp, err)
+				}
+			}
+			sendMsg(ctx, session, seq, yield)
 		}
 	}
 }
 
-func (a *Agent) sendMsg(ctx context.Context, session *Session, streaming bool, params *a2a.MessageSendParams, yield func(*message.ResponseUpdate, error) bool) {
-	var seq iter.Seq2[a2a.Event, error]
-	if streaming {
-		seq = a.Client.SendStreamingMessage(ctx, params)
-	} else {
-		resp, err := a.Client.SendMessage(ctx, params)
-		seq = func(yield func(a2a.Event, error) bool) {
-			yield(resp, err)
-		}
-	}
+func sendMsg(ctx context.Context, session *Session, seq iter.Seq2[a2a.Event, error], yield func(*message.ResponseUpdate, error) bool) {
 	for e, err := range seq {
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 		taskInfo := e.TaskInfo()
-		if err := a.updateSessionContextID(session, taskInfo.ContextID, string(taskInfo.TaskID)); err != nil {
+		if err := updateSessionContextID(session, taskInfo.ContextID, string(taskInfo.TaskID)); err != nil {
 			yield(nil, err)
 			return
 		}
 		switch e := e.(type) {
 		case *a2a.Task:
-			if ok := a.yieldTask(yield, e); !ok {
+			if ok := yieldTask(yield, e); !ok {
 				return
 			}
 		case *a2a.TaskStatusUpdateEvent:
 			if !yield(&message.ResponseUpdate{
 				RawRepresentation:    e,
 				AdditionalProperties: e.Metadata,
-				AuthorID:             a.iden.ID(),
 				MessageID:            string(e.TaskID),
 				ResponseID:           string(e.TaskID),
 				Role:                 message.RoleAssistant,
-				AuthorName:           a.iden.Name(),
 				CreatedAt:            time.Now(),
 			}, nil) {
 				return
@@ -197,12 +195,10 @@ func (a *Agent) sendMsg(ctx context.Context, session *Session, streaming bool, p
 			if !yield(&message.ResponseUpdate{
 				RawRepresentation:    e,
 				AdditionalProperties: e.Metadata,
-				AuthorID:             a.iden.ID(),
 				MessageID:            string(e.Artifact.ID),
 				ResponseID:           string(e.TaskID),
 				Contents:             contents,
 				Role:                 message.RoleAssistant,
-				AuthorName:           a.iden.Name(),
 				CreatedAt:            time.Now(),
 			}, nil) {
 				return
@@ -220,12 +216,10 @@ func (a *Agent) sendMsg(ctx context.Context, session *Session, streaming bool, p
 			if !yield(&message.ResponseUpdate{
 				RawRepresentation:    e,
 				AdditionalProperties: e.Metadata,
-				AuthorID:             a.iden.ID(),
 				MessageID:            e.ID,
 				ResponseID:           e.ID,
 				Role:                 role,
 				Contents:             contents,
-				AuthorName:           a.iden.Name(),
 				CreatedAt:            time.Now(),
 			}, nil) {
 				return
@@ -237,9 +231,8 @@ func (a *Agent) sendMsg(ctx context.Context, session *Session, streaming bool, p
 	}
 }
 
-func (a *Agent) yieldTask(yield func(*message.ResponseUpdate, error) bool, task *a2a.Task) bool {
+func yieldTask(yield func(*message.ResponseUpdate, error) bool, task *a2a.Task) bool {
 	now := time.Now()
-	id, name := a.iden.ID(), a.iden.Name()
 	var continuationToken string
 	switch task.Status.State {
 	case a2a.TaskStateSubmitted, a2a.TaskStateWorking:
@@ -262,20 +255,18 @@ func (a *Agent) yieldTask(yield func(*message.ResponseUpdate, error) bool, task 
 	if !yield(&message.ResponseUpdate{
 		RawRepresentation:    task,
 		AdditionalProperties: task.Metadata,
-		AuthorID:             id,
 		ResponseID:           string(task.ID),
 		Contents:             contents,
 		ContinuationToken:    continuationToken,
 		Role:                 message.RoleAssistant,
 		CreatedAt:            timestamp,
-		AuthorName:           name,
 	}, nil) {
 		return false
 	}
 	return true
 }
 
-func (a *Agent) updateSessionContextID(session *Session, contextID, taskID string) error {
+func updateSessionContextID(session *Session, contextID, taskID string) error {
 	if session == nil {
 		return nil
 	}

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/a2aagent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -120,7 +121,7 @@ func (m *mockA2ATransport) Destroy() error {
 }
 
 // Test fixtures
-func newTestAgent(transport a2aclient.Transport, opts a2aagent.Options) *a2aagent.Agent {
+func newTestAgent(transport a2aclient.Transport, opts a2aagent.Options) agent.Agent {
 	card := &a2a.AgentCard{
 		URL:                "test://localhost",
 		PreferredTransport: "test",
@@ -142,33 +143,6 @@ func newTestAgent(transport a2aclient.Transport, opts a2aagent.Options) *a2aagen
 	return a2aagent.NewAgent(client, opts)
 }
 
-// TestConstructorWithAllParameters tests that the constructor initializes all properties correctly
-func TestConstructorWithAllParameters(t *testing.T) {
-	testID := "test-id"
-	testName := "test-name"
-	testDescription := "test-description"
-	testDisplayName := "test-display-name"
-
-	transport := &mockA2ATransport{}
-	opts := a2aagent.Options{
-		ID:          testID,
-		Name:        testName,
-		Description: testDescription,
-		DisplayName: testDisplayName,
-	}
-	a := newTestAgent(transport, opts)
-
-	if a.Identity().ID() != testID {
-		t.Errorf("ID() = %q, want %q", a.Identity().ID(), testID)
-	}
-	if a.Identity().Name() != testName {
-		t.Errorf("Name() = %q, want %q", a.Identity().Name(), testName)
-	}
-	if a.Identity().Description() != testDescription {
-		t.Errorf("Description() = %q, want %q", a.Identity().Description(), testDescription)
-	}
-}
-
 // TestConstructorWithNilClient tests that nil client is handled
 func TestConstructorWithNilClient(t *testing.T) {
 	defer func() {
@@ -177,23 +151,6 @@ func TestConstructorWithNilClient(t *testing.T) {
 		}
 	}()
 	a2aagent.NewAgent(nil, a2aagent.Options{})
-}
-
-// TestConstructorWithDefaultParameters tests default parameter behavior
-func TestConstructorWithDefaultParameters(t *testing.T) {
-	transport := &mockA2ATransport{}
-	a := newTestAgent(transport, a2aagent.Options{})
-
-	id := a.Identity().ID()
-	if id == "" {
-		t.Error("ID() returned empty string, want non-empty")
-	}
-	if a.Identity().Name() != "" {
-		t.Errorf("Name() = %q, want empty string", a.Identity().Name())
-	}
-	if a.Identity().Description() != "" {
-		t.Errorf("Description() = %q, want empty string", a.Identity().Description())
-	}
 }
 
 // TestRunAllowsNonUserRoleMessages tests that non-user role messages are accepted
@@ -261,9 +218,6 @@ func TestRunWithValidUserMessage(t *testing.T) {
 		t.Fatalf("len(result.Messages) = %d, want 1", len(result.Messages))
 	}
 	msg := result.Messages[0]
-	if msg.AuthorID != a.Identity().ID() {
-		t.Errorf("AuthorID = %q, want %q", msg.AuthorID, a.Identity().ID())
-	}
 	if msg.ID != "response-123" {
 		t.Errorf("ID = %q, want %q", msg.ID, "response-123")
 	}
@@ -420,9 +374,6 @@ func TestRunStreamingWithValidUserMessage(t *testing.T) {
 	}
 	if update.MessageID != "stream-1" {
 		t.Errorf("update.MessageID = %q, want %q", update.MessageID, "stream-1")
-	}
-	if update.AuthorID != a.Identity().ID() {
-		t.Errorf("update.AuthorID = %q, want %q", update.AuthorID, a.Identity().ID())
 	}
 	if update.ResponseID != "stream-1" {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, "stream-1")
@@ -611,7 +562,7 @@ func TestRunWithInvalidSessionType(t *testing.T) {
 	a := newTestAgent(transport, a2aagent.Options{})
 
 	// Create a custom session type that is not an a2aagent.Session
-	invalidSession := &customAgentSession{}
+	invalidSession := agenttest.NewSession()
 
 	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.Session(invalidSession))
 	if err == nil {
@@ -633,7 +584,7 @@ func TestRunStreamingWithInvalidSessionType(t *testing.T) {
 	a := newTestAgent(transport, a2aagent.Options{})
 
 	// Create a custom session type that is not an a2aagent.Session
-	invalidSession := &customAgentSession{}
+	invalidSession := agenttest.NewSession()
 
 	gotError := false
 	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agentopt.Session(invalidSession)) {
@@ -780,9 +731,6 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 		t.Fatalf("len(result.Messages) = %d, want 1", len(result.Messages))
 	}
 	msg := result.Messages[0]
-	if msg.AuthorID != a.Identity().ID() {
-		t.Errorf("AgentID = %q, want %q", msg.AuthorID, a.Identity().ID())
-	}
 	if msg.ID != "" {
 		t.Errorf("ID = %q, want empty", msg.ID)
 	}
@@ -983,9 +931,6 @@ func TestRunStreamingWithAgentMessage(t *testing.T) {
 	if update.ResponseID != messageID {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, messageID)
 	}
-	if update.AuthorID != a.Identity().ID() {
-		t.Errorf("update.AuthorID = %q, want %q", update.AuthorID, a.Identity().ID())
-	}
 	if update.String() != messageText {
 		t.Errorf("update.String() = %q, want %q", update.String(), messageText)
 	}
@@ -1042,9 +987,6 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 	if update.ResponseID != taskID {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
 	}
-	if update.AuthorID != a.Identity().ID() {
-		t.Errorf("update.AuthorID = %q, want %q", update.AuthorID, a.Identity().ID())
-	}
 	if _, ok := update.RawRepresentation.(*a2a.Task); !ok {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.Task", update.RawRepresentation)
 	}
@@ -1100,9 +1042,6 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 	}
 	if update.ResponseID != taskID {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
-	}
-	if update.AuthorID != a.Identity().ID() {
-		t.Errorf("update.AuthorID = %q, want %q", update.AuthorID, a.Identity().ID())
 	}
 	if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
@@ -1164,9 +1103,6 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	if update.ResponseID != taskID {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
 	}
-	if update.AuthorID != a.Identity().ID() {
-		t.Errorf("update.AuthorID = %q, want %q", update.AuthorID, a.Identity().ID())
-	}
 	if _, ok := update.RawRepresentation.(*a2a.TaskArtifactUpdateEvent); !ok {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskArtifactUpdateEvent", update.RawRepresentation)
 	}
@@ -1188,45 +1124,4 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	if a2aSession.TaskID != taskID {
 		t.Errorf("session.TaskID = %q, want %q", a2aSession.TaskID, taskID)
 	}
-}
-
-// TestRunWithAllowBackgroundResponsesAndNoSession tests error when no session provided
-func TestRunWithAllowBackgroundResponsesAndNoSession(t *testing.T) {
-	transport := &mockA2ATransport{}
-	a := newTestAgent(transport, a2aagent.Options{})
-
-	_, err := agent.RunText(t.Context(), a, "Test message", agentopt.AllowBackgroundResponses(true))
-	if err == nil {
-		t.Error("Run() error = nil, want error when AllowBackgroundResponses is true without session")
-	}
-}
-
-// TestRunStreamingWithAllowBackgroundResponsesAndNoSession tests error in streaming mode
-func TestRunStreamingWithAllowBackgroundResponsesAndNoSession(t *testing.T) {
-	transport := &mockA2ATransport{}
-	a := newTestAgent(transport, a2aagent.Options{})
-
-	// Call the agent's Run method directly with streaming enabled
-	gotError := false
-	for _, err := range agent.RunTextStream(t.Context(), a, "Test message", agentopt.AllowBackgroundResponses(true)) {
-		if err != nil {
-			gotError = true
-			break
-		}
-	}
-
-	if !gotError {
-		t.Error("RunStream() expected error when AllowBackgroundResponses is true without session, got nil")
-	}
-}
-
-// customAgentSession is a custom agent session for testing invalid session type scenario
-type customAgentSession struct{}
-
-func (c *customAgentSession) ID() string {
-	return "custom-session-id"
-}
-
-func (c *customAgentSession) MarshalBinary() (data []byte, err error) {
-	return []byte("{}"), nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -12,46 +12,84 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-type Identity struct {
-	id          string
-	name        string
-	description string
-}
-
-func NewIdentity(id, name, description string) Identity {
-	if id == "" {
-		id = uuid.NewString()
-	}
-	return Identity{
-		id:          id,
-		name:        name,
-		description: description,
-	}
-}
-
-func (iden Identity) ID() string {
-	return iden.id
-}
-
-func (iden Identity) Name() string {
-	return iden.name
-}
-
-func (iden Identity) Description() string {
-	return iden.description
-}
-
 type Agent interface {
-	Identity() Identity
+	ID() string
+	Name() string
+	Description() string
 
 	Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 
 	NewSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error)
 	UnmarshalSession(data []byte) (memory.Session, error)
+
+	internal() // unexported method to prevent external implementations
 }
 
-type StructuredOutputAgent interface {
-	Agent
+type Config struct {
+	ID          string
+	Name        string
+	Description string
 
-	RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+	RunOptions []agentopt.RunOption
+
+	NewSession       func(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error)
+	UnmarshalSession func(data []byte) (memory.Session, error)
+	Run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
+
+func New(cfg Config) Agent {
+	return &agent{
+		id:               cfg.ID,
+		name:             cfg.Name,
+		description:      cfg.Description,
+		newSession:       cfg.NewSession,
+		unmarshalSession: cfg.UnmarshalSession,
+		run:              cfg.Run,
+		runOptions:       cfg.RunOptions,
+	}
+}
+
+type agent struct {
+	id          string
+	name        string
+	description string
+
+	runOptions []agentopt.RunOption
+
+	newSession       func(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error)
+	unmarshalSession func(data []byte) (memory.Session, error)
+	run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+}
+
+func (a *agent) ID() string {
+	if a.id == "" {
+		a.id = uuid.NewString()
+	}
+	return a.id
+}
+
+func (a *agent) Name() string {
+	return a.name
+}
+
+func (a *agent) Description() string {
+	return a.description
+}
+
+func (a *agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	return a.run(ctx, messages, options...)
+}
+
+func (a *agent) NewSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
+	return a.newSession(ctx, options...)
+}
+
+func (a *agent) UnmarshalSession(data []byte) (memory.Session, error) {
+	return a.unmarshalSession(data)
+}
+
+func (a *agent) RunOptions() []agentopt.RunOption {
+	return a.runOptions
+}
+
+func (a *agent) internal() {}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/memory"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -77,7 +78,47 @@ func (a *agent) Description() string {
 }
 
 func (a *agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-	return a.run(ctx, messages, options...)
+	if len(a.runOptions) != 0 {
+		// Prepend options from agent configuration.
+		options = append(a.runOptions, options...)
+	}
+	// Ensure a session is provided in the options.
+	if _, ok := agentopt.Get(options, agentopt.Session); !ok {
+		session, err := a.NewSession(ctx)
+		if err != nil {
+			return func(yield func(*message.ResponseUpdate, error) bool) {
+				yield(nil, err)
+			}
+		}
+		options = append(options, agentopt.Session(session))
+	}
+	// Middleware to set AuthorID and AuthorName on each ResponseUpdate.
+	options = append(options, middleware.With(middleware.Func(
+		func(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+			return func(yield func(*message.ResponseUpdate, error) bool) {
+				id, name := a.ID(), a.Name()
+				for update, err := range next(ctx, messages, options...) {
+					if update != nil {
+						if update.AuthorID == "" {
+							update.AuthorID = id
+						}
+						if update.AuthorName == "" {
+							update.AuthorName = name
+						}
+					}
+					if !yield(update, err) {
+						return
+					}
+				}
+			}
+		})))
+
+	// Add agent identity to context so that middlewares can log it.
+	ctx = context.WithValue(ctx, identityKey{}, identity{
+		id:   a.ID(),
+		name: a.Name(),
+	})
+	return middleware.RunChain(ctx, a.run, messages, options...)
 }
 
 func (a *agent) NewSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
@@ -86,10 +127,6 @@ func (a *agent) NewSession(ctx context.Context, options ...agentopt.NewSessionOp
 
 func (a *agent) UnmarshalSession(data []byte) (memory.Session, error) {
 	return a.unmarshalSession(data)
-}
-
-func (a *agent) RunOptions() []agentopt.RunOption {
-	return a.runOptions
 }
 
 func (a *agent) internal() {}

--- a/agent/agentopt/agentopt.go
+++ b/agent/agentopt/agentopt.go
@@ -45,6 +45,8 @@ type (
 	toolModeOpt                 tool.ToolMode
 	streamOpt                   bool
 	allowBackgroundResponsesOpt bool
+
+	structuredOutputOpt struct{ any }
 )
 
 func (responseFormatOpt) RunOption()           {}
@@ -54,6 +56,7 @@ func (continuationTokenOpt) RunOption()        {}
 func (allowBackgroundResponsesOpt) RunOption() {}
 func (toolOpt) RunOption()                     {}
 func (toolModeOpt) RunOption()                 {}
+func (structuredOutputOpt) RunOption()         {}
 
 func (o responseFormatOpt) Value() any           { return o.Format }
 func (o sessionOpt) Value() any                  { return o.Session }
@@ -62,6 +65,11 @@ func (o continuationTokenOpt) Value() any        { return string(o) }
 func (o allowBackgroundResponsesOpt) Value() any { return bool(o) }
 func (o toolModeOpt) Value() any                 { return tool.ToolMode(o) }
 func (o toolOpt) Value() any                     { return o.Tool }
+func (o structuredOutputOpt) Value() any         { return o.any }
+
+func StructuredOutput(v any) RunOption {
+	return structuredOutputOpt{v}
+}
 
 // Tool adds a tool to the agent run.
 func Tool(tool tool.Tool) RunOption {
@@ -141,6 +149,25 @@ func All[T any](opts []RunOption, setter func(T) RunOption) iter.Seq[T] {
 		var zero T
 		var setterType = reflect.TypeOf(setter(zero))
 		for _, opt := range opts {
+			if reflect.TypeOf(opt) == setterType {
+				v, ok := opt.Value().(T)
+				if !ok {
+					panic("option type mismatch")
+				}
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func AllBackward[T any](opts []RunOption, setter func(T) RunOption) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		var zero T
+		var setterType = reflect.TypeOf(setter(zero))
+		for i := len(opts) - 1; i >= 0; i-- {
+			opt := opts[i]
 			if reflect.TypeOf(opt) == setterType {
 				v, ok := opt.Value().(T)
 				if !ok {

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -87,30 +87,34 @@ type Response struct {
 	Error    error
 }
 
-var _ agent.Agent = (*Agent)(nil)
-
-type Agent struct {
-	Iden           agent.Identity
-	NewSessionFunc func(context.Context, ...agentopt.NewSessionOption) (memory.Session, error)
-	Responses      []Turn
+type testagent struct {
+	responses []Turn
 
 	currentTurn int
 }
 
-func (a *Agent) Identity() agent.Identity {
-	if a.Iden == (agent.Identity{}) {
-		return agent.NewIdentity("test-agent-id", "TestAgent", "A test agent")
+func NewAgent(responses []Turn) agent.Agent {
+	a := &testagent{
+		responses: responses,
 	}
-	return a.Iden
+	return agent.New(agent.Config{
+		ID:          "test-agent-id",
+		Name:        "TestAgent",
+		Description: "A test agent",
+
+		NewSession:       a.newSession,
+		UnmarshalSession: a.unmarshalSession,
+		Run:              a.run,
+	})
 }
 
-func (a *Agent) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *testagent) run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { a.currentTurn++ }()
-		if a.currentTurn >= len(a.Responses) {
+		if a.currentTurn >= len(a.responses) {
 			panic("no more predefined turns")
 		}
-		turn := a.Responses[a.currentTurn]
+		turn := a.responses[a.currentTurn]
 		for _, cb := range turn.Callbacks {
 			cb(ctx, messages, opts...)
 		}
@@ -122,14 +126,11 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, opts ...ag
 	}
 }
 
-func (a *Agent) NewSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
-	if a.NewSessionFunc != nil {
-		return a.NewSessionFunc(ctx, opts...)
-	}
+func (a *testagent) newSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
 	return &Session{}, nil
 }
 
-func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
+func (a *testagent) unmarshalSession(data []byte) (memory.Session, error) {
 	return &Session{}, nil
 }
 
@@ -159,7 +160,7 @@ func (m *Middleware) Called() bool {
 	return m.called
 }
 
-func (m *Middleware) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (m *Middleware) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	m.called = true
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { m.currentTurn++ }()
@@ -171,7 +172,7 @@ func (m *Middleware) Run(next middleware.RunFunc, ctx context.Context, a agent.A
 				}
 			}
 		}
-		for update, err := range next(ctx, a, messages, opts...) {
+		for update, err := range next(ctx, messages, opts...) {
 			if !yield(update, err) {
 				return
 			}
@@ -193,7 +194,7 @@ type Runner struct {
 	currentTurn int
 }
 
-func (r *Runner) Run(ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (r *Runner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		defer func() { r.currentTurn++ }()
 		if r.currentTurn >= len(r.Responses) {

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -3,7 +3,6 @@
 package chatagent
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"iter"
@@ -15,6 +14,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent/memory"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/agent/middleware/autocall"
+	"github.com/microsoft/agent-framework-go/agent/middleware/structuredoutput"
 	"github.com/microsoft/agent-framework-go/format"
 	"github.com/microsoft/agent-framework-go/message"
 )
@@ -33,7 +33,6 @@ type Config struct {
 	UnmarshalFn func(format format.Format, data []byte, v any) error
 
 	DisableFuncAutoCall bool
-	Middlewares         []middleware.Middleware
 
 	RunOptions []agentopt.RunOption
 
@@ -46,108 +45,78 @@ func (o *Config) Clone() *Config {
 		return nil
 	}
 	clone := *o
-	clone.Middlewares = slices.Clone(o.Middlewares)
 	clone.RunOptions = slices.Clone(o.RunOptions)
 	return &clone
 }
 
 type RunFunc func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 
-var _ agent.Agent = (*Agent)(nil)
+type chatagent struct {
+	runFn RunFunc
 
-type Agent struct {
-	runFn  RunFunc
-	config Config
-	iden   agent.Identity
+	instructions string
+
+	newMessageStore    func() memory.MessageStore
+	newContextProvider func() memory.ContextProvider
 }
 
 // NewAgent creates a new chat agent with the given chat client and options.
-func NewAgent(runfn RunFunc, cfg Config) *Agent {
+func NewAgent(runfn RunFunc, cfg Config) agent.Agent {
 	opts := *cfg.Clone()
 	if !opts.DisableFuncAutoCall {
-		opts.Middlewares = append(opts.Middlewares,
+		opts.RunOptions = append(opts.RunOptions, middleware.With(
 			autocall.New(autocall.Config{
 				Logger:           opts.Logger,
 				LogSensitiveData: opts.LogSensitiveData,
 			}),
+		))
+	}
+	if opts.FormatOfFn != nil && opts.UnmarshalFn != nil {
+		opts.RunOptions = append(opts.RunOptions, middleware.With(
+			structuredoutput.New(structuredoutput.Config{
+				Format:    opts.FormatOfFn,
+				Unmarshal: opts.UnmarshalFn,
+			})),
 		)
 	}
-	return &Agent{
-		runFn:  runfn,
-		config: opts,
-		iden:   agent.NewIdentity(cfg.ID, cfg.Name, cfg.Description),
+	a := &chatagent{
+		runFn:              runfn,
+		instructions:       opts.Instructions,
+		newMessageStore:    opts.NewMessageStore,
+		newContextProvider: opts.NewContextProvider,
 	}
+	return agent.New(agent.Config{
+		ID:          cfg.ID,
+		Name:        cfg.Name,
+		Description: cfg.Description,
+
+		NewSession:       a.NewSession,
+		UnmarshalSession: a.UnmarshalSession,
+		Run:              a.Run,
+
+		RunOptions: opts.RunOptions,
+	})
 }
 
-func (a *Agent) Identity() agent.Identity {
-	return a.iden
-}
-
-func (a *Agent) Instructions() string {
-	return a.config.Instructions
-}
-
-func (a *Agent) NewSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
+func (a *chatagent) NewSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
 	convID, _ := agentopt.Get(opts, ConversationID)
 	session := &Session{
 		ConversationID: convID,
 	}
-	if a.config.NewContextProvider != nil {
-		session.ContextProvider = a.config.NewContextProvider()
+	if a.newContextProvider != nil {
+		session.ContextProvider = a.newContextProvider()
 	}
 	return session, nil
 }
 
-func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
-	return newSessionFromJSON(data, a.config.NewMessageStore, a.config.NewContextProvider)
+func (a *chatagent) UnmarshalSession(data []byte) (memory.Session, error) {
+	return newSessionFromJSON(data, a.newMessageStore, a.newContextProvider)
 }
 
-func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-	// Prepend options from agent configuration.
-	options = append(a.config.RunOptions, options...)
-	if _, ok := agentopt.Get(options, agentopt.Session); !ok {
-		session, err := a.NewSession(ctx)
-		if err != nil {
-			return func(yield func(*message.ResponseUpdate, error) bool) {
-				yield(nil, err)
-			}
-		}
-		options = append(options, agentopt.Session(session))
-	}
-	return middleware.RunChain(ctx, a.run, a.config.Middlewares, a, messages, options...)
-}
-
-func (a *Agent) RunOf(ctx context.Context, v any, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-	return func(yield func(*message.ResponseUpdate, error) bool) {
-		if a.config.FormatOfFn == nil || a.config.UnmarshalFn == nil {
-			yield(nil, errors.New("agent does not support structured output"))
-			return
-		}
-		format, err := a.config.FormatOfFn(v)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		options = append(options, agentopt.ResponseFormat(format))
-		var data []byte
-		for update, err := range a.Run(ctx, messages, options...) {
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-			data = append(data, update.String()...)
-		}
-		if err := a.config.UnmarshalFn(format, data, v); err != nil {
-			yield(nil, err)
-			return
-		}
-	}
-}
-
-func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *chatagent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		originalMessages := messages
-		session, options, messages, ctxMessages, err := a.prepareSessionAndMessages(ctx, originalMessages, options)
+		session, options, messages, ctxMessages, err := prepareSessionAndMessages(ctx, a.instructions, originalMessages, options)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -160,16 +129,13 @@ func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Mess
 		var resp message.Response
 		for update, err := range a.runFn(ctx, messages, options...) {
 			if err != nil {
-				a.notifyContextProviderOfFailure(ctx, session, err, messages, ctxMessages)
+				notifyContextProviderOfFailure(ctx, session, err, messages, ctxMessages)
 				yield(nil, err)
 				return
 			}
 			if update != nil {
-				update.AuthorName = cmp.Or(update.AuthorName, a.Identity().Name())
 				resp.Update(update)
 				if !yield(&message.ResponseUpdate{
-					AuthorID:             a.Identity().ID(),
-					AuthorName:           update.AuthorName,
 					MessageID:            update.MessageID,
 					ResponseID:           update.ResponseID,
 					CreatedAt:            update.CreatedAt,
@@ -184,10 +150,10 @@ func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Mess
 			}
 		}
 		resp.Coalesce()
-		if session.ConversationID == "" && session.MessageStore == nil && a.config.NewMessageStore != nil {
+		if session.ConversationID == "" && session.MessageStore == nil && a.newMessageStore != nil {
 			// If we don't have a conversation ID then we must be managing the message store ourselves.
 			// If we don't have a message store yet and we have a factory, use it to create a new one.
-			session.MessageStore = a.config.NewMessageStore()
+			session.MessageStore = a.newMessageStore()
 		}
 		// Only notify the session of new messages if the response was successful to avoid inconsistent message state in the session.
 		if err := session.messagesReceived(ctx, append(originalMessages, append(ctxMessages, resp.Messages...)...)...); err != nil {
@@ -195,14 +161,14 @@ func (a *Agent) run(ctx context.Context, _ agent.Agent, messages []*message.Mess
 			return
 		}
 		// Notify the ContextProvider of all new messages.
-		if err := a.notifyContextProviderOfSuccess(ctx, session, messages, ctxMessages, resp.Messages); err != nil {
+		if err := notifyContextProviderOfSuccess(ctx, session, messages, ctxMessages, resp.Messages); err != nil {
 			yield(nil, err)
 			return
 		}
 	}
 }
 
-func (a *Agent) notifyContextProviderOfSuccess(ctx context.Context, session *Session, messages, contextProviderMessages, respMessages []*message.Message) error {
+func notifyContextProviderOfSuccess(ctx context.Context, session *Session, messages, contextProviderMessages, respMessages []*message.Message) error {
 	if session.ContextProvider == nil {
 		return nil
 	}
@@ -214,7 +180,7 @@ func (a *Agent) notifyContextProviderOfSuccess(ctx context.Context, session *Ses
 	})
 }
 
-func (a *Agent) notifyContextProviderOfFailure(ctx context.Context, session *Session, err error, messages, contextProviderMessages []*message.Message) error {
+func notifyContextProviderOfFailure(ctx context.Context, session *Session, err error, messages, contextProviderMessages []*message.Message) error {
 	if session.ContextProvider == nil {
 		return nil
 	}
@@ -226,7 +192,7 @@ func (a *Agent) notifyContextProviderOfFailure(ctx context.Context, session *Ses
 	})
 }
 
-func (a *Agent) prepareSessionAndMessages(ctx context.Context, messages []*message.Message, options []agentopt.RunOption) (session *Session, opts []agentopt.RunOption, msgsForClient, ctxMessages []*message.Message, err error) {
+func prepareSessionAndMessages(ctx context.Context, instr string, messages []*message.Message, options []agentopt.RunOption) (session *Session, opts []agentopt.RunOption, msgsForClient, ctxMessages []*message.Message, err error) {
 	retError := func(e error) (*Session, []agentopt.RunOption, []*message.Message, []*message.Message, error) {
 		return nil, nil, nil, nil, e
 	}
@@ -253,12 +219,12 @@ func (a *Agent) prepareSessionAndMessages(ctx context.Context, messages []*messa
 		}
 	}
 
-	if a.Instructions() != "" {
+	if instr != "" {
 		msgsForClient = append(msgsForClient, &message.Message{
 			Role: message.RoleSystem,
 			Contents: []message.Content{
 				&message.TextContent{
-					Text: a.Instructions(),
+					Text: instr,
 				},
 			},
 		})

--- a/agent/middleware/autocall/autocall.go
+++ b/agent/middleware/autocall/autocall.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/internal/slogx"
@@ -69,7 +68,7 @@ func New(cfg Config) middleware.Middleware {
 	return ac
 }
 
-func (f *autocall) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (f *autocall) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		tools, requiresApproval := f.createToolsMap(agentopt.All(opts, agentopt.Tool))
 
@@ -130,7 +129,7 @@ func (f *autocall) Run(next middleware.RunFunc, ctx context.Context, a agent.Age
 			functionCallContents = functionCallContents[:0]
 			var hasApprovalRequiringFcc bool
 			var lastApprovalCheckedFCCIdx, lastYieldedUpdateIdx int
-			for update, err := range next(ctx, a, messages, opts...) {
+			for update, err := range next(ctx, messages, opts...) {
 				if err != nil {
 					yield(nil, err)
 					return

--- a/agent/middleware/autocall/autocall_approval_test.go
+++ b/agent/middleware/autocall/autocall_approval_test.go
@@ -67,7 +67,7 @@ func invokeAndAssertApprovalWithAgent(t *testing.T, next middleware.RunFunc,
 
 	// Collect all streaming updates into messages
 	var updates []*message.ResponseUpdate
-	for update, err := range autocall.New(autocallOptions).Run(next, ctx, nil, input, opts...) {
+	for update, err := range autocall.New(autocallOptions).Run(next, ctx, input, opts...) {
 		if err != nil {
 			t.Fatalf("StreamingResponse failed: %v", err)
 		}
@@ -91,7 +91,7 @@ func expectApprovalError(t *testing.T, tools []tool.Tool, input []*message.Messa
 	}
 
 	var lastErr error
-	for _, err := range autocall.New(autocall.Config{}).Run(runner.Run, ctx, nil, input, opts...) {
+	for _, err := range autocall.New(autocall.Config{}).Run(runner.Run, ctx, input, opts...) {
 		if err != nil {
 			lastErr = err
 			break

--- a/agent/middleware/autocall/autocall_test.go
+++ b/agent/middleware/autocall/autocall_test.go
@@ -191,7 +191,7 @@ func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, e
 
 	// Collect all updates
 	var resp message.Response
-	for update, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
+	for update, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), initialMessages, opts...) {
 		if err != nil {
 			t.Fatalf("unexpected error during streaming: %v", err)
 		}
@@ -551,7 +551,7 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 			}
 
 			var streamErr error
-			for _, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
+			for _, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), initialMessages, opts...) {
 				if err != nil {
 					streamErr = err
 					break
@@ -667,7 +667,7 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 			}
 
 			var streamErr error
-			for _, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
+			for _, err := range autocall.New(autocallOptions).Run(runner.Run, t.Context(), initialMessages, opts...) {
 				if err != nil {
 					streamErr = err
 					break
@@ -886,7 +886,7 @@ func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 	}
 
 	var resp message.Response
-	for update, err := range autocall.New(autocall.Config{}).Run(runner.Run, t.Context(), nil, initialMessages, opts...) {
+	for update, err := range autocall.New(autocall.Config{}).Run(runner.Run, t.Context(), initialMessages, opts...) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/agent/middleware/logger/logger.go
+++ b/agent/middleware/logger/logger.go
@@ -34,33 +34,34 @@ type logger struct {
 	l slogx.Logger
 }
 
-func (l *logger) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (l *logger) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		start := time.Now()
-		l.log(ctx, a, slog.LevelDebug, "run invoked", slogx.SensitiveData("messages", messages), slogx.SensitiveData("opts", opts))
-		for update, err := range next(ctx, a, messages, opts...) {
+		l.log(ctx, slog.LevelDebug, "run invoked", slogx.SensitiveData("messages", messages), slogx.SensitiveData("opts", opts))
+		for update, err := range next(ctx, messages, opts...) {
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
-					l.log(ctx, a, slog.LevelDebug, "run canceled", "error", err)
+					l.log(ctx, slog.LevelDebug, "run canceled", "error", err)
 				} else {
-					l.log(ctx, a, slog.LevelError, "run failed", "error", err)
+					l.log(ctx, slog.LevelError, "run failed", "error", err)
 				}
 			} else if l.l.SensitiveData {
-				l.log(ctx, a, slog.LevelDebug, "run received update", slogx.SensitiveData("update", update))
+				l.log(ctx, slog.LevelDebug, "run received update", slogx.SensitiveData("update", update))
 			}
 			if !yield(update, err) {
 				return
 			}
 		}
-		l.log(ctx, a, slog.LevelDebug, "run completed", "duration", time.Since(start).String())
+		l.log(ctx, slog.LevelDebug, "run completed", "duration", time.Since(start).String())
 	}
 }
 
-func (l *logger) log(ctx context.Context, a agent.Agent, level slog.Level, msg string, args ...any) {
-	if a != nil {
-		args = append(args, "agentID", a.Identity().ID())
-		if a.Identity().Name() != "" {
-			args = append(args, "agentName", a.Identity().Name())
+func (l *logger) log(ctx context.Context, level slog.Level, msg string, args ...any) {
+	id, name, ok := agent.IdentityFromContext(ctx)
+	if ok {
+		args = append(args, "agentID", id)
+		if name != "" {
+			args = append(args, "agentName", name)
 		}
 	}
 	l.l.Log(ctx, level, msg, args...)

--- a/agent/middleware/logger/logger_test.go
+++ b/agent/middleware/logger/logger_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/agent/middleware/logger"
@@ -30,7 +29,7 @@ func TestLogger_Run_LogsDebugMessage(t *testing.T) {
 
 	// Create a simple next function
 	nextCalled := false
-	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		nextCalled = true
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
@@ -43,7 +42,7 @@ func TestLogger_Run_LogsDebugMessage(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(next, ctx, nil, messages)
+	seq := mw.Run(next, ctx, messages)
 	for range seq {
 	}
 
@@ -73,7 +72,7 @@ func TestLogger_Run_LogsTraceWithDetails(t *testing.T) {
 	mw := logger.New(logger.Config{Logger: log, SensitiveData: true})
 
 	// Create a simple next function
-	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
 		}
@@ -85,7 +84,7 @@ func TestLogger_Run_LogsTraceWithDetails(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(next, ctx, nil, messages)
+	seq := mw.Run(next, ctx, messages)
 	for range seq {
 	}
 
@@ -117,7 +116,7 @@ func TestLogger_Run_LogsErrors(t *testing.T) {
 
 	// Create a next function that returns an error
 	expectedError := errors.New("test error")
-	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(nil, expectedError)
 		}
@@ -129,7 +128,7 @@ func TestLogger_Run_LogsErrors(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(next, ctx, nil, messages)
+	seq := mw.Run(next, ctx, messages)
 	var receivedError error
 	for _, err := range seq {
 		if err != nil {
@@ -163,7 +162,7 @@ func TestLogger_Run_HandlesMultipleUpdates(t *testing.T) {
 	mw := logger.New(logger.Config{Logger: log, SensitiveData: true})
 
 	// Create a next function that yields multiple updates
-	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			if !yield(&message.ResponseUpdate{MessageID: "test-1"}, nil) {
 				return
@@ -181,7 +180,7 @@ func TestLogger_Run_HandlesMultipleUpdates(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(next, ctx, nil, messages)
+	seq := mw.Run(next, ctx, messages)
 	updateCount := 0
 	for range seq {
 		updateCount++
@@ -212,7 +211,7 @@ func TestLogger_Run_EarlyTermination(t *testing.T) {
 
 	// Create a next function that yields multiple updates
 	yieldCount := 0
-	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			for i := 0; i < 5; i++ {
 				yieldCount++
@@ -229,7 +228,7 @@ func TestLogger_Run_EarlyTermination(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(next, ctx, nil, messages)
+	seq := mw.Run(next, ctx, messages)
 	consumedCount := 0
 	for range seq {
 		consumedCount++
@@ -263,7 +262,7 @@ func TestLogger_Run_PropagatesContext(t *testing.T) {
 	type contextKey string
 	key := contextKey("test-key")
 	var receivedCtx context.Context
-	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		receivedCtx = ctx
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
@@ -276,7 +275,7 @@ func TestLogger_Run_PropagatesContext(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(next, ctx, nil, messages)
+	seq := mw.Run(next, ctx, messages)
 	for range seq {
 	}
 
@@ -309,7 +308,7 @@ func TestLogger_Run_WorksInMiddlewareChain(t *testing.T) {
 	}
 
 	// Base function
-	baseFn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	baseFn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		order = append(order, "base")
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{MessageID: "test-1"}, nil)
@@ -322,7 +321,7 @@ func TestLogger_Run_WorksInMiddlewareChain(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := middleware.RunChain(ctx, baseFn, []middleware.Middleware{loggerMw, testMw}, nil, messages)
+	seq := middleware.RunChain(ctx, baseFn, messages, middleware.With(loggerMw), middleware.With(testMw))
 	for range seq {
 	}
 
@@ -358,7 +357,7 @@ func TestLogger_Run_ContextCanceled(t *testing.T) {
 	mw := logger.New(logger.Config{Logger: log})
 
 	// Create a next function that checks for context cancellation
-	next := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	next := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			// Yield first update
 			if !yield(&message.ResponseUpdate{MessageID: "test-1"}, nil) {
@@ -384,7 +383,7 @@ func TestLogger_Run_ContextCanceled(t *testing.T) {
 		message.New(&message.TextContent{Text: "test message"}),
 	}
 
-	seq := mw.Run(next, ctx, nil, messages)
+	seq := mw.Run(next, ctx, messages)
 	var receivedError error
 	updateCount := 0
 	for _, err := range seq {
@@ -419,7 +418,7 @@ type testMiddleware struct {
 	onRun func(string)
 }
 
-func (tm *testMiddleware) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (tm *testMiddleware) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	tm.onRun(tm.name)
-	return next(ctx, nil, messages, options...)
+	return next(ctx, messages, options...)
 }

--- a/agent/middleware/middleware.go
+++ b/agent/middleware/middleware.go
@@ -5,35 +5,49 @@ package middleware
 import (
 	"context"
 	"iter"
-	"slices"
 
-	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-type RunFunc func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+type withMiddlewareOpt struct{ Middleware }
 
-type Middleware interface {
-	Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+func (o withMiddlewareOpt) Value() any {
+	return o.Middleware
 }
 
-type Func func(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+func (withMiddlewareOpt) RunOption() {}
 
-func (mf Func) Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-	return mf(next, ctx, a, messages, options...)
+func With(mw Middleware) agentopt.RunOption {
+	return withMiddlewareOpt{mw}
+}
+
+func WithFunc(fn Func) agentopt.RunOption {
+	return withMiddlewareOpt{fn}
+}
+
+type RunFunc = func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+
+type Middleware interface {
+	Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+}
+
+type Func func(next RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
+
+func (mf Func) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	return mf(next, ctx, messages, options...)
 }
 
 // RunChain applies the given middlewares around the given RunFunc.
-func RunChain(ctx context.Context, fn RunFunc, middlewares []Middleware, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func RunChain(ctx context.Context, fn RunFunc, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	// Chain the middlewares together.
-	for _, mw := range slices.Backward(middlewares) {
+	for mw := range agentopt.AllBackward(options, With) {
 		fn = middlewareRunner{
 			Middleware: mw,
 			next:       fn,
 		}.Run
 	}
-	return fn(ctx, a, messages, options...)
+	return fn(ctx, messages, options...)
 }
 
 type middlewareRunner struct {
@@ -41,6 +55,6 @@ type middlewareRunner struct {
 	next RunFunc
 }
 
-func (mr middlewareRunner) Run(ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-	return mr.Middleware.Run(mr.next, ctx, a, messages, opts...)
+func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	return mr.Middleware.Run(mr.next, ctx, messages, opts...)
 }

--- a/agent/middleware/middleware_test.go
+++ b/agent/middleware/middleware_test.go
@@ -1,27 +1,27 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package middleware
+package middleware_test
 
 import (
 	"context"
 	"iter"
 	"testing"
 
-	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
 func TestChain(t *testing.T) {
 	t.Run("empty middleware chain", func(t *testing.T) {
 		called := false
-		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			called = true
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{}, nil, []*message.Message{})
+		seq := middleware.RunChain(ctx, fn, []*message.Message{})
 		for range seq {
 		}
 
@@ -33,7 +33,7 @@ func TestChain(t *testing.T) {
 	t.Run("single middleware", func(t *testing.T) {
 		order := []string{}
 
-		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			order = append(order, "base")
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -46,7 +46,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{})
+		seq := middleware.RunChain(ctx, fn, []*message.Message{}, middleware.With(mw))
 		for range seq {
 		}
 
@@ -64,7 +64,7 @@ func TestChain(t *testing.T) {
 	t.Run("multiple middlewares", func(t *testing.T) {
 		order := []string{}
 
-		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			order = append(order, "base")
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -89,7 +89,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw1, mw2, mw3}, nil, []*message.Message{})
+		seq := middleware.RunChain(ctx, fn, []*message.Message{}, middleware.With(mw1), middleware.With(mw2), middleware.With(mw3))
 		for range seq {
 		}
 
@@ -108,7 +108,7 @@ func TestChain(t *testing.T) {
 	t.Run("middleware can modify options", func(t *testing.T) {
 		receivedOpts := []agentopt.RunOption{}
 
-		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			receivedOpts = options
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -124,23 +124,23 @@ func TestChain(t *testing.T) {
 
 		initialOpt := &testOption{value: "initial"}
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{}, initialOpt)
+		seq := middleware.RunChain(ctx, fn, []*message.Message{}, middleware.With(mw), initialOpt)
 		for range seq {
 		}
 
-		if len(receivedOpts) != 2 {
-			t.Fatalf("expected 2 options, got %d", len(receivedOpts))
+		if len(receivedOpts) != 3 {
+			t.Fatalf("expected 3 options, got %d", len(receivedOpts))
 		}
-		if receivedOpts[0].(*testOption).value != "initial" {
-			t.Errorf("expected first option to be 'initial', got %s", receivedOpts[0].(*testOption).value)
+		if receivedOpts[1].(*testOption).value != "initial" {
+			t.Errorf("expected first option to be 'initial', got %s", receivedOpts[1].(*testOption).value)
 		}
-		if receivedOpts[1].(*testOption).value != "injected" {
-			t.Errorf("expected second option to be 'injected', got %s", receivedOpts[1].(*testOption).value)
+		if receivedOpts[2].(*testOption).value != "injected" {
+			t.Errorf("expected second option to be 'injected', got %s", receivedOpts[2].(*testOption).value)
 		}
 	})
 
 	t.Run("middleware can intercept and modify sequence", func(t *testing.T) {
-		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			return func(yield func(*message.ResponseUpdate, error) bool) {
 				if !yield(&message.ResponseUpdate{}, nil) {
 					return
@@ -154,7 +154,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{})
+		seq := middleware.RunChain(ctx, fn, []*message.Message{}, middleware.With(mw))
 
 		count := 0
 		for range seq {
@@ -172,7 +172,7 @@ func TestChain(t *testing.T) {
 		key := contextKey("test")
 
 		var capturedCtx context.Context
-		fn := func(ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		fn := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			capturedCtx = ctx
 			return func(yield func(*message.ResponseUpdate, error) bool) {}
 		}
@@ -183,7 +183,7 @@ func TestChain(t *testing.T) {
 		}
 
 		ctx := context.WithValue(context.Background(), key, "value")
-		seq := RunChain(ctx, fn, []Middleware{mw}, nil, []*message.Message{})
+		seq := middleware.RunChain(ctx, fn, []*message.Message{}, middleware.With(mw))
 		for range seq {
 		}
 
@@ -203,7 +203,7 @@ type testMiddleware struct {
 	modifyOpts func([]agentopt.RunOption) []agentopt.RunOption
 }
 
-func (tm *testMiddleware) Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (tm *testMiddleware) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	tm.onRun(tm.name)
 
 	opts := options
@@ -211,7 +211,7 @@ func (tm *testMiddleware) Run(next RunFunc, ctx context.Context, a agent.Agent, 
 		opts = tm.modifyOpts(options)
 	}
 
-	return next(ctx, a, messages, opts...)
+	return next(ctx, messages, opts...)
 }
 
 // interceptMiddleware intercepts and limits the number of updates
@@ -219,10 +219,10 @@ type interceptMiddleware struct {
 	interceptCount int
 }
 
-func (im *interceptMiddleware) Run(next RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (im *interceptMiddleware) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		count := 0
-		for update, err := range next(ctx, a, messages, options...) {
+		for update, err := range next(ctx, messages, options...) {
 			if count >= im.interceptCount {
 				return
 			}

--- a/agent/middleware/structuredoutput/structuredoutput.go
+++ b/agent/middleware/structuredoutput/structuredoutput.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package structuredoutput
+
+import (
+	"context"
+	"errors"
+	"iter"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/format"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+type Config struct {
+	Format    func(v any) (format.Format, error)
+	Unmarshal func(format format.Format, data []byte, v any) error
+}
+
+func New(cfg Config) middleware.Middleware {
+	return &so{
+		Format:    cfg.Format,
+		Unmarshal: cfg.Unmarshal,
+	}
+}
+
+var _ middleware.Middleware = (*so)(nil)
+
+type so struct {
+	Format    func(v any) (format.Format, error)
+	Unmarshal func(format format.Format, data []byte, v any) error
+}
+
+func (a *so) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	return func(yield func(*message.ResponseUpdate, error) bool) {
+		v, ok := agentopt.Get(options, agentopt.StructuredOutput)
+		if !ok || v == nil {
+			// No structured output requested or nil value, just pass through.
+			for update, err := range next(ctx, messages, options...) {
+				if !yield(update, err) {
+					break
+				}
+			}
+			return
+		}
+		if a.Format == nil || a.Unmarshal == nil {
+			yield(nil, errors.New("structured output not supported"))
+			return
+		}
+		format, err := a.Format(v)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		options = append(options, agentopt.ResponseFormat(format))
+		var data []byte
+		for update, err := range next(ctx, messages, options...) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			data = append(data, update.String()...)
+		}
+		if err := a.Unmarshal(format, data, v); err != nil {
+			yield(nil, err)
+			return
+		}
+	}
+}

--- a/agent/middleware/structuredoutput/structuredoutput_test.go
+++ b/agent/middleware/structuredoutput/structuredoutput_test.go
@@ -1,0 +1,550 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package structuredoutput_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/agent/middleware/structuredoutput"
+	"github.com/microsoft/agent-framework-go/format"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+type testFormat struct {
+	kind string
+}
+
+func (t testFormat) Kind() string {
+	return t.kind
+}
+
+func TestStructuredOutput_NoStructuredOutputOption(t *testing.T) {
+	// Test that middleware passes through when no structured output option is provided
+	baseCalled := false
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		baseCalled = true
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: "test response"},
+				},
+			}, nil)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+
+	var updates []*message.ResponseUpdate
+	seq := middleware.RunChain(ctx, baseFunc, messages, middleware.With(mw))
+	for update, err := range seq {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if !baseCalled {
+		t.Error("expected base function to be called")
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updates))
+	}
+
+	if updates[0].String() != "test response" {
+		t.Errorf("expected 'test response', got '%s'", updates[0].String())
+	}
+}
+
+func TestStructuredOutput_NilStructuredOutputOption(t *testing.T) {
+	// Test that middleware passes through when structured output option is nil
+	baseCalled := false
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		baseCalled = true
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: "test response"},
+				},
+			}, nil)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(nil)}
+
+	var updates []*message.ResponseUpdate
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for update, err := range seq {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if !baseCalled {
+		t.Error("expected base function to be called")
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updates))
+	}
+}
+
+func TestStructuredOutput_MissingFormat(t *testing.T) {
+	// Test that middleware returns error when Format is nil
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `{"name":"test"}`},
+				},
+			}, nil)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: nil, // Missing Format
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct{ Name string }{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err == nil {
+			t.Fatal("expected error for missing Format")
+		}
+		if err.Error() != "structured output not supported" {
+			t.Errorf("expected 'structured output not supported', got '%s'", err.Error())
+		}
+		return
+	}
+	t.Fatal("expected error to be yielded")
+}
+
+func TestStructuredOutput_MissingUnmarshal(t *testing.T) {
+	// Test that middleware returns error when Unmarshal is nil
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `{"name":"test"}`},
+				},
+			}, nil)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: nil, // Missing Unmarshal
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct{ Name string }{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err == nil {
+			t.Fatal("expected error for missing Unmarshal")
+		}
+		if err.Error() != "structured output not supported" {
+			t.Errorf("expected 'structured output not supported', got '%s'", err.Error())
+		}
+		return
+	}
+	t.Fatal("expected error to be yielded")
+}
+
+func TestStructuredOutput_FormatError(t *testing.T) {
+	// Test that middleware propagates Format errors
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `{"name":"test"}`},
+				},
+			}, nil)
+		}
+	}
+
+	expectedErr := errors.New("format creation failed")
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return nil, expectedErr
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct{ Name string }{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err == nil {
+			t.Fatal("expected error for Format failure")
+		}
+		if !errors.Is(err, expectedErr) {
+			t.Errorf("expected error to be %v, got %v", expectedErr, err)
+		}
+		return
+	}
+	t.Fatal("expected error to be yielded")
+}
+
+func TestStructuredOutput_SuccessfulUnmarshal(t *testing.T) {
+	// Test successful structured output parsing
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			// Verify that ResponseFormat option was added
+			v, ok := agentopt.Get(options, agentopt.ResponseFormat)
+			if !ok {
+				yield(nil, errors.New("ResponseFormat option not found"))
+				return
+			}
+			if v.Kind() != "json" {
+				yield(nil, errors.New("ResponseFormat is not the expected format"))
+				return
+			}
+
+			// Simulate streaming response in parts
+			if !yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `{"name":`},
+				},
+			}, nil) {
+				return
+			}
+			if !yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `"Alice",`},
+				},
+			}, nil) {
+				return
+			}
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `"age":30}`},
+				},
+			}, nil)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if output.Name != "Alice" {
+		t.Errorf("expected Name to be 'Alice', got '%s'", output.Name)
+	}
+	if output.Age != 30 {
+		t.Errorf("expected Age to be 30, got %d", output.Age)
+	}
+}
+
+func TestStructuredOutput_UnmarshalError(t *testing.T) {
+	// Test that middleware propagates Unmarshal errors
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `{"name":"test"}`},
+				},
+			}, nil)
+		}
+	}
+
+	expectedErr := errors.New("unmarshal failed")
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return expectedErr
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct{ Name string }{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err == nil {
+			t.Fatal("expected error for Unmarshal failure")
+		}
+		if !errors.Is(err, expectedErr) {
+			t.Errorf("expected error to be %v, got %v", expectedErr, err)
+		}
+		return
+	}
+	t.Fatal("expected error to be yielded")
+}
+
+func TestStructuredOutput_BaseErrorPropagation(t *testing.T) {
+	// Test that errors from the base function are propagated
+	expectedErr := errors.New("base function error")
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(nil, expectedErr)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct{ Name string }{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err == nil {
+			t.Fatal("expected error from base function")
+		}
+		if !errors.Is(err, expectedErr) {
+			t.Errorf("expected error to be %v, got %v", expectedErr, err)
+		}
+		return
+	}
+	t.Fatal("expected error to be yielded")
+}
+
+func TestStructuredOutput_ComplexStructure(t *testing.T) {
+	// Test with a more complex nested structure
+	type Address struct {
+		Street string `json:"street"`
+		City   string `json:"city"`
+	}
+	type Person struct {
+		Name    string   `json:"name"`
+		Age     int      `json:"age"`
+		Address Address  `json:"address"`
+		Tags    []string `json:"tags"`
+	}
+
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			jsonStr := `{"name":"Bob","age":25,"address":{"street":"123 Main St","city":"Springfield"},"tags":["developer","golang"]}`
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: jsonStr},
+				},
+			}, nil)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &Person{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if output.Name != "Bob" {
+		t.Errorf("expected Name to be 'Bob', got '%s'", output.Name)
+	}
+	if output.Age != 25 {
+		t.Errorf("expected Age to be 25, got %d", output.Age)
+	}
+	if output.Address.Street != "123 Main St" {
+		t.Errorf("expected Street to be '123 Main St', got '%s'", output.Address.Street)
+	}
+	if output.Address.City != "Springfield" {
+		t.Errorf("expected City to be 'Springfield', got '%s'", output.Address.City)
+	}
+	if len(output.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(output.Tags))
+	}
+	if output.Tags[0] != "developer" || output.Tags[1] != "golang" {
+		t.Errorf("expected tags to be [developer, golang], got %v", output.Tags)
+	}
+}
+
+func TestStructuredOutput_EmptyResponse(t *testing.T) {
+	// Test with an empty response
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			// Empty response
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			if len(data) == 0 {
+				return errors.New("empty data")
+			}
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct{ Name string }{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err == nil {
+			t.Fatal("expected error for empty response")
+		}
+		if err.Error() != "empty data" {
+			t.Errorf("expected 'empty data' error, got '%s'", err.Error())
+		}
+		return
+	}
+	t.Fatal("expected error to be yielded")
+}
+
+func TestStructuredOutput_MultipleContentTypes(t *testing.T) {
+	// Test that only text content is collected for unmarshaling
+	baseFunc := func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			if !yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `{"name":`},
+				},
+			}, nil) {
+				return
+			}
+			if !yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.FunctionCallContent{
+						CallID:    "call1",
+						Name:      "test",
+						Arguments: "{}",
+					},
+				},
+			}, nil) {
+				return
+			}
+			yield(&message.ResponseUpdate{
+				Contents: message.Contents{
+					&message.TextContent{Text: `"Charlie"}`},
+				},
+			}, nil)
+		}
+	}
+
+	cfg := structuredoutput.Config{
+		Format: func(v any) (format.Format, error) {
+			return testFormat{kind: "json"}, nil
+		},
+		Unmarshal: func(format format.Format, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}
+
+	mw := structuredoutput.New(cfg)
+	ctx := context.Background()
+	messages := []*message.Message{}
+	output := &struct {
+		Name string `json:"name"`
+	}{}
+	options := []agentopt.RunOption{agentopt.StructuredOutput(output)}
+
+	seq := middleware.RunChain(ctx, baseFunc, messages, append([]agentopt.RunOption{middleware.With(mw)}, options...)...)
+	for _, err := range seq {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if output.Name != "Charlie" {
+		t.Errorf("expected Name to be 'Charlie', got '%s'", output.Name)
+	}
+}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -4,17 +4,32 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"iter"
 
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/message"
 )
+
+type identityKey struct{}
+
+type identity struct {
+	id   string
+	name string
+}
+
+func IdentityFromContext(ctx context.Context) (id, name string, ok bool) {
+	if v := ctx.Value(identityKey{}); v != nil {
+		ident := v.(identity)
+		return ident.id, ident.name, true
+	}
+	return "", "", false
+}
 
 // Run executes the agent with the given options and returns the response.
 func Run(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) (*message.Response, error) {
 	var resp message.Response
-	for update, err := range a.Run(ctx, messages, opts...) {
+	for update, err := range run(ctx, a, messages, opts...) {
 		if err != nil {
 			return nil, err
 		}
@@ -37,7 +52,7 @@ func RunMessage(ctx context.Context, a Agent, msg *message.Message, opts ...agen
 // RunStream executes the agent with the given options and returns a streaming sequence of response updates.
 func RunStream(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	opts = append(opts, agentopt.Stream(true))
-	return a.Run(ctx, messages, opts...)
+	return run(ctx, a, messages, opts...)
 }
 
 // RunTextStream executes the agent with a single text message and returns a streaming sequence of response updates.
@@ -63,14 +78,51 @@ func RunMessageFor[T any](ctx context.Context, a Agent, msg *message.Message, op
 // RunFor executes the agent with the given messages and returns the result of type T.
 func RunFor[T any](ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) (T, error) {
 	var v T
-	if a, ok := a.(StructuredOutputAgent); ok {
-		for _, err := range a.RunOf(ctx, &v, messages, opts...) {
-			if err != nil {
-				return v, err
-			}
-			// Exhaust the iterator to get the final result.
-		}
-		return v, nil
+	opts = append(opts, agentopt.StructuredOutput(&v))
+	_, err := Run(ctx, a, messages, opts...)
+	return v, err
+}
+
+func run(ctx context.Context, a Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+	if a, ok := a.(interface{ RunOptions() []agentopt.RunOption }); ok {
+		// Prepend options from agent configuration.
+		options = append(a.RunOptions(), options...)
 	}
-	return v, errors.New("agent does not support structured output")
+	// Ensure a session is provided in the options.
+	if _, ok := agentopt.Get(options, agentopt.Session); !ok {
+		session, err := a.NewSession(ctx)
+		if err != nil {
+			return func(yield func(*message.ResponseUpdate, error) bool) {
+				yield(nil, err)
+			}
+		}
+		options = append(options, agentopt.Session(session))
+	}
+	// Middleware to set AuthorID and AuthorName on each ResponseUpdate.
+	options = append(options, middleware.With(middleware.Func(
+		func(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+			return func(yield func(*message.ResponseUpdate, error) bool) {
+				id, name := a.ID(), a.Name()
+				for update, err := range next(ctx, messages, options...) {
+					if update != nil {
+						if update.AuthorID == "" {
+							update.AuthorID = id
+						}
+						if update.AuthorName == "" {
+							update.AuthorName = name
+						}
+					}
+					if !yield(update, err) {
+						return
+					}
+				}
+			}
+		})))
+
+	// Add agent identity to context so that middlewares can log it.
+	ctx = context.WithValue(ctx, identityKey{}, identity{
+		id:   a.ID(),
+		name: a.Name(),
+	})
+	return middleware.RunChain(ctx, a.Run, messages, options...)
 }

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -7,7 +7,6 @@ import (
 	"iter"
 
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
-	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -29,7 +28,7 @@ func IdentityFromContext(ctx context.Context) (id, name string, ok bool) {
 // Run executes the agent with the given options and returns the response.
 func Run(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) (*message.Response, error) {
 	var resp message.Response
-	for update, err := range run(ctx, a, messages, opts...) {
+	for update, err := range a.Run(ctx, messages, opts...) {
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +51,7 @@ func RunMessage(ctx context.Context, a Agent, msg *message.Message, opts ...agen
 // RunStream executes the agent with the given options and returns a streaming sequence of response updates.
 func RunStream(ctx context.Context, a Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	opts = append(opts, agentopt.Stream(true))
-	return run(ctx, a, messages, opts...)
+	return a.Run(ctx, messages, opts...)
 }
 
 // RunTextStream executes the agent with a single text message and returns a streaming sequence of response updates.
@@ -81,48 +80,4 @@ func RunFor[T any](ctx context.Context, a Agent, messages []*message.Message, op
 	opts = append(opts, agentopt.StructuredOutput(&v))
 	_, err := Run(ctx, a, messages, opts...)
 	return v, err
-}
-
-func run(ctx context.Context, a Agent, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-	if a, ok := a.(interface{ RunOptions() []agentopt.RunOption }); ok {
-		// Prepend options from agent configuration.
-		options = append(a.RunOptions(), options...)
-	}
-	// Ensure a session is provided in the options.
-	if _, ok := agentopt.Get(options, agentopt.Session); !ok {
-		session, err := a.NewSession(ctx)
-		if err != nil {
-			return func(yield func(*message.ResponseUpdate, error) bool) {
-				yield(nil, err)
-			}
-		}
-		options = append(options, agentopt.Session(session))
-	}
-	// Middleware to set AuthorID and AuthorName on each ResponseUpdate.
-	options = append(options, middleware.With(middleware.Func(
-		func(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
-			return func(yield func(*message.ResponseUpdate, error) bool) {
-				id, name := a.ID(), a.Name()
-				for update, err := range next(ctx, messages, options...) {
-					if update != nil {
-						if update.AuthorID == "" {
-							update.AuthorID = id
-						}
-						if update.AuthorName == "" {
-							update.AuthorName = name
-						}
-					}
-					if !yield(update, err) {
-						return
-					}
-				}
-			}
-		})))
-
-	// Add agent identity to context so that middlewares can log it.
-	ctx = context.WithValue(ctx, identityKey{}, identity{
-		id:   a.ID(),
-		name: a.Name(),
-	})
-	return middleware.RunChain(ctx, a.Run, messages, options...)
 }

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -14,13 +14,12 @@ import (
 // FuncTool creates a function tool that invokes the given agent.
 // The provided session is used for the agent's context during invocations,
 // or nil to create a new session for each invocation.
-func FuncTool(agent Agent, session memory.Session) tool.FuncTool {
-	iden := agent.Identity()
+func FuncTool(a Agent, session memory.Session) tool.FuncTool {
 	return functool{
-		name:        iden.Name(),
-		description: iden.Description(),
+		name:        a.Name(),
+		description: a.Description(),
 		session:     session,
-		agent:       agent,
+		agent:       a,
 	}
 }
 

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -89,24 +89,21 @@ func newExecutor(a Agent, emitEvents bool) *workflow.Executor {
 	return ex
 }
 
-func Bind(ag Agent, emitEvents bool) *workflow.ExecutorBinding {
+func Bind(a Agent, emitEvents bool) *workflow.ExecutorBinding {
 	return &workflow.ExecutorBinding{
-		ID:           agentDescriptiveID(ag),
-		ExecutorType: reflect.TypeOf(ag),
-		Raw:          ag,
+		ID:           agentDescriptiveID(a),
+		ExecutorType: reflect.TypeOf(a),
+		Raw:          a,
 		NewExecutor: func(_ string) (*workflow.Executor, error) {
-			return newExecutor(ag, emitEvents), nil
+			return newExecutor(a, emitEvents), nil
 		},
 		SupportsConcurrentSharedExecution: true,
 	}
 }
 
-func agentDescriptiveID(ag Agent) string {
-	iden := ag.Identity()
-	id := iden.ID()
-	name := iden.Name()
-	if name != "" {
-		return name + "_" + id
+func agentDescriptiveID(a Agent) string {
+	if a.Name() != "" {
+		return a.Name() + "_" + a.ID()
 	}
-	return id
+	return a.ID()
 }

--- a/anthropic/chat.go
+++ b/anthropic/chat.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/message"
@@ -32,7 +33,7 @@ type ClientConfig struct {
 	BaseURL string // Optional, defaults to Anthropic API
 }
 
-func NewChatAgent(config ClientConfig, options chatagent.Config) *chatagent.Agent {
+func NewChatAgent(config ClientConfig, options chatagent.Config) agent.Agent {
 	opts := []option.RequestOption{}
 	if config.APIKey != "" {
 		opts = append(opts, option.WithAPIKey(config.APIKey))

--- a/examples/getting_started/agent/step01_running/main.go
+++ b/examples/getting_started/agent/step01_running/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
@@ -24,7 +25,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 	})
 
 	ctx := context.Background()

--- a/examples/getting_started/agent/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/agent/step02_multiturn_conversation/main.go
@@ -25,7 +25,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 	})
 
 	ctx := context.Background()

--- a/examples/getting_started/agent/step03_using_function_tools/main.go
+++ b/examples/getting_started/agent/step03_using_function_tools/main.go
@@ -34,9 +34,9 @@ func main() {
 		Model: "gpt-4o-mini",
 	}, chatagent.Config{
 		Instructions: "You are a helpful assistant",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
 		RunOptions: []agentopt.RunOption{
 			agentopt.Tool(weatherTool),
+			middleware.With(logger), // for logging agent interactions
 		},
 	})
 

--- a/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
@@ -37,9 +37,9 @@ func main() {
 		Model: "gpt-4o-mini",
 	}, chatagent.Config{
 		Instructions: "You are a helpful assistant",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
 		RunOptions: []agentopt.RunOption{
 			agentopt.Tool(tool.ApprovalRequiredFunc(weatherTool)),
+			middleware.With(logger), // for logging agent interactions
 		},
 	})
 

--- a/examples/getting_started/agent/step05_structured_output/main.go
+++ b/examples/getting_started/agent/step05_structured_output/main.go
@@ -34,7 +34,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are a helpful assistant.",
 		Name:         "HelpfulAssistant",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 	})
 
 	ctx := context.Background()
@@ -57,9 +57,9 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are a helpful assistant.",
 		Name:         "HelpfulAssistant",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
 		RunOptions: []agentopt.RunOption{
 			agentopt.ResponseFormat(jsonformat.MustFor[PersonInfo]()),
+			middleware.With(logger), // for logging agent interactions
 		},
 	})
 

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -28,7 +28,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 	})
 
 	ctx := context.Background()

--- a/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
+++ b/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
@@ -41,7 +41,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 		NewMessageStore: func() memory.MessageStore {
 			return &fsMessageStore{Dir: tmpDir}
 		},

--- a/examples/getting_started/agent/step11_using_images/main.go
+++ b/examples/getting_started/agent/step11_using_images/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
@@ -26,7 +27,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are a helpful agent that can analyze images.",
 		Name:         "VisionAgent",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 	})
 
 	ctx := context.Background()

--- a/examples/getting_started/agent/step12_as_function_tool/main.go
+++ b/examples/getting_started/agent/step12_as_function_tool/main.go
@@ -38,9 +38,9 @@ func main() {
 		Instructions: "You answer questions about the weather.",
 		Name:         "WeatherAgent",
 		Description:  "An agent that answers questions about the weather.",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
 		RunOptions: []agentopt.RunOption{
 			agentopt.Tool(weatherTool),
+			middleware.With(logger), // for logging agent interactions
 		},
 	})
 

--- a/examples/getting_started/agent/step14_middleware/main.go
+++ b/examples/getting_started/agent/step14_middleware/main.go
@@ -27,14 +27,14 @@ func main() {
 		Model: "gpt-5-nano",
 	}, chatagent.Config{
 		Instructions: "You are an AI assistant that helps people find information.",
-		Middlewares:  []middleware.Middleware{logger, middleware.Func(guardrailsMiddleware)},
+		RunOptions:   []agentopt.RunOption{middleware.With(logger), middleware.WithFunc(guardrailsMiddleware)},
 	})
 
 	demo.Response(agent.RunText(context.Background(), a, "Tell me something that contains the word harmful."))
 }
 
 // guardrailsMiddleware enforces guardrails by redacting certain keywords from input and output messages.
-func guardrailsMiddleware(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func guardrailsMiddleware(next middleware.RunFunc, ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	redact := func(contents message.Contents) message.Contents {
 		// Simple redaction logic for demonstration purposes.
 		for _, c := range contents {
@@ -51,7 +51,7 @@ func guardrailsMiddleware(next middleware.RunFunc, ctx context.Context, a agent.
 			msg.Contents = redact(msg.Contents)
 		}
 		// Call the next middleware/agent in the chain.
-		for update, err := range next(ctx, a, messages, opts...) {
+		for update, err := range next(ctx, messages, opts...) {
 			if err == nil && update != nil {
 				// Redact keywords from output messages
 				update.Contents = redact(update.Contents)

--- a/examples/getting_started/agent/step17_background_responses/main.go
+++ b/examples/getting_started/agent/step17_background_responses/main.go
@@ -24,7 +24,7 @@ func main() {
 	a := openai.NewResponsesAgent(openai.ClientConfig{
 		Model: "gpt-5-nano",
 	}, chatagent.Config{
-		Middlewares: []middleware.Middleware{logger},
+		RunOptions: []agentopt.RunOption{middleware.With(logger)},
 	})
 
 	ctx := context.Background()

--- a/examples/getting_started/anthropic/step01_running/main.go
+++ b/examples/getting_started/anthropic/step01_running/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/anthropic"
@@ -25,7 +26,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 	})
 
 	ctx := context.Background()

--- a/examples/getting_started/azure_openai/step01_running/main.go
+++ b/examples/getting_started/azure_openai/step01_running/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
@@ -29,7 +30,7 @@ func main() {
 	}, chatagent.Config{
 		Instructions: "You are good at telling jokes.",
 		Name:         "Joker",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
 	})
 
 	ctx := context.Background()

--- a/examples/getting_started/mcp/agent_mcp_server/main.go
+++ b/examples/getting_started/mcp/agent_mcp_server/main.go
@@ -43,6 +43,7 @@ func main() {
 	for _, t := range tools {
 		opts = append(opts, agentopt.Tool(t))
 	}
+	opts = append(opts, middleware.With(logger)) // for logging agent interactions
 
 	// Create the Agent with MCP tools
 	// In Go, we configure tools as default options that will be used for all runs
@@ -51,7 +52,6 @@ func main() {
 	}, chatagent.Config{
 		Name:         "DocsAgent",
 		Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
-		Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
 		RunOptions:   opts,
 	})
 

--- a/examples/internal/demo/demo.go
+++ b/examples/internal/demo/demo.go
@@ -8,7 +8,6 @@ import (
 	"iter"
 	"strings"
 
-	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/middleware"
 	"github.com/microsoft/agent-framework-go/message"
@@ -44,7 +43,7 @@ func NewLogger(name, description string, metadata ...string) middleware.Middlewa
 	return &logger{}
 }
 
-func (mw *logger) Run(next middleware.RunFunc, ctx context.Context, a agent.Agent, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (mw *logger) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		mw.n++
 		fmt.Printf("===== Run %d =====\n\n", mw.n)
@@ -54,7 +53,7 @@ func (mw *logger) Run(next middleware.RunFunc, ctx context.Context, a agent.Agen
 			}
 		}
 		first := true
-		for update, err := range next(ctx, a, messages, opts...) {
+		for update, err := range next(ctx, messages, opts...) {
 			if err == nil && update.String() != "" {
 				if first {
 					assistant()

--- a/openai/chat.go
+++ b/openai/chat.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/format"
@@ -60,7 +61,7 @@ type ClientConfig struct {
 	APIVersion string
 }
 
-func newChatAgent(isAzure bool, config ClientConfig, options chatagent.Config) *chatagent.Agent {
+func newChatAgent(isAzure bool, config ClientConfig, options chatagent.Config) agent.Agent {
 	ops := make([]option.RequestOption, 0, 2)
 	if isAzure {
 		if config.Endpoint != "" {
@@ -97,12 +98,12 @@ func newChatAgent(isAzure bool, config ClientConfig, options chatagent.Config) *
 	return chatagent.NewAgent(c.run, options)
 }
 
-func NewChatAgent(config ClientConfig, options chatagent.Config) *chatagent.Agent {
+func NewChatAgent(config ClientConfig, options chatagent.Config) agent.Agent {
 	return newChatAgent(false, config, options)
 }
 
 // NewChatAgentAzure creates a new [Agent].
-func NewChatAgentAzure(config ClientConfig, options chatagent.Config) *chatagent.Agent {
+func NewChatAgentAzure(config ClientConfig, options chatagent.Config) agent.Agent {
 	return newChatAgent(true, config, options)
 }
 

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/agentopt"
 	"github.com/microsoft/agent-framework-go/agent/chatagent"
 	"github.com/microsoft/agent-framework-go/format"
@@ -36,7 +37,7 @@ type responsesClient struct {
 	config ClientConfig
 }
 
-func newResponsesAgent(isAzure bool, config ClientConfig, options chatagent.Config) *chatagent.Agent {
+func newResponsesAgent(isAzure bool, config ClientConfig, options chatagent.Config) agent.Agent {
 	ops := make([]option.RequestOption, 0, 2)
 	if isAzure {
 		if config.Endpoint != "" {
@@ -81,12 +82,12 @@ func (a *responsesClient) unmarshal(format format.Format, data []byte, v any) er
 	return jsonformat.Unmarshal(format.(*jsonformat.Format), data, v)
 }
 
-func NewResponsesAgent(config ClientConfig, options chatagent.Config) *chatagent.Agent {
+func NewResponsesAgent(config ClientConfig, options chatagent.Config) agent.Agent {
 	return newResponsesAgent(false, config, options)
 }
 
 // NewResponsesAgentAzure creates a new [Agent].
-func NewResponsesAgentAzure(config ClientConfig, options chatagent.Config) *chatagent.Agent {
+func NewResponsesAgentAzure(config ClientConfig, options chatagent.Config) agent.Agent {
 	return newResponsesAgent(true, config, options)
 }
 

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -4462,7 +4462,7 @@ func TestResponsesBackgroundResponses_StreamResumption_WithMessages(t *testing.T
 	token := `{"response_id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","sequence_number":9}`
 
 	// Attempt to resume stream with messages should fail
-	for _, err := range a.Run(context.Background(), []*message.Message{
+	for _, err := range agent.RunStream(context.Background(), a, []*message.Message{
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Please book a hotel for me"}}},
 	},
 		agentopt.AllowBackgroundResponses(true),


### PR DESCRIPTION
The .NET and Python sdk's support having common pre/post-processing login in the Agent base class without requiring all implementations to duplicate it. That is achieved using different language features not fully supported by Go, like inheritance and abstract methods.

Until now we have been duplicating logic here and there, adding burden to the agent providers. This PR resolves the issue by adding a private method to the `agent.Agent` interface, effectively rendering it unimplementable by third party packages. Instead, the `agent` package provides a new `New` function, which instantiates an agent that implements all the common processing, and opens the door to adding new common features in the future.

The main benefit the our users will notice is a consolidated way to run middlewares, support for per-run middlewares, and messages updates with consistent author IDs and names.