### PR TITLE
Added Azure OpenAI Getting Started Examples

### DIFF
--- a/examples/getting_started/azure_openai/step01_running/main.go
+++ b/examples/getting_started/azure_openai/step01_running/main.go
@@ -14,6 +14,8 @@ import (
 )
 
 var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
 
 var logger = demo.NewLogger(
 	"Basic Run",
@@ -24,6 +26,8 @@ var logger = demo.NewLogger(
 func main() {
 	// Create Azure OpenAI agent with weather tool
 	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
 		Model:      deployment,
 		APIVersion: "2025-01-01-preview",
 	}, chatagent.Config{

--- a/examples/getting_started/azure_openai/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/azure_openai/step02_multiturn_conversation/main.go
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/openai"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"Multi-Turn Conversation",
+	"Demonstrates how to preserve conversation context with sessions.",
+	"Model", deployment,
+)
+
+func main() {
+	// Create Azure OpenAI agent.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are good at telling jokes.",
+		Name:         "Joker",
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
+	})
+
+	ctx := context.Background()
+
+	// Invoke the agent with a multi-turn conversation, where the context is preserved in the session object.
+	session, err := a.CreateSession(ctx)
+	if err != nil {
+		demo.Panic(err)
+	}
+	resp, err := a.RunText("Tell me a joke about a pirate.", agentopt.Session(session)).Collect(ctx)
+	demo.Response(resp, err)
+	resp, err = a.RunText("Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Session(session)).Collect(ctx)
+	demo.Response(resp, err)
+
+	// Invoke the agent with a multi-turn conversation and streaming, where the context is preserved in the session object.
+	session2, err := a.CreateSession(ctx)
+	if err != nil {
+		demo.Panic(err)
+	}
+	for update, err := range a.RunText("Tell me a joke about a pirate.", agentopt.Session(session2)).All(ctx) {
+		demo.Response(update, err)
+	}
+	for update, err := range a.RunText("Now add some emojis to the joke and tell it in the voice of a pirate's parrot.", agentopt.Session(session2)).All(ctx) {
+		demo.Response(update, err)
+	}
+}

--- a/examples/getting_started/azure_openai/step03_using_function_tools/main.go
+++ b/examples/getting_started/azure_openai/step03_using_function_tools/main.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/openai"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"Function Tools",
+	"Demonstrates how to use function tools.",
+	"Model", deployment,
+)
+
+var weatherTool = functool.MustNew(&functool.Func{
+	Name:        "weather",
+	Description: "Get the current weather for a given location",
+}, func(_ context.Context, location string) (string, error) {
+	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
+})
+
+func main() {
+	// Create Azure OpenAI agent, and provide the function tool to the agent.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are a helpful assistant",
+		RunOptions: []agentopt.RunOption{
+			agentopt.Tool(weatherTool),
+			middleware.With(logger), // for logging agent interactions
+		},
+	})
+
+	ctx := context.Background()
+
+	// Non-streaming agent interaction with function tools.
+	resp, err := a.RunText("What is the weather like in Amsterdam?").Collect(ctx)
+	demo.Response(resp, err)
+
+	// Invoke the agent with streaming support.
+	for update, err := range a.RunText("What is the weather like in Amsterdam?").All(ctx) {
+		demo.Response(update, err)
+	}
+}

--- a/examples/getting_started/azure_openai/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/azure_openai/step04_using_function_tools_with_approvals/main.go
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/openai"
+	"github.com/microsoft/agent-framework-go/tool"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"Function Tools With User Approvals",
+	"Demonstrates how to use function tools that require user approval.",
+	"Model", deployment,
+)
+
+var weatherTool = functool.MustNew(&functool.Func{
+	Name:        "weather",
+	Description: "Get the current weather for a given location",
+}, func(_ context.Context, location string) (string, error) {
+	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
+})
+
+func main() {
+	// Create Azure OpenAI agent.
+	// Note that we are wrapping the function tool with tool.ApprovalRequiredFunc to require user approval before invoking it.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are a helpful assistant",
+		RunOptions: []agentopt.RunOption{
+			agentopt.Tool(tool.ApprovalRequiredFunc(weatherTool)),
+			middleware.With(logger), // for logging agent interactions
+		},
+	})
+
+	ctx := context.Background()
+
+	// Call the agent and check if there are any user input requests to handle.
+	session, err := a.CreateSession(ctx)
+	if err != nil {
+		demo.Panic(err)
+	}
+	resp, err := a.RunText("What is the weather like in Amsterdam?", agentopt.Session(session)).Collect(ctx)
+	demo.Response(resp, err)
+
+	var userResponses []message.Content
+	var approvedRequests bool
+	for req := range resp.UserInputRequests() {
+		// Ask the user to approve each function call request.
+		request, ok := req.(*message.FunctionApprovalRequestContent)
+		if !ok {
+			demo.Panicf("unexpected request type: %T", req)
+			continue
+		}
+		approved := demo.UserInputRequest(request)
+		if approved {
+			approvedRequests = true
+		}
+		userResponses = append(userResponses, request.Response(approved))
+	}
+	if !approvedRequests {
+		demo.Assistant("User did not approve any function calls.")
+		return
+	}
+	// Pass the user input responses back to the agent for further processing.
+	resp, err = a.RunMessage(message.New(userResponses...), agentopt.Session(session)).Collect(ctx)
+	demo.Response(resp, err)
+}

--- a/examples/getting_started/azure_openai/step05_structured_output/main.go
+++ b/examples/getting_started/azure_openai/step05_structured_output/main.go
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/format/jsonformat"
+	"github.com/microsoft/agent-framework-go/openai"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"Structured Output",
+	"Demonstrates how to produce structured output.",
+	"Model", deployment,
+)
+
+type PersonInfo struct {
+	Name       string `json:"name"`
+	Age        int    `json:"age"`
+	Occupation string `json:"occupation"`
+}
+
+// runFor executes the agent with the given messages and returns the result of type T.
+func runFor[T any](ctx context.Context, a *agent.Agent, message string, opts ...agentopt.RunOption) (T, error) {
+	var v T
+	opts = append(opts, agentopt.StructuredOutput(&v), agentopt.Stream(false))
+	for _, err := range a.RunText(message, opts...).All(ctx) {
+		if err != nil {
+			return v, err
+		}
+	}
+	return v, nil
+}
+
+func main() {
+	// Create Azure OpenAI agent.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are a helpful assistant.",
+		Name:         "HelpfulAssistant",
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
+	})
+
+	ctx := context.Background()
+
+	// Set PersonInfo as the type parameter of runFor method to specify the expected structured output from the agent and invoke the agent with some unstructured input.
+	person, err := runFor[PersonInfo](ctx, a, "Please provide information about John Smith, who is a 35-year-old software engineer.")
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	fmt.Println("Structured Output:")
+	fmt.Println("\tName:", person.Name)
+	fmt.Println("\tAge:", person.Age)
+	fmt.Println("\tOccupation:", person.Occupation)
+	fmt.Println()
+
+	// Create the agent with the specified name, instructions, and expected structured output the agent should produce.
+	a = openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are a helpful assistant.",
+		Name:         "HelpfulAssistant",
+		RunOptions: []agentopt.RunOption{
+			agentopt.ResponseFormat(jsonformat.MustFor[PersonInfo]()),
+			middleware.With(logger), // for logging agent interactions
+		},
+	})
+
+	// Invoke the agent with some unstructured input while streaming, to extract the structured information from.
+	var personRaw []byte
+	for update, err := range a.RunText("Please provide information about John Smith, who is a 35-year-old software engineer.").All(ctx) {
+		demo.Response(update, err)
+		personRaw = append(personRaw, update.String()...)
+	}
+	var person2 PersonInfo
+	if err := json.Unmarshal(personRaw, &person2); err != nil {
+		demo.Panic(err)
+	}
+
+	fmt.Println("Structured Output:")
+	fmt.Println("\tName:", person2.Name)
+	fmt.Println("\tAge:", person2.Age)
+	fmt.Println("\tOccupation:", person2.Occupation)
+	fmt.Println()
+}

--- a/examples/getting_started/azure_openai/step06_persisted_conversation/main.go
+++ b/examples/getting_started/azure_openai/step06_persisted_conversation/main.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/openai"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"Persisted Conversation",
+	"Demonstrates how to persist a conversation to disk and resume it later.",
+	"Model", deployment,
+)
+
+func main() {
+	// Create Azure OpenAI agent.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are good at telling jokes.",
+		Name:         "Joker",
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
+	})
+
+	ctx := context.Background()
+
+	// Start a new session for the agent conversation.
+	session, err := a.CreateSession(ctx)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	// Run the agent with a new session.
+	resp, err := a.RunText("Tell me a joke about a pirate.", agentopt.Session(session)).Collect(ctx)
+	demo.Response(resp, err)
+
+	// Serialize the session state so it can be stored for later use.
+	serializedSession, err := session.MarshalBinary()
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	// Save the serialized session to a temporary file (for demonstration purposes).
+	tmpDir, err := os.MkdirTemp("", "agent_session")
+	if err != nil {
+		demo.Panic(err)
+	}
+	tmpPath := filepath.Join(tmpDir, "session.json")
+	if err := os.WriteFile(tmpPath, serializedSession, 0644); err != nil {
+		demo.Panic(err)
+	}
+
+	// Load the serialized session from the temporary file (for demonstration purposes).
+	loadedData, err := os.ReadFile(tmpPath)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	// Deserialize the session state after loading from storage.
+	resumedSession, err := a.UnmarshalSession(loadedData)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	// Run the agent again with the resumed session.
+	resp, err = a.RunText("Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Session(resumedSession)).Collect(ctx)
+	demo.Response(resp, err)
+}

--- a/examples/getting_started/azure_openai/step07_3rdparty_session_storage/main.go
+++ b/examples/getting_started/azure_openai/step07_3rdparty_session_storage/main.go
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/memory"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/openai"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"3rd-Party Session Storage",
+	"Demonstrates how to use a custom message store to persist conversation history to disk.",
+	"Model", deployment,
+)
+
+func main() {
+	// Create a temporary directory to store messages.
+	tmpDir, err := os.MkdirTemp("", "agent_session_storage")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create Azure OpenAI agent with a custom message store that persists messages to disk.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are good at telling jokes.",
+		Name:         "Joker",
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
+		NewMessageHistoryProvider: func() memory.ContextProvider {
+			return &fsMessageStore{Dir: tmpDir}
+		},
+	})
+
+	ctx := context.Background()
+
+	// Start a new session for the agent conversation.
+	session, err := a.CreateSession(ctx)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	// Run the agent with the session that stores conversation history in the disk store.
+	resp, err := a.RunText("Tell me a joke about a pirate.", agentopt.Session(session)).Collect(ctx)
+	demo.Response(resp, err)
+
+	// Serialize the session state, so it can be stored for later use.
+	// Since the chat history is stored in the disk store, the serialized session
+	// only contains the ID that the messages are stored under in the store.
+	serializedSession, err := json.MarshalIndent(session, "", "\t")
+	if err != nil {
+		demo.Panic(err)
+	}
+	fmt.Println("\n--- Serialized session ---")
+	fmt.Println(string(serializedSession))
+
+	// The serialized session can now be saved to a database, file, or any other storage mechanism
+	// and loaded again later.
+
+	// Deserialize the session state after loading from storage.
+	resumedSession, err := a.UnmarshalSession(serializedSession)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	// Run the agent with the session that stores conversation history in the disk store a second time.
+	resp, err = a.RunText("Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agentopt.Session(resumedSession)).Collect(ctx)
+	demo.Response(resp, err)
+}
+
+type fsMessageStore struct {
+	Dir   string
+	Files []string
+}
+
+func (d *fsMessageStore) Invoking(ctx *memory.InvokingContext) (*memory.Context, error) {
+	var msgs []*message.Message
+	for _, file := range d.Files {
+		data, err := os.ReadFile(filepath.Join(d.Dir, file))
+		if err != nil {
+			return nil, err
+		}
+		var msg message.Message
+		err = json.Unmarshal(data, &msg)
+		if err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, &msg)
+	}
+	return &memory.Context{Messages: msgs}, nil
+}
+
+func (d *fsMessageStore) Invoked(ctx *memory.InvokedContext) error {
+	if ctx.Error != nil {
+		return nil
+	}
+	persist := func(msg *message.Message) error {
+		if msg.ID == "" {
+			// Skip messages without an ID.
+			return nil
+		}
+		if slices.Contains(d.Files, msg.ID) {
+			return fmt.Errorf("duplicated message %q", msg.ID)
+		}
+		data, err := json.Marshal(msg)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(d.Dir, msg.ID), data, 0644); err != nil {
+			return err
+		}
+		d.Files = append(d.Files, msg.ID)
+		return nil
+	}
+	for _, msg := range ctx.RequestMessages {
+		if err := persist(msg); err != nil {
+			return err
+		}
+	}
+	for _, msg := range ctx.ContextProviderMessages {
+		if err := persist(msg); err != nil {
+			return err
+		}
+	}
+	for _, msg := range ctx.ResponsesMessages {
+		if err := persist(msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/examples/getting_started/azure_openai/step08_observability/main.go
+++ b/examples/getting_started/azure_openai/step08_observability/main.go
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to create and use a simple Agent with Azure OpenAI as the backend that logs telemetry using OpenTelemetry.
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/agent/middleware/otel"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/openai"
+
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	otellib "go.opentelemetry.io/otel"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"OpenTelemetry Observability",
+	"Demonstrates how to use OpenTelemetry for observability in the agent framework.",
+	"Model", deployment,
+)
+
+func main() {
+	// Create TracerProvider with console exporter.
+	// This will output the telemetry data to the console.
+	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	if err != nil {
+		log.Fatalf("failed to create stdout exporter: %v", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+	)
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("failed to shutdown tracer provider: %v", err)
+		}
+	}()
+	otellib.SetTracerProvider(tp)
+
+	// Create Azure OpenAI agent, and enable OpenTelemetry instrumentation.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are good at telling jokes.",
+		Name:         "Joker",
+		RunOptions: []agentopt.RunOption{
+			middleware.With(otel.New(otel.Config{})), // for OpenTelemetry observability
+			middleware.With(logger),                  // for logging agent interactions
+		},
+	})
+
+	ctx := context.Background()
+
+	// Invoke the agent and output the text result.
+	resp, err := a.RunText("Tell me a joke about a pirate.").Collect(ctx)
+	demo.Response(resp, err)
+
+	// Invoke the agent with streaming support.
+	for update, err := range a.RunText("Tell me a joke about a pirate.").All(ctx) {
+		demo.Response(update, err)
+	}
+}

--- a/examples/getting_started/azure_openai/step09_dependency_injection/main.go
+++ b/examples/getting_started/azure_openai/step09_dependency_injection/main.go
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to use dependency injection to register an Agent and use it from a hosted service with a user input chat loop.
+
+package main
+
+func main() {
+	// TODO
+}

--- a/examples/getting_started/azure_openai/step10_as_mcp_tool/main.go
+++ b/examples/getting_started/azure_openai/step10_as_mcp_tool/main.go
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to expose an Agent as an MCP tool.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/openai"
+	"github.com/microsoft/agent-framework-go/tool/mcptool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+// Run "npx @modelcontextprotocol/inspector go run ." to connect to this MCP server.
+
+func main() {
+	// Create Azure OpenAI agent with the same configuration as the C# example.
+	agent := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Name:         "Joker",
+		Description:  "An agent that tells jokes.",
+		Instructions: "You are good at telling jokes, and you always start each joke with 'Aye aye, captain!'.",
+	})
+
+	// Create an MCP server with the agent exposed as a tool.
+	srv := mcp.NewServer(&mcp.Implementation{
+		Name:    "agent-mcp-server",
+		Version: "1.0.0",
+	}, nil)
+
+	// Register the agent as an MCP tool.
+	mcptool.AddTool(srv, agent.AsFuncTool())
+
+	// Run the MCP server with StdIO transport.
+	if err := srv.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+		panic(err)
+	}
+}

--- a/examples/getting_started/azure_openai/step11_using_images/main.go
+++ b/examples/getting_started/azure_openai/step11_using_images/main.go
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/openai"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"Using Images",
+	"Demonstrates how to use Image Multi-Modality with an Agent.",
+	"Model", deployment,
+)
+
+func main() {
+	// Create Azure OpenAI agent.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are a helpful agent that can analyze images.",
+		Name:         "VisionAgent",
+		RunOptions:   []agentopt.RunOption{middleware.With(logger)}, // for logging agent interactions
+	})
+
+	ctx := context.Background()
+	msg := message.New(
+		&message.TextContent{Text: "What do you see in this image?"},
+		&message.URIContent{
+			URI:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+			MediaType: "image/jpeg",
+		},
+	)
+
+	resp, err := a.RunMessage(msg).Collect(ctx)
+	demo.Response(resp, err)
+}

--- a/examples/getting_started/azure_openai/step12_as_function_tool/main.go
+++ b/examples/getting_started/azure_openai/step12_as_function_tool/main.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to create and use an Agent as a function tool.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent/agentopt"
+	"github.com/microsoft/agent-framework-go/agent/chatagent"
+	"github.com/microsoft/agent-framework-go/agent/middleware"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/openai"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+)
+
+var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+
+var logger = demo.NewLogger(
+	"Agent As Function Tool",
+	"Demonstrates how to create and use an Agent as a function tool.",
+	"Model", deployment,
+)
+
+var weatherTool = functool.MustNew(&functool.Func{
+	Name:        "weather",
+	Description: "Get the current weather for a given location",
+}, func(_ context.Context, location string) (string, error) {
+	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
+})
+
+func main() {
+	// Create Azure OpenAI agent and provide the function tool.
+	weatherAgent := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You answer questions about the weather.",
+		Name:         "WeatherAgent",
+		Description:  "An agent that answers questions about the weather.",
+		RunOptions: []agentopt.RunOption{
+			agentopt.Tool(weatherTool),
+			middleware.With(logger), // for logging agent interactions
+		},
+	})
+
+	// Create the main Azure OpenAI agent, and provide the weather agent as a function tool.
+	// Note that the main agent is instructed to respond in French.
+	a := openai.NewChatAgentAzure(openai.ClientConfig{
+		Endpoint:   endpoint,
+		APIKey:     apiKey,
+		Model:      deployment,
+		APIVersion: "2025-01-01-preview",
+	}, chatagent.Config{
+		Instructions: "You are a helpful assistant who responds in French.",
+		RunOptions: []agentopt.RunOption{
+			agentopt.Tool(weatherAgent.AsFuncTool()),
+		},
+	})
+
+	resp, err := a.RunText("What is the weather like in Amsterdam?").Collect(context.Background())
+	demo.Response(resp, err)
+}

--- a/examples/internal/demo/demo.go
+++ b/examples/internal/demo/demo.go
@@ -47,7 +47,7 @@ func NewLogger(name, description string, metadata ...string) middleware.Middlewa
 func (mw *logger) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, opts ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		mw.n++
-		fmt.Printf("===== Run %d =====\n\n", mw.n)
+		fmt.Printf("%s%s===== Run %d =====%s\n\n", colorYellow, colorBold, mw.n, colorReset)
 		for _, msg := range messages {
 			if msg.Role == message.RoleUser {
 				user(msg.String())
@@ -79,7 +79,7 @@ func welcome(name, description string, kvs []kv) {
 	fmt.Printf("╚%s╝\n", strings.Repeat("═", size))
 	fmt.Printf("%s\n", colorReset)
 	for _, kv := range kvs {
-		fmt.Printf("%s%s:%s %s%s%s\n", colorGray, kv.key, colorReset, colorGreen, kv.value, colorReset)
+		fmt.Printf("%s%s:%s %s%s%s\n", colorGray, kv.key, colorReset, colorMagenta, kv.value, colorReset)
 	}
 	fmt.Printf("%s%s%s\n", colorGray, description, colorReset)
 	fmt.Printf("\n")
@@ -147,7 +147,7 @@ func UserInputRequest(req *message.FunctionApprovalRequestContent) bool {
 	var approval string
 	fmt.Scanln(&approval)
 	fmt.Printf("\n")
-	return approval == "Y"
+	return approval == "Y" || approval == "y"
 }
 
 func assistant() {


### PR DESCRIPTION
## Summary
Adds Azure OpenAI versions of the getting started examples (steps 01-12), mirroring the existing agent examples.

## Changes
- **New examples**: Azure OpenAI versions using `NewChatAgentAzure` with `AZURE_OPENAI_DEPLOYMENT_NAME` env var
- **API updates**: Migrated to new API (`chatagent.Config`, `NewSession`, `RunOptions`, etc.)
- **Bug fix**: Allow both 'Y' and 'y' for approval in demo helper
- **Bug fix**: Replace unreliable Wikipedia image URL with Unsplash URL in step11

## Examples Added
- step01: Basic run
- step02: Multi-turn conversation
- step03: Function tools
- step04: Function tools with approvals
- step05: Structured output
- step06: Persisted conversation
- step07: 3rd-party session storage
- step08-10: Placeholders (TODO)
- step11: Image multi-modality
- step12: Agent as function tool