### PR TITLE
Rename NewSession to CreateSession

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -32,10 +32,10 @@ type Options struct {
 
 type contextIDOpt struct{ string }
 
-func (contextIDOpt) NewSessionOption() {}
-func (o contextIDOpt) Value() any      { return o.string }
+func (contextIDOpt) CreateSessionOption() {}
+func (o contextIDOpt) Value() any         { return o.string }
 
-func WithContextID(id string) agentopt.NewSessionOption {
+func WithContextID(id string) agentopt.CreateSessionOption {
 	return contextIDOpt{id}
 }
 
@@ -60,13 +60,13 @@ func NewAgent(client *a2aclient.Client, options Options) *agent.Agent {
 			Description:  options.Description,
 		},
 
-		NewSession:       a.newSession,
+		CreateSession:    a.createSession,
 		UnmarshalSession: a.unmarshalSession,
 		Run:              a.run,
 	})
 }
 
-func (a *a2aagent) newSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
+func (a *a2aagent) createSession(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error) {
 	contextID, _ := agentopt.Get(options, WithContextID)
 	return &Session{
 		ContextID: contextID,
@@ -92,7 +92,7 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 				yield(nil, errors.New("a session must be provided when AllowBackgroundResponses is enabled"))
 				return
 			}
-			s, err := a.newSession(ctx)
+			s, err := a.createSession(ctx)
 			if err != nil {
 				yield(nil, err)
 				return

--- a/agent/a2aagent/a2a_test.go
+++ b/agent/a2aagent/a2a_test.go
@@ -238,8 +238,8 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	}
 }
 
-// TestRunWithNewSession tests that new session updates context ID
-func TestRunWithNewSession(t *testing.T) {
+// TestRunWithCreateSession tests that new session updates context ID
+func TestRunWithCreateSession(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Message{
 			ID:        "response-123",
@@ -250,7 +250,7 @@ func TestRunWithNewSession(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +273,7 @@ func TestRunWithExistingSession(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.CreateSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestRunWithSessionHavingDifferentContextID(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.CreateSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +404,7 @@ func TestRunStreamingWithSession(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -431,7 +431,7 @@ func TestRunStreamingWithExistingSession(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.CreateSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +462,7 @@ func TestRunStreamingWithSessionHavingDifferentContextID(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
+	session, err := a.CreateSession(t.Context(), a2aagent.WithContextID("existing-context-id"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,7 +562,7 @@ func TestRunWithInvalidSessionType(t *testing.T) {
 	a := newTestAgent(transport, a2aagent.Options{})
 
 	// Create a custom session type that is not an a2aagent.Session
-	invalidSession := agenttest.NewSession()
+	invalidSession := agenttest.CreateSession()
 
 	_, err := a.RunText("Test message", agentopt.Session(invalidSession)).Collect(t.Context())
 	if err == nil {
@@ -584,7 +584,7 @@ func TestRunStreamingWithInvalidSessionType(t *testing.T) {
 	a := newTestAgent(transport, a2aagent.Options{})
 
 	// Create a custom session type that is not an a2aagent.Session
-	invalidSession := agenttest.NewSession()
+	invalidSession := agenttest.CreateSession()
 
 	gotError := false
 	for _, err := range a.RunText("Test message", agentopt.Session(invalidSession)).All(t.Context()) {
@@ -639,7 +639,7 @@ func TestRunWithTaskInSessionAndMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,7 +674,7 @@ func TestRunWithAgentTask(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -714,7 +714,7 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -829,7 +829,7 @@ func TestRunStreamingWithTaskInSessionAndMessage(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -871,7 +871,7 @@ func TestRunStreamingWithAgentTaskUpdatesSession(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -963,7 +963,7 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1019,7 +1019,7 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1079,7 +1079,7 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	}
 	a := newTestAgent(transport, a2aagent.Options{})
 
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -25,7 +25,7 @@ type Config struct {
 
 	RunOptions []agentopt.RunOption
 
-	NewSession       func(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error)
+	CreateSession    func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error)
 	UnmarshalSession func(data []byte) (memory.Session, error)
 	Run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
@@ -36,7 +36,7 @@ func New(cfg Config) *Agent {
 	}
 	return &Agent{
 		metadata:         cfg.Metadata,
-		newSession:       cfg.NewSession,
+		createSession:    cfg.CreateSession,
 		unmarshalSession: cfg.UnmarshalSession,
 		run:              cfg.Run,
 		runOptions:       cfg.RunOptions,
@@ -73,7 +73,7 @@ type Agent struct {
 
 	runOptions []agentopt.RunOption
 
-	newSession       func(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error)
+	createSession    func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error)
 	unmarshalSession func(data []byte) (memory.Session, error)
 	run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
@@ -90,8 +90,8 @@ func (a *Agent) Metadata() Metadata {
 	return a.metadata
 }
 
-func (a *Agent) NewSession(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
-	return a.newSession(ctx, options...)
+func (a *Agent) CreateSession(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error) {
+	return a.createSession(ctx, options...)
 }
 
 func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
@@ -132,7 +132,7 @@ func (a *Agent) prepareRun(ctx context.Context, stream bool, options []agentopt.
 
 	// Ensure a session is provided in the options.
 	if _, ok := agentopt.Get(options, agentopt.Session); !ok {
-		session, err := a.NewSession(ctx)
+		session, err := a.CreateSession(ctx)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -177,7 +177,7 @@ func TestAgent_Run_UsesProvidedSession(t *testing.T) {
 	a := agenttest.NewAgent(responseBuilder.Build())
 
 	ctx := t.Context()
-	providedSession := agenttest.NewSession()
+	providedSession := agenttest.CreateSession()
 	_, err := a.Run([]*message.Message{message.NewText("test")}, agentopt.Session(providedSession)).Collect(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -220,10 +220,10 @@ func TestAgent_Run_PrependsAgentOptions(t *testing.T) {
 			Name: "test",
 		},
 		RunOptions: []agentopt.RunOption{agentOption},
-		NewSession: func(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
-			return agenttest.NewSession(), nil
+		CreateSession: func(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
+			return agenttest.CreateSession(), nil
 		},
-		UnmarshalSession: func(data []byte) (memory.Session, error) { return agenttest.NewSession(), nil },
+		UnmarshalSession: func(data []byte) (memory.Session, error) { return agenttest.CreateSession(), nil },
 		Run:              runner.Run,
 	})
 

--- a/agent/agentopt/agentopt.go
+++ b/agent/agentopt/agentopt.go
@@ -28,11 +28,11 @@ type RunOption interface {
 	RunOption()
 }
 
-// A NewSessionOption configures the behavior of a new Session created by an Agent.
-type NewSessionOption interface {
+// A CreateSessionOption configures the behavior of a new Session created by an Agent.
+type CreateSessionOption interface {
 	Option
 
-	NewSessionOption()
+	CreateSessionOption()
 }
 
 type (

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -104,7 +104,7 @@ func NewAgent(responses []Turn) *agent.Agent {
 			Description:  "A test agent",
 			ProviderName: "agenttest",
 		},
-		NewSession:       a.newSession,
+		CreateSession:    a.createSession,
 		UnmarshalSession: a.unmarshalSession,
 		Run:              a.run,
 	})
@@ -128,7 +128,7 @@ func (a *testagent) run(ctx context.Context, messages []*message.Message, opts .
 	}
 }
 
-func (a *testagent) newSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
+func (a *testagent) createSession(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
 	return &Session{}, nil
 }
 
@@ -141,7 +141,7 @@ type Session struct {
 	messages []*message.Message
 }
 
-func NewSession() *Session {
+func CreateSession() *Session {
 	return &Session{}
 }
 

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -96,7 +96,7 @@ func NewAgent(runfn RunFunc, cfg Config, prov ProviderConfig) *agent.Agent {
 			Description:  cfg.Description,
 		},
 
-		NewSession:       a.NewSession,
+		CreateSession:    a.CreateSession,
 		UnmarshalSession: a.UnmarshalSession,
 		Run:              a.Run,
 
@@ -104,7 +104,7 @@ func NewAgent(runfn RunFunc, cfg Config, prov ProviderConfig) *agent.Agent {
 	})
 }
 
-func (a *chatagent) NewSession(ctx context.Context, opts ...agentopt.NewSessionOption) (memory.Session, error) {
+func (a *chatagent) CreateSession(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
 	convID, _ := agentopt.Get(opts, ConversationID)
 	session := &Session{
 		ConversationID: convID,

--- a/agent/chatagent/config.go
+++ b/agent/chatagent/config.go
@@ -19,7 +19,7 @@ type (
 	modelOpt                  string
 )
 
-func (conversationIDOpt) NewSessionOption() {}
+func (conversationIDOpt) CreateSessionOption() {}
 
 func (temperatureOpt) RunOption()            {}
 func (topPOpt) RunOption()                   {}
@@ -42,7 +42,7 @@ func (o allowMultipleToolCallsOpt) Value() any { return bool(o) }
 func (o stopSequenceOpt) Value() any           { return []string(o) }
 func (o modelOpt) Value() any                  { return string(o) }
 
-func ConversationID(conversationID string) agentopt.NewSessionOption {
+func ConversationID(conversationID string) agentopt.CreateSessionOption {
 	return conversationIDOpt(conversationID)
 }
 

--- a/agent/memory/session.go
+++ b/agent/memory/session.go
@@ -17,7 +17,7 @@ import "encoding"
 //   - Chat history reduction, e.g. where messages needs to be summarized or truncated to reduce the size.
 //
 // A Session is always constructed by an [agent.Agent] so that the [agent.Agent] can attach any necessary behaviors to the Session.
-// See the [agent.Agent.NewSession] and [agent.Agent.UnmarshalSession] methods for more information.
+// See the [agent.Agent.CreateSession] and [agent.Agent.UnmarshalSession] methods for more information.
 //
 // Because of these behaviors, a Session may not be reusable across different agents, since each agent may add different
 // behaviors to the Session it creates.

--- a/agent/middleware/otel/otel_test.go
+++ b/agent/middleware/otel/otel_test.go
@@ -90,11 +90,11 @@ func TestOtel_Run_SpanHasCorrectAttributes(t *testing.T) {
 			Description:  "A test agent",
 			ProviderName: "test-provider",
 		},
-		NewSession: func(ctx context.Context, options ...agentopt.NewSessionOption) (memory.Session, error) {
-			return agenttest.NewSession(), nil
+		CreateSession: func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error) {
+			return agenttest.CreateSession(), nil
 		},
 		UnmarshalSession: func(data []byte) (memory.Session, error) {
-			return agenttest.NewSession(), nil
+			return agenttest.CreateSession(), nil
 		},
 		Run: func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 			return func(yield func(*message.ResponseUpdate, error) bool) {

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -19,7 +19,7 @@ func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {
 	ensureSession := func(ctx context.Context) (memory.Session, error) {
 		var err error
 		if session == nil {
-			session, err = a.NewSession(ctx)
+			session, err = a.CreateSession(ctx)
 		}
 		sessionStateKey = reflect.ValueOf(session).String()
 		return session, err

--- a/examples/chat_cli/main.go
+++ b/examples/chat_cli/main.go
@@ -43,7 +43,7 @@ func main() {
 
 func runChatLoop(ctx context.Context, a *agent.Agent) {
 	// Create a session to maintain conversation history
-	session, err := a.NewSession(ctx)
+	session, err := a.CreateSession(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +73,7 @@ func runChatLoop(ctx context.Context, a *agent.Agent) {
 		}
 
 		if userInput == "clear" {
-			session, err = a.NewSession(ctx)
+			session, err = a.CreateSession(ctx)
 			if err != nil {
 				panic(err)
 			}

--- a/examples/getting_started/agent/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/agent/step02_multiturn_conversation/main.go
@@ -30,7 +30,7 @@ func main() {
 	ctx := context.Background()
 
 	// Invoke the agent with a multi-turn conversation, where the context is preserved in the session object.
-	session, err := a.NewSession(ctx)
+	session, err := a.CreateSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -40,7 +40,7 @@ func main() {
 	demo.Response(resp, err)
 
 	// Invoke the agent with a multi-turn conversation and streaming, where the context is preserved in the session object.
-	session2, err := a.NewSession(ctx)
+	session2, err := a.CreateSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
@@ -45,7 +45,7 @@ func main() {
 	ctx := context.Background()
 
 	// Call the agent and check if there are any user input requests to handle.
-	session, err := a.NewSession(ctx)
+	session, err := a.CreateSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -33,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Start a new session for the agent conversation.
-	session, err := a.NewSession(ctx)
+	session, err := a.CreateSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
+++ b/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
@@ -48,7 +48,7 @@ func main() {
 	ctx := context.Background()
 
 	// Start a new session for the agent conversation.
-	session, err := a.NewSession(ctx)
+	session, err := a.CreateSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/agent/step17_background_responses/main.go
+++ b/examples/getting_started/agent/step17_background_responses/main.go
@@ -27,7 +27,7 @@ func main() {
 	})
 
 	ctx := context.Background()
-	session, err := a.NewSession(ctx)
+	session, err := a.CreateSession(ctx)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -3745,7 +3745,7 @@ func TestResponsesConversationId_AsResponseId_NonStreaming(t *testing.T) {
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	session, err := a.NewSession(t.Context(), chatagent.ConversationID("resp_12345"))
+	session, err := a.CreateSession(t.Context(), chatagent.ConversationID("resp_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3811,7 +3811,7 @@ func TestResponsesConversationId_AsConversationId_NonStreaming(t *testing.T) {
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	session, err := a.NewSession(t.Context(), chatagent.ConversationID("conv_12345"))
+	session, err := a.CreateSession(t.Context(), chatagent.ConversationID("conv_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3881,7 +3881,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	session, err := a.NewSession(t.Context(), chatagent.ConversationID("resp_12345"))
+	session, err := a.CreateSession(t.Context(), chatagent.ConversationID("resp_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3959,7 +3959,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	session, err := a.NewSession(t.Context(), chatagent.ConversationID("conv_12345"))
+	session, err := a.CreateSession(t.Context(), chatagent.ConversationID("conv_12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4019,7 +4019,7 @@ func TestResponsesBackgroundResponses_FirstCall(t *testing.T) {
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4103,7 +4103,7 @@ func testResponsesBackgroundPolling(t *testing.T, status string) {
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
 	// Create session with ConversationID to simulate a previous call (polling scenario)
-	session, err := a.NewSession(t.Context(), chatagent.ConversationID("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8"))
+	session, err := a.CreateSession(t.Context(), chatagent.ConversationID("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4233,7 +4233,7 @@ data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_6
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-2024-08-06")
-	session, err := a.NewSession(t.Context())
+	session, err := a.CreateSession(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The .NET SDK is renaming Agent.GetNewSession to Agent.CreateSession, see https://github.com/microsoft/agent-framework/pull/3501, we should follow suit.