### PR TITLE
Move agent.Session marshaling to agent.Agent

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -59,8 +59,8 @@ func NewAgent(client *a2aclient.Client, options Options) *agent.Agent {
 			ProviderName: "a2a",
 			Description:  options.Description,
 		},
-
 		CreateSession:    a.createSession,
+		MarshalSession:   a.marshalSession,
 		UnmarshalSession: a.unmarshalSession,
 		Run:              a.run,
 	})
@@ -71,6 +71,13 @@ func (a *a2aagent) createSession(ctx context.Context, options ...agentopt.Create
 	return &Session{
 		ContextID: contextID,
 	}, nil
+}
+
+func (a *a2aagent) marshalSession(session memory.Session) ([]byte, error) {
+	if _, ok := session.(*Session); !ok {
+		return nil, errors.New("the provided session is not compatible with the agent, only sessions created by the agent can be used")
+	}
+	return json.Marshal(session)
 }
 
 func (a *a2aagent) unmarshalSession(data []byte) (memory.Session, error) {

--- a/agent/a2aagent/session.go
+++ b/agent/a2aagent/session.go
@@ -2,14 +2,10 @@
 
 package a2aagent
 
-import "encoding/json"
-
 // Session represents a session identified by a service-managed identifier.
 type Session struct {
 	ContextID string
 	TaskID    string
 }
 
-func (t *Session) MarshalBinary() (data []byte, err error) {
-	return json.Marshal(t)
-}
+func (t *Session) IsAgentSession() {}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -25,12 +25,26 @@ type Config struct {
 
 	RunOptions []agentopt.RunOption
 
+	//Required functions
 	CreateSession    func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error)
+	MarshalSession   func(session memory.Session) ([]byte, error)
 	UnmarshalSession func(data []byte) (memory.Session, error)
 	Run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
 
 func New(cfg Config) *Agent {
+	if cfg.CreateSession == nil {
+		panic("CreateSession function is required")
+	}
+	if cfg.MarshalSession == nil {
+		panic("MarshalSession function is required")
+	}
+	if cfg.UnmarshalSession == nil {
+		panic("UnmarshalSession function is required")
+	}
+	if cfg.Run == nil {
+		panic("Run function is required")
+	}
 	if cfg.Metadata.ID == "" {
 		cfg.Metadata.ID = uuid.NewString()
 	}
@@ -74,6 +88,7 @@ type Agent struct {
 	runOptions []agentopt.RunOption
 
 	createSession    func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error)
+	marshalSession   func(session memory.Session) ([]byte, error)
 	unmarshalSession func(data []byte) (memory.Session, error)
 	run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
@@ -92,6 +107,10 @@ func (a *Agent) Metadata() Metadata {
 
 func (a *Agent) CreateSession(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error) {
 	return a.createSession(ctx, options...)
+}
+
+func (a *Agent) MarshalSession(session memory.Session) ([]byte, error) {
+	return a.marshalSession(session)
 }
 
 func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -4,6 +4,7 @@ package agent_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -220,6 +221,9 @@ func TestAgent_Run_PrependsAgentOptions(t *testing.T) {
 			Name: "test",
 		},
 		RunOptions: []agentopt.RunOption{agentOption},
+		MarshalSession: func(session memory.Session) ([]byte, error) {
+			return json.Marshal(session)
+		},
 		CreateSession: func(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
 			return agenttest.CreateSession(), nil
 		},

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -5,6 +5,7 @@ package agenttest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"iter"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -105,6 +106,7 @@ func NewAgent(responses []Turn) *agent.Agent {
 			ProviderName: "agenttest",
 		},
 		CreateSession:    a.createSession,
+		MarshalSession:   a.marshalSession,
 		UnmarshalSession: a.unmarshalSession,
 		Run:              a.run,
 	})
@@ -132,6 +134,10 @@ func (a *testagent) createSession(ctx context.Context, opts ...agentopt.CreateSe
 	return &Session{}, nil
 }
 
+func (a *testagent) marshalSession(session memory.Session) ([]byte, error) {
+	return json.Marshal(session)
+}
+
 func (a *testagent) unmarshalSession(data []byte) (memory.Session, error) {
 	return &Session{}, nil
 }
@@ -141,12 +147,17 @@ type Session struct {
 	messages []*message.Message
 }
 
+func (t *Session) IsAgentSession() {}
+
 func CreateSession() *Session {
 	return &Session{}
 }
 
-func (t *Session) MarshalBinary() (data []byte, err error) {
-	return json.Marshal(t.messages)
+func MarshalSession(session memory.Session) ([]byte, error) {
+	if _, ok := session.(*Session); !ok {
+		return nil, errors.New("the provided session is not compatible with the test agent, only sessions created by the test agent can be used")
+	}
+	return json.Marshal(session)
 }
 
 // Middleware is a test implementation of the Middleware interface

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -4,6 +4,7 @@ package chatagent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"iter"
 	"log/slog"
@@ -96,15 +97,16 @@ func NewAgent(runfn RunFunc, cfg Config, prov ProviderConfig) *agent.Agent {
 			Description:  cfg.Description,
 		},
 
-		CreateSession:    a.CreateSession,
-		UnmarshalSession: a.UnmarshalSession,
-		Run:              a.Run,
+		CreateSession:    a.createSession,
+		MarshalSession:   a.marshalSession,
+		UnmarshalSession: a.unmarshalSession,
+		Run:              a.run,
 
 		RunOptions: opts.RunOptions,
 	})
 }
 
-func (a *chatagent) CreateSession(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
+func (a *chatagent) createSession(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
 	convID, _ := agentopt.Get(opts, ConversationID)
 	session := &Session{
 		ConversationID: convID,
@@ -115,11 +117,18 @@ func (a *chatagent) CreateSession(ctx context.Context, opts ...agentopt.CreateSe
 	return session, nil
 }
 
-func (a *chatagent) UnmarshalSession(data []byte) (memory.Session, error) {
+func (a *chatagent) marshalSession(session memory.Session) ([]byte, error) {
+	if _, ok := session.(*Session); !ok {
+		return nil, errors.New("the provided session is not compatible with the agent, only sessions created by the agent can be used")
+	}
+	return json.Marshal(session)
+}
+
+func (a *chatagent) unmarshalSession(data []byte) (memory.Session, error) {
 	return newSessionFromJSON(data, a.newMessageHistoryProvider, a.newContextProvider)
 }
 
-func (a *chatagent) Run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
+func (a *chatagent) run(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		originalMessages := messages
 		session, options, messages, ctxMessages, err := prepareSessionAndMessages(ctx, a.instructions, originalMessages, options)

--- a/agent/chatagent/session.go
+++ b/agent/chatagent/session.go
@@ -16,6 +16,8 @@ type Session struct {
 	ContextProvider        memory.ContextProvider
 }
 
+func (t *Session) IsAgentSession() {}
+
 func newSessionFromJSON(data []byte, newMessageHistoryProvider func() memory.ContextProvider, newContextProvider func() memory.ContextProvider) (*Session, error) {
 	var tmp struct {
 		ConversationID         string
@@ -46,10 +48,6 @@ func newSessionFromJSON(data []byte, newMessageHistoryProvider func() memory.Con
 		return nil, err
 	}
 	return session, nil
-}
-
-func (t *Session) MarshalBinary() (data []byte, err error) {
-	return json.Marshal(t)
 }
 
 func (t *Session) messagesReceived(ctx *memory.InvokedContext) error {

--- a/agent/memory/session.go
+++ b/agent/memory/session.go
@@ -2,8 +2,6 @@
 
 package memory
 
-import "encoding"
-
 // Session contains the state of a specific conversation with an agent which may include:
 //
 //   - Conversation history or a reference to externally stored conversation history.
@@ -17,7 +15,7 @@ import "encoding"
 //   - Chat history reduction, e.g. where messages needs to be summarized or truncated to reduce the size.
 //
 // A Session is always constructed by an [agent.Agent] so that the [agent.Agent] can attach any necessary behaviors to the Session.
-// See the [agent.Agent.CreateSession] and [agent.Agent.UnmarshalSession] methods for more information.
+// See the [agent.Agent.CreateSession], [agent.Agent.MarshalSession], and [agent.Agent.UnmarshalSession] methods for more information.
 //
 // Because of these behaviors, a Session may not be reusable across different agents, since each agent may add different
 // behaviors to the Session it creates.
@@ -25,5 +23,6 @@ import "encoding"
 // To support conversations that may need to survive application restarts or separate service requests,
 // a Session can be serialized and deserialized, so that it can be saved in a persistent store.
 type Session interface {
-	encoding.BinaryMarshaler
+	// IsAgentSession marks the type as a Session to avoid accidental implementations.
+	IsAgentSession()
 }

--- a/agent/middleware/otel/otel_test.go
+++ b/agent/middleware/otel/otel_test.go
@@ -93,6 +93,9 @@ func TestOtel_Run_SpanHasCorrectAttributes(t *testing.T) {
 		CreateSession: func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error) {
 			return agenttest.CreateSession(), nil
 		},
+		MarshalSession: func(session memory.Session) ([]byte, error) {
+			return agenttest.MarshalSession(session)
+		},
 		UnmarshalSession: func(data []byte) (memory.Session, error) {
 			return agenttest.CreateSession(), nil
 		},

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -33,7 +33,7 @@ func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {
 					if session == nil {
 						return nil
 					}
-					data, err := session.MarshalBinary()
+					data, err := a.MarshalSession(session)
 					if err != nil {
 						return err
 					}

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -43,7 +43,7 @@ func main() {
 	demo.Response(resp, err)
 
 	// Serialize the session state so it can be stored for later use.
-	serializedSession, err := session.MarshalBinary()
+	serializedSession, err := a.MarshalSession(session)
 	if err != nil {
 		demo.Panic(err)
 	}


### PR DESCRIPTION
.NET sdk is doing this same change: https://github.com/microsoft/agent-framework/issues/3646. We should follow suit.