### PR TITLE
Accept contexts when marshaling and unmarshaling sessions

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -73,14 +73,14 @@ func (a *a2aagent) createSession(ctx context.Context, options ...agentopt.Create
 	}, nil
 }
 
-func (a *a2aagent) marshalSession(session memory.Session) ([]byte, error) {
+func (a *a2aagent) marshalSession(_ context.Context, session memory.Session) ([]byte, error) {
 	if _, ok := session.(*Session); !ok {
 		return nil, errors.New("the provided session is not compatible with the agent, only sessions created by the agent can be used")
 	}
 	return json.Marshal(session)
 }
 
-func (a *a2aagent) unmarshalSession(data []byte) (memory.Session, error) {
+func (a *a2aagent) unmarshalSession(_ context.Context, data []byte) (memory.Session, error) {
 	var session Session
 	if err := json.Unmarshal(data, &session); err != nil {
 		return nil, err

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -27,8 +27,8 @@ type Config struct {
 
 	//Required functions
 	CreateSession    func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error)
-	MarshalSession   func(session memory.Session) ([]byte, error)
-	UnmarshalSession func(data []byte) (memory.Session, error)
+	MarshalSession   func(ctx context.Context, session memory.Session) ([]byte, error)
+	UnmarshalSession func(ctx context.Context, data []byte) (memory.Session, error)
 	Run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
 
@@ -88,8 +88,8 @@ type Agent struct {
 	runOptions []agentopt.RunOption
 
 	createSession    func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error)
-	marshalSession   func(session memory.Session) ([]byte, error)
-	unmarshalSession func(data []byte) (memory.Session, error)
+	marshalSession   func(ctx context.Context, session memory.Session) ([]byte, error)
+	unmarshalSession func(ctx context.Context, data []byte) (memory.Session, error)
 	run              func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error]
 }
 
@@ -109,12 +109,12 @@ func (a *Agent) CreateSession(ctx context.Context, options ...agentopt.CreateSes
 	return a.createSession(ctx, options...)
 }
 
-func (a *Agent) MarshalSession(session memory.Session) ([]byte, error) {
-	return a.marshalSession(session)
+func (a *Agent) MarshalSession(ctx context.Context, session memory.Session) ([]byte, error) {
+	return a.marshalSession(ctx, session)
 }
 
-func (a *Agent) UnmarshalSession(data []byte) (memory.Session, error) {
-	return a.unmarshalSession(data)
+func (a *Agent) UnmarshalSession(ctx context.Context, data []byte) (memory.Session, error) {
+	return a.unmarshalSession(ctx, data)
 }
 
 func (a *Agent) RunText(msg string, options ...agentopt.RunOption) ResponseStream {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -221,13 +221,13 @@ func TestAgent_Run_PrependsAgentOptions(t *testing.T) {
 			Name: "test",
 		},
 		RunOptions: []agentopt.RunOption{agentOption},
-		MarshalSession: func(session memory.Session) ([]byte, error) {
-			return json.Marshal(session)
-		},
 		CreateSession: func(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
 			return agenttest.CreateSession(), nil
 		},
-		UnmarshalSession: func(data []byte) (memory.Session, error) { return agenttest.CreateSession(), nil },
+		MarshalSession: func(_ context.Context, session memory.Session) ([]byte, error) {
+			return json.Marshal(session)
+		},
+		UnmarshalSession: func(_ context.Context, data []byte) (memory.Session, error) { return agenttest.CreateSession(), nil },
 		Run:              runner.Run,
 	})
 

--- a/agent/agenttest/agenttest.go
+++ b/agent/agenttest/agenttest.go
@@ -130,15 +130,15 @@ func (a *testagent) run(ctx context.Context, messages []*message.Message, opts .
 	}
 }
 
-func (a *testagent) createSession(ctx context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
+func (a *testagent) createSession(_ context.Context, opts ...agentopt.CreateSessionOption) (memory.Session, error) {
 	return &Session{}, nil
 }
 
-func (a *testagent) marshalSession(session memory.Session) ([]byte, error) {
+func (a *testagent) marshalSession(_ context.Context, session memory.Session) ([]byte, error) {
 	return json.Marshal(session)
 }
 
-func (a *testagent) unmarshalSession(data []byte) (memory.Session, error) {
+func (a *testagent) unmarshalSession(_ context.Context, data []byte) (memory.Session, error) {
 	return &Session{}, nil
 }
 

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -117,14 +117,14 @@ func (a *chatagent) createSession(ctx context.Context, opts ...agentopt.CreateSe
 	return session, nil
 }
 
-func (a *chatagent) marshalSession(session memory.Session) ([]byte, error) {
+func (a *chatagent) marshalSession(_ context.Context, session memory.Session) ([]byte, error) {
 	if _, ok := session.(*Session); !ok {
 		return nil, errors.New("the provided session is not compatible with the agent, only sessions created by the agent can be used")
 	}
 	return json.Marshal(session)
 }
 
-func (a *chatagent) unmarshalSession(data []byte) (memory.Session, error) {
+func (a *chatagent) unmarshalSession(_ context.Context, data []byte) (memory.Session, error) {
 	return newSessionFromJSON(data, a.newMessageHistoryProvider, a.newContextProvider)
 }
 

--- a/agent/middleware/otel/otel_test.go
+++ b/agent/middleware/otel/otel_test.go
@@ -93,10 +93,10 @@ func TestOtel_Run_SpanHasCorrectAttributes(t *testing.T) {
 		CreateSession: func(ctx context.Context, options ...agentopt.CreateSessionOption) (memory.Session, error) {
 			return agenttest.CreateSession(), nil
 		},
-		MarshalSession: func(session memory.Session) ([]byte, error) {
+		MarshalSession: func(_ context.Context, session memory.Session) ([]byte, error) {
 			return agenttest.MarshalSession(session)
 		},
-		UnmarshalSession: func(data []byte) (memory.Session, error) {
+		UnmarshalSession: func(_ context.Context, data []byte) (memory.Session, error) {
 			return agenttest.CreateSession(), nil
 		},
 		Run: func(ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -33,7 +33,7 @@ func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {
 					if session == nil {
 						return nil
 					}
-					data, err := a.MarshalSession(session)
+					data, err := a.MarshalSession(wctx, session)
 					if err != nil {
 						return err
 					}
@@ -47,7 +47,7 @@ func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {
 					if data == nil {
 						return nil
 					}
-					session, err = a.UnmarshalSession(data.([]byte))
+					session, err = a.UnmarshalSession(wctx, data.([]byte))
 					return err
 				},
 			},

--- a/examples/getting_started/agent/step06_persisted_conversation/main.go
+++ b/examples/getting_started/agent/step06_persisted_conversation/main.go
@@ -43,7 +43,7 @@ func main() {
 	demo.Response(resp, err)
 
 	// Serialize the session state so it can be stored for later use.
-	serializedSession, err := a.MarshalSession(session)
+	serializedSession, err := a.MarshalSession(ctx, session)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	// Deserialize the session state after loading from storage.
-	resumedSession, err := a.UnmarshalSession(loadedData)
+	resumedSession, err := a.UnmarshalSession(ctx, loadedData)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
+++ b/examples/getting_started/agent/step07_3rdparty_session_storage/main.go
@@ -71,7 +71,7 @@ func main() {
 	// and loaded again later.
 
 	// Deserialize the session state after loading from storage.
-	resumedSession, err := a.UnmarshalSession(serializedSession)
+	resumedSession, err := a.UnmarshalSession(ctx, serializedSession)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/azure_openai/step06_persisted_conversation/main.go
+++ b/examples/getting_started/azure_openai/step06_persisted_conversation/main.go
@@ -50,7 +50,7 @@ func main() {
 	demo.Response(resp, err)
 
 	// Serialize the session state so it can be stored for later use.
-	serializedSession, err := a.MarshalSession(session)
+	serializedSession, err := a.MarshalSession(ctx, session)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	// Deserialize the session state after loading from storage.
-	resumedSession, err := a.UnmarshalSession(loadedData)
+	resumedSession, err := a.UnmarshalSession(ctx, loadedData)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/getting_started/azure_openai/step07_3rdparty_session_storage/main.go
+++ b/examples/getting_started/azure_openai/step07_3rdparty_session_storage/main.go
@@ -78,7 +78,7 @@ func main() {
 	// and loaded again later.
 
 	// Deserialize the session state after loading from storage.
-	resumedSession, err := a.UnmarshalSession(serializedSession)
+	resumedSession, err := a.UnmarshalSession(ctx, serializedSession)
 	if err != nil {
 		demo.Panic(err)
 	}


### PR DESCRIPTION
The .NET SDK recently made session serialization async. We should follow suit.