### PR TITLE
Remove agent.Metadata

### DIFF
--- a/agent/a2aagent/a2a.go
+++ b/agent/a2aagent/a2a.go
@@ -53,12 +53,10 @@ func NewAgent(client *a2aclient.Client, options Options) *agent.Agent {
 		Options: options,
 	}
 	return agent.New(agent.Config{
-		Metadata: agent.Metadata{
-			ID:           options.ID,
-			Name:         options.Name,
-			ProviderName: "a2a",
-			Description:  options.Description,
-		},
+		ID:               options.ID,
+		Name:             options.Name,
+		ProviderName:     "a2a",
+		Description:      options.Description,
 		CreateSession:    a.createSession,
 		MarshalSession:   a.marshalSession,
 		UnmarshalSession: a.unmarshalSession,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,15 +14,11 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-type Metadata struct {
+type Config struct {
 	ID           string
 	Name         string
 	Description  string
 	ProviderName string
-}
-
-type Config struct {
-	Metadata Metadata
 
 	Instructions string
 
@@ -48,11 +44,14 @@ func New(cfg Config) *Agent {
 	if cfg.Run == nil {
 		panic("Run function is required")
 	}
-	if cfg.Metadata.ID == "" {
-		cfg.Metadata.ID = uuid.NewString()
+	if cfg.ID == "" {
+		cfg.ID = uuid.NewString()
 	}
 	return &Agent{
-		metadata:         cfg.Metadata,
+		id:               cfg.ID,
+		name:             cfg.Name,
+		description:      cfg.Description,
+		providerName:     cfg.ProviderName,
 		instructions:     cfg.Instructions,
 		createSession:    cfg.CreateSession,
 		marshalSession:   cfg.MarshalSession,
@@ -88,7 +87,11 @@ func (r ResponseStream) Collect(ctx context.Context) (*message.Response, error) 
 }
 
 type Agent struct {
-	metadata     Metadata
+	id           string
+	name         string
+	description  string
+	providerName string
+
 	instructions string
 
 	runOptions []agentopt.RunOption
@@ -100,15 +103,31 @@ type Agent struct {
 }
 
 func (a *Agent) ID() string {
-	return a.metadata.ID
+	if a == nil {
+		return ""
+	}
+	return a.id
 }
 
 func (a *Agent) Name() string {
-	return a.metadata.Name
+	if a == nil {
+		return ""
+	}
+	return a.name
 }
 
-func (a *Agent) Metadata() Metadata {
-	return a.metadata
+func (a *Agent) Description() string {
+	if a == nil {
+		return ""
+	}
+	return a.description
+}
+
+func (a *Agent) ProviderName() string {
+	if a == nil {
+		return ""
+	}
+	return a.providerName
 }
 
 func (a *Agent) CreateSession(ctx context.Context, options ...agentopt.CreateSessionOption) (*memory.Session, error) {
@@ -185,7 +204,7 @@ func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, str
 	options = append(options, middleware.With(middleware.Func(a.authorMiddleware)))
 
 	// Add agent identity to context so that middlewares can log it.
-	ctx = context.WithValue(ctx, metadataKey{}, a.Metadata())
+	ctx = context.WithValue(ctx, agentKey{}, a)
 
 	// If Run.All() is called, set the Stream option to true
 	// unless already specified in options.
@@ -217,13 +236,13 @@ func (a *Agent) authorMiddleware(next middleware.RunFunc, ctx context.Context, m
 	}
 }
 
-type metadataKey struct{}
+type agentKey struct{}
 
-// MetadataFromContext retrieves the agent metadata from the context.
-// Returns the metadata and true if found, or zero value and false otherwise.
-func MetadataFromContext(ctx context.Context) (Metadata, bool) {
-	if v := ctx.Value(metadataKey{}); v != nil {
-		return v.(Metadata), true
+// AgentFromContext retrieves the agent that initiated the run from the context.
+// Returns the agent and true if found, or nil and false otherwise.
+func AgentFromContext(ctx context.Context) (*Agent, bool) {
+	if v := ctx.Value(agentKey{}); v != nil {
+		return v.(*Agent), true
 	}
-	return Metadata{}, false
+	return nil, false
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -82,7 +82,7 @@ func failRunFunc(runErr error) func(_ context.Context, _ []*message.Message, _ .
 
 func newGenericTestAgent(runFn func(context.Context, []*message.Message, ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error], instructions string, runOptions ...agentopt.RunOption) *agent.Agent {
 	return agent.New(agent.Config{
-		Metadata:     agent.Metadata{ID: "test-agent", Name: "test-agent"},
+		ID: "test-agent", Name: "test-agent",
 		Instructions: instructions,
 		RunOptions:   runOptions,
 		CreateSession: func(ctx context.Context, opts ...agentopt.CreateSessionOption) (*memory.Session, error) {
@@ -342,10 +342,8 @@ func TestAgent_Run_PrependsAgentOptions(t *testing.T) {
 
 	agentOption := agentopt.Stream(true)
 	a := agent.New(agent.Config{
-		Metadata: agent.Metadata{
-			ID:   "test",
-			Name: "test",
-		},
+		ID:         "test",
+		Name:       "test",
 		RunOptions: []agentopt.RunOption{agentOption},
 		CreateSession: func(ctx context.Context, opts ...agentopt.CreateSessionOption) (*memory.Session, error) {
 			return agenttest.CreateSession(), nil
@@ -408,13 +406,13 @@ func TestAgent_Run_AddsMetadataToContext(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	metadata, ok := agent.MetadataFromContext(capturedCtx)
+	actx, ok := agent.AgentFromContext(capturedCtx)
 	if !ok {
 		t.Fatal("expected metadata in context")
 	}
 
-	if metadata != a.Metadata() {
-		t.Errorf("expected metadata %+v, got %+v", a.Metadata(), metadata)
+	if a != actx {
+		t.Errorf("expected agent %+v, got %+v", a, actx)
 	}
 }
 

--- a/agent/chatagent/chatagent.go
+++ b/agent/chatagent/chatagent.go
@@ -79,12 +79,10 @@ func NewAgent(runfn RunFunc, cfg Config, prov ProviderConfig) *agent.Agent {
 		runFn: runfn,
 	}
 	return agent.New(agent.Config{
-		Metadata: agent.Metadata{
-			ID:           cfg.ID,
-			Name:         cfg.Name,
-			ProviderName: prov.Name,
-			Description:  cfg.Description,
-		},
+		ID:           cfg.ID,
+		Name:         cfg.Name,
+		ProviderName: prov.Name,
+		Description:  cfg.Description,
 
 		Instructions: opts.Instructions,
 

--- a/agent/middleware/logger/logger.go
+++ b/agent/middleware/logger/logger.go
@@ -57,11 +57,11 @@ func (l *logger) Run(next middleware.RunFunc, ctx context.Context, messages []*m
 }
 
 func (l *logger) log(ctx context.Context, level slog.Level, msg string, args ...any) {
-	metadata, ok := agent.MetadataFromContext(ctx)
+	a, ok := agent.AgentFromContext(ctx)
 	if ok {
-		args = append(args, "agentID", metadata.ID)
-		if metadata.Name != "" {
-			args = append(args, "agentName", metadata.Name)
+		args = append(args, "agentID", a.ID())
+		if a.Name() != "" {
+			args = append(args, "agentName", a.Name())
 		}
 	}
 	l.l.Log(ctx, level, msg, args...)

--- a/agent/middleware/otel/otel.go
+++ b/agent/middleware/otel/otel.go
@@ -48,13 +48,13 @@ type mw struct {
 
 func (m *mw) Run(next middleware.RunFunc, ctx context.Context, messages []*message.Message, options ...agentopt.RunOption) iter.Seq2[*message.ResponseUpdate, error] {
 	return func(yield func(*message.ResponseUpdate, error) bool) {
-		metadata, _ := agent.MetadataFromContext(ctx)
-		ctx, span := m.tracer.Start(ctx, metadata.Name, trace.WithAttributes(
+		a, _ := agent.AgentFromContext(ctx)
+		ctx, span := m.tracer.Start(ctx, a.Name(), trace.WithAttributes(
 			attribute.String(attrKeyOperationName, opInvoke),
-			attribute.String(attrKeyProviderName, cmp.Or(metadata.ProviderName, "unknown")),
-			attribute.String(attrKeyAgentID, metadata.ID),
-			attribute.String(attrKeyAgentName, metadata.Name),
-			attribute.String(attrKeyAgentDesc, metadata.Description),
+			attribute.String(attrKeyProviderName, cmp.Or(a.ProviderName(), "unknown")),
+			attribute.String(attrKeyAgentID, a.ID()),
+			attribute.String(attrKeyAgentName, a.Name()),
+			attribute.String(attrKeyAgentDesc, a.Description()),
 		))
 		defer span.End()
 

--- a/agent/middleware/otel/otel_test.go
+++ b/agent/middleware/otel/otel_test.go
@@ -84,12 +84,10 @@ func TestOtel_Run_SpanHasCorrectAttributes(t *testing.T) {
 
 	// Override the agent metadata for this test
 	a = agent.New(agent.Config{
-		Metadata: agent.Metadata{
-			ID:           "test-agent-id",
-			Name:         "test-agent",
-			Description:  "A test agent",
-			ProviderName: "test-provider",
-		},
+		ID:           "test-agent-id",
+		Name:         "test-agent",
+		Description:  "A test agent",
+		ProviderName: "test-provider",
 		CreateSession: func(ctx context.Context, options ...agentopt.CreateSessionOption) (*memory.Session, error) {
 			return agenttest.CreateSession(), nil
 		},

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -14,7 +14,7 @@ import (
 func (a *Agent) AsFuncTool(options ...agentopt.RunOption) tool.FuncTool {
 	return functool{
 		name:        a.Name(),
-		description: a.Metadata().Description,
+		description: a.Description(),
 		opts:        options,
 		agent:       a,
 	}

--- a/internal/agenttest/agenttest.go
+++ b/internal/agenttest/agenttest.go
@@ -98,12 +98,10 @@ func NewAgent(responses []Turn) *agent.Agent {
 		responses: responses,
 	}
 	return agent.New(agent.Config{
-		Metadata: agent.Metadata{
-			ID:           "test-agent-id",
-			Name:         "TestAgent",
-			Description:  "A test agent",
-			ProviderName: "agenttest",
-		},
+		ID:               "test-agent-id",
+		Name:             "TestAgent",
+		Description:      "A test agent",
+		ProviderName:     "agenttest",
 		CreateSession:    a.createSession,
 		MarshalSession:   a.marshalSession,
 		UnmarshalSession: a.unmarshalSession,


### PR DESCRIPTION
`agent.Metadata` was a necessary extension point when `agent.Agent` was an interfaces. That's no longer the case if we need to extend the properties of an agent we can add new fields to it.