### PR TITLE
Allow FunctionResultContent pass-through when CallId matches

### DIFF
--- a/agent/provider/openaichat/chat_test.go
+++ b/agent/provider/openaichat/chat_test.go
@@ -3,7 +3,6 @@
 package openaichat_test
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -709,7 +708,7 @@ func TestChatFunctionCallContent_NonStreaming(t *testing.T) {
 	type GetPersonAgeInput struct {
 		PersonName string `json:"personName" jsonschema:"The person whose age is being requested"`
 	}
-	getPersonAge := func(ctx context.Context, input GetPersonAgeInput) (int, error) {
+	getPersonAge := func(ctx tool.Context, input GetPersonAgeInput) (int, error) {
 		return 42, nil
 	}
 	tool := functool.MustNew(&functool.Func{
@@ -823,7 +822,7 @@ data: [DONE]
 	type GetPersonAgeInput struct {
 		PersonName string `json:"personName"`
 	}
-	getPersonAge := func(ctx context.Context, input GetPersonAgeInput) (int, error) {
+	getPersonAge := func(ctx tool.Context, input GetPersonAgeInput) (int, error) {
 		return 42, nil
 	}
 	tool := functool.MustNew(&functool.Func{
@@ -1385,11 +1384,11 @@ func TestChatMultipleRequiredFunctions(t *testing.T) {
 		Location string `json:"location" jsonschema:"The city and state, e.g. San Francisco, CA"`
 	}
 
-	getWeather := func(ctx context.Context, input LocationInput) (string, error) {
+	getWeather := func(ctx tool.Context, input LocationInput) (string, error) {
 		return "Sunny, 72°F", nil
 	}
 
-	getTime := func(ctx context.Context, input LocationInput) (string, error) {
+	getTime := func(ctx tool.Context, input LocationInput) (string, error) {
 		return "3:45 PM", nil
 	}
 

--- a/agent/provider/openairesponses/responses_test.go
+++ b/agent/provider/openairesponses/responses_test.go
@@ -3,7 +3,6 @@
 package openairesponses_test
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -1291,7 +1290,7 @@ func TestResponsesFunctionCallWithResult_NonStreaming(t *testing.T) {
 	type GetWeatherInput struct {
 		Location string `json:"location" jsonschema:"The city and state"`
 	}
-	getWeather := func(ctx context.Context, input GetWeatherInput) (map[string]any, error) {
+	getWeather := func(ctx tool.Context, input GetWeatherInput) (map[string]any, error) {
 		return map[string]any{"temperature": 72, "condition": "sunny"}, nil
 	}
 	tool := functool.MustNew(&functool.Func{
@@ -1480,7 +1479,7 @@ func TestResponsesFunctionCall_UsesCallIDWhenDifferentFromID(t *testing.T) {
 	type GetWeatherInput struct {
 		Location string `json:"location" jsonschema:"The city and country"`
 	}
-	getWeather := func(ctx context.Context, input GetWeatherInput) (string, error) {
+	getWeather := func(ctx tool.Context, input GetWeatherInput) (string, error) {
 		return "Cloudy, 15°C", nil
 	}
 	weatherTool := functool.MustNew(&functool.Func{
@@ -4799,11 +4798,11 @@ func TestResponsesMultipleRequiredFunctions(t *testing.T) {
 		Location string `json:"location" jsonschema:"The city and state, e.g. San Francisco, CA"`
 	}
 
-	getWeather := func(ctx context.Context, input LocationInput) (string, error) {
+	getWeather := func(ctx tool.Context, input LocationInput) (string, error) {
 		return "Sunny, 72°F", nil
 	}
 
-	getTime := func(ctx context.Context, input LocationInput) (string, error) {
+	getTime := func(ctx tool.Context, input LocationInput) (string, error) {
 		return "3:45 PM", nil
 	}
 

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -3,7 +3,6 @@
 package agent
 
 import (
-	"context"
 	"encoding/json"
 
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -54,7 +53,7 @@ func (t functool) ReturnSchema() any {
 	}
 }
 
-func (t functool) Call(ctx context.Context, args string) (any, error) {
+func (t functool) Call(ctx tool.Context, args string) (any, error) {
 	var in struct {
 		Query string `json:"query"`
 	}

--- a/examples/chat_cli/main.go
+++ b/examples/chat_cli/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
@@ -23,7 +24,7 @@ var logger = demo.NewLogger(
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, location string) (string, error) {
+}, func(_ tool.Context, location string) (string, error) {
 	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
 })
 

--- a/examples/getting_started/agent/step03_using_function_tools/main.go
+++ b/examples/getting_started/agent/step03_using_function_tools/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/middleware"
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
@@ -23,7 +24,7 @@ var logger = demo.NewLogger(
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, location string) (string, error) {
+}, func(_ tool.Context, location string) (string, error) {
 	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
 })
 

--- a/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/agent/step04_using_function_tools_with_approvals/main.go
@@ -25,7 +25,7 @@ var logger = demo.NewLogger(
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, location string) (string, error) {
+}, func(_ tool.Context, location string) (string, error) {
 	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
 })
 

--- a/examples/getting_started/agent/step12_as_function_tool/main.go
+++ b/examples/getting_started/agent/step12_as_function_tool/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/middleware"
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
@@ -25,7 +26,7 @@ var logger = demo.NewLogger(
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, location string) (string, error) {
+}, func(_ tool.Context, location string) (string, error) {
 	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
 })
 

--- a/examples/getting_started/azure_openai/step03_using_function_tools/main.go
+++ b/examples/getting_started/azure_openai/step03_using_function_tools/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/middleware"
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/azure"
@@ -31,7 +32,7 @@ var logger = demo.NewLogger(
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, location string) (string, error) {
+}, func(_ tool.Context, location string) (string, error) {
 	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
 })
 

--- a/examples/getting_started/azure_openai/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/azure_openai/step04_using_function_tools_with_approvals/main.go
@@ -33,7 +33,7 @@ var logger = demo.NewLogger(
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, location string) (string, error) {
+}, func(_ tool.Context, location string) (string, error) {
 	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
 })
 

--- a/examples/getting_started/azure_openai/step12_as_function_tool/main.go
+++ b/examples/getting_started/azure_openai/step12_as_function_tool/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/middleware"
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/azure"
@@ -33,7 +34,7 @@ var logger = demo.NewLogger(
 var weatherTool = functool.MustNew(&functool.Func{
 	Name:        "weather",
 	Description: "Get the current weather for a given location",
-}, func(_ context.Context, location string) (string, error) {
+}, func(_ tool.Context, location string) (string, error) {
 	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
 })
 

--- a/middleware/autocall/autocall.go
+++ b/middleware/autocall/autocall.go
@@ -475,7 +475,10 @@ func (f *autocall) processFunctionCall(ctx context.Context, tools map[string]too
 				}
 			}
 		}()
-		result, err = tl.Call(ctx, funcCall.Arguments)
+		result, err = tl.Call(tool.Context{
+			Context: ctx,
+			CallID:  funcCall.CallID,
+		}, funcCall.Arguments)
 	}()
 	if err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/middleware/autocall/autocall.go
+++ b/middleware/autocall/autocall.go
@@ -492,6 +492,12 @@ func (f *autocall) processFunctionCall(ctx context.Context, tools map[string]too
 // createFunctionResult creates a FunctionResultContent with proper error handling.
 // It formats errors into the Result string and preserves the error for re-throwing when limits are exceeded.
 func (f *autocall) createFunctionResult(callID string, result any, err error) *message.FunctionResultContent {
+	if err == nil {
+		if frc, ok := result.(*message.FunctionResultContent); ok && frc.CallID == callID {
+			return frc
+		}
+	}
+
 	if err == nil && result == nil {
 		result = "Success: Function completed."
 	}

--- a/middleware/autocall/autocall_approval_test.go
+++ b/middleware/autocall/autocall_approval_test.go
@@ -792,7 +792,7 @@ func TestFunctionInvoking_ApprovalRequestWithoutApprovalResponseThrows(t *testin
 // Helper functions to create test tools
 func createFunc1() *functool.Tool {
 	return functool.MustNew(&functool.Func{Name: "Func1"},
-		func(ctx context.Context, args struct{}) (string, error) {
+		func(ctx tool.Context, args struct{}) (string, error) {
 			return "Result 1", nil
 		})
 }
@@ -802,7 +802,7 @@ func createFunc2() *functool.Tool {
 		I int `json:"i"`
 	}
 	return functool.MustNew(&functool.Func{Name: "Func2"},
-		func(ctx context.Context, args Func2Args) (string, error) {
+		func(ctx tool.Context, args Func2Args) (string, error) {
 			return fmt.Sprintf("Result 2: %d", args.I), nil
 		})
 }

--- a/middleware/autocall/autocall_log_test.go
+++ b/middleware/autocall/autocall_log_test.go
@@ -28,7 +28,7 @@ func TestAutocall_LogsSuccessfulFunctionCall(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "TestFunc"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "Success", nil
 			}),
 	}
@@ -80,7 +80,7 @@ func TestAutocall_LogsSensitiveData(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "TestFunc"},
-			func(ctx context.Context, args TestArgs) (string, error) {
+			func(ctx tool.Context, args TestArgs) (string, error) {
 				return "Result: " + args.Value, nil
 			}),
 	}
@@ -133,7 +133,7 @@ func TestAutocall_DoesNotLogSensitiveDataByDefault(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "TestFunc"},
-			func(ctx context.Context, args TestArgs) (string, error) {
+			func(ctx tool.Context, args TestArgs) (string, error) {
 				return "Result: " + args.Value, nil
 			}),
 	}
@@ -183,7 +183,7 @@ func TestAutocall_LogsFailedFunctionCall(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "FailingFunc"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "", errors.New("something went wrong")
 			}),
 	}
@@ -232,7 +232,7 @@ func TestAutocall_LogsCanceledFunctionCall(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "CancelableFunc"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "", context.Canceled
 			}),
 	}
@@ -275,11 +275,11 @@ func TestAutocall_LogsMultipleFunctionCalls(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "Result1", nil
 			}),
 		functool.MustNew(&functool.Func{Name: "Func2"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "Result2", nil
 			}),
 	}
@@ -328,12 +328,12 @@ func TestAutocall_LoggingWithConcurrentInvocations(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "SlowFunc1"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				time.Sleep(10 * time.Millisecond)
 				return "Result1", nil
 			}),
 		functool.MustNew(&functool.Func{Name: "SlowFunc2"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				time.Sleep(10 * time.Millisecond)
 				return "Result2", nil
 			}),

--- a/middleware/autocall/autocall_test.go
+++ b/middleware/autocall/autocall_test.go
@@ -213,6 +213,166 @@ func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, e
 	return actual
 }
 
+func TestFunctionInvoking_FunctionReturningFunctionResultContentWithMatchingCallID_UsesItDirectly(t *testing.T) {
+	returnedFrc := &message.FunctionResultContent{
+		CallID: "callId1",
+		Result: "Custom result from function",
+		ContentHeader: message.ContentHeader{
+			RawRepresentation: "CustomRaw",
+		},
+	}
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "Func1"},
+			func(ctx context.Context, args struct{}) (any, error) {
+				return returnedFrc, nil
+			}),
+	}
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&message.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`}},
+			}).
+			NewTurn().
+			Add(&message.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.TextContent{Text: "done"}},
+			}).
+			Build(),
+	}
+
+	var opts []agentopt.Option
+	for _, tl := range tools {
+		opts = append(opts, agentopt.Tool(tl))
+	}
+
+	initialMessages := []*message.Message{message.NewText("hello")}
+	var resp message.Response
+	for update, err := range autocall.New(autocall.Config{}).Run(runner.Run, t.Context(), initialMessages, opts...) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resp.Update(update)
+	}
+
+	var toolMessage *message.Message
+	for _, msg := range resp.Messages {
+		if msg.Role == message.RoleTool {
+			toolMessage = msg
+			break
+		}
+	}
+	if toolMessage == nil {
+		t.Fatal("expected a tool message in response")
+	}
+
+	var frcs []*message.FunctionResultContent
+	for _, c := range toolMessage.Contents {
+		if frc, ok := c.(*message.FunctionResultContent); ok {
+			frcs = append(frcs, frc)
+		}
+	}
+	if len(frcs) != 1 {
+		t.Fatalf("expected exactly one FunctionResultContent in tool message, got %d", len(frcs))
+	}
+
+	if frcs[0] != returnedFrc {
+		t.Fatalf("expected tool FunctionResultContent to be the same instance returned by tool")
+	}
+	if frcs[0].Result != "Custom result from function" {
+		t.Fatalf("expected result %q, got %v", "Custom result from function", frcs[0].Result)
+	}
+	if frcs[0].RawRepresentation != "CustomRaw" {
+		t.Fatalf("expected RawRepresentation %q, got %v", "CustomRaw", frcs[0].RawRepresentation)
+	}
+	if frcs[0].CallID != "callId1" {
+		t.Fatalf("expected CallID %q, got %q", "callId1", frcs[0].CallID)
+	}
+}
+
+func TestFunctionInvoking_FunctionReturningFunctionResultContentWithMismatchedCallID_WrapsIt(t *testing.T) {
+	returnedFrc := &message.FunctionResultContent{
+		CallID: "differentCallId",
+		Result: "Result from function",
+	}
+
+	tools := []tool.Tool{
+		functool.MustNew(&functool.Func{Name: "Func1"},
+			func(ctx context.Context, args struct{}) (any, error) {
+				return returnedFrc, nil
+			}),
+	}
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&message.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`}},
+			}).
+			NewTurn().
+			Add(&message.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.TextContent{Text: "done"}},
+			}).
+			Build(),
+	}
+
+	var opts []agentopt.Option
+	for _, tl := range tools {
+		opts = append(opts, agentopt.Tool(tl))
+	}
+
+	initialMessages := []*message.Message{message.NewText("hello")}
+	var resp message.Response
+	for update, err := range autocall.New(autocall.Config{}).Run(runner.Run, t.Context(), initialMessages, opts...) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resp.Update(update)
+	}
+
+	var toolMessage *message.Message
+	for _, msg := range resp.Messages {
+		if msg.Role == message.RoleTool {
+			toolMessage = msg
+			break
+		}
+	}
+	if toolMessage == nil {
+		t.Fatal("expected a tool message in response")
+	}
+
+	var frcs []*message.FunctionResultContent
+	for _, c := range toolMessage.Contents {
+		if frc, ok := c.(*message.FunctionResultContent); ok {
+			frcs = append(frcs, frc)
+		}
+	}
+	if len(frcs) != 1 {
+		t.Fatalf("expected exactly one FunctionResultContent in tool message, got %d", len(frcs))
+	}
+
+	frc := frcs[0]
+	if frc.CallID != "callId1" {
+		t.Fatalf("expected outer CallID %q, got %q", "callId1", frc.CallID)
+	}
+	inner, ok := frc.Result.(*message.FunctionResultContent)
+	if !ok {
+		t.Fatalf("expected outer Result to be *message.FunctionResultContent, got %T", frc.Result)
+	}
+	if inner != returnedFrc {
+		t.Fatalf("expected wrapped inner FunctionResultContent to be the same instance returned by tool")
+	}
+	if inner.CallID != "differentCallId" {
+		t.Fatalf("expected inner CallID %q, got %q", "differentCallId", inner.CallID)
+	}
+	if inner.Result != "Result from function" {
+		t.Fatalf("expected inner result %q, got %v", "Result from function", inner.Result)
+	}
+}
+
 // TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools tests AdditionalTools functionality
 func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 	type Func1Args struct{}

--- a/middleware/autocall/autocall_test.go
+++ b/middleware/autocall/autocall_test.go
@@ -28,15 +28,15 @@ func TestFunctionInvoking_SupportsSingleFunctionCallPerRequest(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1", Description: "Function 1"},
-			func(ctx context.Context, args EmptyArgs) (string, error) {
+			func(ctx tool.Context, args EmptyArgs) (string, error) {
 				return "Result 1", nil
 			}),
 		functool.MustNew(&functool.Func{Name: "Func2", Description: "Function 2"},
-			func(ctx context.Context, args Func2Args) (string, error) {
+			func(ctx tool.Context, args Func2Args) (string, error) {
 				return "Result 2: 42", nil
 			}),
 		functool.MustNew(&functool.Func{Name: "VoidReturn", Description: "Void return"},
-			func(ctx context.Context, args Func2Args) (string, error) {
+			func(ctx tool.Context, args Func2Args) (string, error) {
 				return "Success: Function completed.", nil
 			}),
 	}
@@ -89,11 +89,11 @@ func TestFunctionInvoking_SupportsMultipleFunctionCallsPerRequest(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			tools := []tool.Tool{
 				functool.MustNew(&functool.Func{Name: "Func1"},
-					func(ctx context.Context, args Func1Args) (string, error) {
+					func(ctx tool.Context, args Func1Args) (string, error) {
 						return "Result 1", nil
 					}),
 				functool.MustNew(&functool.Func{Name: "Func2"},
-					func(ctx context.Context, args Func2Args) (string, error) {
+					func(ctx tool.Context, args Func2Args) (string, error) {
 						switch args.I {
 						case 34:
 							return "Result 2: 34", nil
@@ -214,17 +214,18 @@ func invokeAndAssert(t *testing.T, tools []tool.Tool, plan []*message.Message, e
 }
 
 func TestFunctionInvoking_FunctionReturningFunctionResultContentWithMatchingCallID_UsesItDirectly(t *testing.T) {
-	returnedFrc := &message.FunctionResultContent{
-		CallID: "callId1",
-		Result: "Custom result from function",
-		ContentHeader: message.ContentHeader{
-			RawRepresentation: "CustomRaw",
-		},
-	}
+	var returnedFrc *message.FunctionResultContent
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1"},
-			func(ctx context.Context, args struct{}) (any, error) {
+			func(ctx tool.Context, args struct{}) (any, error) {
+				returnedFrc = &message.FunctionResultContent{
+					CallID: ctx.CallID,
+					Result: "Custom result from function",
+					ContentHeader: message.ContentHeader{
+						RawRepresentation: "CustomRaw",
+					},
+				}
 				return returnedFrc, nil
 			}),
 	}
@@ -300,7 +301,7 @@ func TestFunctionInvoking_FunctionReturningFunctionResultContentWithMismatchedCa
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1"},
-			func(ctx context.Context, args struct{}) (any, error) {
+			func(ctx tool.Context, args struct{}) (any, error) {
 				return returnedFrc, nil
 			}),
 	}
@@ -394,7 +395,7 @@ func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 			if tt.provideOptions {
 				tools = []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "OptionsFunc"},
-						func(ctx context.Context, args struct{}) (string, error) {
+						func(ctx tool.Context, args struct{}) (string, error) {
 							t.Error("OptionsFunc should not be invoked")
 							return "Shouldn't be invoked", nil
 						}),
@@ -404,15 +405,15 @@ func TestFunctionInvoking_SupportsToolsProvidedByAdditionalTools(t *testing.T) {
 			autocallOptions := autocall.Config{
 				AdditionalTools: []tool.Tool{
 					functool.MustNew(&functool.Func{Name: "Func1"},
-						func(ctx context.Context, args Func1Args) (string, error) {
+						func(ctx tool.Context, args Func1Args) (string, error) {
 							return "Result 1", nil
 						}),
 					functool.MustNew(&functool.Func{Name: "Func2"},
-						func(ctx context.Context, args Func2Args) (string, error) {
+						func(ctx tool.Context, args Func2Args) (string, error) {
 							return fmt.Sprintf("Result 2: %d", args.I), nil
 						}),
 					functool.MustNew(&functool.Func{Name: "VoidReturn"},
-						func(ctx context.Context, args Func2Args) (string, error) {
+						func(ctx tool.Context, args Func2Args) (string, error) {
 							return "Success: Function completed.", nil
 						}),
 				},
@@ -456,7 +457,7 @@ func TestFunctionInvoking_PrefersToolsProvidedByOptions(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "Result 1", nil
 			}),
 	}
@@ -464,16 +465,16 @@ func TestFunctionInvoking_PrefersToolsProvidedByOptions(t *testing.T) {
 	autocallOptions := autocall.Config{
 		AdditionalTools: []tool.Tool{
 			functool.MustNew(&functool.Func{Name: "Func1"},
-				func(ctx context.Context, args struct{}) (string, error) {
+				func(ctx tool.Context, args struct{}) (string, error) {
 					t.Error("AdditionalTools Func1 should not be invoked")
 					return "Should never be invoked", nil
 				}),
 			functool.MustNew(&functool.Func{Name: "Func2"},
-				func(ctx context.Context, args Func2Args) (string, error) {
+				func(ctx tool.Context, args Func2Args) (string, error) {
 					return fmt.Sprintf("Result 2: %d", args.I), nil
 				}),
 			functool.MustNew(&functool.Func{Name: "VoidReturn"},
-				func(ctx context.Context, args Func2Args) (string, error) {
+				func(ctx tool.Context, args Func2Args) (string, error) {
 					return "Success: Function completed.", nil
 				}),
 		},
@@ -515,7 +516,7 @@ func TestFunctionInvoking_ParallelFunctionCallsMayBeInvokedConcurrently(t *testi
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func"},
-			func(ctx context.Context, args struct{ Arg string }) (string, error) {
+			func(ctx tool.Context, args struct{ Arg string }) (string, error) {
 				if remaining.Add(-1) == 0 {
 					close(done)
 				}
@@ -552,7 +553,7 @@ func TestFunctionInvoking_ConcurrentInvocationOfParallelCallsDisabledByDefault(t
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func"},
-			func(ctx context.Context, args struct{ Arg string }) (string, error) {
+			func(ctx tool.Context, args struct{ Arg string }) (string, error) {
 				activeCount.Add(1)
 				time.Sleep(100 * time.Millisecond)
 				if activeCount.Load() != 1 {
@@ -588,7 +589,7 @@ func TestFunctionInvoking_ContinuesWithSuccessfulCallsUntilMaximumIterations(t *
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "VoidReturn"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				actualCallCount++
 				return "Success: Function completed.", nil
 			}),
@@ -646,7 +647,7 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 
 			tools := []tool.Tool{
 				functool.MustNew(&functool.Func{Name: "Func"},
-					func(ctx context.Context, args struct {
+					func(ctx tool.Context, args struct {
 						ShouldThrow bool `json:"shouldThrow"`
 						CallIndex   int  `json:"callIndex"`
 					}) (string, error) {
@@ -783,7 +784,7 @@ func TestFunctionInvoking_CanFailOnFirstException(t *testing.T) {
 
 			tools := []tool.Tool{
 				functool.MustNew(&functool.Func{Name: "Func"},
-					func(ctx context.Context, args struct{}) (string, error) {
+					func(ctx tool.Context, args struct{}) (string, error) {
 						return "", errors.New("It failed")
 					}),
 			}
@@ -849,15 +850,15 @@ func TestFunctionInvoking_KeepsFunctionCallingContent(t *testing.T) {
 
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "Result 1", nil
 			}),
 		functool.MustNew(&functool.Func{Name: "Func2"},
-			func(ctx context.Context, args Func2Args) (string, error) {
+			func(ctx tool.Context, args Func2Args) (string, error) {
 				return fmt.Sprintf("Result 2: %d", args.I), nil
 			}),
 		functool.MustNew(&functool.Func{Name: "VoidReturn"},
-			func(ctx context.Context, args Func2Args) (string, error) {
+			func(ctx tool.Context, args Func2Args) (string, error) {
 				return "Success: Function completed.", nil
 			}),
 	}
@@ -928,7 +929,7 @@ func TestFunctionInvoking_TerminateOnUnknownCalls(t *testing.T) {
 
 			tools := []tool.Tool{
 				functool.MustNew(&functool.Func{Name: "KnownFunc"},
-					func(ctx context.Context, args Func2Args) (string, error) {
+					func(ctx tool.Context, args Func2Args) (string, error) {
 						return fmt.Sprintf("Known: %d", args.I), nil
 					}),
 			}
@@ -979,7 +980,7 @@ func TestFunctionInvoking_ExceptionDetailsOnlyReportedWhenRequested(t *testing.T
 		t.Run(tt.name, func(t *testing.T) {
 			tools := []tool.Tool{
 				functool.MustNew(&functool.Func{Name: "Func1"},
-					func(ctx context.Context, args struct{}) (string, error) {
+					func(ctx tool.Context, args struct{}) (string, error) {
 						return "", errors.New("Oh no!")
 					}),
 			}
@@ -1011,7 +1012,7 @@ func TestFunctionInvoking_ExceptionDetailsOnlyReportedWhenRequested(t *testing.T
 func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "doesn't matter", nil
 			}),
 	}
@@ -1089,7 +1090,7 @@ func TestFunctionInvoking_AllResponseMessagesReturned(t *testing.T) {
 func TestFunctionInvoking_NextIterationIncludesAssistantFunctionCallMessage(t *testing.T) {
 	tools := []tool.Tool{
 		functool.MustNew(&functool.Func{Name: "Func1"},
-			func(ctx context.Context, args struct{}) (string, error) {
+			func(ctx tool.Context, args struct{}) (string, error) {
 				return "Result 1", nil
 			}),
 	}

--- a/middleware/skills/skills.go
+++ b/middleware/skills/skills.go
@@ -29,6 +29,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/middleware"
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
@@ -105,7 +106,7 @@ func New(opts *Config, fsys ...fs.FS) middleware.Middleware {
 				Name:        "load_skill",
 				Description: "Loads the full instructions for a specific skill.",
 			},
-			func(_ context.Context, in struct {
+			func(_ tool.Context, in struct {
 				SkillName string `json:"skillName" jsonschema:"The name of the skill to load"`
 			}) (string, error) {
 				return p.loadSkill(in.SkillName)
@@ -116,7 +117,7 @@ func New(opts *Config, fsys ...fs.FS) middleware.Middleware {
 				Name:        "read_skill_resource",
 				Description: "Reads a file associated with a skill, such as references or assets.",
 			},
-			func(_ context.Context, in struct {
+			func(_ tool.Context, in struct {
 				SkillName    string `json:"skillName" jsonschema:"The name of the skill"`
 				ResourceName string `json:"resourceName" jsonschema:"The relative path of the resource file within the skill"`
 			}) (string, error) {
@@ -233,7 +234,10 @@ func (p *skills) autocallSkillTool(ctx context.Context, fcc *message.FunctionCal
 		if tl.Name() != fcc.Name {
 			continue
 		}
-		result, err := tl.Call(ctx, fcc.Arguments)
+		result, err := tl.Call(tool.Context{
+			Context: ctx,
+			CallID:  fcc.CallID,
+		}, fcc.Arguments)
 		if err != nil {
 			return fmt.Sprintf("Error: %v", err), true
 		}

--- a/middleware/skills/skills_test.go
+++ b/middleware/skills/skills_test.go
@@ -679,7 +679,7 @@ func TestLoadSkill_ReturnsBody(t *testing.T) {
 	_, tools := captureRunContext(t, p)
 	loadTool := findTool(t, tools, "load_skill")
 
-	result, err := loadTool.Call(t.Context(), `{"skillName":"load-test"}`)
+	result, err := loadTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"load-test"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +696,7 @@ func TestLoadSkill_NotFound(t *testing.T) {
 	_, tools := captureRunContext(t, p)
 	loadTool := findTool(t, tools, "load_skill")
 
-	_, err := loadTool.Call(t.Context(), `{"skillName":"nonexistent"}`)
+	_, err := loadTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"nonexistent"}`)
 	if err == nil || !strings.HasPrefix(err.Error(), "Error:") {
 		t.Fatalf("expected error, got %v", err)
 	}
@@ -710,7 +710,7 @@ func TestLoadSkill_EmptyName(t *testing.T) {
 	_, tools := captureRunContext(t, p)
 	loadTool := findTool(t, tools, "load_skill")
 
-	_, err := loadTool.Call(t.Context(), `{"skillName":""}`)
+	_, err := loadTool.Call(tool.Context{Context: t.Context()}, `{"skillName":""}`)
 	if err == nil || !strings.HasPrefix(err.Error(), "Error:") {
 		t.Fatalf("expected error, got %v", err)
 	}
@@ -727,7 +727,7 @@ func TestReadResource_ReturnsContent(t *testing.T) {
 	_, tools := captureRunContext(t, p)
 	readTool := findTool(t, tools, "read_skill_resource")
 
-	result, err := readTool.Call(t.Context(), `{"skillName":"res-test","resourceName":"refs/doc.md"}`)
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"res-test","resourceName":"refs/doc.md"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -745,7 +745,7 @@ func TestReadResource_DotSlashPrefix(t *testing.T) {
 	_, tools := captureRunContext(t, p)
 	readTool := findTool(t, tools, "read_skill_resource")
 
-	result, err := readTool.Call(t.Context(), `{"skillName":"dotslash-read","resourceName":"./refs/doc.md"}`)
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"dotslash-read","resourceName":"./refs/doc.md"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -762,7 +762,7 @@ func TestReadResource_UnregisteredResource(t *testing.T) {
 	_, tools := captureRunContext(t, p)
 	readTool := findTool(t, tools, "read_skill_resource")
 
-	_, err := readTool.Call(t.Context(), `{"skillName":"simple-skill","resourceName":"unknown.md"}`)
+	_, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"simple-skill","resourceName":"unknown.md"}`)
 	if err == nil || !strings.HasPrefix(err.Error(), "Error:") {
 		t.Fatalf("expected error, got %v", err)
 	}
@@ -776,7 +776,7 @@ func TestReadResource_SkillNotFound(t *testing.T) {
 	_, tools := captureRunContext(t, p)
 	readTool := findTool(t, tools, "read_skill_resource")
 
-	_, err := readTool.Call(t.Context(), `{"skillName":"nonexistent","resourceName":"file.md"}`)
+	_, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"nonexistent","resourceName":"file.md"}`)
 	if err == nil || !strings.HasPrefix(err.Error(), "Error:") {
 		t.Fatalf("expected error, got %v", err)
 	}

--- a/tool/functool/func.go
+++ b/tool/functool/func.go
@@ -3,7 +3,6 @@
 package functool
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 
@@ -27,7 +26,7 @@ type Func struct {
 // request or result: the params contain raw arguments, no input validation
 // is performed, and the result is returned to the user as-is, without any
 // validation of the output.
-type Handler func(_ context.Context, args string) (any, error)
+type Handler func(ctx tool.Context, args string) (any, error)
 
 // A HandlerFor handles a call to tools/call with typed arguments and results.
 //
@@ -37,7 +36,7 @@ type Handler func(_ context.Context, args string) (any, error)
 //   - The input value is automatically unmarshaled from req.Params.Arguments.
 //   - The input value is automatically validated against its input schema.
 //     Invalid input is rejected before getting to the handler.
-type HandlerFor[In, Out any] func(context.Context, In) (Out, error)
+type HandlerFor[In, Out any] func(tool.Context, In) (Out, error)
 
 var _ tool.Tool = (*Tool)(nil)
 var _ tool.FuncTool = (*Tool)(nil)
@@ -63,19 +62,11 @@ func (t *Tool) ReturnSchema() any {
 	return t.Func.outputFormat.Schema()
 }
 
-func (t *Tool) Call(ctx context.Context, args string) (any, error) {
+func (t *Tool) Call(ctx tool.Context, args string) (any, error) {
 	if args == "" {
 		args = "{}"
 	}
 	return t.Handler(ctx, args)
-}
-
-func MustNew[In, Out any](fnp *Func, h HandlerFor[In, Out]) *Tool {
-	t, err := New(fnp, h)
-	if err != nil {
-		panic(err)
-	}
-	return t
 }
 
 type inputWrapper[T any] struct {
@@ -93,6 +84,14 @@ func formatFor[T any](needObject bool) (format *jsonformat.Format, wrapped bool,
 	}
 	format, err = jsonformat.ForType(typ)
 	return format, wrapped, err
+}
+
+func MustNew[In, Out any](fnp *Func, h HandlerFor[In, Out]) *Tool {
+	t, err := New(fnp, h)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }
 
 func New[In, Out any](fnp *Func, h HandlerFor[In, Out]) (*Tool, error) {
@@ -113,7 +112,7 @@ func New[In, Out any](fnp *Func, h HandlerFor[In, Out]) (*Tool, error) {
 		return nil, fmt.Errorf("resolving output schema: %w", err)
 	}
 
-	t.Handler = func(ctx context.Context, args string) (any, error) {
+	t.Handler = func(ctx tool.Context, args string) (any, error) {
 		var in In
 		if t.Func.inputWrapped {
 			// Extract wrapped value.

--- a/tool/functool/func_test.go
+++ b/tool/functool/func_test.go
@@ -3,10 +3,10 @@
 package functool_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
@@ -16,7 +16,7 @@ func TestFuncTool_Basic(t *testing.T) {
 		Message string `json:"message"`
 	}
 
-	handler := func(ctx context.Context, input Input) (string, error) {
+	handler := func(ctx tool.Context, input Input) (string, error) {
 		return "output: " + input.Message, nil
 	}
 
@@ -46,7 +46,7 @@ func TestFuncTool_Basic(t *testing.T) {
 }
 
 func TestFuncTool_MustNew(t *testing.T) {
-	handler := func(ctx context.Context, input string) (string, error) {
+	handler := func(ctx tool.Context, input string) (string, error) {
 		return "result", nil
 	}
 
@@ -71,13 +71,13 @@ func TestFuncTool_CallMissingArg0(t *testing.T) {
 		&functool.Func{
 			Name: "test",
 		},
-		func(ctx context.Context, input string) (string, error) {
+		func(ctx tool.Context, input string) (string, error) {
 			return "result", nil
 		},
 	)
 
 	// Call without required arg0
-	_, err := tl.Call(t.Context(), `{}`)
+	_, err := tl.Call(tool.Context{Context: t.Context()}, `{}`)
 	if err == nil {
 		t.Error("expected error for missing arg0, got nil")
 	}
@@ -91,12 +91,12 @@ func TestFuncTool_CallStruct(t *testing.T) {
 		&functool.Func{
 			Name: "test",
 		},
-		func(ctx context.Context, input In) (string, error) {
+		func(ctx tool.Context, input In) (string, error) {
 			return input.V, nil
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), `{"v":"hello"}`)
+	ret, err := tl.Call(tool.Context{Context: t.Context()}, `{"v":"hello"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,12 +110,12 @@ func TestFuncTool_CallString(t *testing.T) {
 		&functool.Func{
 			Name: "test",
 		},
-		func(ctx context.Context, input string) (string, error) {
+		func(ctx tool.Context, input string) (string, error) {
 			return input, nil
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), `{"arg0":"hello"}`)
+	ret, err := tl.Call(tool.Context{Context: t.Context()}, `{"arg0":"hello"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,12 +129,12 @@ func TestFuncTool_CallNoArg(t *testing.T) {
 		&functool.Func{
 			Name: "test",
 		},
-		func(ctx context.Context, _ struct{}) (string, error) {
+		func(ctx tool.Context, _ struct{}) (string, error) {
 			return "hello", nil
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), "")
+	ret, err := tl.Call(tool.Context{Context: t.Context()}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,12 +148,12 @@ func TestFuncTool_CallNoRet(t *testing.T) {
 		&functool.Func{
 			Name: "test",
 		},
-		func(ctx context.Context, _ struct{}) (struct{}, error) {
+		func(ctx tool.Context, _ struct{}) (struct{}, error) {
 			return struct{}{}, nil
 		},
 	)
 
-	ret, err := tl.Call(t.Context(), "")
+	ret, err := tl.Call(tool.Context{Context: t.Context()}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestFuncTool_CallError(t *testing.T) {
 	}
 
 	expectedErr := errors.New("handler error")
-	handler := func(ctx context.Context, input Input) (string, error) {
+	handler := func(ctx tool.Context, input Input) (string, error) {
 		return "", expectedErr
 	}
 
@@ -179,7 +179,7 @@ func TestFuncTool_CallError(t *testing.T) {
 		handler,
 	)
 
-	_, err := tl.Call(t.Context(), `{"value":"test"}`)
+	_, err := tl.Call(tool.Context{Context: tool.Context{Context: t.Context()}}, `{"value":"test"}`)
 	if err != expectedErr {
 		t.Errorf("expected error %v, got %v", expectedErr, err)
 	}

--- a/tool/mcptool/mcp.go
+++ b/tool/mcptool/mcp.go
@@ -21,7 +21,7 @@ func AddTool(src *mcp.Server, tl tool.FuncTool) {
 		Description: tl.Description(),
 		InputSchema: tl.Schema(),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		result, err := tl.Call(ctx, string(req.Params.Arguments))
+		result, err := tl.Call(tool.Context{Context: ctx}, string(req.Params.Arguments))
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ func (w *mcpWrapper) ReturnSchema() any {
 }
 
 // Call implements the Func-like calling pattern for MCP tools.
-func (w *mcpWrapper) Call(ctx context.Context, args string) (any, error) {
+func (w *mcpWrapper) Call(ctx tool.Context, args string) (any, error) {
 	// Call the MCP tool
 	result, err := w.session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      w.tool.Name,

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -48,13 +48,19 @@ type Tool interface {
 	Description() string
 }
 
+type Context struct {
+	context.Context
+
+	CallID string
+}
+
 type FuncTool interface {
 	Tool
 
 	Schema() any
 	ReturnSchema() any
 
-	Call(ctx context.Context, args string) (any, error)
+	Call(ctx Context, args string) (any, error)
 }
 
 // ApprovalRequiredTool indicates that a tool requires user approval before invocation.


### PR DESCRIPTION
Ports https://github.com/dotnet/extensions/pull/7229 