### PR TITLE
Support more credential types in Azure OpenAI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,27 @@ package main
 import (
   "context"
 	"fmt"
-	"os"
 
-	"github.com/microsoft/agent-framework-go/openai"
+	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+  openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/azure"
 )
 
 func main() {
-	// Azure OpenAI configuration
-	// You can also set these via environment variables:
-	// - AZURE_OPENAI_API_KEY
-	// - AZURE_OPENAI_ENDPOINT
-	// - AZURE_OPENAI_DEPLOYMENT_NAME
-	a := openai.NewChatAgentAzure(openai.ClientConfig{
-		APIKey:     os.Getenv("AZURE_OPENAI_API_KEY"),         // or set directly
-		Endpoint:   os.Getenv("AZURE_OPENAI_ENDPOINT"),        // e.g., "https://your-resource.openai.azure.com/"
-		Model:      os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), // e.g., "gpt-4o"
-	}, nil)
+  token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	a := openaichat.NewAgent(openaichat.Config{
+		Client: openai.NewClient(
+			azure.WithEndpoint("<endpoint>", "<apiVersion>"), // replace <endpoint> and <apiVersion> with your Azure Foundry endpoint and API version
+			azure.WithTokenCredential(token),
+		),
+		Model: "gpt-4o-mini",
+  })
 
   resp, err := a.RunText(context.Background(), "Write a haiku about the Microsoft Agent Framework").Collect()
   if err != nil {

--- a/examples/getting_started/azure_openai/step01_running/main.go
+++ b/examples/getting_started/azure_openai/step01_running/main.go
@@ -3,22 +3,23 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/middleware"
-	"github.com/openai/openai-go/v3"
+	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 
 var logger = demo.NewLogger(
 	"Basic Run",
@@ -27,11 +28,18 @@ var logger = demo.NewLogger(
 )
 
 func main() {
+	// Create a token credential using Azure Identity.
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent with weather tool
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step02_multiturn_conversation/main.go
+++ b/examples/getting_started/azure_openai/step02_multiturn_conversation/main.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -15,10 +17,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"Multi-Turn Conversation",
@@ -27,11 +28,17 @@ var logger = demo.NewLogger(
 )
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent.
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step03_using_function_tools/main.go
+++ b/examples/getting_started/azure_openai/step03_using_function_tools/main.go
@@ -3,10 +3,12 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -18,10 +20,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"Function Tools",
@@ -37,11 +38,17 @@ var weatherTool = functool.MustNew(&functool.Func{
 })
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent, and provide the function tool to the agent.
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step04_using_function_tools_with_approvals/main.go
+++ b/examples/getting_started/azure_openai/step04_using_function_tools_with_approvals/main.go
@@ -3,10 +3,12 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -19,10 +21,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"Function Tools With User Approvals",
@@ -38,12 +39,18 @@ var weatherTool = functool.MustNew(&functool.Func{
 })
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent.
 	// Note that we are wrapping the function tool with tool.ApprovalRequiredFunc to require user approval before invoking it.
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step05_structured_output/main.go
+++ b/examples/getting_started/azure_openai/step05_structured_output/main.go
@@ -3,11 +3,13 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -18,10 +20,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"Structured Output",
@@ -48,11 +49,17 @@ func runFor[T any](ctx context.Context, a *agent.Agent, message string, opts ...
 }
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent.
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{
@@ -80,7 +87,7 @@ func main() {
 	a = openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step06_persisted_conversation/main.go
+++ b/examples/getting_started/azure_openai/step06_persisted_conversation/main.go
@@ -3,10 +3,12 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"os"
 	"path/filepath"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -16,10 +18,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"Persisted Conversation",
@@ -28,11 +29,17 @@ var logger = demo.NewLogger(
 )
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent.
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step07_3rdparty_session_storage/main.go
+++ b/examples/getting_started/azure_openai/step07_3rdparty_session_storage/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -22,10 +24,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"3rd-Party Session Storage",
@@ -34,6 +35,12 @@ var logger = demo.NewLogger(
 )
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create a temporary directory to store messages.
 	tmpDir, err := os.MkdirTemp("", "agent_session_storage")
 	if err != nil {
@@ -45,7 +52,7 @@ func main() {
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step08_observability/main.go
+++ b/examples/getting_started/azure_openai/step08_observability/main.go
@@ -5,10 +5,12 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"log"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -24,10 +26,9 @@ import (
 	otellib "go.opentelemetry.io/otel"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"OpenTelemetry Observability",
@@ -36,6 +37,12 @@ var logger = demo.NewLogger(
 )
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create TracerProvider with console exporter.
 	// This will output the telemetry data to the console.
 	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
@@ -57,7 +64,7 @@ func main() {
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step10_as_mcp_tool/main.go
+++ b/examples/getting_started/azure_openai/step10_as_mcp_tool/main.go
@@ -5,30 +5,38 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/tool/mcptool"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 // Run "npx @modelcontextprotocol/inspector go run ." to connect to this MCP server.
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent with the same configuration as the C# example.
 	agent := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step11_using_images/main.go
+++ b/examples/getting_started/azure_openai/step11_using_images/main.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
@@ -15,10 +17,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"Using Images",
@@ -27,11 +28,17 @@ var logger = demo.NewLogger(
 )
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent.
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/getting_started/azure_openai/step12_as_function_tool/main.go
+++ b/examples/getting_started/azure_openai/step12_as_function_tool/main.go
@@ -5,10 +5,12 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichat"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -20,10 +22,9 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
 var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = os.Getenv("AZURE_OPENAI_API_VERSION")
-var apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
 
 var logger = demo.NewLogger(
 	"Agent As Function Tool",
@@ -39,11 +40,17 @@ var weatherTool = functool.MustNew(&functool.Func{
 })
 
 func main() {
+	demo.CheckAzureEndpoint(endpoint)
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create Azure OpenAI agent and provide the function tool.
 	weatherAgent := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{
@@ -62,7 +69,7 @@ func main() {
 	a := openaichat.NewAgent(openaichat.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
-			azure.WithAPIKey(apiKey),
+			azure.WithTokenCredential(token),
 		),
 		Model: deployment,
 		Agent: agent.Config{

--- a/examples/internal/demo/demo.go
+++ b/examples/internal/demo/demo.go
@@ -27,6 +27,12 @@ const (
 	colorBold    = "\033[1m"
 )
 
+func CheckAzureEndpoint(endpoint string) {
+	if endpoint == "" {
+		Panic("AZURE_OPENAI_ENDPOINT environment variable is not set.")
+	}
+}
+
 type kv struct {
 	key, value string
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/microsoft/agent-framework-go
 go 1.24.4
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/a2aproject/a2a-go v0.3.4
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/google/jsonschema-go v0.4.2
@@ -18,9 +19,13 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.3 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
@@ -30,6 +35,7 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,12 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEB
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0/go.mod h1:t76Ruy8AHvUAC8GfMWJMa0ElSbuIcO03NLpynfbgsPA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 h1:B+blDbyVIG3WaikNxPnhPiJ1MThR03b3vKGtER95TP4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1/go.mod h1:JdM5psgjfBf5fo2uWOZhflPWyDBZ/O/CNAH9CtsuZE4=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+8ez6T3HWXPmwOK7Yvq8QxDBD3SKY=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
+github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/a2aproject/a2a-go v0.3.4 h1:rSMR/IryydWkIjtxDLZCVgSc3RrVF4eHrycKlBC/WE0=
@@ -14,6 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -29,6 +35,8 @@ github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbc
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
+github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/modelcontextprotocol/go-sdk v1.3.1 h1:TfqtNKOIWN4Z1oqmPAiWDC2Jq7K9OdJaooe0teoXASI=
@@ -39,6 +47,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=
+github.com/redis/go-redis/v9 v9.8.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.3 h1:OjMgICtcSFuNvQCdwqMCv9Tg7lEOXGwm1J5RPQccx6w=
@@ -82,6 +92,7 @@ golang.org/x/oauth2 v0.32.0 h1:jsCblLleRMDrxMN29H3z/k1KliIvpLgCkE6R8FXXNgY=
 golang.org/x/oauth2 v0.32.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=


### PR DESCRIPTION
This allows running the Azure examples using a managed identity.

While here fix the example in the readme.