### PR TITLE
Bump go directive to 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ['1.24', '1.25']
+        go-version: ['1.25', '1.26']
     
     steps:
     - name: Checkout code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/agent-framework-go
 
-go 1.24.4
+go 1.25
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1


### PR DESCRIPTION
Go 1.24 is no longer supported.