### PR TITLE
skills: switch to directory-based resource scanning

### DIFF
--- a/examples/skills/01_basic_skills/main.go
+++ b/examples/skills/01_basic_skills/main.go
@@ -40,6 +40,12 @@ func main() {
 		panic(err)
 	}
 
+	skillsRoot, err := os.OpenRoot("skills")
+	if err != nil {
+		panic(err)
+	}
+	defer skillsRoot.Close()
+
 	a := openaichatagent.New(openaichatagent.Config{
 		Client: openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
@@ -50,7 +56,7 @@ func main() {
 			Name:             "SkillsAgent",
 			Instructions:     "You are a helpful assistant.",
 			Middlewares:      []middleware.Middleware{logger},
-			ContextProviders: []*memory.ContextProvider{memskills.New(nil, os.DirFS("skills"))},
+			ContextProviders: []*memory.ContextProvider{memskills.New(nil, skillsRoot.FS())},
 		},
 	})
 

--- a/memory/skills/loader.go
+++ b/memory/skills/loader.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -16,14 +17,18 @@ const (
 	maxSearchDepth       = 2
 	maxNameLength        = 64
 	maxDescriptionLength = 1024
+
+	// "." means the skill directory root itself (no subdirectory descent constraint).
+	rootDirectoryIndicator = "."
 )
+
+// Standard subdirectory names per https://agentskills.io/specification#directory-structure.
+var defaultResourceDirectories = []string{"references", "assets"}
+
+var defaultResourceExtensions = []string{".md", ".json", ".yaml", ".yml", ".csv", ".xml", ".txt"}
 
 // Matches YAML frontmatter delimited by "---" lines.
 var frontmatterRegex = regexp.MustCompile(`(?ms)\A^---\s*$(.+?)^---\s*$`)
-
-// Matches markdown links to local resource files.
-// Supports optional ./ or ../ prefixes; excludes URLs (no ":" in the path character class).
-var resourceLinkRegex = regexp.MustCompile(`\[.*?\]\((\.?\.?/?[\w][\w\-./]*\.\w+)\)`)
 
 // Matches valid skill names: lowercase letters, numbers, and single hyphens,
 // not starting or ending with a hyphen, and not containing consecutive hyphens.
@@ -33,7 +38,9 @@ var validNameRegex = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 var yamlKeyValueRegex = regexp.MustCompile(`(?m)^\s*(\w+)\s*:\s*(?:["'](.+?)["']|(.+?))\s*$`)
 
 type skillLoader struct {
-	logger *slog.Logger
+	logger                    *slog.Logger
+	resourceDirectories       []string
+	allowedResourceExtensions map[string]bool
 }
 
 // discoveredSkillDir represents a discovered skill directory with its sub-filesystem.
@@ -72,7 +79,7 @@ func (l *skillLoader) discoverAndLoadSkills(filesystems []fs.FS) map[string]*fil
 // readSkillResource reads a resource file from the skill's filesystem.
 // Path traversal is prevented by the [fs.FS] contract, which rejects paths containing "..".
 func (l *skillLoader) readSkillResource(skill *fileAgentSkill, resourceName string) (string, error) {
-	resourceName = normalizeResourcePath(resourceName)
+	resourceName = normalizePath(resourceName)
 
 	found := false
 	for _, r := range skill.resourceNames {
@@ -138,10 +145,7 @@ func (l *skillLoader) parseSkillFile(skillFS fs.FS, logPath string) *fileAgentSk
 		return nil
 	}
 
-	resourceNames := extractResourcePaths(body)
-	if !l.validateResources(skillFS, resourceNames, fm.Name) {
-		return nil
-	}
+	resourceNames := l.discoverResourceFiles(skillFS, fm.Name)
 
 	return &fileAgentSkill{
 		frontmatter:   *fm,
@@ -226,40 +230,134 @@ func (l *skillLoader) tryParseSkillDocument(content, skillFilePath string) (*fro
 	return &frontmatter{Name: name, Description: description}, body, true
 }
 
-// validateResources checks that all referenced resources exist and are accessible
-// within the skill's filesystem.
-func (l *skillLoader) validateResources(skillFS fs.FS, resourceNames []string, skillName string) bool {
-	for _, resourceName := range resourceNames {
-		if _, err := fs.Stat(skillFS, resourceName); err != nil {
-			l.logger.Warn("Excluding skill: resource is not accessible",
-				"skillName", skillName,
-				"resourceName", resourceName,
-				"error", err)
-			return false
-		}
-	}
-	return true
-}
-
-// extractResourcePaths extracts relative resource file paths from markdown link syntax.
-func extractResourcePaths(content string) []string {
+// discoverResourceFiles scans configured resource directories within a skill's filesystem
+// for resource files matching the configured extensions.
+//
+// By default, scans "references/" and "assets/" subdirectories as specified by the
+// Agent Skills specification (https://agentskills.io/specification).
+// Configure [Config.ResourceDirectories] to scan different or additional directories,
+// including "." for the skill root itself.
+// Each directory is scanned non-recursively (only direct children).
+func (l *skillLoader) discoverResourceFiles(skillFS fs.FS, skillName string) []string {
 	seen := make(map[string]bool)
-	var paths []string
-	for _, match := range resourceLinkRegex.FindAllStringSubmatch(content, -1) {
-		path := normalizeResourcePath(match[1])
-		lower := strings.ToLower(path)
-		if !seen[lower] {
-			seen[lower] = true
-			paths = append(paths, path)
+	var resources []string
+
+	for _, dir := range l.resourceDirectories {
+		isRoot := dir == rootDirectoryIndicator
+		fsDir := dir
+		if isRoot {
+			fsDir = "."
+		}
+
+		entries, err := fs.ReadDir(skillFS, fsDir)
+		if err != nil {
+			continue // directory doesn't exist
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			fileName := entry.Name()
+
+			// Exclude SKILL.md itself.
+			if strings.EqualFold(fileName, skillFileName) {
+				continue
+			}
+
+			// Filter by extension.
+			ext := strings.ToLower(path.Ext(fileName))
+			if ext == "" || !l.allowedResourceExtensions[ext] {
+				l.logger.Debug("Skipping file: extension not in the allowed list",
+					"skillName", skillName,
+					"filePath", path.Join(dir, fileName),
+					"extension", ext)
+				continue
+			}
+
+			resourcePath := path.Join(fsDir, fileName)
+			lower := strings.ToLower(resourcePath)
+			if !seen[lower] {
+				seen[lower] = true
+				resources = append(resources, resourcePath)
+			}
 		}
 	}
-	return paths
+
+	return resources
 }
 
-// normalizeResourcePath normalizes a relative resource path by trimming a leading "./" prefix
-// and replacing backslashes with forward slashes.
-func normalizeResourcePath(path string) string {
-	path = strings.ReplaceAll(path, "\\", "/")
-	path = strings.TrimPrefix(path, "./")
-	return path
+// validateAndNormalizeDirectoryNames validates and normalizes directory names.
+// Empty/whitespace names cause a panic (programming error). Absolute paths and
+// paths containing ".." segments are silently skipped with a warning.
+//
+// To additionally prevent symlink escapes out of the directory tree,
+// callers should prefer [os.Root.FS] over [os.DirFS] when constructing the
+// fs.FS passed to [New].
+func validateAndNormalizeDirectoryNames(directories []string, defaults []string, logger *slog.Logger) []string {
+	if directories == nil {
+		return defaults
+	}
+
+	var normalized []string
+	seen := make(map[string]bool)
+
+	for _, dir := range directories {
+		if strings.TrimSpace(dir) == "" {
+			panic("directory names must not be empty or whitespace")
+		}
+
+		// "." is valid — it means the skill root directory.
+		if dir == rootDirectoryIndicator {
+			if !seen[dir] {
+				seen[dir] = true
+				normalized = append(normalized, dir)
+			}
+			continue
+		}
+
+		// Reject absolute paths and any path segments that escape upward.
+		if !filepath.IsLocal(dir) {
+			logger.Warn("Skipping invalid directory name: must be a relative path with no '..' segments",
+				"directoryName", dir)
+			continue
+		}
+
+		norm := normalizePath(dir)
+		if !seen[norm] {
+			seen[norm] = true
+			normalized = append(normalized, norm)
+		}
+	}
+
+	return normalized
+}
+
+// buildExtensionSet creates a set from the given extensions, using defaults if none are provided.
+// Each extension must start with ".".
+func buildExtensionSet(extensions []string, defaults []string) map[string]bool {
+	if extensions == nil {
+		extensions = defaults
+	}
+	validateExtensions(extensions)
+	set := make(map[string]bool, len(extensions))
+	for _, ext := range extensions {
+		set[strings.ToLower(ext)] = true
+	}
+	return set
+}
+
+func validateExtensions(extensions []string) {
+	for _, ext := range extensions {
+		if ext == "" || ext[0] != '.' {
+			panic(fmt.Sprintf("invalid extension %q: must start with '.'", ext))
+		}
+	}
+}
+
+// normalizePath normalizes a relative path or directory name using
+// [filepath.Clean] and converts to forward slashes.
+func normalizePath(p string) string {
+	return filepath.ToSlash(filepath.Clean(p))
 }

--- a/memory/skills/loader.go
+++ b/memory/skills/loader.go
@@ -3,6 +3,7 @@
 package skills
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -251,7 +252,13 @@ func (l *skillLoader) discoverResourceFiles(skillFS fs.FS, skillName string) []s
 
 		entries, err := fs.ReadDir(skillFS, fsDir)
 		if err != nil {
-			continue // directory doesn't exist
+			if !errors.Is(err, fs.ErrNotExist) {
+				l.logger.Warn("Failed to read resource directory",
+					"skillName", skillName,
+					"directory", fsDir,
+					"error", err)
+			}
+			continue
 		}
 
 		for _, entry := range entries {

--- a/memory/skills/skills.go
+++ b/memory/skills/skills.go
@@ -43,6 +43,23 @@ type Config struct {
 	// When empty, a default template is used.
 	SkillsInstructionPrompt string
 
+	// ResourceDirectories specifies relative directory paths to scan for resource
+	// files within each skill directory.
+	// Values may be single-segment names (e.g., "references") or multi-segment
+	// relative paths (e.g., "sub/resources"). Use "." to include files directly
+	// at the skill root. Leading "./" prefixes, trailing separators, and
+	// backslashes are normalized automatically; paths containing ".." segments
+	// or absolute paths are rejected.
+	// When nil, defaults to ["references", "assets"] (per the Agent Skills
+	// specification at https://agentskills.io/specification).
+	// When set, replaces the defaults entirely.
+	ResourceDirectories []string
+
+	// AllowedResourceExtensions specifies file extensions for resource file
+	// discovery. Each extension must start with ".".
+	// When nil, defaults to [".md", ".json", ".yaml", ".yml", ".csv", ".xml", ".txt"].
+	AllowedResourceExtensions []string
+
 	// Logger is an optional structured logger for skill loading diagnostics.
 	Logger *slog.Logger
 }
@@ -56,10 +73,10 @@ type provider struct {
 
 // New creates a memory.ContextProvider that searches the given filesystems for skills.
 //
-// Each fs.FS can represent an individual skill folder (containing a SKILL.md file) or a parent folder
-// with skill subdirectories. The provider discovers SKILL.md files up to 2 levels deep.
+// Each fs.FS can represent an individual skill directory (containing a SKILL.md file) or a parent
+// directory with skill subdirectories. The provider discovers SKILL.md files up to 2 levels deep.
 //
-// Use os.DirFS to create an fs.FS from a directory path on disk.
+// To prevent escapes from the tree via symbolic links, callers should prefer [os.Root.FS] over [os.DirFS].
 func New(opts *Config, fsys ...fs.FS) *memory.ContextProvider {
 	if opts == nil {
 		opts = &Config{}
@@ -69,7 +86,11 @@ func New(opts *Config, fsys ...fs.FS) *memory.ContextProvider {
 		logger = slog.New(slog.DiscardHandler)
 	}
 
-	loader := &skillLoader{logger: logger}
+	loader := &skillLoader{
+		logger:                    logger,
+		resourceDirectories:       validateAndNormalizeDirectoryNames(opts.ResourceDirectories, defaultResourceDirectories, logger),
+		allowedResourceExtensions: buildExtensionSet(opts.AllowedResourceExtensions, defaultResourceExtensions),
+	}
 	loaded := loader.discoverAndLoadSkills(fsys)
 	instructionPrompt := buildSkillsInstructionPrompt(opts, loaded)
 

--- a/memory/skills/skills_test.go
+++ b/memory/skills/skills_test.go
@@ -224,7 +224,7 @@ func TestDiscovery_FileWithUtf8Bom(t *testing.T) {
 	}
 }
 
-func TestDiscovery_PathTraversal_Excluded(t *testing.T) {
+func TestDiscovery_ResourceOutsideConfiguredDirectory_NotDiscoverable(t *testing.T) {
 	root := t.TempDir()
 	skillDir := filepath.Join(root, "traversal-skill")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -238,9 +238,24 @@ func TestDiscovery_PathTraversal_Excluded(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Skill is discovered (body content doesn't affect discovery),
+	// but ../secret.txt is not in any configured resource directory.
 	p := newProvider(t, root)
-	if hasSkill(t, p, "traversal-skill") {
-		t.Fatal("expected traversal skill to be excluded")
+	if !hasSkill(t, p, "traversal-skill") {
+		t.Fatal("expected skill to be discovered")
+	}
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"traversal-skill","resourceName":"../secret.txt"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error when reading resource outside configured directories")
 	}
 }
 
@@ -367,13 +382,13 @@ func TestLoadSkill_NotFound(t *testing.T) {
 func TestReadResource_ReturnsContent(t *testing.T) {
 	root := t.TempDir()
 	createSkillDirWithResource(t, root, "res-test", "A skill",
-		"See [doc](refs/doc.md).", "refs/doc.md", "Resource content here.")
+		"See [doc](references/doc.md).", "references/doc.md", "Resource content here.")
 
 	p := newProvider(t, root)
 	_, tools := captureProviderContext(t, p)
 	readTool := findTool(t, tools, "read_skill_resource")
 
-	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"res-test","resourceName":"refs/doc.md"}`)
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"res-test","resourceName":"references/doc.md"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,13 +400,13 @@ func TestReadResource_ReturnsContent(t *testing.T) {
 func TestReadResource_DotSlashPrefix(t *testing.T) {
 	root := t.TempDir()
 	createSkillDirWithResource(t, root, "dotslash-read", "A skill",
-		"See [doc](refs/doc.md).", "refs/doc.md", "Document content.")
+		"See [doc](references/doc.md).", "references/doc.md", "Document content.")
 
 	p := newProvider(t, root)
 	_, tools := captureProviderContext(t, p)
 	readTool := findTool(t, tools, "read_skill_resource")
 
-	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"dotslash-read","resourceName":"./refs/doc.md"}`)
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"dotslash-read","resourceName":"./references/doc.md"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,5 +433,474 @@ func TestReadResource_UnregisteredResource(t *testing.T) {
 	}
 	if !strings.HasPrefix(resultStr, "Error:") {
 		t.Fatalf("expected error text result, got %q", resultStr)
+	}
+}
+
+func newProviderWithConfig(t *testing.T, cfg *skills.Config, roots ...string) *memory.ContextProvider {
+	t.Helper()
+	fsList := make([]fs.FS, len(roots))
+	for i, r := range roots {
+		fsList[i] = os.DirFS(r)
+	}
+	return skills.New(cfg, fsList...)
+}
+
+func TestDiscovery_ResourcesInDefaultDirectories(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "res-skill", "Resource skill", "Body.")
+	skillDir := filepath.Join(root, "res-skill")
+
+	// Create resources in both default directories
+	refsDir := filepath.Join(skillDir, "references")
+	assetsDir := filepath.Join(skillDir, "assets")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "FAQ.md"), []byte("FAQ content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assetsDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProvider(t, root)
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"res-skill","resourceName":"references/FAQ.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "FAQ content" {
+		t.Errorf("expected FAQ content, got %q", result)
+	}
+
+	result, err = readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"res-skill","resourceName":"assets/data.json"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "{}" {
+		t.Errorf("expected {}, got %q", result)
+	}
+}
+
+func TestDiscovery_ResourceInNonSpecDirectory_NotDiscoveredByDefault(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "non-spec-skill", "Non-spec directory", "Body.")
+	skillDir := filepath.Join(root, "non-spec-skill")
+
+	// Create resource in a non-default directory
+	docsDir := filepath.Join(skillDir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "readme.md"), []byte("docs content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProvider(t, root)
+	if !hasSkill(t, p, "non-spec-skill") {
+		t.Fatal("expected skill to be discovered")
+	}
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"non-spec-skill","resourceName":"docs/readme.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error for resource in non-default directory")
+	}
+}
+
+func TestDiscovery_ResourceInSkillRoot_NotDiscoveredByDefault(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "root-resource-skill", "Root resource", "Body.")
+	skillDir := filepath.Join(root, "root-resource-skill")
+
+	if err := os.WriteFile(filepath.Join(skillDir, "guide.md"), []byte("guide content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProvider(t, root)
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"root-resource-skill","resourceName":"guide.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error for root-level resource when '.' not configured")
+	}
+}
+
+func TestDiscovery_ResourceInSkillRoot_DiscoveredWhenRootDirectoryConfigured(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "root-opt-in-skill", "Root opt-in", "Body.")
+	skillDir := filepath.Join(root, "root-opt-in-skill")
+
+	if err := os.WriteFile(filepath.Join(skillDir, "guide.md"), []byte("guide content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "config.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProviderWithConfig(t, &skills.Config{
+		ResourceDirectories: []string{"references", "assets", "."},
+	}, root)
+
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"root-opt-in-skill","resourceName":"guide.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "guide content" {
+		t.Errorf("expected guide content, got %q", result)
+	}
+
+	result, err = readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"root-opt-in-skill","resourceName":"config.json"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "{}" {
+		t.Errorf("expected {}, got %q", result)
+	}
+}
+
+func TestDiscovery_SkillMdNotIncludedAsResource(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "selfref-skill", "Self ref test", "Body.")
+
+	// Opt into root scanning — SKILL.md should still be excluded
+	p := newProviderWithConfig(t, &skills.Config{
+		ResourceDirectories: []string{"."},
+	}, root)
+
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"selfref-skill","resourceName":"SKILL.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error — SKILL.md should not be a discoverable resource")
+	}
+}
+
+func TestDiscovery_CustomResourceDirectories_ReplacesDefaults(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "custom-directory-skill", "Custom directory", "Body.")
+	skillDir := filepath.Join(root, "custom-directory-skill")
+
+	docsDir := filepath.Join(skillDir, "docs")
+	refsDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "readme.md"), []byte("docs content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "ref.md"), []byte("ref content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set custom directories — only "docs" should be scanned
+	p := newProviderWithConfig(t, &skills.Config{
+		ResourceDirectories: []string{"docs"},
+	}, root)
+
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	// docs/readme.md should be readable
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"custom-directory-skill","resourceName":"docs/readme.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "docs content" {
+		t.Errorf("expected docs content, got %q", result)
+	}
+
+	// references/ref.md should NOT be readable (defaults replaced)
+	result, err = readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"custom-directory-skill","resourceName":"references/ref.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error for resource in replaced default directory")
+	}
+}
+
+func TestDiscovery_ResourceExtensionFiltering(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "ext-skill", "Extension test", "Body.")
+	skillDir := filepath.Join(root, "ext-skill")
+
+	refsDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "image.png"), []byte("fake image"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProvider(t, root)
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	// .json is allowed by default
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"ext-skill","resourceName":"references/data.json"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "{}" {
+		t.Errorf("expected {}, got %q", result)
+	}
+
+	// .png is NOT allowed by default
+	result, err = readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"ext-skill","resourceName":"references/image.png"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error for .png file not in default extensions")
+	}
+}
+
+func TestDiscovery_NestedResourceFiles_NotDiscovered(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "nested-res-skill", "Nested resources", "Body.")
+	skillDir := filepath.Join(root, "nested-res-skill")
+
+	refsDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "top.md"), []byte("top content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deepDir := filepath.Join(refsDir, "level1", "level2")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deepDir, "deep.md"), []byte("deep content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProvider(t, root)
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	// Top-level file in references/ should be found
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"nested-res-skill","resourceName":"references/top.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "top content" {
+		t.Errorf("expected top content, got %q", result)
+	}
+
+	// Nested file should NOT be found (non-recursive)
+	result, err = readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"nested-res-skill","resourceName":"references/level1/level2/deep.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error for nested file — scanning is non-recursive")
+	}
+}
+
+func TestDiscovery_ResourceDirectoriesWithNestedPath(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "nested-directory-skill", "Nested directory", "Body.")
+	skillDir := filepath.Join(root, "nested-directory-skill")
+
+	nestedDir := filepath.Join(skillDir, "f1", "f2", "f3")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProviderWithConfig(t, &skills.Config{
+		ResourceDirectories: []string{"f1/f2/f3"},
+	}, root)
+
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"nested-directory-skill","resourceName":"f1/f2/f3/data.json"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "{}" {
+		t.Errorf("expected {}, got %q", result)
+	}
+}
+
+func TestConfig_InvalidDirectoryName_Skipped(t *testing.T) {
+	tests := []string{"..", "../escape", "sub/../escape", "/absolute"}
+	for _, bad := range tests {
+		t.Run(bad, func(t *testing.T) {
+			// Invalid directories are skipped with a warning, not a panic
+			p := newProviderWithConfig(t, &skills.Config{
+				ResourceDirectories: []string{bad},
+			}, t.TempDir())
+			if p == nil {
+				t.Fatal("expected non-nil provider")
+			}
+		})
+	}
+}
+
+func TestConfig_EmptyDirectoryName_Panics(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{"empty", ""},
+		{"spaces", "   "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatal("expected panic for empty/whitespace directory name")
+				}
+			}()
+			newProviderWithConfig(t, &skills.Config{
+				ResourceDirectories: []string{tt.dir},
+			}, t.TempDir())
+		})
+	}
+}
+
+func TestConfig_ValidDirectoryNames(t *testing.T) {
+	tests := []string{"scripts", "my-scripts", "sub/directory", ".", "./scripts", "./scripts/f1", "my..scripts"}
+	for _, valid := range tests {
+		t.Run(valid, func(t *testing.T) {
+			p := newProviderWithConfig(t, &skills.Config{
+				ResourceDirectories: []string{valid},
+			}, t.TempDir())
+			if p == nil {
+				t.Fatal("expected non-nil provider")
+			}
+		})
+	}
+}
+
+func TestDiscovery_DuplicateDirectoriesAfterNormalization_NoDuplicateResources(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "dedup-directory-skill", "Dedup test", "Body.")
+	skillDir := filepath.Join(root, "dedup-directory-skill")
+
+	refsDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "faq.md"), []byte("FAQ content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// "references" and "./references" should be deduplicated
+	p := newProviderWithConfig(t, &skills.Config{
+		ResourceDirectories: []string{"references", "./references"},
+	}, root)
+
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"dedup-directory-skill","resourceName":"references/faq.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "FAQ content" {
+		t.Errorf("expected FAQ content, got %q", result)
+	}
+}
+
+func TestDiscovery_CustomResourceExtensions(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "custom-ext-skill", "Custom extensions", "Body.")
+	skillDir := filepath.Join(root, "custom-ext-skill")
+
+	refsDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "data.custom"), []byte("custom data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newProviderWithConfig(t, &skills.Config{
+		AllowedResourceExtensions: []string{".custom"},
+	}, root)
+
+	_, tools := captureProviderContext(t, p)
+	readTool := findTool(t, tools, "read_skill_resource")
+
+	// .custom should be discoverable
+	result, err := readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"custom-ext-skill","resourceName":"references/data.custom"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "custom data" {
+		t.Errorf("expected custom data, got %q", result)
+	}
+
+	// .json is NOT in custom extensions
+	result, err = readTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"custom-ext-skill","resourceName":"references/data.json"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatal("expected error for .json — not in custom extensions")
 	}
 }


### PR DESCRIPTION
Port of microsoft/agent-framework#5078 and microsoft/agent-framework#5205.

## Summary

Replace markdown-link-based resource extraction with directory-based scanning per the [Agent Skills specification](https://agentskills.io/specification).

## Changes

### Resource discovery (loader.go)
- **Directory-based scanning**: Resources are now discovered by scanning configured directories non-recursively, filtered by extension. Replaces the previous approach of extracting resource paths from markdown links in the SKILL.md body.
- **Default directories**: `references/` and `assets/` (per the spec).
- **Default extensions**: `.md`, `.json`, `.yaml`, `.yml`, `.csv`, `.xml`, `.txt`.
- **Root opt-in**: Use `"."` in `ResourceDirectories` to scan the skill root; `SKILL.md` is always excluded.
- **Path validation**: Uses `filepath.IsLocal` to reject absolute paths and `..` segments. Normalizes with `filepath.Clean` + `filepath.ToSlash`.
- Removed `extractResourcePaths`, `validateResources`, `resourceLinkRegex`.

### Config (skills.go)
- Added `Config.ResourceDirectories` -- configurable directories (replaces defaults when set).
- Added `Config.AllowedResourceExtensions` -- configurable extensions (replaces defaults when set).
- Updated `New()` doc to recommend `os.Root.FS` over `os.DirFS` for symlink protection.

### Example
- Updated `01_basic_skills` to use `os.OpenRoot().FS()`.

### Tests
- 17 new/updated tests covering default directories, custom directories, root opt-in, extension filtering, non-recursive scanning, nested paths, SKILL.md exclusion, config validation, and deduplication.