### PR TITLE
Make LLM clients mandatory and add Gemini example

### DIFF
--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -22,8 +22,7 @@ import (
 )
 
 type Config struct {
-	Client *a2aclient.Client
-	Agent  agent.Config
+	agent.Config
 }
 
 type taskIDOpt struct{ string }
@@ -39,20 +38,20 @@ type a2aagent struct {
 	cfg    Config
 }
 
-func New(config Config) *agent.Agent {
-	if config.Client == nil {
-		panic("client cannot be nil")
+func New(aclient *a2aclient.Client, config Config) *agent.Agent {
+	if aclient == nil {
+		panic("a2aagent: client cannot be nil")
 	}
 	a := &a2aagent{
-		client: config.Client,
+		client: aclient,
 		cfg:    config,
 	}
-	config.Agent.DisableFuncAutoCall = true // a2a doesn't support tool calls
+	config.DisableFuncAutoCall = true // a2a doesn't support tool calls
 	return agent.New(agent.ProviderConfig{
 		ProviderName:  "a2a",
 		Run:           a.run,
 		CreateSession: a.createSession,
-	}, config.Agent)
+	}, config.Config)
 }
 
 func (a *a2aagent) createSession(ctx context.Context, options ...agentopt.Option) (*memory.Session, error) {

--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -42,11 +42,11 @@ func New(aclient *a2aclient.Client, config Config) *agent.Agent {
 	if aclient == nil {
 		panic("a2aagent: client cannot be nil")
 	}
+	config.DisableFuncAutoCall = true // a2a doesn't support tool calls
 	a := &a2aagent{
 		client: aclient,
 		cfg:    config,
 	}
-	config.DisableFuncAutoCall = true // a2a doesn't support tool calls
 	return agent.New(agent.ProviderConfig{
 		ProviderName:  "a2a",
 		Run:           a.run,

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -140,7 +140,7 @@ func newTestAgent(transport a2aclient.Transport, config agent.Config) *agent.Age
 	if err != nil {
 		panic(err)
 	}
-	return a2a1.New(a2a1.Config{Client: client, Agent: config})
+	return a2a1.New(client, a2a1.Config{Config: config})
 }
 
 func latestTaskID(session *memory.Session) string {
@@ -158,7 +158,7 @@ func TestConstructorWithNilClient(t *testing.T) {
 			t.Error("Expected panic when client is nil")
 		}
 	}()
-	a2a1.New(a2a1.Config{})
+	a2a1.New(nil, a2a1.Config{})
 }
 
 // TestRunAllowsNonUserRoleMessages tests that non-user role messages are accepted

--- a/agent/provider/aguiagent/agui.go
+++ b/agent/provider/aguiagent/agui.go
@@ -23,10 +23,9 @@ import (
 )
 
 type Config struct {
-	Client  *aguiSSEClient.Client
-	Decoder *aguiEvents.EventDecoder
+	agent.Config
 
-	Agent agent.Config
+	Decoder *aguiEvents.EventDecoder
 }
 
 type provider struct {
@@ -35,22 +34,20 @@ type provider struct {
 	cfg     Config
 }
 
-func New(config Config) *agent.Agent {
-	if config.Client == nil {
-		panic("Client is required")
+func New(aclient *aguiSSEClient.Client, config Config) *agent.Agent {
+	p := &provider{
+		cfg:    config,
+		client: aclient,
 	}
-	p := &provider{cfg: config}
-	p.client = config.Client
 	if config.Decoder != nil {
 		p.decoder = config.Decoder
 	} else {
 		p.decoder = aguiEvents.NewEventDecoder(nil)
 	}
-
 	return agent.New(agent.ProviderConfig{
 		ProviderName: "agui",
 		Run:          p.run,
-	}, config.Agent)
+	}, config.Config)
 }
 
 func (p *provider) run(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {

--- a/agent/provider/aguiagent/agui_test.go
+++ b/agent/provider/aguiagent/agui_test.go
@@ -34,7 +34,7 @@ func TestAGUIAgentRun_AggregatesStreamingText(t *testing.T) {
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	resp, err := a.RunText(context.Background(), "hi").Collect()
 	if err != nil {
 		t.Fatalf("run error: %v", err)
@@ -52,7 +52,7 @@ func TestAGUIAgentRun_WithEmptyEventStream_EmitsMetadataUpdate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	resp, err := a.RunText(context.Background(), "hi").Collect()
 	if err != nil {
 		t.Fatalf("run error: %v", err)
@@ -68,7 +68,7 @@ func TestAGUIAgentRun_WithEmptyEventStream_EmitsMetadataUpdate(t *testing.T) {
 }
 
 func TestAGUIAgentCreateSession_UsesServiceIDAsThreadID(t *testing.T) {
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient("http://localhost")})
+	a := aguiagent.New(newTestClient("http://localhost"), aguiagent.Config{})
 	s, err := a.CreateSession(context.Background(), agentopt.ServiceID("thread-existing"))
 	if err != nil {
 		t.Fatalf("create session error: %v", err)
@@ -97,7 +97,7 @@ func TestAGUIAgentRun_UsesExistingSessionServiceIDAsThreadID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	session, err := a.CreateSession(context.Background(), agentopt.ServiceID("thread-existing"))
 	if err != nil {
 		t.Fatalf("create session error: %v", err)
@@ -134,7 +134,7 @@ func TestAGUIAgentRun_GeneratesUniqueRunIDPerInvocation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	_, err := a.RunText(context.Background(), "first").Collect()
 	if err != nil {
 		t.Fatalf("first run error: %v", err)
@@ -194,7 +194,7 @@ func TestAGUIAgentRun_InvokesTools_WhenFunctionCallsReturned(t *testing.T) {
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	invoked := false
 	type weatherInput struct {
 		Location string `json:"location"`
@@ -278,7 +278,7 @@ func TestAGUIAgentRun_ForwardsAllToolResults_WhenMultipleToolCallsReturned(t *te
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	weatherInvoked := false
 	timeInvoked := false
 	type weatherInput struct {
@@ -329,7 +329,7 @@ func TestAGUIAgentRun_ConvertsStateSnapshotEventToDataContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	resp, err := a.RunText(context.Background(), "hi").Collect()
 	if err != nil {
 		t.Fatalf("run error: %v", err)
@@ -371,7 +371,7 @@ func TestAGUIAgentRun_WithUnknownEventType_ReturnsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	a := aguiagent.New(aguiagent.Config{Client: newTestClient(server.URL)})
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
 	_, err := a.RunText(context.Background(), "hi").Collect()
 	if err == nil {
 		t.Fatal("expected error for unknown event type")

--- a/agent/provider/anthropicagent/agent.go
+++ b/agent/provider/anthropicagent/agent.go
@@ -38,19 +38,14 @@ type client struct {
 
 // Config contains configuration for [New].
 type Config struct {
-	Model  string
-	Client anthropic.Client
+	agent.Config
 
-	Agent agent.Config
+	Model string
 }
 
-func New(config Config) *agent.Agent {
-	if len(config.Client.Options) == 0 {
-		config.Client = anthropic.NewClient()
-	}
-
+func New(aclient anthropic.Client, config Config) *agent.Agent {
 	c := &client{
-		client: config.Client,
+		client: aclient,
 		config: config,
 	}
 	return agent.New(agent.ProviderConfig{
@@ -58,7 +53,7 @@ func New(config Config) *agent.Agent {
 		ProviderName: "anthropic",
 		FormatOfFn:   c.formatOf,
 		UnmarshalFn:  c.unmarshal,
-	}, config.Agent)
+	}, config.Config)
 }
 
 func (a *client) formatOf(v any) (format.Format, error) {

--- a/agent/provider/anthropicagent/agent_test.go
+++ b/agent/provider/anthropicagent/agent_test.go
@@ -24,14 +24,15 @@ type testOutput struct {
 
 func newTestClient(t *testing.T, server *httptest.Server) *agent.Agent {
 	t.Helper()
-	return anthropicagent.New(anthropicagent.Config{
-		Model: "claude-3-5-sonnet-20241022",
-		Client: anthropic.NewClient(
+	return anthropicagent.New(
+		anthropic.NewClient(
 			option.WithBaseURL(server.URL),
 			option.WithAPIKey("test"),
 		),
-		Agent: agent.Config{DisableFuncAutoCall: true},
-	})
+		anthropicagent.Config{
+			Model:  "claude-3-5-sonnet-20241022",
+			Config: agent.Config{DisableFuncAutoCall: true},
+		})
 }
 
 // nestedKey traverses a decoded JSON map following the given path of keys and

--- a/agent/provider/geminiagent/agent.go
+++ b/agent/provider/geminiagent/agent.go
@@ -36,34 +36,16 @@ type client struct {
 
 // Config contains configuration for [New].
 type Config struct {
+	agent.Config
+
 	Model  string
 	Client *genai.Client
-
-	Agent agent.Config
 }
 
 // New creates a new [agent.Agent] backed by the Google Gemini API via the genai client.
-// If Client is nil, [genai.NewClient] is called with nil config, which reads credentials
-// from the GOOGLE_API_KEY or GEMINI_API_KEY environment variables.
-func New(config Config) *agent.Agent {
-	a, err := NewWithContext(context.Background(), config)
-	if err != nil {
-		panic(err)
-	}
-	return a
-}
-
-// NewWithContext is like [New], but allows passing a context when creating a default genai client.
-func NewWithContext(ctx context.Context, config Config) (*agent.Agent, error) {
-	if config.Client == nil {
-		var err error
-		config.Client, err = genai.NewClient(ctx, nil)
-		if err != nil {
-			return nil, fmt.Errorf("geminiagent: failed to create genai client: %w", err)
-		}
-	}
+func New(gclient *genai.Client, config Config) *agent.Agent {
 	c := &client{
-		client: config.Client,
+		client: gclient,
 		config: config,
 	}
 	return agent.New(agent.ProviderConfig{
@@ -71,7 +53,7 @@ func NewWithContext(ctx context.Context, config Config) (*agent.Agent, error) {
 		ProviderName: "gemini",
 		FormatOfFn:   c.formatOf,
 		UnmarshalFn:  c.unmarshal,
-	}, config.Agent), nil
+	}, config.Config)
 }
 
 func (a *client) formatOf(v any) (format.Format, error) {

--- a/agent/provider/geminiagent/agent.go
+++ b/agent/provider/geminiagent/agent.go
@@ -38,8 +38,7 @@ type client struct {
 type Config struct {
 	agent.Config
 
-	Model  string
-	Client *genai.Client
+	Model string
 }
 
 // New creates a new [agent.Agent] backed by the Google Gemini API via the genai client.

--- a/agent/provider/geminiagent/agent_test.go
+++ b/agent/provider/geminiagent/agent_test.go
@@ -39,12 +39,11 @@ func newTestClient(t *testing.T, server *httptest.Server) *agent.Agent {
 	if err != nil {
 		t.Fatalf("genai.NewClient: %v", err)
 	}
-	a := geminiagent.New(geminiagent.Config{
+	return geminiagent.New(client, geminiagent.Config{
 		Model:  testModel,
 		Client: client,
-		Agent:  agent.Config{DisableFuncAutoCall: true},
+		Config: agent.Config{DisableFuncAutoCall: true},
 	})
-	return a
 }
 
 // captureAndRespond returns a handler that saves the request body to bodyCh and

--- a/agent/provider/geminiagent/agent_test.go
+++ b/agent/provider/geminiagent/agent_test.go
@@ -41,7 +41,6 @@ func newTestClient(t *testing.T, server *httptest.Server) *agent.Agent {
 	}
 	return geminiagent.New(client, geminiagent.Config{
 		Model:  testModel,
-		Client: client,
 		Config: agent.Config{DisableFuncAutoCall: true},
 	})
 }

--- a/agent/provider/openaichatagent/chat.go
+++ b/agent/provider/openaichatagent/chat.go
@@ -40,18 +40,14 @@ func ChatCompletionNewParams(params openai.ChatCompletionNewParams) agentopt.Opt
 
 // Config contains configuration for [Agent].
 type Config struct {
-	Model  string
-	Client openai.Client
+	agent.Config
 
-	Agent agent.Config
+	Model string
 }
 
-func newAgent(config Config) *agent.Agent {
-	if len(config.Client.Options) == 0 {
-		config.Client = openai.NewClient()
-	}
+func New(oclient openai.Client, config Config) *agent.Agent {
 	c := &client{
-		client: config.Client,
+		client: oclient,
 		config: config,
 	}
 	return agent.New(agent.ProviderConfig{
@@ -59,11 +55,7 @@ func newAgent(config Config) *agent.Agent {
 		FormatOfFn:   c.formatOf,
 		UnmarshalFn:  c.unmarshal,
 		Run:          c.run,
-	}, config.Agent)
-}
-
-func New(config Config) *agent.Agent {
-	return newAgent(config)
+	}, config.Config)
 }
 
 func (a *client) formatOf(v any) (format.Format, error) {

--- a/agent/provider/openaichatagent/chat_test.go
+++ b/agent/provider/openaichatagent/chat_test.go
@@ -62,10 +62,10 @@ func newTestServer(t *testing.T, input string, output string) *httptest.Server {
 
 func newTestClient(server *httptest.Server) *agent.Agent {
 	return openaichatagent.New(
+		openai.NewClient(option.WithBaseURL(server.URL)),
 		openaichatagent.Config{
-			Model:  "gpt-4o-mini",
-			Client: openai.NewClient(option.WithBaseURL(server.URL)),
-			Agent:  agent.Config{DisableFuncAutoCall: true},
+			Model: "gpt-4o-mini",
+			Config: agent.Config{DisableFuncAutoCall: true},
 		},
 	)
 }

--- a/agent/provider/openairesponsesagent/responses.go
+++ b/agent/provider/openairesponsesagent/responses.go
@@ -32,10 +32,23 @@ import (
 
 // Config contains configuration for [Agent].
 type Config struct {
-	Model  string // required
-	Client openai.Client
+	agent.Config
 
-	Agent agent.Config
+	Model string // required
+}
+
+func New(oclient openai.Client, config Config) *agent.Agent {
+	c := &responsesClient{
+		client: oclient,
+		config: config,
+	}
+	return agent.New(
+		agent.ProviderConfig{
+			ProviderName: "openai",
+			FormatOfFn:   c.formatOf,
+			UnmarshalFn:  c.unmarshal,
+			Run:          c.run,
+		}, config.Config)
 }
 
 type responsesClient struct {
@@ -54,33 +67,12 @@ func ResponsesNewParams(params responses.ResponseNewParams) agentopt.Option {
 	return responsesNewParamsOpt(params)
 }
 
-func newAgent(config Config) *agent.Agent {
-	if len(config.Client.Options) == 0 {
-		config.Client = openai.NewClient()
-	}
-	c := &responsesClient{
-		client: config.Client,
-		config: config,
-	}
-	return agent.New(
-		agent.ProviderConfig{
-			ProviderName: "openai",
-			FormatOfFn:   c.formatOf,
-			UnmarshalFn:  c.unmarshal,
-			Run:          c.run,
-		}, config.Agent)
-}
-
 func (a *responsesClient) formatOf(v any) (format.Format, error) {
 	return jsonformat.ForType(reflect.TypeOf(v))
 }
 
 func (a *responsesClient) unmarshal(format format.Format, data []byte, v any) error {
 	return jsonformat.Unmarshal(format.(*jsonformat.Format), data, v)
-}
-
-func New(config Config) *agent.Agent {
-	return newAgent(config)
 }
 
 func (a *responsesClient) run(ctx context.Context, messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {

--- a/agent/provider/openairesponsesagent/responses_test.go
+++ b/agent/provider/openairesponsesagent/responses_test.go
@@ -64,10 +64,10 @@ func newTestResponsesServerStreaming(t *testing.T, input string, output string) 
 
 func newTestResponsesClient(server *httptest.Server, model string) *agent.Agent {
 	return openairesponsesagent.New(
+		openai.NewClient(option.WithBaseURL(server.URL)),
 		openairesponsesagent.Config{
 			Model:  model,
-			Client: openai.NewClient(option.WithBaseURL(server.URL)),
-			Agent:  agent.Config{DisableFuncAutoCall: true},
+			Config: agent.Config{DisableFuncAutoCall: true},
 		},
 	)
 }

--- a/examples/01-get-started/01_hello_agent/main.go
+++ b/examples/01-get-started/01_hello_agent/main.go
@@ -37,17 +37,18 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.", Name: "Joker",
-			Middlewares: []middleware.Middleware{logger}, // for logging agent interactions
-		},
-	})
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.", Name: "Joker",
+				Middlewares: []middleware.Middleware{logger}, // for logging agent interactions
+			},
+		})
 
 	ctx := context.Background()
 

--- a/examples/01-get-started/02_add_tools/main.go
+++ b/examples/01-get-started/02_add_tools/main.go
@@ -46,18 +46,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent, and provide the function tool to the agent.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are a helpful assistant",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
-			Tools:        []tool.Tool{weatherTool},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a helpful assistant",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+				Tools:        []tool.Tool{weatherTool},
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/01-get-started/03_multi_turn/main.go
+++ b/examples/01-get-started/03_multi_turn/main.go
@@ -35,17 +35,19 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.", Name: "Joker",
-			Middlewares: []middleware.Middleware{logger}, // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.", Name: "Joker",
+				Middlewares: []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/01-get-started/04_memory/main.go
+++ b/examples/01-get-started/04_memory/main.go
@@ -38,19 +38,21 @@ func main() {
 		panic(err)
 	}
 
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions:     "You are a friendly assistant.",
-			Name:             "MemoryAgent",
-			Middlewares:      []middleware.Middleware{logger}, // for logging agent interactions
-			ContextProviders: []*memory.ContextProvider{newUserMemoryProvider()},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions:     "You are a friendly assistant.",
+				Name:             "MemoryAgent",
+				Middlewares:      []middleware.Middleware{logger}, // for logging agent interactions
+				ContextProviders: []*memory.ContextProvider{newUserMemoryProvider()},
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 	session, err := a.CreateSession(ctx)

--- a/examples/02-agents/agents/step01_running/main.go
+++ b/examples/02-agents/agents/step01_running/main.go
@@ -36,18 +36,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent with weather tool
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/02-agents/agents/step02_multiturn_conversation/main.go
+++ b/examples/02-agents/agents/step02_multiturn_conversation/main.go
@@ -35,18 +35,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/02-agents/agents/step03_using_function_tools/main.go
+++ b/examples/02-agents/agents/step03_using_function_tools/main.go
@@ -45,18 +45,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent, and provide the function tool to the agent.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are a helpful assistant",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
-			Tools:        []tool.Tool{weatherTool},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a helpful assistant",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+				Tools:        []tool.Tool{weatherTool},
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/02-agents/agents/step04_using_function_tools_with_approvals/main.go
+++ b/examples/02-agents/agents/step04_using_function_tools_with_approvals/main.go
@@ -47,18 +47,20 @@ func main() {
 
 	// Create Azure OpenAI agent.
 	// Note that we are wrapping the function tool with tool.ApprovalRequiredFunc to require user approval before invoking it.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are a helpful assistant",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
-			Tools:        []tool.Tool{tool.ApprovalRequiredFunc(weatherTool)},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a helpful assistant",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+				Tools:        []tool.Tool{tool.ApprovalRequiredFunc(weatherTool)},
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/02-agents/agents/step05_structured_output/main.go
+++ b/examples/02-agents/agents/step05_structured_output/main.go
@@ -56,18 +56,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are a helpful assistant.",
-			Name:         "HelpfulAssistant",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a helpful assistant.",
+				Name:         "HelpfulAssistant",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 
@@ -84,21 +86,23 @@ func main() {
 	fmt.Println()
 
 	// Create the agent with the specified name, instructions, and expected structured output the agent should produce.
-	a = openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a = openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are a helpful assistant.",
-			Name:         "HelpfulAssistant",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
-			RunOptions: []agentopt.Option{
-				agentopt.ResponseFormat(jsonformat.MustFor[PersonInfo]()),
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a helpful assistant.",
+				Name:         "HelpfulAssistant",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+				RunOptions: []agentopt.Option{
+					agentopt.ResponseFormat(jsonformat.MustFor[PersonInfo]()),
+				},
 			},
 		},
-	})
+	)
 
 	// Invoke the agent with some unstructured input while streaming, to extract the structured information from.
 	var personRaw []byte

--- a/examples/02-agents/agents/step06_persisted_conversation/main.go
+++ b/examples/02-agents/agents/step06_persisted_conversation/main.go
@@ -36,18 +36,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -49,21 +49,23 @@ func main() {
 	defer os.RemoveAll(tmpDir)
 
 	// Create Azure OpenAI agent with a custom message store that persists messages to disk.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares: []middleware.Middleware{
-				logger,                       // for logging agent interactions
-				&fsMessageStore{Dir: tmpDir}, // for persistent message history
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares: []middleware.Middleware{
+					logger,                       // for logging agent interactions
+					&fsMessageStore{Dir: tmpDir}, // for persistent message history
+				},
 			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/02-agents/agents/step08_observability/main.go
+++ b/examples/02-agents/agents/step08_observability/main.go
@@ -61,21 +61,23 @@ func main() {
 	otellib.SetTracerProvider(tp)
 
 	// Create Azure OpenAI agent, and enable OpenTelemetry instrumentation.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares: []middleware.Middleware{
-				otel.New(otel.Config{}), // for OpenTelemetry observability
-				logger,                  // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares: []middleware.Middleware{
+					otel.New(otel.Config{}), // for OpenTelemetry observability
+					logger,                  // for logging agent interactions
+				},
 			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 

--- a/examples/02-agents/agents/step10_as_mcp_tool/main.go
+++ b/examples/02-agents/agents/step10_as_mcp_tool/main.go
@@ -33,18 +33,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent with the same configuration as the C# example.
-	agent := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	agent := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:         "Joker",
-			Description:  "An agent that tells jokes.",
-			Instructions: "You are good at telling jokes, and you always start each joke with 'Aye aye, captain!'.",
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:         "Joker",
+				Description:  "An agent that tells jokes.",
+				Instructions: "You are good at telling jokes, and you always start each joke with 'Aye aye, captain!'.",
+			},
 		},
-	})
+	)
 
 	// Create an MCP server with the agent exposed as a tool.
 	srv := mcp.NewServer(&mcp.Implementation{

--- a/examples/02-agents/agents/step11_using_images/main.go
+++ b/examples/02-agents/agents/step11_using_images/main.go
@@ -35,18 +35,20 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are a helpful agent that can analyze images.",
-			Name:         "VisionAgent",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a helpful agent that can analyze images.",
+				Name:         "VisionAgent",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 	msg := message.New(

--- a/examples/02-agents/agents/step12_as_function_tool/main.go
+++ b/examples/02-agents/agents/step12_as_function_tool/main.go
@@ -46,34 +46,38 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent and provide the function tool.
-	weatherAgent := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	weatherAgent := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You answer questions about the weather.",
-			Name:         "WeatherAgent",
-			Description:  "An agent that answers questions about the weather.",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
-			Tools:        []tool.Tool{weatherTool},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You answer questions about the weather.",
+				Name:         "WeatherAgent",
+				Description:  "An agent that answers questions about the weather.",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+				Tools:        []tool.Tool{weatherTool},
+			},
 		},
-	})
+	)
 
 	// Create the main Azure OpenAI agent, and provide the weather agent as a function tool.
 	// Note that the main agent is instructed to respond in French.
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are a helpful assistant who responds in French.",
-			Tools:        []tool.Tool{weatherAgent.AsFuncTool()},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a helpful assistant who responds in French.",
+				Tools:        []tool.Tool{weatherAgent.AsFuncTool()},
+			},
 		},
-	})
+	)
 
 	resp, err := a.RunText(context.Background(), "What is the weather like in Amsterdam?").Collect()
 	demo.Response(resp, err)

--- a/examples/02-agents/agui/step01_getting_started/client/main.go
+++ b/examples/02-agents/agui/step01_getting_started/client/main.go
@@ -19,7 +19,10 @@ import (
 
 func main() {
 	serverURL := cmp.Or(os.Getenv("AGUI_SERVER_URL"), "http://localhost:8888")
-	a := aguiagent.New(aguiagent.Config{Client: aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL})})
+	a := aguiagent.New(
+		aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL}),
+		aguiagent.Config{},
+	)
 
 	session, err := a.CreateSession(context.Background())
 	if err != nil {

--- a/examples/02-agents/agui/step01_getting_started/server/main.go
+++ b/examples/02-agents/agui/step01_getting_started/server/main.go
@@ -28,17 +28,19 @@ func main() {
 		log.Fatal(err)
 	}
 
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:         "AGUIAssistant",
-			Instructions: "You are a helpful assistant.",
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:         "AGUIAssistant",
+				Instructions: "You are a helpful assistant.",
+			},
 		},
-	})
+	)
 	mux := http.NewServeMux()
 	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 

--- a/examples/02-agents/agui/step02_backend_tools/client/main.go
+++ b/examples/02-agents/agui/step02_backend_tools/client/main.go
@@ -19,7 +19,10 @@ import (
 
 func main() {
 	serverURL := cmp.Or(os.Getenv("AGUI_SERVER_URL"), "http://localhost:8888")
-	a := aguiagent.New(aguiagent.Config{Client: aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL})})
+	a := aguiagent.New(
+		aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL}),
+		aguiagent.Config{},
+	)
 
 	session, err := a.CreateSession(context.Background())
 	if err != nil {

--- a/examples/02-agents/agui/step02_backend_tools/server/main.go
+++ b/examples/02-agents/agui/step02_backend_tools/server/main.go
@@ -67,18 +67,20 @@ func main() {
 		log.Fatal(err)
 	}
 
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:         "AGUIAssistant",
-			Instructions: "You are a helpful assistant with access to restaurant information.",
-			Tools:        []tool.Tool{searchRestaurants},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:         "AGUIAssistant",
+				Instructions: "You are a helpful assistant with access to restaurant information.",
+				Tools:        []tool.Tool{searchRestaurants},
+			},
 		},
-	})
+	)
 	mux := http.NewServeMux()
 	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 

--- a/examples/02-agents/agui/step03_frontend_tools/client/main.go
+++ b/examples/02-agents/agui/step03_frontend_tools/client/main.go
@@ -30,12 +30,14 @@ func main() {
 		return "Amsterdam, Netherlands (52.37°N, 4.90°E)", nil
 	})
 
-	a := aguiagent.New(aguiagent.Config{
-		Client: aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL}),
-		Agent: agent.Config{
-			Tools: []tool.Tool{frontendTool},
+	a := aguiagent.New(
+		aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL}),
+		aguiagent.Config{
+			Config: agent.Config{
+				Tools: []tool.Tool{frontendTool},
+			},
 		},
-	})
+	)
 
 	session, err := a.CreateSession(context.Background())
 	if err != nil {

--- a/examples/02-agents/agui/step03_frontend_tools/server/main.go
+++ b/examples/02-agents/agui/step03_frontend_tools/server/main.go
@@ -28,18 +28,20 @@ func main() {
 		log.Fatal(err)
 	}
 
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:                "AGUIAssistant",
-			Instructions:        "You are a helpful assistant.",
-			DisableFuncAutoCall: true,
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:                "AGUIAssistant",
+				Instructions:        "You are a helpful assistant.",
+				DisableFuncAutoCall: true,
+			},
 		},
-	})
+	)
 	mux := http.NewServeMux()
 	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 

--- a/examples/02-agents/agui/step04_human_in_loop/client/main.go
+++ b/examples/02-agents/agui/step04_human_in_loop/client/main.go
@@ -22,7 +22,10 @@ import (
 
 func main() {
 	serverURL := cmp.Or(os.Getenv("AGUI_SERVER_URL"), "http://localhost:8888")
-	a := aguiagent.New(aguiagent.Config{Client: aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL})})
+	a := aguiagent.New(
+		aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL}),
+		aguiagent.Config{},
+	)
 
 	session, err := a.CreateSession(context.Background())
 	if err != nil {

--- a/examples/02-agents/agui/step04_human_in_loop/server/main.go
+++ b/examples/02-agents/agui/step04_human_in_loop/server/main.go
@@ -38,18 +38,20 @@ func main() {
 		log.Fatal(err)
 	}
 
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:         "AGUIAssistant",
-			Instructions: "You are a helpful assistant in charge of approving expenses.",
-			Tools:        []tool.Tool{tool.ApprovalRequiredFunc(approveExpense)},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:         "AGUIAssistant",
+				Instructions: "You are a helpful assistant in charge of approving expenses.",
+				Tools:        []tool.Tool{tool.ApprovalRequiredFunc(approveExpense)},
+			},
 		},
-	})
+	)
 	mux := http.NewServeMux()
 	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 

--- a/examples/02-agents/agui/step05_state_management/client/main.go
+++ b/examples/02-agents/agui/step05_state_management/client/main.go
@@ -21,7 +21,10 @@ import (
 
 func main() {
 	serverURL := cmp.Or(os.Getenv("AGUI_SERVER_URL"), "http://localhost:8888")
-	a := aguiagent.New(aguiagent.Config{Client: aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL})})
+	a := aguiagent.New(
+		aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: serverURL}),
+		aguiagent.Config{},
+	)
 
 	session, err := a.CreateSession(context.Background())
 	if err != nil {

--- a/examples/02-agents/agui/step05_state_management/server/main.go
+++ b/examples/02-agents/agui/step05_state_management/server/main.go
@@ -69,15 +69,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name: "RecipeAgent",
-			Instructions: `You are a helpful recipe assistant. When users ask for recipes, respond with a JSON object in this shape:
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name: "RecipeAgent",
+				Instructions: `You are a helpful recipe assistant. When users ask for recipes, respond with a JSON object in this shape:
 {
   "recipe": {
     "title": "...",
@@ -90,9 +91,10 @@ func main() {
   }
 }
 Then also provide a concise summary in one sentence.`,
-			Middlewares: []middleware.Middleware{stateSnapshotMiddleware},
+				Middlewares: []middleware.Middleware{stateSnapshotMiddleware},
+			},
 		},
-	})
+	)
 	mux := http.NewServeMux()
 	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 

--- a/examples/02-agents/mcp/agent_mcp_server/main.go
+++ b/examples/02-agents/mcp/agent_mcp_server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/agent-framework-go/middleware"
 	"github.com/microsoft/agent-framework-go/tool/mcptool"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/openai/openai-go/v3"
 )
 
 var logger = demo.NewLogger(
@@ -38,15 +39,18 @@ func main() {
 	}
 
 	// Create the Agent with MCP tools
-	a := openaichatagent.New(openaichatagent.Config{
-		Model: "gpt-4o-mini",
-		Agent: agent.Config{
-			Name:         "DocsAgent",
-			Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
-			Tools:        tools,
+	a := openaichatagent.New(
+		openai.NewClient(),
+		openaichatagent.Config{
+			Model: "gpt-4o-mini",
+			Config: agent.Config{
+				Name:         "DocsAgent",
+				Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+				Tools:        tools,
+			},
 		},
-	})
+	)
 
 	// Invoke the agent and output the text result.
 	resp, err := a.RunText(ctx, "How to create an Azure storage account using az cli?").Collect()

--- a/examples/02-agents/providers/a2a/main.go
+++ b/examples/02-agents/providers/a2a/main.go
@@ -42,14 +42,16 @@ func main() {
 		demo.Panicf("Failed to create a client: %v", err)
 	}
 
-	a := a2aagent.New(a2aagent.Config{
-		Client: client,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+	a := a2aagent.New(
+		client,
+		a2aagent.Config{
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	// Invoke the agent and output the text result.
 	resp, err := a.RunText(ctx, "Tell me a joke about a pirate.").Collect()

--- a/examples/02-agents/providers/anthrophic/main.go
+++ b/examples/02-agents/providers/anthrophic/main.go
@@ -20,15 +20,17 @@ var logger = demo.NewLogger(
 
 func main() {
 	// Create Anthropic agent
-	a := anthropicagent.New(anthropicagent.Config{
-		Client: anthropic.NewClient(),
-		Model:  "claude-sonnet-4-5",
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+	a := anthropicagent.New(
+		anthropic.NewClient(),
+		anthropicagent.Config{
+			Model: "claude-sonnet-4-5",
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	// Invoke the agent and output the text result.
 	resp, err := a.RunText(context.Background(), "Tell me a joke about a pirate.").Collect()

--- a/examples/02-agents/providers/azure/main.go
+++ b/examples/02-agents/providers/azure/main.go
@@ -36,17 +36,19 @@ func main() {
 	}
 
 	// Create Azure OpenAI agent
-	a := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	a := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.", Name: "Joker",
-			Middlewares: []middleware.Middleware{logger}, // for logging agent interactions
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.", Name: "Joker",
+				Middlewares: []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	// Invoke the agent and output the text result.
 	resp, err := a.RunText(context.Background(), "Tell me a joke about a pirate.").Collect()

--- a/examples/02-agents/providers/gemini/main.go
+++ b/examples/02-agents/providers/gemini/main.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"cmp"
+	"context"
+	"os"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/provider/geminiagent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/middleware"
+	"google.golang.org/genai"
+)
+
+var apiKey = os.Getenv("GEMINI_API_KEY")
+var model = cmp.Or(os.Getenv("GEMINI_MODEL"), "gemini-2.5-flash")
+
+var logger = demo.NewLogger(
+	"Basic Run",
+	"Demonstrates a simple Gemini agent run.",
+	"Model", model,
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		APIKey:  apiKey,
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		demo.Panicf("failed to create Gemini client: %v", err)
+	}
+
+	// Create Gemini agent
+	a := geminiagent.New(
+		client,
+		geminiagent.Config{
+			Model: model,
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
+		},
+	)
+
+	// Invoke the agent and output the text result.
+	resp, err := a.RunText(ctx, "Tell me a joke about a pirate.").Collect()
+	demo.Response(resp, err)
+}

--- a/examples/02-agents/providers/openai/main.go
+++ b/examples/02-agents/providers/openai/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/middleware"
+	"github.com/openai/openai-go/v3"
 )
 
 var logger = demo.NewLogger(
@@ -18,14 +19,17 @@ var logger = demo.NewLogger(
 )
 
 func main() {
-	a := openaichatagent.New(openaichatagent.Config{
-		Model: "gpt-4o-mini",
-		Agent: agent.Config{
-			Instructions: "You are good at telling jokes.",
-			Name:         "Joker",
-			Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+	a := openaichatagent.New(
+		openai.NewClient(),
+		openaichatagent.Config{
+			Model: "gpt-4o-mini",
+			Config: agent.Config{
+				Instructions: "You are good at telling jokes.",
+				Name:         "Joker",
+				Middlewares:  []middleware.Middleware{logger}, // for logging agent interactions
+			},
 		},
-	})
+	)
 
 	// Invoke the agent and output the text result.
 	resp, err := a.RunText(context.Background(), "Tell me a joke about a pirate.").Collect()

--- a/examples/02-agents/skills/step01_file_based_skills/main.go
+++ b/examples/02-agents/skills/step01_file_based_skills/main.go
@@ -52,19 +52,21 @@ func main() {
 		},
 	})
 
-	agent := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	agent := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:             "UnitConverterAgent",
-			Instructions:     "You are a helpful assistant that can convert units.",
-			Middlewares:      []middleware.Middleware{logger},
-			ContextProviders: []*memory.ContextProvider{skillsProvider},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:             "UnitConverterAgent",
+				Instructions:     "You are a helpful assistant that can convert units.",
+				Middlewares:      []middleware.Middleware{logger},
+				ContextProviders: []*memory.ContextProvider{skillsProvider},
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 	response, err := agent.RunText(ctx, "How many kilometers is a marathon (26.2 miles)? And how many pounds is 75 kilograms?").Collect()

--- a/examples/02-agents/skills/step02_code_defined_skills/main.go
+++ b/examples/02-agents/skills/step02_code_defined_skills/main.go
@@ -104,19 +104,21 @@ func main() {
 	}
 
 	skillsProvider := skills.NewContextProvider(skills.ContextProviderOptions{Skills: []*skills.Skill{unitConverterSkill}})
-	agent := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	agent := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:             "UnitConverterAgent",
-			Instructions:     "You are a helpful assistant that can convert units.",
-			Middlewares:      []middleware.Middleware{logger},
-			ContextProviders: []*memory.ContextProvider{skillsProvider},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:             "UnitConverterAgent",
+				Instructions:     "You are a helpful assistant that can convert units.",
+				Middlewares:      []middleware.Middleware{logger},
+				ContextProviders: []*memory.ContextProvider{skillsProvider},
+			},
 		},
-	})
+	)
 
 	ctx := context.Background()
 	response, err := agent.RunText(ctx, "How many kilometers is a marathon (26.2 miles)? And how many pounds is 75 kilograms?").Collect()

--- a/examples/02-agents/skills/step03_mixed_skills/main.go
+++ b/examples/02-agents/skills/step03_mixed_skills/main.go
@@ -177,19 +177,21 @@ func main() {
 		},
 	})
 
-	agent := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	agent := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:             "MultiConverterAgent",
-			Instructions:     "You are a helpful assistant that can convert units, volumes, and temperatures.",
-			Middlewares:      []middleware.Middleware{logger},
-			ContextProviders: []*memory.ContextProvider{skillsProvider},
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:             "MultiConverterAgent",
+				Instructions:     "You are a helpful assistant that can convert units, volumes, and temperatures.",
+				Middlewares:      []middleware.Middleware{logger},
+				ContextProviders: []*memory.ContextProvider{skillsProvider},
+			},
 		},
-	})
+	)
 
 	response, err := agent.RunText(
 		context.Background(),

--- a/examples/03-workflows/_start-here/03_agents/main.go
+++ b/examples/03-workflows/_start-here/03_agents/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/workflow"
 	"github.com/microsoft/agent-framework-go/workflow/inproc"
+	"github.com/openai/openai-go/v3"
 )
 
 // This sample introduces the use of AI agents as executors within a workflow.
@@ -54,10 +55,12 @@ func main() {
 }
 
 func newAgent(language string) *agent.Agent {
-	return openaichatagent.NewAgent(openaichatagent.Config{
-		Model: "gpt-5-nano",
-		Config: agent.Config{
-			Instructions: fmt.Sprintf("You are a helpful assistant who translates text to %s.", language),
-		},
-	})
+	return openaichatagent.New(
+		openai.NewClient(),
+		openaichatagent.Config{
+			Model: "gpt-5-nano",
+			Config: agent.Config{
+				Instructions: fmt.Sprintf("You are a helpful assistant who translates text to %s.", language),
+			},
+		})
 }

--- a/examples/03-workflows/_start-here/3_agents/main.go
+++ b/examples/03-workflows/_start-here/3_agents/main.go
@@ -56,7 +56,7 @@ func main() {
 func newAgent(language string) *agent.Agent {
 	return openaichatagent.NewAgent(openaichatagent.Config{
 		Model: "gpt-5-nano",
-		Agent: agent.Config{
+		Config: agent.Config{
 			Instructions: fmt.Sprintf("You are a helpful assistant who translates text to %s.", language),
 		},
 	})

--- a/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
@@ -57,29 +57,33 @@ func main() {
 			demo.Panicf("failed to create A2A client for %s: %v", url, err)
 		}
 
-		remoteAgent := a2aagent.New(a2aagent.Config{
-			Client: client,
-			Agent: agent.Config{
-				Name:        card.Name,
-				Description: card.Description,
+		remoteAgent := a2aagent.New(
+			client,
+			a2aagent.Config{
+				Config: agent.Config{
+					Name:        card.Name,
+					Description: card.Description,
+				},
 			},
-		})
+		)
 		tools = append(tools, remoteAgent.AsFuncTool())
 	}
 
-	host := openaichatagent.New(openaichatagent.Config{
-		Client: openai.NewClient(
+	host := openaichatagent.New(
+		openai.NewClient(
 			azure.WithEndpoint(endpoint, apiVersion),
 			azure.WithTokenCredential(token),
 		),
-		Model: deployment,
-		Agent: agent.Config{
-			Name:         "HostClient",
-			Instructions: "You specialize in handling user queries and using your tools to provide answers.",
-			Middlewares:  []middleware.Middleware{logger},
-			Tools:        tools,
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:         "HostClient",
+				Instructions: "You specialize in handling user queries and using your tools to provide answers.",
+				Middlewares:  []middleware.Middleware{logger},
+				Tools:        tools,
+			},
 		},
-	})
+	)
 
 	session, err := host.CreateSession(ctx)
 	if err != nil {

--- a/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
@@ -115,13 +115,14 @@ func main() {
 		"URL", url,
 	)
 
-	cfg, card := buildAgent(*agentType, deployment)
-	cfg.Client = openai.NewClient(
+	oclient := openai.NewClient(
 		azure.WithEndpoint(endpoint, apiVersion),
 		azure.WithTokenCredential(token),
 	)
-	cfg.Agent.Middlewares = append(cfg.Agent.Middlewares, logger)
-	hostAgent := openaichatagent.New(cfg)
+
+	cfg, card := buildAgent(*agentType, deployment)
+	cfg.Middlewares = append(cfg.Middlewares, logger)
+	hostAgent := openaichatagent.New(oclient, cfg)
 
 	card.URL = url
 	card.PreferredTransport = a2a.TransportProtocolJSONRPC
@@ -167,7 +168,7 @@ func buildAgent(agentType, model string) (openaichatagent.Config, *a2a.AgentCard
 			return q.QueryByInvoiceID(invoiceID), nil
 		})
 
-		cfg.Agent = agent.Config{
+		cfg.Config = agent.Config{
 			Name:         "InvoiceAgent",
 			Description:  "Handles requests relating to invoices.",
 			Instructions: "You specialize in handling queries related to invoices.",
@@ -187,7 +188,7 @@ func buildAgent(agentType, model string) (openaichatagent.Config, *a2a.AgentCard
 			Examples:    []string{"List the latest invoices for Contoso."},
 		}}
 	case "POLICY":
-		cfg.Agent = agent.Config{
+		cfg.Config = agent.Config{
 			Name:        "PolicyAgent",
 			Description: "Handles requests relating to policies and customer communications.",
 			Instructions: `You specialize in handling queries related to policies and customer communications.
@@ -204,16 +205,16 @@ original invoice and the credit memo number. Use the 'Formal Credit Notification
 template."`,
 		}
 		card.Name = "PolicyAgent"
-		card.Description = cfg.Agent.Description
+		card.Description = cfg.Config.Description
 		card.Skills = []a2a.AgentSkill{{
 			ID:          "id_policy_agent",
 			Name:        "PolicyAgent",
-			Description: cfg.Agent.Description,
+			Description: cfg.Config.Description,
 			Tags:        []string{"policy", "agent-framework-go"},
 			Examples:    []string{"What is the policy for short shipments?"},
 		}}
 	case "LOGISTICS":
-		cfg.Agent = agent.Config{
+		cfg.Config = agent.Config{
 			Name:        "LogisticsAgent",
 			Description: "Handles requests relating to logistics.",
 			Instructions: `You specialize in handling queries related to logistics.
@@ -225,11 +226,11 @@ Item: TSHIRT-RED-L
 Quantity: 900`,
 		}
 		card.Name = "LogisticsAgent"
-		card.Description = cfg.Agent.Description
+		card.Description = cfg.Config.Description
 		card.Skills = []a2a.AgentSkill{{
 			ID:          "id_logistics_agent",
 			Name:        "LogisticsQuery",
-			Description: cfg.Agent.Description,
+			Description: cfg.Config.Description,
 			Tags:        []string{"logistics", "agent-framework-go"},
 			Examples:    []string{"What is the status for SHPMT-SAP-001"},
 		}}

--- a/examples/demos/chat_cli/main.go
+++ b/examples/demos/chat_cli/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
+	"github.com/openai/openai-go/v3"
 )
 
 var logger = demo.NewLogger(
@@ -29,13 +30,16 @@ var weatherTool = functool.MustNew(&functool.Func{
 })
 
 func main() {
-	a := openaichatagent.New(openaichatagent.Config{
-		Model: "gpt-4o-mini",
-		Agent: agent.Config{
-			Instructions: "You are a helpful assistant with access to weather information. Be concise and friendly.",
-			Tools:        []tool.Tool{weatherTool},
+	a := openaichatagent.New(
+		openai.NewClient(),
+		openaichatagent.Config{
+			Model: "gpt-4o-mini",
+			Config: agent.Config{
+				Instructions: "You are a helpful assistant with access to weather information. Be concise and friendly.",
+				Tools:        []tool.Tool{weatherTool},
+			},
 		},
-	})
+	)
 
 	runChatLoop(context.Background(), a)
 }


### PR DESCRIPTION
Some agents require to pass a valid LLM client instance, others fallback to creating a default one. The logic to detect when a LLM client is valid is a bit obscure, and it adds complexity to our APIs. Better be consistent and always require a valid LLM client to be passed to the agent constructor.

While here, add a Gemini example and make the agent providers configuration structs to embed `agent.Config` instead of presenting it as a normal property. This makes using the config a bit easier, and will enable further simplifications in Go 1.27 due to various language changes. 