### PR TITLE
Upgrade a2a-go integration to v2

### DIFF
--- a/agent/hosting/a2ahosting/a2a.go
+++ b/agent/hosting/a2ahosting/a2a.go
@@ -5,7 +5,7 @@ package a2ahosting
 import (
 	"net/http"
 
-	"github.com/a2aproject/a2a-go/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
 )
 
 func NewRequestHandler(cfg ExecutorConfig, options ...a2asrv.RequestHandlerOption) a2asrv.RequestHandler {

--- a/agent/hosting/a2ahosting/a2a_test.go
+++ b/agent/hosting/a2ahosting/a2a_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/hosting/a2ahosting"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -40,8 +40,8 @@ func TestRequestHandler_OnSendMessage_ReturnsMessage_WhenBackgroundDisabled(t *t
 	})
 
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
-	result, err := h.OnSendMessage(context.Background(), &a2a.MessageSendParams{
-		Message: &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.TextPart{Text: "ping"}}},
+	result, err := h.SendMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
 	})
 	if err != nil {
 		t.Fatalf("OnSendMessage returned error: %v", err)
@@ -57,12 +57,8 @@ func TestRequestHandler_OnSendMessage_ReturnsMessage_WhenBackgroundDisabled(t *t
 	if len(msg.Parts) == 0 {
 		t.Fatal("expected at least one message part")
 	}
-	textPart, ok := msg.Parts[0].(a2a.TextPart)
-	if !ok {
-		t.Fatalf("part type = %T, want a2a.TextPart", msg.Parts[0])
-	}
-	if textPart.Text != "hello from agent" {
-		t.Fatalf("text = %q, want %q", textPart.Text, "hello from agent")
+	if got := msg.Parts[0].Text(); got != "hello from agent" {
+		t.Fatalf("text = %q, want %q", got, "hello from agent")
 	}
 }
 
@@ -74,13 +70,9 @@ func TestRequestHandler_OnSendMessage_WithReferenceTaskIDs_ReturnsError(t *testi
 	})
 
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
-	_, err := h.OnSendMessage(context.Background(), &a2a.MessageSendParams{
-		Message: &a2a.Message{
-			Role:           a2a.MessageRoleUser,
-			Parts:          []a2a.Part{a2a.TextPart{Text: "ping"}},
-			ReferenceTasks: []a2a.TaskID{"task-123"},
-		},
-	})
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping"))
+	msg.ReferenceTasks = []a2a.TaskID{"task-123"}
+	_, err := h.SendMessage(context.Background(), &a2a.SendMessageRequest{Message: msg})
 	if err == nil {
 		t.Fatal("expected error for referenceTaskIds")
 	}
@@ -101,9 +93,9 @@ func TestRequestHandler_OnSendMessage_PreservesContextID(t *testing.T) {
 	})
 
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
-	result, err := h.OnSendMessage(context.Background(), &a2a.MessageSendParams{
-		Message: &a2a.Message{ContextID: "ctx-123", Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.TextPart{Text: "ping"}}},
-	})
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping"))
+	msg.ContextID = "ctx-123"
+	result, err := h.SendMessage(context.Background(), &a2a.SendMessageRequest{Message: msg})
 	if err != nil {
 		t.Fatalf("OnSendMessage returned error: %v", err)
 	}
@@ -135,8 +127,8 @@ func TestRequestHandler_OnSendMessageStream_UsesTaskLifecycle_WhenContinuationTo
 	})
 
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true})
-	stream := h.OnSendMessageStream(context.Background(), &a2a.MessageSendParams{
-		Message: &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.TextPart{Text: "ping"}}},
+	stream := h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
 	})
 
 	var submitted, working bool
@@ -179,8 +171,8 @@ func TestRequestHandler_OnSendMessageStream_WhenContinuationTokenAndNoMessages_S
 	})
 
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true})
-	stream := h.OnSendMessageStream(context.Background(), &a2a.MessageSendParams{
-		Message: &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.TextPart{Text: "ping"}}},
+	stream := h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
 	})
 
 	var working *a2a.TaskStatusUpdateEvent
@@ -216,11 +208,8 @@ func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
 	})
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true})
 
-	stream := h.OnSendMessageStream(context.Background(), &a2a.MessageSendParams{
-		Message: &a2a.Message{
-			Role:  a2a.MessageRoleUser,
-			Parts: []a2a.Part{a2a.TextPart{Text: "hi"}},
-		},
+	stream := h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi")),
 	})
 
 	var taskID a2a.TaskID
@@ -239,7 +228,7 @@ func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
 		t.Fatal("expected task id")
 	}
 
-	canceled, err := h.OnCancelTask(context.Background(), &a2a.TaskIDParams{ID: taskID})
+	canceled, err := h.CancelTask(context.Background(), &a2a.CancelTaskRequest{ID: taskID})
 	if err != nil {
 		t.Fatalf("OnCancelTask returned error: %v", err)
 	}

--- a/agent/hosting/a2ahosting/convert.go
+++ b/agent/hosting/a2ahosting/convert.go
@@ -10,7 +10,7 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -39,44 +39,44 @@ func toAgentMessage(in *a2a.Message) (*message.Message, error) {
 	return out, nil
 }
 
-func partsToContents(parts []a2a.Part) (message.Contents, error) {
+func partsToContents(parts a2a.ContentParts) (message.Contents, error) {
 	contents := make(message.Contents, 0, len(parts))
 	for _, part := range parts {
-		switch p := part.(type) {
-		case a2a.TextPart:
+		if part == nil {
+			continue
+		}
+		switch c := part.Content.(type) {
+		case a2a.Text:
 			contents = append(contents, &message.TextContent{
-				ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(p.Metadata), RawRepresentation: p},
-				Text:          p.Text,
+				ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(part.Metadata), RawRepresentation: part},
+				Text:          string(c),
 			})
-		case a2a.FilePart:
-			switch file := p.File.(type) {
-			case a2a.FileURI:
-				contents = append(contents, &message.URIContent{
-					ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(p.Metadata), RawRepresentation: p},
-					URI:           file.URI,
-					MediaType:     cmp.Or(file.MimeType, "application/octet-stream"),
-				})
-			case a2a.FileBytes:
-				contents = append(contents, &message.DataContent{
-					ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(p.Metadata), RawRepresentation: p},
-					Data:          file.Bytes,
-					MediaType:     cmp.Or(file.MimeType, "application/octet-stream"),
-				})
-			default:
-				return nil, fmt.Errorf("unsupported A2A file content type: %T", file)
-			}
-		case a2a.DataPart:
-			dump, err := json.Marshal(p.Data)
+		case a2a.URL:
+			contents = append(contents, &message.URIContent{
+				ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(part.Metadata), RawRepresentation: part},
+				URI:           string(c),
+				MediaType:     cmp.Or(part.MediaType, "application/octet-stream"),
+			})
+		case a2a.Raw:
+			contents = append(contents, &message.DataContent{
+				ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(part.Metadata), RawRepresentation: part},
+				Name:          part.Filename,
+				Data:          base64.StdEncoding.EncodeToString([]byte(c)),
+				MediaType:     cmp.Or(part.MediaType, "application/octet-stream"),
+			})
+		case a2a.Data:
+			dump, err := json.Marshal(c.Value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal A2A data part: %w", err)
 			}
 			contents = append(contents, &message.DataContent{
-				ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(p.Metadata), RawRepresentation: p},
+				ContentHeader: message.ContentHeader{AdditionalProperties: maps.Clone(part.Metadata), RawRepresentation: part},
+				Name:          part.Filename,
 				Data:          base64.StdEncoding.EncodeToString(dump),
-				MediaType:     "application/json",
+				MediaType:     cmp.Or(part.MediaType, "application/json"),
 			})
 		default:
-			return nil, fmt.Errorf("unsupported A2A part type: %T", part)
+			return nil, fmt.Errorf("unsupported A2A part type: %T", c)
 		}
 	}
 	return contents, nil
@@ -87,7 +87,7 @@ func responseToMessage(infoProvider a2a.TaskInfoProvider, resp *message.Response
 		return a2a.NewMessageForTask(a2a.MessageRoleAgent, infoProvider), nil
 	}
 
-	parts := make([]a2a.Part, 0)
+	parts := make(a2a.ContentParts, 0)
 	for _, msg := range resp.Messages {
 		converted, err := contentsToParts(msg.Contents)
 		if err != nil {
@@ -108,7 +108,7 @@ func responseToMessage(infoProvider a2a.TaskInfoProvider, resp *message.Response
 }
 
 func responseToArtifactEvent(infoProvider a2a.TaskInfoProvider, resp *message.Response) (*a2a.TaskArtifactUpdateEvent, error) {
-	parts := make([]a2a.Part, 0)
+	parts := make(a2a.ContentParts, 0)
 	if resp != nil {
 		for _, msg := range resp.Messages {
 			converted, err := contentsToParts(msg.Contents)
@@ -119,75 +119,64 @@ func responseToArtifactEvent(infoProvider a2a.TaskInfoProvider, resp *message.Re
 		}
 	}
 	evt := a2a.NewArtifactEvent(infoProvider, parts...)
+	evt.LastChunk = true
 	if resp != nil {
 		evt.Metadata = maps.Clone(resp.AdditionalProperties)
 	}
 	return evt, nil
 }
 
-func contentsToParts(contents message.Contents) ([]a2a.Part, error) {
-	parts := make([]a2a.Part, 0, len(contents))
+func contentsToParts(contents message.Contents) (a2a.ContentParts, error) {
+	parts := make(a2a.ContentParts, 0, len(contents))
 	for _, content := range contents {
+		var part *a2a.Part
 		switch c := content.(type) {
 		case *message.TextContent:
 			if c.Text == "" {
 				continue
 			}
-			parts = append(parts, a2a.TextPart{Text: c.Text, Metadata: maps.Clone(c.AdditionalProperties)})
+			part = a2a.NewTextPart(c.Text)
 		case *message.URIContent:
-			parts = append(parts, a2a.FilePart{
-				Metadata: maps.Clone(c.AdditionalProperties),
-				File: a2a.FileURI{
-					URI: c.URI,
-					FileMeta: a2a.FileMeta{
-						MimeType: c.MediaType,
-					},
-				},
-			})
+			part = a2a.NewFileURLPart(a2a.URL(c.URI), c.MediaType)
 		case *message.DataContent:
-			parts = append(parts, a2a.FilePart{
-				Metadata: maps.Clone(c.AdditionalProperties),
-				File: a2a.FileBytes{
-					Bytes: c.Data,
-					FileMeta: a2a.FileMeta{
-						MimeType: c.MediaType,
-						Name:     c.Name,
-					},
-				},
-			})
 			if c.MediaType == "application/json" {
 				bytes, err := c.Bytes()
 				if err != nil {
 					return nil, err
 				}
-				var value map[string]any
+				var value any
 				if err := json.Unmarshal(bytes, &value); err == nil {
-					parts[len(parts)-1] = a2a.DataPart{Metadata: maps.Clone(c.AdditionalProperties), Data: value}
+					part = a2a.NewDataPart(value)
 				}
 			}
+			if part == nil {
+				bytes, err := c.Bytes()
+				if err != nil {
+					return nil, err
+				}
+				part = a2a.NewRawPart(bytes)
+				part.MediaType = c.MediaType
+			}
+			part.Filename = c.Name
 		case *message.HostedFileContent:
-			parts = append(parts, a2a.FilePart{
-				Metadata: maps.Clone(c.AdditionalProperties),
-				File: a2a.FileURI{
-					URI: c.FileID,
-					FileMeta: a2a.FileMeta{
-						MimeType: c.MediaType,
-						Name:     c.Name,
-					},
-				},
-			})
+			part = a2a.NewFileURLPart(a2a.URL(c.FileID), c.MediaType)
+			part.Filename = c.Name
 		case *message.FunctionCallContent, *message.FunctionResultContent:
 			data, err := json.Marshal(c)
 			if err != nil {
 				return nil, err
 			}
-			parts = append(parts, a2a.TextPart{Text: string(data)})
+			part = a2a.NewTextPart(string(data))
 		default:
 			data, err := json.Marshal(c)
 			if err != nil {
 				return nil, fmt.Errorf("unsupported content type: %T", c)
 			}
-			parts = append(parts, a2a.TextPart{Text: string(data)})
+			part = a2a.NewTextPart(string(data))
+		}
+		if part != nil {
+			part.Metadata = maps.Clone(content.Header().AdditionalProperties)
+			parts = append(parts, part)
 		}
 	}
 	return parts, nil

--- a/agent/hosting/a2ahosting/convert_test.go
+++ b/agent/hosting/a2ahosting/convert_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -28,7 +28,7 @@ func TestToAgentMessage_Nil_ReturnsNil(t *testing.T) {
 }
 
 func TestToAgentMessage_WithTextPart_MapsToTextContent(t *testing.T) {
-	in := &a2a.Message{ID: "m1", Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.TextPart{Text: "hello"}}}
+	in := &a2a.Message{ID: "m1", Role: a2a.MessageRoleUser, Parts: a2a.ContentParts{a2a.NewTextPart("hello")}}
 	got, err := toAgentMessage(in)
 	if err != nil {
 		t.Fatalf("toAgentMessage returned error: %v", err)
@@ -73,12 +73,12 @@ func TestContentsToParts_JSONDataContent_MapsToDataPart(t *testing.T) {
 	if len(parts) != 1 {
 		t.Fatalf("parts len = %d, want 1", len(parts))
 	}
-	dp, ok := parts[0].(a2a.DataPart)
+	gotData, ok := parts[0].Data().(map[string]any)
 	if !ok {
-		t.Fatalf("part type = %T, want a2a.DataPart", parts[0])
+		t.Fatalf("part payload type = %T, want map[string]any", parts[0].Data())
 	}
-	if okValue, _ := dp.Data["ok"].(bool); !okValue {
-		t.Fatalf("unexpected data part payload: %#v", dp.Data)
+	if okValue, _ := gotData["ok"].(bool); !okValue {
+		t.Fatalf("unexpected data part payload: %#v", gotData)
 	}
 }
 

--- a/agent/hosting/a2ahosting/executor.go
+++ b/agent/hosting/a2ahosting/executor.go
@@ -115,15 +115,13 @@ func (e *executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 			return
 		}
 
-		if len(resp.Messages) > 0 {
-			artifact, err := responseToArtifactEvent(execCtx, resp)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-			if !yield(artifact, nil) {
-				return
-			}
+		artifact, err := responseToArtifactEvent(execCtx, resp)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		if !yield(artifact, nil) {
+			return
 		}
 
 		yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil), nil)

--- a/agent/hosting/a2ahosting/executor.go
+++ b/agent/hosting/a2ahosting/executor.go
@@ -5,10 +5,10 @@ package a2ahosting
 import (
 	"context"
 	"fmt"
+	"iter"
 
-	"github.com/a2aproject/a2a-go/a2a"
-	"github.com/a2aproject/a2a-go/a2asrv"
-	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/message"
@@ -21,9 +21,7 @@ type ExecutorConfig struct {
 	AllowBackgroundResponses bool
 	// AllowBackgroundResponsesWhen is a callback that determines on a per-message basis whether background responses should be allowed.
 	// If both AllowBackgroundResponses and AllowBackgroundResponsesWhen are set, the callback takes precedence.
-	AllowBackgroundResponsesWhen func(context.Context, *a2asrv.RequestContext) (bool, error)
-
-	Options []a2asrv.RequestHandlerOption
+	AllowBackgroundResponsesWhen func(context.Context, *a2asrv.ExecutorContext) (bool, error)
 }
 
 type executor struct {
@@ -34,117 +32,119 @@ func NewExecutor(cfg ExecutorConfig) a2asrv.AgentExecutor {
 	return &executor{cfg: cfg}
 }
 
-func (e *executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, queue eventqueue.Queue) error {
-	if reqCtx == nil || reqCtx.Message == nil {
-		return fmt.Errorf("request message is required")
-	}
-	if len(reqCtx.Message.ReferenceTasks) > 0 {
-		return fmt.Errorf("referenceTaskIds are not supported")
-	}
-
-	allowBackground, err := e.shouldRunInBackground(ctx, reqCtx)
-	if err != nil {
-		return err
-	}
-
-	messagesIn, err := e.buildMessages(reqCtx)
-	if err != nil {
-		return err
-	}
-
-	session, err := e.cfg.Agent.CreateSession(ctx, agentopt.ServiceID(reqCtx.ContextID))
-	if err != nil {
-		return err
-	}
-
-	runOptions := []agentopt.Option{
-		agentopt.Session(session),
-		agentopt.AllowBackgroundResponses(allowBackground),
-	}
-
-	resp, runErr := e.cfg.Agent.Run(ctx, messagesIn, runOptions...).Collect()
-	if runErr != nil {
-		if reqCtx.StoredTask != nil {
-			statusErr := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateFailed, nil)
-			statusErr.Final = true
-			if err := queue.Write(ctx, statusErr); err != nil {
-				return fmt.Errorf("failed to write failed status: %w", err)
-			}
-			return nil
+func (e *executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		if execCtx == nil || execCtx.Message == nil {
+			yield(nil, fmt.Errorf("request message is required"))
+			return
 		}
-		return runErr
-	}
+		if len(execCtx.Message.ReferenceTasks) > 0 {
+			yield(nil, fmt.Errorf("referenceTaskIds are not supported"))
+			return
+		}
 
-	if reqCtx.StoredTask == nil && resp.ContinuationToken == "" {
-		msg, err := responseToMessage(reqCtx, resp)
+		allowBackground, err := e.shouldRunInBackground(ctx, execCtx)
 		if err != nil {
-			return err
+			yield(nil, err)
+			return
 		}
-		return queue.Write(ctx, msg)
-	}
 
-	if reqCtx.StoredTask == nil {
-		submitted := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateSubmitted, nil)
-		if err := queue.Write(ctx, submitted); err != nil {
-			return fmt.Errorf("failed to write submitted status: %w", err)
+		messagesIn, err := e.buildMessages(execCtx)
+		if err != nil {
+			yield(nil, err)
+			return
 		}
-	}
 
-	if resp.ContinuationToken != "" {
-		var progressMessage *a2a.Message
-		if len(resp.Messages) > 0 {
-			progressMessage, err = responseToMessage(reqCtx, resp)
+		session, err := e.cfg.Agent.CreateSession(ctx, agentopt.ServiceID(execCtx.ContextID))
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		runOptions := []agentopt.Option{
+			agentopt.Session(session),
+			agentopt.AllowBackgroundResponses(allowBackground),
+		}
+
+		resp, runErr := e.cfg.Agent.Run(ctx, messagesIn, runOptions...).Collect()
+		if runErr != nil {
+			if execCtx.StoredTask != nil {
+				statusMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(runErr.Error()))
+				yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed, statusMsg), nil)
+				return
+			}
+			yield(nil, runErr)
+			return
+		}
+
+		if execCtx.StoredTask == nil && resp.ContinuationToken == "" {
+			msg, err := responseToMessage(execCtx, resp)
 			if err != nil {
-				return err
+				yield(nil, err)
+				return
+			}
+			yield(msg, nil)
+			return
+		}
+
+		if execCtx.StoredTask == nil {
+			if !yield(a2a.NewSubmittedTask(execCtx, execCtx.Message), nil) {
+				return
+			}
+			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateSubmitted, nil), nil) {
+				return
 			}
 		}
 
-		working := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateWorking, progressMessage)
-		working.Metadata = map[string]any{continuationTokenMetadataKey: resp.ContinuationToken}
-		if err := queue.Write(ctx, working); err != nil {
-			return fmt.Errorf("failed to write working status: %w", err)
+		if resp.ContinuationToken != "" {
+			var progressMessage *a2a.Message
+			if len(resp.Messages) > 0 {
+				progressMessage, err = responseToMessage(execCtx, resp)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+			}
+
+			working := a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, progressMessage)
+			if working.Metadata == nil {
+				working.Metadata = map[string]any{}
+			}
+			working.Metadata[continuationTokenMetadataKey] = resp.ContinuationToken
+			yield(working, nil)
+			return
 		}
-		return nil
-	}
 
-	artifact, err := responseToArtifactEvent(reqCtx, resp)
-	if err != nil {
-		return err
-	}
-	if err := queue.Write(ctx, artifact); err != nil {
-		return fmt.Errorf("failed to write artifact event: %w", err)
-	}
+		if len(resp.Messages) > 0 {
+			artifact, err := responseToArtifactEvent(execCtx, resp)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(artifact, nil) {
+				return
+			}
+		}
 
-	completed := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateCompleted, nil)
-	completed.Final = true
-	if err := queue.Write(ctx, completed); err != nil {
-		return fmt.Errorf("failed to write completed status: %w", err)
+		yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil), nil)
 	}
-
-	return nil
 }
 
-func (e *executor) Cancel(ctx context.Context, reqCtx *a2asrv.RequestContext, queue eventqueue.Queue) error {
-	if reqCtx == nil || reqCtx.StoredTask == nil {
-		return a2a.ErrTaskNotFound
+func (e *executor) Cancel(_ context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		if execCtx == nil || execCtx.StoredTask == nil {
+			yield(nil, a2a.ErrTaskNotFound)
+			return
+		}
+		yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCanceled, nil), nil)
 	}
-	if reqCtx.StoredTask.Metadata != nil {
-		delete(reqCtx.StoredTask.Metadata, continuationTokenMetadataKey)
-	}
-
-	event := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateCanceled, nil)
-	event.Final = true
-	if err := queue.Write(ctx, event); err != nil {
-		return fmt.Errorf("failed to write canceled status: %w", err)
-	}
-	return nil
 }
 
-func (e *executor) buildMessages(reqCtx *a2asrv.RequestContext) ([]*message.Message, error) {
+func (e *executor) buildMessages(execCtx *a2asrv.ExecutorContext) ([]*message.Message, error) {
 	messages := make([]*message.Message, 0, 1)
 
-	if reqCtx != nil && reqCtx.StoredTask != nil && len(reqCtx.StoredTask.History) > 0 {
-		for _, m := range reqCtx.StoredTask.History {
+	if execCtx != nil && execCtx.StoredTask != nil && len(execCtx.StoredTask.History) > 0 {
+		for _, m := range execCtx.StoredTask.History {
 			msg, err := toAgentMessage(m)
 			if err != nil {
 				return nil, err
@@ -155,7 +155,7 @@ func (e *executor) buildMessages(reqCtx *a2asrv.RequestContext) ([]*message.Mess
 		}
 	}
 
-	incoming, err := toAgentMessage(reqCtx.Message)
+	incoming, err := toAgentMessage(execCtx.Message)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (e *executor) buildMessages(reqCtx *a2asrv.RequestContext) ([]*message.Mess
 	return messages, nil
 }
 
-func (e *executor) shouldRunInBackground(ctx context.Context, decisionContext *a2asrv.RequestContext) (bool, error) {
+func (e *executor) shouldRunInBackground(ctx context.Context, decisionContext *a2asrv.ExecutorContext) (bool, error) {
 	if e.cfg.AllowBackgroundResponsesWhen != nil {
 		return e.cfg.AllowBackgroundResponsesWhen(ctx, decisionContext)
 	}

--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -10,11 +10,12 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"slices"
 	"time"
 
-	"github.com/a2aproject/a2a-go/a2a"
-	"github.com/a2aproject/a2a-go/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agentopt"
 	"github.com/microsoft/agent-framework-go/memory"
@@ -72,7 +73,7 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 				yield(nil, errors.New("reconnecting to task streams using continuation tokens is not supported yet"))
 				return
 			}
-			task, err := a.client.GetTask(ctx, &a2a.TaskQueryParams{ID: a2a.TaskID(token)})
+			task, err := a.client.GetTask(ctx, &a2a.GetTaskRequest{ID: a2a.TaskID(token)})
 			if err != nil {
 				yield(nil, err)
 				return
@@ -84,7 +85,7 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 			yieldTask(yield, task)
 			return
 		}
-		var parts []a2a.Part
+		var parts a2a.ContentParts
 		for _, msg := range messages {
 			parts = parts[:0] // reset parts slice
 			parts, err := contentsToParts(msg.Contents, parts)
@@ -96,15 +97,15 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 			for _, taskID := range getTaskIDs(session) {
 				taskIDs = append(taskIDs, a2a.TaskID(taskID))
 			}
-			params := &a2a.MessageSendParams{
-				Message: &a2a.Message{
-					ID:             msg.ID,
-					Role:           a2a.MessageRoleUser,
-					Parts:          parts,
-					ReferenceTasks: taskIDs,
-					ContextID:      getContextID(session),
-				},
+			userMsg := a2a.NewMessage(a2a.MessageRoleUser, parts...)
+			if msg.ID != "" {
+				userMsg.ID = msg.ID
 			}
+			userMsg.ContextID = getContextID(session)
+			userMsg.ReferenceTasks = taskIDs
+			userMsg.Metadata = maps.Clone(msg.AdditionalProperties)
+
+			params := &a2a.SendMessageRequest{Message: userMsg}
 			var seq iter.Seq2[a2a.Event, error]
 			if stream {
 				seq = a.client.SendStreamingMessage(ctx, params)
@@ -241,104 +242,102 @@ func updateSessionContextID(session *memory.Session, contextID, taskID string) e
 	return nil
 }
 
-func partsToContents(parts []a2a.Part, contents []message.Content) ([]message.Content, error) {
+func partsToContents(parts a2a.ContentParts, contents []message.Content) ([]message.Content, error) {
 	contents = slices.Grow(contents, len(parts))
 	for _, part := range parts {
+		if part == nil {
+			continue
+		}
+
 		var content message.Content
-		switch p := part.(type) {
-		case a2a.TextPart:
+		switch c := part.Content.(type) {
+		case a2a.Text:
 			content = &message.TextContent{
 				ContentHeader: message.ContentHeader{
-					AdditionalProperties: p.Metadata,
-					RawRepresentation:    p,
+					AdditionalProperties: maps.Clone(part.Metadata),
+					RawRepresentation:    part,
 				},
-				Text: p.Text,
+				Text: string(c),
 			}
-		case a2a.FilePart:
-			switch f := p.File.(type) {
-			case a2a.FileURI:
-				content = &message.URIContent{
-					ContentHeader: message.ContentHeader{
-						AdditionalProperties: p.Metadata,
-						RawRepresentation:    p,
-					},
-					MediaType: cmp.Or(f.MimeType, "application/octet-stream"),
-					URI:       f.URI,
-				}
-			case a2a.FileBytes:
-				content = &message.DataContent{
-					ContentHeader: message.ContentHeader{
-						AdditionalProperties: p.Metadata,
-						RawRepresentation:    p,
-					},
-					MediaType: cmp.Or(f.MimeType, "application/octet-stream"),
-					Data:      f.Bytes,
-				}
+		case a2a.URL:
+			content = &message.URIContent{
+				ContentHeader: message.ContentHeader{
+					AdditionalProperties: maps.Clone(part.Metadata),
+					RawRepresentation:    part,
+				},
+				MediaType: cmp.Or(part.MediaType, "application/octet-stream"),
+				URI:       string(c),
 			}
-		case a2a.DataPart:
-			dump, err := json.Marshal(p.Data)
+		case a2a.Raw:
+			content = &message.DataContent{
+				ContentHeader: message.ContentHeader{
+					AdditionalProperties: maps.Clone(part.Metadata),
+					RawRepresentation:    part,
+				},
+				Name:      part.Filename,
+				MediaType: cmp.Or(part.MediaType, "application/octet-stream"),
+				Data:      base64.StdEncoding.EncodeToString([]byte(c)),
+			}
+		case a2a.Data:
+			dump, err := json.Marshal(c.Value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal A2A data part: %w", err)
 			}
 			content = &message.DataContent{
 				ContentHeader: message.ContentHeader{
-					AdditionalProperties: p.Metadata,
-					RawRepresentation:    p,
+					AdditionalProperties: maps.Clone(part.Metadata),
+					RawRepresentation:    part,
 				},
+				Name:      part.Filename,
 				Data:      base64.StdEncoding.EncodeToString(dump),
-				MediaType: "application/json",
+				MediaType: cmp.Or(part.MediaType, "application/json"),
 			}
 		default:
-			return nil, fmt.Errorf("unsupported A2A part type: %T", part)
+			return nil, fmt.Errorf("unsupported A2A part type: %T", c)
 		}
-		if content != nil {
-			contents = append(contents, content)
-		}
+
+		contents = append(contents, content)
 	}
 	return contents, nil
 }
 
-func contentsToParts(contents []message.Content, parts []a2a.Part) ([]a2a.Part, error) {
+func contentsToParts(contents []message.Content, parts a2a.ContentParts) (a2a.ContentParts, error) {
 	for _, content := range contents {
+		var part *a2a.Part
 		switch c := content.(type) {
 		case *message.TextContent:
-			parts = append(parts, a2a.TextPart{
-				Metadata: c.AdditionalProperties,
-				Text:     c.Text,
-			})
+			part = a2a.NewTextPart(c.Text)
 		case *message.URIContent:
-			parts = append(parts, a2a.FilePart{
-				Metadata: c.AdditionalProperties,
-				File: a2a.FileURI{
-					URI: c.URI,
-					FileMeta: a2a.FileMeta{
-						MimeType: c.MediaType,
-					},
-				},
-			})
+			part = a2a.NewFileURLPart(a2a.URL(c.URI), c.MediaType)
 		case *message.DataContent:
-			parts = append(parts, a2a.FilePart{
-				Metadata: c.AdditionalProperties,
-				File: a2a.FileBytes{
-					Bytes: c.Data,
-					FileMeta: a2a.FileMeta{
-						MimeType: c.MediaType,
-					},
-				},
-			})
+			if c.MediaType == "application/json" {
+				bytes, err := c.Bytes()
+				if err != nil {
+					return nil, err
+				}
+				var value any
+				if err := json.Unmarshal(bytes, &value); err == nil {
+					part = a2a.NewDataPart(value)
+				}
+			}
+			if part == nil {
+				bytes, err := c.Bytes()
+				if err != nil {
+					return nil, err
+				}
+				part = a2a.NewRawPart(bytes)
+				part.MediaType = c.MediaType
+			}
+			part.Filename = c.Name
 		case *message.HostedFileContent:
-			parts = append(parts, a2a.FilePart{
-				Metadata: c.AdditionalProperties,
-				File: a2a.FileURI{
-					URI: c.FileID,
-					FileMeta: a2a.FileMeta{
-						MimeType: c.MediaType,
-						Name:     c.Name,
-					},
-				},
-			})
+			part = a2a.NewFileURLPart(a2a.URL(c.FileID), c.MediaType)
+			part.Filename = c.Name
 		default:
 			return nil, fmt.Errorf("unsupported content type: %T", c)
+		}
+		if part != nil {
+			part.Metadata = maps.Clone(content.Header().AdditionalProperties)
+			parts = append(parts, part)
 		}
 	}
 	return parts, nil

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -8,8 +8,8 @@ import (
 	"iter"
 	"testing"
 
-	"github.com/a2aproject/a2a-go/a2a"
-	"github.com/a2aproject/a2a-go/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
 	"github.com/microsoft/agent-framework-go/agent"
 	a2a1 "github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
 	"github.com/microsoft/agent-framework-go/agentopt"
@@ -19,14 +19,14 @@ import (
 
 // mockA2ATransport is a stub that implements a2aclient.Transport for testing
 type mockA2ATransport struct {
-	capturedMessageSendParams  *a2a.MessageSendParams
+	capturedMessageSendParams  *a2a.SendMessageRequest
 	responseToReturn           a2a.SendMessageResult
 	streamingResponseToReturn  a2a.Event
 	sendMessageCalled          bool
 	sendStreamingMessageCalled bool
 }
 
-func (m *mockA2ATransport) SendMessage(ctx context.Context, params *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
+func (m *mockA2ATransport) SendMessage(ctx context.Context, _ a2aclient.ServiceParams, params *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
 	m.sendMessageCalled = true
 	m.capturedMessageSendParams = params
 	if m.responseToReturn != nil {
@@ -40,7 +40,7 @@ func (m *mockA2ATransport) SendMessage(ctx context.Context, params *a2a.MessageS
 	}, nil
 }
 
-func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, params *a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
+func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, _ a2aclient.ServiceParams, params *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error] {
 	m.sendStreamingMessageCalled = true
 	m.capturedMessageSendParams = params
 	responseToYield := m.streamingResponseToReturn
@@ -77,7 +77,7 @@ func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, params *a2a
 	}
 }
 
-func (m *mockA2ATransport) GetTask(ctx context.Context, params *a2a.TaskQueryParams) (*a2a.Task, error) {
+func (m *mockA2ATransport) GetTask(ctx context.Context, _ a2aclient.ServiceParams, params *a2a.GetTaskRequest) (*a2a.Task, error) {
 	if m.responseToReturn != nil {
 		if task, ok := m.responseToReturn.(*a2a.Task); ok {
 			return task, nil
@@ -86,33 +86,37 @@ func (m *mockA2ATransport) GetTask(ctx context.Context, params *a2a.TaskQueryPar
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockA2ATransport) CancelTask(ctx context.Context, params *a2a.TaskIDParams) (*a2a.Task, error) {
+func (m *mockA2ATransport) ListTasks(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockA2ATransport) ResubscribeToTask(ctx context.Context, params *a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
+func (m *mockA2ATransport) CancelTask(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.CancelTaskRequest) (*a2a.Task, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockA2ATransport) SubscribeToTask(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
 		yield(nil, errors.New("not implemented"))
 	}
 }
 
-func (m *mockA2ATransport) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error) {
+func (m *mockA2ATransport) GetTaskPushConfig(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockA2ATransport) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
+func (m *mockA2ATransport) ListTaskPushConfigs(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockA2ATransport) SetTaskPushConfig(ctx context.Context, config *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
+func (m *mockA2ATransport) CreateTaskPushConfig(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockA2ATransport) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
+func (m *mockA2ATransport) DeleteTaskPushConfig(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.DeleteTaskPushConfigRequest) error {
 	return errors.New("not implemented")
 }
 
-func (m *mockA2ATransport) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
+func (m *mockA2ATransport) GetExtendedAgentCard(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.GetExtendedAgentCardRequest) (*a2a.AgentCard, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -123,17 +127,18 @@ func (m *mockA2ATransport) Destroy() error {
 // Test fixtures
 func newTestAgent(transport a2aclient.Transport, config agent.Config) *agent.Agent {
 	card := &a2a.AgentCard{
-		URL:                "test://localhost",
-		PreferredTransport: "test",
 		Capabilities: a2a.AgentCapabilities{
 			Streaming: true,
+		},
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface("test://localhost", a2a.TransportProtocol("test")),
 		},
 	}
 	client, err := a2aclient.NewFromCard(
 		context.Background(),
 		card,
 		a2aclient.WithDefaultsDisabled(),
-		a2aclient.WithTransport("test", a2aclient.TransportFactoryFn(func(ctx context.Context, url string, card *a2a.AgentCard) (a2aclient.Transport, error) {
+		a2aclient.WithTransport("test", a2aclient.TransportFactoryFn(func(ctx context.Context, card *a2a.AgentCard, iface *a2a.AgentInterface) (a2aclient.Transport, error) {
 			return transport, nil
 		})),
 	)
@@ -182,11 +187,9 @@ func TestRunAllowsNonUserRoleMessages(t *testing.T) {
 func TestRunWithValidUserMessage(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Message{
-			ID:   "response-123",
-			Role: a2a.MessageRoleAgent,
-			Parts: []a2a.Part{
-				a2a.TextPart{Text: "Hello! How can I help you today?"},
-			},
+			ID:    "response-123",
+			Role:  a2a.MessageRoleAgent,
+			Parts: a2a.ContentParts{a2a.NewTextPart("Hello! How can I help you today?")},
 		},
 	}
 	a := newTestAgent(transport, agent.Config{})
@@ -210,12 +213,8 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	if inputMessage.Role != a2a.MessageRoleUser {
 		t.Errorf("captured message role = %q, want %q", inputMessage.Role, a2a.MessageRoleUser)
 	}
-	if textPart, ok := inputMessage.Parts[0].(a2a.TextPart); ok {
-		if textPart.Text != "Hello, world!" {
-			t.Errorf("captured message text = %q, want %q", textPart.Text, "Hello, world!")
-		}
-	} else {
-		t.Errorf("captured message part is not TextPart")
+	if got := inputMessage.Parts[0].Text(); got != "Hello, world!" {
+		t.Errorf("captured message text = %q, want %q", got, "Hello, world!")
 	}
 
 	// Assert response from A2AClient is converted correctly
@@ -252,7 +251,7 @@ func TestRunWithCreateSession(t *testing.T) {
 		responseToReturn: &a2a.Message{
 			ID:        "response-123",
 			Role:      a2a.MessageRoleAgent,
-			Parts:     []a2a.Part{a2a.TextPart{Text: "Response"}},
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Response")},
 			ContextID: "new-context-id",
 		},
 	}
@@ -302,7 +301,7 @@ func TestRunWithSessionHavingDifferentContextID(t *testing.T) {
 		responseToReturn: &a2a.Message{
 			ID:        "response-123",
 			Role:      a2a.MessageRoleAgent,
-			Parts:     []a2a.Part{a2a.TextPart{Text: "Response"}},
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Response")},
 			ContextID: "different-context",
 		},
 	}
@@ -325,7 +324,7 @@ func TestRunStreamingWithValidUserMessage(t *testing.T) {
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
 			Role:      a2a.MessageRoleAgent,
-			Parts:     []a2a.Part{a2a.TextPart{Text: "Hello"}},
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Hello")},
 			ContextID: "stream-context",
 		},
 	}
@@ -362,10 +361,8 @@ func TestRunStreamingWithValidUserMessage(t *testing.T) {
 	if inputMessage.Role != a2a.MessageRoleUser {
 		t.Errorf("captured message role = %q, want %q", inputMessage.Role, a2a.MessageRoleUser)
 	}
-	if textPart, ok := inputMessage.Parts[0].(a2a.TextPart); ok {
-		if textPart.Text != "Hello, streaming!" {
-			t.Errorf("captured message text = %q, want %q", textPart.Text, "Hello, streaming!")
-		}
+	if got := inputMessage.Parts[0].Text(); got != "Hello, streaming!" {
+		t.Errorf("captured message text = %q, want %q", got, "Hello, streaming!")
 	}
 
 	// Assert response from A2AClient is converted correctly
@@ -402,7 +399,7 @@ func TestRunStreamingWithSession(t *testing.T) {
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
 			Role:      a2a.MessageRoleAgent,
-			Parts:     []a2a.Part{a2a.TextPart{Text: "Response"}},
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Response")},
 			ContextID: "new-stream-context",
 		},
 	}
@@ -456,7 +453,7 @@ func TestRunStreamingWithSessionHavingDifferentContextID(t *testing.T) {
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
 			Role:      a2a.MessageRoleAgent,
-			Parts:     []a2a.Part{a2a.TextPart{Text: "Response"}},
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Response")},
 			ContextID: "different-context",
 		},
 	}
@@ -486,7 +483,7 @@ func TestRunStreamingAllowsNonUserRoleMessages(t *testing.T) {
 		streamingResponseToReturn: &a2a.Message{
 			ID:        "stream-1",
 			Role:      a2a.MessageRoleAgent,
-			Parts:     []a2a.Part{a2a.TextPart{Text: "Response"}},
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Response")},
 			ContextID: "new-stream-context",
 		},
 	}
@@ -536,23 +533,13 @@ func TestRunWithHostedFileContent(t *testing.T) {
 		t.Fatalf("len(message.Parts) = %d, want 2", len(capturedMsg.Parts))
 	}
 
-	if textPart, ok := capturedMsg.Parts[0].(a2a.TextPart); !ok {
-		t.Errorf("Parts[0] type = %T, want a2a.TextPart", capturedMsg.Parts[0])
-	} else if textPart.Text != "Check this file:" {
-		t.Errorf("TextPart.Text = %q, want %q", textPart.Text, "Check this file:")
+	if got := capturedMsg.Parts[0].Text(); got != "Check this file:" {
+		t.Errorf("Parts[0].Text() = %q, want %q", got, "Check this file:")
 	}
 
-	if filePart, ok := capturedMsg.Parts[1].(a2a.FilePart); !ok {
-		t.Errorf("Parts[1] type = %T, want a2a.FilePart", capturedMsg.Parts[1])
-	} else {
-		if fileURI, ok := filePart.File.(a2a.FileURI); !ok {
-			t.Errorf("FilePart.File type = %T, want a2a.FileURI", filePart.File)
-		} else {
-			expectedURI := "https://example.com/file.pdf"
-			if fileURI.URI != expectedURI {
-				t.Errorf("FileURI.URI = %q, want %q", fileURI.URI, expectedURI)
-			}
-		}
+	expectedURI := "https://example.com/file.pdf"
+	if got := string(capturedMsg.Parts[1].URL()); got != expectedURI {
+		t.Errorf("Parts[1].URL() = %q, want %q", got, expectedURI)
 	}
 }
 
@@ -587,11 +574,9 @@ func TestRunWithContinuationToken(t *testing.T) {
 func TestRunWithTaskInSessionAndMessage(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Message{
-			ID:   "response-123",
-			Role: a2a.MessageRoleAgent,
-			Parts: []a2a.Part{
-				a2a.TextPart{Text: "Response to task"},
-			},
+			ID:    "response-123",
+			Role:  a2a.MessageRoleAgent,
+			Parts: a2a.ContentParts{a2a.NewTextPart("Response to task")},
 		},
 	}
 	a := newTestAgent(transport, agent.Config{})
@@ -620,11 +605,9 @@ func TestRunWithTaskInSessionAndMessage(t *testing.T) {
 func TestRunWithMultipleTaskIDsInSessionAndMessage(t *testing.T) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Message{
-			ID:   "response-123",
-			Role: a2a.MessageRoleAgent,
-			Parts: []a2a.Part{
-				a2a.TextPart{Text: "Response to tasks"},
-			},
+			ID:    "response-123",
+			Role:  a2a.MessageRoleAgent,
+			Parts: a2a.ContentParts{a2a.NewTextPart("Response to tasks")},
 		},
 	}
 	a := newTestAgent(transport, agent.Config{})
@@ -693,10 +676,8 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 			},
 			Artifacts: []*a2a.Artifact{
 				{
-					ID: a2a.ArtifactID("art-1"),
-					Parts: []a2a.Part{
-						a2a.TextPart{Text: "Artifact content"},
-					},
+					ID:    a2a.ArtifactID("art-1"),
+					Parts: a2a.ContentParts{a2a.NewTextPart("Artifact content")},
 				},
 			},
 		},
@@ -762,7 +743,7 @@ func TestRunWithVariousTaskStates(t *testing.T) {
 					Artifacts: []*a2a.Artifact{
 						{
 							ID:    a2a.ArtifactID("art-1"),
-							Parts: []a2a.Part{a2a.TextPart{Text: "Content"}},
+							Parts: a2a.ContentParts{a2a.NewTextPart("Content")},
 						},
 					},
 				},
@@ -805,11 +786,9 @@ func TestRunStreamingWithContinuationTokenAndMessages(t *testing.T) {
 func TestRunStreamingWithTaskInSessionAndMessage(t *testing.T) {
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.Message{
-			ID:   "response-123",
-			Role: a2a.MessageRoleAgent,
-			Parts: []a2a.Part{
-				a2a.TextPart{Text: "Response to task"},
-			},
+			ID:    "response-123",
+			Role:  a2a.MessageRoleAgent,
+			Parts: a2a.ContentParts{a2a.NewTextPart("Response to task")},
 		},
 	}
 	a := newTestAgent(transport, agent.Config{})
@@ -848,7 +827,7 @@ func TestRunStreamingWithAgentTaskUpdatesSession(t *testing.T) {
 			Artifacts: []*a2a.Artifact{
 				{
 					ID:    a2a.ArtifactID("art-1"),
-					Parts: []a2a.Part{a2a.TextPart{Text: "Task content"}},
+					Parts: a2a.ContentParts{a2a.NewTextPart("Task content")},
 				},
 			},
 		},
@@ -882,9 +861,7 @@ func TestRunStreamingWithAgentMessage(t *testing.T) {
 			ID:        messageID,
 			Role:      a2a.MessageRoleAgent,
 			ContextID: contextID,
-			Parts: []a2a.Part{
-				a2a.TextPart{Text: messageText},
-			},
+			Parts:     a2a.ContentParts{a2a.NewTextPart(messageText)},
 		},
 	}
 	a := newTestAgent(transport, agent.Config{})
@@ -933,10 +910,8 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 			},
 			Artifacts: []*a2a.Artifact{
 				{
-					ID: a2a.ArtifactID("art-123"),
-					Parts: []a2a.Part{
-						a2a.TextPart{Text: "Task artifact content"},
-					},
+					ID:    a2a.ArtifactID("art-123"),
+					Parts: a2a.ContentParts{a2a.NewTextPart("Task artifact content")},
 				},
 			},
 		},
@@ -1042,10 +1017,8 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 			TaskID:    a2a.TaskID(taskID),
 			ContextID: contextID,
 			Artifact: &a2a.Artifact{
-				ID: a2a.ArtifactID("artifact-789"),
-				Parts: []a2a.Part{
-					a2a.TextPart{Text: artifactContent},
-				},
+				ID:    a2a.ArtifactID("artifact-789"),
+				Parts: a2a.ContentParts{a2a.NewTextPart(artifactContent)},
 			},
 		},
 	}

--- a/examples/02-agents/providers/a2a/main.go
+++ b/examples/02-agents/providers/a2a/main.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/a2aproject/a2a-go/a2aclient"
-	"github.com/a2aproject/a2a-go/a2aclient/agentcard"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
+	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
@@ -34,7 +35,7 @@ func main() {
 	}
 
 	// Insecure connection is used for example purposes
-	withInsecureGRPC := a2aclient.WithGRPCTransport(grpc.WithTransportCredentials(insecure.NewCredentials()))
+	withInsecureGRPC := a2agrpc.WithGRPCTransport(grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 	// Create a client connected to one of the interfaces specified in the AgentCard.
 	client, err := a2aclient.NewFromCard(ctx, card, withInsecureGRPC)

--- a/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/a2aproject/a2a-go/a2aclient"
-	"github.com/a2aproject/a2a-go/a2aclient/agentcard"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"

--- a/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/a2aproject/a2a-go/a2a"
-	"github.com/a2aproject/a2a-go/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/hosting/a2ahosting"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
@@ -124,12 +124,9 @@ func main() {
 	cfg.Middlewares = append(cfg.Middlewares, logger)
 	hostAgent := openaichatagent.New(oclient, cfg)
 
-	card.URL = url
-	card.PreferredTransport = a2a.TransportProtocolJSONRPC
-	card.AdditionalInterfaces = []a2a.AgentInterface{{
-		Transport: a2a.TransportProtocolJSONRPC,
-		URL:       url,
-	}}
+	card.SupportedInterfaces = []*a2a.AgentInterface{
+		a2a.NewAgentInterface(url, a2a.TransportProtocolJSONRPC),
+	}
 	mux := http.NewServeMux()
 	mux.Handle("/", a2ahosting.NewHTTPHandler(a2ahosting.ExecutorConfig{
 		Agent: hostAgent,
@@ -146,7 +143,6 @@ func buildAgent(agentType, model string) (openaichatagent.Config, *a2a.AgentCard
 	t := strings.ToUpper(strings.TrimSpace(agentType))
 	cfg := openaichatagent.Config{Model: model}
 	card := &a2a.AgentCard{
-		ProtocolVersion:    "0.3.0",
 		Version:            "1.0.0",
 		DefaultInputModes:  []string{"text"},
 		DefaultOutputModes: []string{"text"},

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
-	github.com/a2aproject/a2a-go v0.3.4
+	github.com/a2aproject/a2a-go/v2 v2.2.0
 	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260312103001-8e7ab1df34c8
 	github.com/anthropics/anthropic-sdk-go v1.27.1
 	github.com/google/jsonschema-go v0.4.2
@@ -49,12 +49,13 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260114163908-3f89685c29c3 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260114163908-3f89685c29c3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mo
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/a2aproject/a2a-go v0.3.4 h1:rSMR/IryydWkIjtxDLZCVgSc3RrVF4eHrycKlBC/WE0=
-github.com/a2aproject/a2a-go v0.3.4/go.mod h1:8C0O6lsfR7zWFEqVZz/+zWCoxe8gSWpknEpqm/Vgj3E=
+github.com/a2aproject/a2a-go/v2 v2.2.0 h1:eayiNXYpyTOLVhhQrGmIHlcy8GnOdnwaNdYQPvS84Ik=
+github.com/a2aproject/a2a-go/v2 v2.2.0/go.mod h1:htTxMwicNXXXEwwfjuB/Pd1g7UHDrswhSievncmTVcE=
 github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260312103001-8e7ab1df34c8 h1:gcgM2iVSJ+5v1Li2O2xBm8jdY9bIo0coZdOlXOd0uLU=
 github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260312103001-8e7ab1df34c8/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
 github.com/anthropics/anthropic-sdk-go v1.27.1 h1:7DgMZ2Ng3C2mPzJGHA30NXQTZolcF07mHd0tGaLwfzk=
@@ -151,6 +151,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
+golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -196,8 +198,8 @@ google.golang.org/genai v1.54.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5g
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto/googleapis/api v0.0.0-20260114163908-3f89685c29c3 h1:X9z6obt+cWRX8XjDVOn+SZWhWe5kZHm46TThU9j+jss=
-google.golang.org/genproto/googleapis/api v0.0.0-20260114163908-3f89685c29c3/go.mod h1:dd646eSK+Dk9kxVBl1nChEOhJPtMXriCcVb4x3o6J+E=
+google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 h1:fCvbg86sFXwdrl5LgVcTEvNC+2txB5mgROGmRL5mrls=
+google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:+rXWjjaukWZun3mLfjmVnQi18E1AsFbDN9QdJ5YXLto=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260114163908-3f89685c29c3 h1:C4WAdL+FbjnGlpp2S+HMVhBeCq2Lcib4xZqfPNF6OoQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260114163908-3f89685c29c3/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=


### PR DESCRIPTION
## Summary
- upgrade the A2A Go dependency to v2
- migrate the provider and hosting adapters to the newer request, executor, and content part patterns
- update tests and examples to match the v2 APIs

## Verification
- go test ./...
