### PR TITLE
refactor: rename NewHTTPHandler to NewJSONHTTPHandler

### DIFF
--- a/agent/hosting/a2ahosting/a2a.go
+++ b/agent/hosting/a2ahosting/a2a.go
@@ -8,6 +8,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 )
 
+// NewRequestHandler creates a new request handler.
 func NewRequestHandler(cfg ExecutorConfig, options ...a2asrv.RequestHandlerOption) a2asrv.RequestHandler {
 	if cfg.Agent == nil {
 		panic("agent is required")
@@ -15,6 +16,12 @@ func NewRequestHandler(cfg ExecutorConfig, options ...a2asrv.RequestHandlerOptio
 	return a2asrv.NewHandler(NewExecutor(cfg), options...)
 }
 
-func NewHTTPHandler(cfg ExecutorConfig, options ...a2asrv.RequestHandlerOption) http.Handler {
+// NewJSONRPCHandler creates an [http.Handler] which implements JSONRPC A2A protocol binding.
+func NewJSONRPCHandler(cfg ExecutorConfig, options ...a2asrv.RequestHandlerOption) http.Handler {
 	return a2asrv.NewJSONRPCHandler(NewRequestHandler(cfg, options...))
+}
+
+// NewRESTHandler creates an [http.Handler] which implements the HTTP+JSON A2A protocol binding.
+func NewJSONHTTPHandler(cfg ExecutorConfig, options ...a2asrv.RequestHandlerOption) http.Handler {
+	return a2asrv.NewRESTHandler(NewRequestHandler(cfg, options...))
 }

--- a/agent/hosting/aguihosting/agui.go
+++ b/agent/hosting/aguihosting/agui.go
@@ -23,7 +23,7 @@ type HandlerConfig struct {
 	Logger *slog.Logger
 }
 
-func NewHTTPHandler(cfg HandlerConfig) http.Handler {
+func NewJSONHTTPHandler(cfg HandlerConfig) http.Handler {
 	if cfg.Agent == nil {
 		panic("agent is required")
 	}

--- a/agent/hosting/aguihosting/agui_test.go
+++ b/agent/hosting/aguihosting/agui_test.go
@@ -25,7 +25,7 @@ func TestHandler_MethodNotAllowed(t *testing.T) {
 	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {}
 	})
-	h := aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a})
+	h := aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
@@ -40,7 +40,7 @@ func TestHandler_InvalidInput_ReturnsBadRequest(t *testing.T) {
 	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {}
 	})
-	h := aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a})
+	h := aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a})
 
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{not-json"))
 	rr := httptest.NewRecorder()
@@ -61,7 +61,7 @@ func TestHandler_StreamsSSEText(t *testing.T) {
 			}, nil)
 		}
 	})
-	h := aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a})
+	h := aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a})
 
 	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
@@ -93,7 +93,7 @@ func TestHandler_MixedToolInvocations_OnlyClientToolEmitted(t *testing.T) {
 			}, nil)
 		}
 	})
-	h := aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a})
+	h := aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a})
 
 	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}],"tools":[{"name":"client_tool","description":"client","parameters":{"type":"object"}}]}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
@@ -123,7 +123,7 @@ func TestHandler_StateSnapshotEmitsStateEvent(t *testing.T) {
 			}, nil)
 		}
 	})
-	h := aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a})
+	h := aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a})
 
 	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
@@ -157,7 +157,7 @@ func TestHandler_MixedToolInvocations_SuppressesServerToolResults(t *testing.T) 
 			}, nil)
 		}
 	})
-	h := aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a})
+	h := aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a})
 
 	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}],"tools":[{"name":"client_tool","description":"client","parameters":{"type":"object"}}]}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
@@ -186,7 +186,7 @@ func TestHandler_UnknownDataContent_UsesCurrentMessageLifecycle(t *testing.T) {
 			}, nil)
 		}
 	})
-	h := aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a})
+	h := aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a})
 
 	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))

--- a/examples/02-agents/agui/step01_getting_started/server/main.go
+++ b/examples/02-agents/agui/step01_getting_started/server/main.go
@@ -42,7 +42,7 @@ func main() {
 		},
 	)
 	mux := http.NewServeMux()
-	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
+	mux.Handle("/", aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 
 	log.Printf("AG-UI server listening on %s", ":8888")
 	if err := http.ListenAndServe(":8888", mux); err != nil {

--- a/examples/02-agents/agui/step02_backend_tools/server/main.go
+++ b/examples/02-agents/agui/step02_backend_tools/server/main.go
@@ -82,7 +82,7 @@ func main() {
 		},
 	)
 	mux := http.NewServeMux()
-	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
+	mux.Handle("/", aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 
 	log.Printf("AG-UI server listening on %s", ":8888")
 	if err := http.ListenAndServe(":8888", mux); err != nil {

--- a/examples/02-agents/agui/step03_frontend_tools/server/main.go
+++ b/examples/02-agents/agui/step03_frontend_tools/server/main.go
@@ -43,7 +43,7 @@ func main() {
 		},
 	)
 	mux := http.NewServeMux()
-	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
+	mux.Handle("/", aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 
 	log.Printf("AG-UI server listening on %s", ":8888")
 	if err := http.ListenAndServe(":8888", mux); err != nil {

--- a/examples/02-agents/agui/step04_human_in_loop/server/main.go
+++ b/examples/02-agents/agui/step04_human_in_loop/server/main.go
@@ -53,7 +53,7 @@ func main() {
 		},
 	)
 	mux := http.NewServeMux()
-	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
+	mux.Handle("/", aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 
 	log.Printf("AG-UI server listening on %s", ":8888")
 	if err := http.ListenAndServe(":8888", mux); err != nil {

--- a/examples/02-agents/agui/step05_state_management/server/main.go
+++ b/examples/02-agents/agui/step05_state_management/server/main.go
@@ -94,7 +94,7 @@ Then also provide a concise summary in one sentence.`,
 		},
 	)
 	mux := http.NewServeMux()
-	mux.Handle("/", aguihosting.NewHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
+	mux.Handle("/", aguihosting.NewJSONHTTPHandler(aguihosting.HandlerConfig{Agent: a}))
 
 	log.Printf("AG-UI server listening on %s", ":8888")
 	if err := http.ListenAndServe(":8888", mux); err != nil {

--- a/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
@@ -128,7 +128,7 @@ func main() {
 		a2a.NewAgentInterface(url, a2a.TransportProtocolJSONRPC),
 	}
 	mux := http.NewServeMux()
-	mux.Handle("/", a2ahosting.NewHTTPHandler(a2ahosting.ExecutorConfig{
+	mux.Handle("/", a2ahosting.NewJSONRPCHandler(a2ahosting.ExecutorConfig{
 		Agent: hostAgent,
 	}, a2asrv.WithExtendedAgentCard(card)))
 	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(card))


### PR DESCRIPTION
## Overview
Clarifies the protocol used by renaming the handler function.

## Changes
- Renamed NewHTTPHandler to NewJSONHTTPHandler for clarity
- The handler uses JSON over HTTP, not JSON-RPC protocol
- Updated all usages across agui.go, tests, and AGUI examples