### PR TITLE
Improve A2A continuation handling and examples

### DIFF
--- a/agent/hosting/a2ahosting/a2a_test.go
+++ b/agent/hosting/a2ahosting/a2a_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/hosting/a2ahosting"
 	"github.com/microsoft/agent-framework-go/message"
@@ -107,7 +109,378 @@ func TestRequestHandler_OnSendMessage_PreservesContextID(t *testing.T) {
 	}
 }
 
-func TestRequestHandler_OnSendMessageStream_UsesTaskLifecycle_WhenContinuationTokenPresent(t *testing.T) {
+func TestRequestHandler_OnSendMessageContinuation_UsesStoredTaskHistoryOnly(t *testing.T) {
+	var callCount int
+	var continuationInputs []string
+
+	a := newTestAgent(func(_ context.Context, messagesIn []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		callCount++
+		continuationInputs = agentMessageTexts(messagesIn)
+
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			if callCount != 1 {
+				yield(nil, assertErr("unexpected agent invocation"))
+				return
+			}
+			yield(&message.ResponseUpdate{
+				MessageID: "m-done",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.TextContent{Text: "done"}},
+			}, nil)
+		}
+	})
+
+	store := taskstore.NewInMemory(nil)
+	seededTask := &a2a.Task{
+		ID:        a2a.NewTaskID(),
+		ContextID: "ctx-1",
+		History: []*a2a.Message{
+			a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("original request")),
+			a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("working")),
+		},
+	}
+	if _, err := store.Create(context.Background(), seededTask); err != nil {
+		t.Fatalf("task store Create returned error: %v", err)
+	}
+
+	h := a2ahosting.NewRequestHandler(
+		a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true},
+		a2asrv.WithTaskStore(store),
+	)
+	storedTask, err := h.GetTask(context.Background(), &a2a.GetTaskRequest{ID: seededTask.ID})
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	continueMsg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("continue"))
+	continueMsg.TaskID = seededTask.ID
+
+	continued, err := h.SendMessage(context.Background(), &a2a.SendMessageRequest{Message: continueMsg})
+	if err != nil {
+		t.Fatalf("continuation SendMessage returned error: %v", err)
+	}
+	continuedTask, ok := continued.(*a2a.Task)
+	if !ok {
+		t.Fatalf("continuation result type = %T, want *a2a.Task", continued)
+	}
+	if continuedTask.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("task status = %q, want %q", continuedTask.Status.State, a2a.TaskStateCompleted)
+	}
+	if callCount != 1 {
+		t.Fatalf("agent call count = %d, want %d", callCount, 1)
+	}
+	expectedInputs := a2aMessageTexts(storedTask.History)
+	if len(continuationInputs) != len(expectedInputs) {
+		t.Fatalf("continuation input count = %d, want %d", len(continuationInputs), len(expectedInputs))
+	}
+	for i, got := range continuationInputs {
+		if got != expectedInputs[i] {
+			t.Fatalf("continuation input %d = %q, want %q", i, got, expectedInputs[i])
+		}
+	}
+	for _, got := range continuationInputs {
+		if got == "continue" {
+			t.Fatal("expected continuation request message to be excluded from continuation inputs")
+		}
+	}
+}
+
+func TestRequestHandler_OnSendStreamingMessageContinuation_UsesTaskUpdatePath(t *testing.T) {
+	var callCount int
+	var continuationInputs []string
+	var continuationStream bool
+
+	a := newTestAgent(func(_ context.Context, messagesIn []*message.Message, options ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		callCount++
+		continuationInputs = agentMessageTexts(messagesIn)
+		continuationStream, _ = agent.GetOption(options, agent.Stream)
+
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			if callCount != 1 {
+				yield(nil, assertErr("unexpected agent invocation"))
+				return
+			}
+			yield(&message.ResponseUpdate{
+				MessageID: "m-done",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.TextContent{Text: "done"}},
+			}, nil)
+		}
+	})
+
+	store := taskstore.NewInMemory(nil)
+	seededTask := &a2a.Task{
+		ID:        a2a.NewTaskID(),
+		ContextID: "ctx-1",
+		History: []*a2a.Message{
+			a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("original request")),
+			a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("working")),
+		},
+	}
+	if _, err := store.Create(context.Background(), seededTask); err != nil {
+		t.Fatalf("task store Create returned error: %v", err)
+	}
+
+	h := a2ahosting.NewRequestHandler(
+		a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true},
+		a2asrv.WithTaskStore(store),
+	)
+	storedTask, err := h.GetTask(context.Background(), &a2a.GetTaskRequest{ID: seededTask.ID})
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	continueMsg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("continue"))
+	continueMsg.TaskID = seededTask.ID
+
+	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{Message: continueMsg}))
+	if callCount != 1 {
+		t.Fatalf("agent call count = %d, want %d", callCount, 1)
+	}
+	if continuationStream {
+		t.Fatal("expected continuation request to use task update path without agent.Stream(true)")
+	}
+	expectedInputs := a2aMessageTexts(storedTask.History)
+	if len(continuationInputs) != len(expectedInputs) {
+		t.Fatalf("continuation input count = %d, want %d", len(continuationInputs), len(expectedInputs))
+	}
+	for i, got := range continuationInputs {
+		if got != expectedInputs[i] {
+			t.Fatalf("continuation input %d = %q, want %q", i, got, expectedInputs[i])
+		}
+	}
+	for _, got := range continuationInputs {
+		if got == "continue" {
+			t.Fatal("expected continuation request message to be excluded from continuation inputs")
+		}
+	}
+	if len(collectStreamingTasks(events)) != 0 {
+		t.Fatalf("task event count = %d, want 0", len(collectStreamingTasks(events)))
+	}
+	statuses := collectStreamingStatuses(events)
+	if len(statuses) != 1 {
+		t.Fatalf("status event count = %d, want 1", len(statuses))
+	}
+	if statuses[0].Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("status = %q, want %q", statuses[0].Status.State, a2a.TaskStateCompleted)
+	}
+	if len(collectStreamingArtifacts(events)) != 1 {
+		t.Fatalf("artifact event count = %d, want 1", len(collectStreamingArtifacts(events)))
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_UsesTaskLifecycleAndArtifacts(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		stream, _ := agent.GetOption(options, agent.Stream)
+		if !stream {
+			return func(yield func(*message.ResponseUpdate, error) bool) {
+				yield(nil, assertErr("expected Stream=true"))
+			}
+		}
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			if !yield(&message.ResponseUpdate{
+				ResponseID: "r1",
+				Role:       message.RoleAssistant,
+				Contents:   message.Contents{&message.TextContent{Text: "chunk 1"}},
+			}, nil) {
+				return
+			}
+			yield(&message.ResponseUpdate{
+				ResponseID: "r2",
+				Role:       message.RoleAssistant,
+				Contents:   message.Contents{&message.TextContent{Text: "chunk 2"}},
+			}, nil)
+		}
+	})
+
+	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
+	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	}))
+
+	if len(collectStreamingTasks(events)) != 1 {
+		t.Fatalf("task event count = %d, want 1", len(collectStreamingTasks(events)))
+	}
+	statuses := collectStreamingStatuses(events)
+	if len(statuses) != 3 {
+		t.Fatalf("status event count = %d, want 3", len(statuses))
+	}
+	if statuses[0].Status.State != a2a.TaskStateSubmitted || statuses[1].Status.State != a2a.TaskStateWorking || statuses[2].Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("unexpected status sequence: %q, %q, %q", statuses[0].Status.State, statuses[1].Status.State, statuses[2].Status.State)
+	}
+	artifacts := collectStreamingArtifacts(events)
+	if len(artifacts) != 2 {
+		t.Fatalf("artifact event count = %d, want 2", len(artifacts))
+	}
+	if got := a2aArtifactText(artifacts[0]); got != "chunk 1" {
+		t.Fatalf("first streamed artifact text = %q, want %q", got, "chunk 1")
+	}
+	if got := a2aArtifactText(artifacts[1]); got != "chunk 2" {
+		t.Fatalf("second streamed artifact text = %q, want %q", got, "chunk 2")
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_UsesProvidedContextID(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				ResponseID: "r1",
+				Role:       message.RoleAssistant,
+				Contents:   message.Contents{&message.TextContent{Text: "reply"}},
+			}, nil)
+		}
+	})
+
+	req := &a2a.SendMessageRequest{Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping"))}
+	req.Message.ContextID = "ctx-stream"
+
+	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
+	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), req))
+
+	if len(events) == 0 {
+		t.Fatal("expected streamed events")
+	}
+	for _, task := range collectStreamingTasks(events) {
+		if task.ContextID != "ctx-stream" {
+			t.Fatalf("task context id = %q, want %q", task.ContextID, "ctx-stream")
+		}
+	}
+	for _, status := range collectStreamingStatuses(events) {
+		if status.ContextID != "ctx-stream" {
+			t.Fatalf("status context id = %q, want %q", status.ContextID, "ctx-stream")
+		}
+	}
+	for _, artifact := range collectStreamingArtifacts(events) {
+		if artifact.ContextID != "ctx-stream" {
+			t.Fatalf("artifact context id = %q, want %q", artifact.ContextID, "ctx-stream")
+		}
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_GeneratesContextIDWhenMissing(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				ResponseID: "r1",
+				Role:       message.RoleAssistant,
+				Contents:   message.Contents{&message.TextContent{Text: "reply"}},
+			}, nil)
+		}
+	})
+
+	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
+	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	}))
+
+	tasks := collectStreamingTasks(events)
+	if len(tasks) != 1 {
+		t.Fatalf("task event count = %d, want 1", len(tasks))
+	}
+	if tasks[0].ContextID == "" {
+		t.Fatal("expected generated context id")
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_WhenMessageIsNil_ReturnsError(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(func(*message.ResponseUpdate, error) bool) {}
+	})
+
+	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
+	var gotErr error
+	for evt, err := range h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{}) {
+		if evt != nil {
+			t.Fatalf("unexpected event: %#v", evt)
+		}
+		gotErr = err
+	}
+	if gotErr == nil {
+		t.Fatal("expected error")
+	}
+	if gotErr.Error() != "message is required: invalid params" {
+		t.Fatalf("error = %v, want %q", gotErr, "message is required: invalid params")
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_WithResponseAdditionalProperties_SetsArtifactMetadata(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				ResponseID: "r1",
+				Role:       message.RoleAssistant,
+				Contents:   message.Contents{&message.TextContent{Text: "reply"}},
+				AdditionalProperties: map[string]any{
+					"streamKey": "streamValue",
+					"count":     2,
+				},
+			}, nil)
+		}
+	})
+
+	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
+	artifacts := collectStreamingArtifacts(collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	})))
+
+	if len(artifacts) != 1 {
+		t.Fatalf("artifact event count = %d, want 1", len(artifacts))
+	}
+	if got := artifacts[0].Metadata["streamKey"]; got != "streamValue" {
+		t.Fatalf("metadata streamKey = %v, want %q", got, "streamValue")
+	}
+	if got := artifacts[0].Metadata["count"]; got != 2 {
+		t.Fatalf("metadata count = %v, want %d", got, 2)
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_WithNilAdditionalProperties_LeavesArtifactMetadataNil(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(yield func(*message.ResponseUpdate, error) bool) {
+			yield(&message.ResponseUpdate{
+				ResponseID: "r1",
+				Role:       message.RoleAssistant,
+				Contents:   message.Contents{&message.TextContent{Text: "reply"}},
+			}, nil)
+		}
+	})
+
+	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
+	artifacts := collectStreamingArtifacts(collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	})))
+
+	if len(artifacts) != 1 {
+		t.Fatalf("artifact event count = %d, want 1", len(artifacts))
+	}
+	if artifacts[0].Metadata != nil {
+		t.Fatalf("expected nil metadata, got %#v", artifacts[0].Metadata)
+	}
+}
+func TestRequestHandler_OnSendMessageStream_WhenAgentYieldsNoUpdates_ReturnsLifecycleOnly(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+		return func(func(*message.ResponseUpdate, error) bool) {}
+	})
+
+	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a})
+	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	}))
+
+	if len(collectStreamingTasks(events)) != 1 {
+		t.Fatalf("task event count = %d, want 1", len(collectStreamingTasks(events)))
+	}
+	statuses := collectStreamingStatuses(events)
+	if len(statuses) != 2 {
+		t.Fatalf("status event count = %d, want 2", len(statuses))
+	}
+	if statuses[0].Status.State != a2a.TaskStateSubmitted || statuses[1].Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("unexpected status sequence: %q, %q", statuses[0].Status.State, statuses[1].Status.State)
+	}
+	if len(collectStreamingArtifacts(events)) != 0 {
+		t.Fatalf("artifact event count = %d, want 0", len(collectStreamingArtifacts(events)))
+	}
+}
+
+func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
 	a := newTestAgent(func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
 		allowBackground, _ := agent.GetOption(options, agent.AllowBackgroundResponses)
 		if !allowBackground {
@@ -115,87 +488,6 @@ func TestRequestHandler_OnSendMessageStream_UsesTaskLifecycle_WhenContinuationTo
 				yield(nil, assertErr("expected AllowBackgroundResponses=true"))
 			}
 		}
-		return func(yield func(*message.ResponseUpdate, error) bool) {
-			yield(&message.ResponseUpdate{
-				MessageID:         "m2",
-				Role:              message.RoleAssistant,
-				Contents:          message.Contents{&message.TextContent{Text: "working"}},
-				ContinuationToken: "token-123",
-			}, nil)
-		}
-	})
-
-	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true})
-	stream := h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
-		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
-	})
-
-	var submitted, working bool
-	for evt, err := range stream {
-		if err != nil {
-			t.Fatalf("stream returned error: %v", err)
-		}
-		status, ok := evt.(*a2a.TaskStatusUpdateEvent)
-		if !ok {
-			continue
-		}
-		switch status.Status.State {
-		case a2a.TaskStateSubmitted:
-			submitted = true
-		case a2a.TaskStateWorking:
-			working = true
-			if got := status.Metadata["__a2a__continuationToken"]; got != "token-123" {
-				t.Fatalf("continuation token metadata = %v, want %q", got, "token-123")
-			}
-			break
-		}
-		if working {
-			break
-		}
-	}
-
-	if !submitted {
-		t.Fatal("expected submitted status update")
-	}
-	if !working {
-		t.Fatal("expected working status update")
-	}
-}
-
-func TestRequestHandler_OnSendMessageStream_WhenContinuationTokenAndNoMessages_StatusMessageIsNil(t *testing.T) {
-	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
-		return func(yield func(*message.ResponseUpdate, error) bool) {
-			yield(&message.ResponseUpdate{ContinuationToken: "token-no-msg"}, nil)
-		}
-	})
-
-	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true})
-	stream := h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
-		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
-	})
-
-	var working *a2a.TaskStatusUpdateEvent
-	for evt, err := range stream {
-		if err != nil {
-			t.Fatalf("stream returned error: %v", err)
-		}
-		status, ok := evt.(*a2a.TaskStatusUpdateEvent)
-		if !ok || status.Status.State != a2a.TaskStateWorking {
-			continue
-		}
-		working = status
-		break
-	}
-	if working == nil {
-		t.Fatal("expected working status event")
-	}
-	if working.Status.Message != nil && len(working.Status.Message.Parts) > 0 {
-		t.Fatalf("expected nil or empty working status message, got %#v", working.Status.Message)
-	}
-}
-
-func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
-	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(yield func(*message.ResponseUpdate, error) bool) {
 			yield(&message.ResponseUpdate{
 				MessageID:         "m-cancel",
@@ -207,27 +499,19 @@ func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
 	})
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true})
 
-	stream := h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
 		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi")),
-	})
-
-	var taskID a2a.TaskID
-	for evt, err := range stream {
-		if err != nil {
-			t.Fatalf("OnSendMessageStream returned error: %v", err)
-		}
-		status, ok := evt.(*a2a.TaskStatusUpdateEvent)
-		if !ok {
-			continue
-		}
-		taskID = status.TaskID
-		break
+	}))
+	tasks := collectStreamingTasks(events)
+	if len(tasks) != 1 {
+		t.Fatalf("task event count = %d, want 1", len(tasks))
 	}
-	if taskID == "" {
+	task := tasks[0]
+	if task.ID == "" {
 		t.Fatal("expected task id")
 	}
 
-	canceled, err := h.CancelTask(context.Background(), &a2a.CancelTaskRequest{ID: taskID})
+	canceled, err := h.CancelTask(context.Background(), &a2a.CancelTaskRequest{ID: task.ID})
 	if err != nil {
 		t.Fatalf("OnCancelTask returned error: %v", err)
 	}
@@ -239,3 +523,117 @@ func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
+
+func collectStreamingMessages(t *testing.T, stream iter.Seq2[a2a.Event, error]) []*a2a.Message {
+	t.Helper()
+
+	var messages []*a2a.Message
+	for evt, err := range stream {
+		if err != nil {
+			t.Fatalf("stream returned error: %v", err)
+		}
+		msg, ok := evt.(*a2a.Message)
+		if !ok {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+func collectStreamingEvents(t *testing.T, stream iter.Seq2[a2a.Event, error]) []a2a.Event {
+	t.Helper()
+
+	var events []a2a.Event
+	for evt, err := range stream {
+		if err != nil {
+			t.Fatalf("stream returned error: %v", err)
+		}
+		if evt == nil {
+			continue
+		}
+		events = append(events, evt)
+	}
+	return events
+}
+
+func collectStreamingArtifacts(events []a2a.Event) []*a2a.TaskArtifactUpdateEvent {
+	artifacts := make([]*a2a.TaskArtifactUpdateEvent, 0)
+	for _, evt := range events {
+		artifact, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+		if ok {
+			artifacts = append(artifacts, artifact)
+		}
+	}
+	return artifacts
+}
+
+func collectStreamingStatuses(events []a2a.Event) []*a2a.TaskStatusUpdateEvent {
+	statuses := make([]*a2a.TaskStatusUpdateEvent, 0)
+	for _, evt := range events {
+		status, ok := evt.(*a2a.TaskStatusUpdateEvent)
+		if ok {
+			statuses = append(statuses, status)
+		}
+	}
+	return statuses
+}
+
+func collectStreamingTasks(events []a2a.Event) []*a2a.Task {
+	tasks := make([]*a2a.Task, 0)
+	for _, evt := range events {
+		task, ok := evt.(*a2a.Task)
+		if ok {
+			tasks = append(tasks, task)
+		}
+	}
+	return tasks
+}
+
+func agentMessageTexts(messages []*message.Message) []string {
+	texts := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		if msg == nil {
+			texts = append(texts, "")
+			continue
+		}
+		texts = append(texts, msg.String())
+	}
+	return texts
+}
+
+func a2aMessageTexts(messages []*a2a.Message) []string {
+	texts := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		texts = append(texts, a2aMessageText(msg))
+	}
+	return texts
+}
+
+func a2aMessageText(msg *a2a.Message) string {
+	if msg == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range msg.Parts {
+		if part == nil {
+			continue
+		}
+		sb.WriteString(part.Text())
+	}
+	return sb.String()
+}
+
+func a2aArtifactText(evt *a2a.TaskArtifactUpdateEvent) string {
+	if evt == nil || evt.Artifact == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range evt.Artifact.Parts {
+		if part == nil {
+			continue
+		}
+		sb.WriteString(part.Text())
+	}
+	return sb.String()
+}

--- a/agent/hosting/a2ahosting/a2a_test.go
+++ b/agent/hosting/a2ahosting/a2a_test.go
@@ -499,14 +499,9 @@ func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
 	})
 	h := a2ahosting.NewRequestHandler(a2ahosting.ExecutorConfig{Agent: a, AllowBackgroundResponses: true})
 
-	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+	task := collectFirstStreamingTask(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
 		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi")),
 	}))
-	tasks := collectStreamingTasks(events)
-	if len(tasks) != 1 {
-		t.Fatalf("task event count = %d, want 1", len(tasks))
-	}
-	task := tasks[0]
 	if task.ID == "" {
 		t.Fatal("expected task id")
 	}
@@ -539,6 +534,22 @@ func collectStreamingMessages(t *testing.T, stream iter.Seq2[a2a.Event, error]) 
 		messages = append(messages, msg)
 	}
 	return messages
+}
+
+func collectFirstStreamingTask(t *testing.T, stream iter.Seq2[a2a.Event, error]) *a2a.Task {
+	t.Helper()
+
+	for evt, err := range stream {
+		if err != nil {
+			t.Fatalf("stream returned error: %v", err)
+		}
+		task, ok := evt.(*a2a.Task)
+		if ok {
+			return task
+		}
+	}
+	t.Fatal("expected task event")
+	return nil
 }
 
 func collectStreamingEvents(t *testing.T, stream iter.Seq2[a2a.Event, error]) []a2a.Event {

--- a/agent/hosting/a2ahosting/convert.go
+++ b/agent/hosting/a2ahosting/convert.go
@@ -119,7 +119,7 @@ func responseUpdateToMessage(infoProvider a2a.TaskInfoProvider, update *message.
 	}
 	out.Parts = parts
 	out.Metadata = maps.Clone(update.AdditionalProperties)
-	out.ID = cmp.Or(update.ResponseID, update.MessageID, out.ID)
+	out.ID = cmp.Or(update.MessageID, update.ResponseID, out.ID)
 	return out, nil
 }
 

--- a/agent/hosting/a2ahosting/convert.go
+++ b/agent/hosting/a2ahosting/convert.go
@@ -107,6 +107,75 @@ func responseToMessage(infoProvider a2a.TaskInfoProvider, resp *message.Response
 	return out, nil
 }
 
+func responseUpdateToMessage(infoProvider a2a.TaskInfoProvider, update *message.ResponseUpdate) (*a2a.Message, error) {
+	out := a2a.NewMessageForTask(a2a.MessageRoleAgent, infoProvider)
+	if update == nil {
+		return out, nil
+	}
+
+	parts, err := contentsToParts(update.Contents)
+	if err != nil {
+		return nil, err
+	}
+	out.Parts = parts
+	out.Metadata = maps.Clone(update.AdditionalProperties)
+	out.ID = cmp.Or(update.ResponseID, update.MessageID, out.ID)
+	return out, nil
+}
+
+func responseUpdateToWorkingStatusEvent(infoProvider a2a.TaskInfoProvider, update *message.ResponseUpdate) (*a2a.TaskStatusUpdateEvent, error) {
+	var progressMessage *a2a.Message
+	var err error
+	if update != nil && len(update.Contents) > 0 {
+		progressMessage, err = responseUpdateToMessage(infoProvider, update)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	working := a2a.NewStatusUpdateEvent(infoProvider, a2a.TaskStateWorking, progressMessage)
+	if update != nil {
+		working.Metadata = maps.Clone(update.AdditionalProperties)
+		if update.ContinuationToken != "" {
+			if working.Metadata == nil {
+				working.Metadata = map[string]any{}
+			}
+			working.Metadata[continuationTokenMetadataKey] = update.ContinuationToken
+		}
+	}
+	return working, nil
+}
+
+func responseUpdateToArtifactEvent(infoProvider a2a.TaskInfoProvider, artifactID a2a.ArtifactID, update *message.ResponseUpdate) (*a2a.TaskArtifactUpdateEvent, a2a.ArtifactID, error) {
+	if update == nil {
+		return nil, artifactID, nil
+	}
+
+	parts, err := contentsToParts(update.Contents)
+	if err != nil {
+		return nil, artifactID, err
+	}
+	if len(parts) == 0 {
+		return nil, artifactID, nil
+	}
+
+	nextArtifactID := artifactID
+	stableID := cmp.Or(update.ResponseID, update.MessageID)
+	if stableID != "" {
+		nextArtifactID = a2a.ArtifactID(stableID)
+	}
+	if nextArtifactID == "" {
+		nextArtifactID = a2a.NewArtifactID()
+	}
+
+	evt := a2a.NewArtifactEvent(infoProvider, parts...)
+	evt.Artifact.ID = nextArtifactID
+	evt.Append = artifactID != "" && artifactID == nextArtifactID
+	evt.LastChunk = false
+	evt.Metadata = maps.Clone(update.AdditionalProperties)
+	return evt, nextArtifactID, nil
+}
+
 func responseToArtifactEvent(infoProvider a2a.TaskInfoProvider, resp *message.Response) (*a2a.TaskArtifactUpdateEvent, error) {
 	parts := make(a2a.ContentParts, 0)
 	if resp != nil {

--- a/agent/hosting/a2ahosting/convert_test.go
+++ b/agent/hosting/a2ahosting/convert_test.go
@@ -61,6 +61,22 @@ func TestResponseToMessage_NilResponse_ReturnsAgentMessage(t *testing.T) {
 	}
 }
 
+func TestResponseToMessage_WithEmptyAdditionalProperties_PreservesEmptyMetadataMap(t *testing.T) {
+	got, err := responseToMessage(testTaskInfoProvider{}, &message.Response{
+		AdditionalProperties: map[string]any{},
+		Messages:             []*message.Message{{Role: message.RoleAssistant, Contents: message.Contents{&message.TextContent{Text: "chunk"}}}},
+	})
+	if err != nil {
+		t.Fatalf("responseToMessage returned error: %v", err)
+	}
+	if got.Metadata == nil {
+		t.Fatal("expected non-nil metadata map")
+	}
+	if len(got.Metadata) != 0 {
+		t.Fatalf("expected empty metadata map, got %#v", got.Metadata)
+	}
+}
+
 func TestContentsToParts_JSONDataContent_MapsToDataPart(t *testing.T) {
 	payload := map[string]any{"ok": true}
 	bytes, _ := json.Marshal(payload)
@@ -92,5 +108,76 @@ func TestResponseToArtifactEvent_NilResponse_ReturnsArtifactEvent(t *testing.T) 
 	}
 	if evt.TaskID != "task-1" || evt.ContextID != "ctx-1" {
 		t.Fatalf("unexpected task info in artifact event: task=%q context=%q", evt.TaskID, evt.ContextID)
+	}
+}
+
+func TestResponseUpdateToMessage_UsesResponseIDWhenMessageIDMissing(t *testing.T) {
+	got, err := responseUpdateToMessage(testTaskInfoProvider{}, &message.ResponseUpdate{
+		ResponseID: "resp-99",
+		Role:       message.RoleAssistant,
+		Contents:   message.Contents{&message.TextContent{Text: "chunk"}},
+	})
+	if err != nil {
+		t.Fatalf("responseUpdateToMessage returned error: %v", err)
+	}
+	if got.ID != "resp-99" {
+		t.Fatalf("id = %q, want %q", got.ID, "resp-99")
+	}
+	if got.TaskID != "task-1" || got.ContextID != "ctx-1" {
+		t.Fatalf("unexpected task info in message: task=%q context=%q", got.TaskID, got.ContextID)
+	}
+}
+
+func TestResponseUpdateToWorkingStatusEvent_WithContinuationToken_CopiesMetadata(t *testing.T) {
+	got, err := responseUpdateToWorkingStatusEvent(testTaskInfoProvider{}, &message.ResponseUpdate{
+		ResponseID:        "resp-1",
+		ContinuationToken: "token-123",
+		Contents:          message.Contents{&message.TextContent{Text: "working"}},
+		AdditionalProperties: map[string]any{
+			"count": 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("responseUpdateToWorkingStatusEvent returned error: %v", err)
+	}
+	if got.Status.State != a2a.TaskStateWorking {
+		t.Fatalf("state = %q, want %q", got.Status.State, a2a.TaskStateWorking)
+	}
+	if got.Metadata[continuationTokenMetadataKey] != "token-123" {
+		t.Fatalf("continuation token = %v, want %q", got.Metadata[continuationTokenMetadataKey], "token-123")
+	}
+	if got.Metadata["count"] != 2 {
+		t.Fatalf("metadata count = %v, want %d", got.Metadata["count"], 2)
+	}
+	if got.Status.Message == nil || got.Status.Message.ID != "resp-1" {
+		t.Fatalf("status message = %#v, want response ID %q", got.Status.Message, "resp-1")
+	}
+}
+
+func TestResponseUpdateToArtifactEvent_UsesResponseIDAndCopiesMetadata(t *testing.T) {
+	got, artifactID, err := responseUpdateToArtifactEvent(testTaskInfoProvider{}, "", &message.ResponseUpdate{
+		ResponseID: "resp-42",
+		Contents:   message.Contents{&message.TextContent{Text: "chunk"}},
+		AdditionalProperties: map[string]any{
+			"streamKey": "streamValue",
+		},
+	})
+	if err != nil {
+		t.Fatalf("responseUpdateToArtifactEvent returned error: %v", err)
+	}
+	if artifactID != "resp-42" {
+		t.Fatalf("artifact id = %q, want %q", artifactID, "resp-42")
+	}
+	if got == nil || got.Artifact == nil {
+		t.Fatalf("expected non-nil artifact event, got %#v", got)
+	}
+	if got.Artifact.ID != "resp-42" {
+		t.Fatalf("artifact event id = %q, want %q", got.Artifact.ID, "resp-42")
+	}
+	if got.Metadata["streamKey"] != "streamValue" {
+		t.Fatalf("metadata streamKey = %v, want %q", got.Metadata["streamKey"], "streamValue")
+	}
+	if got.LastChunk {
+		t.Fatalf("lastChunk = %v, want false", got.LastChunk)
 	}
 }

--- a/agent/hosting/a2ahosting/convert_test.go
+++ b/agent/hosting/a2ahosting/convert_test.go
@@ -128,6 +128,21 @@ func TestResponseUpdateToMessage_UsesResponseIDWhenMessageIDMissing(t *testing.T
 	}
 }
 
+func TestResponseUpdateToMessage_PrefersMessageIDOverResponseID(t *testing.T) {
+	got, err := responseUpdateToMessage(testTaskInfoProvider{}, &message.ResponseUpdate{
+		MessageID:  "msg-7",
+		ResponseID: "resp-7",
+		Role:       message.RoleAssistant,
+		Contents:   message.Contents{&message.TextContent{Text: "chunk"}},
+	})
+	if err != nil {
+		t.Fatalf("responseUpdateToMessage returned error: %v", err)
+	}
+	if got.ID != "msg-7" {
+		t.Fatalf("id = %q, want %q", got.ID, "msg-7")
+	}
+}
+
 func TestResponseUpdateToWorkingStatusEvent_WithContinuationToken_CopiesMetadata(t *testing.T) {
 	got, err := responseUpdateToWorkingStatusEvent(testTaskInfoProvider{}, &message.ResponseUpdate{
 		ResponseID:        "resp-1",

--- a/agent/hosting/a2ahosting/executor.go
+++ b/agent/hosting/a2ahosting/executor.go
@@ -15,9 +15,14 @@ import (
 
 const continuationTokenMetadataKey = "__a2a__continuationToken"
 
+// ExecutorConfig defines the configuration for [NewExecutor].
 type ExecutorConfig struct {
-	Agent                    *agent.Agent
+	// The hosted agent that provides the execution logic.
+	Agent *agent.Agent
+
+	// Whether the executor should allow background responses from the agent.
 	AllowBackgroundResponses bool
+
 	// AllowBackgroundResponsesWhen is a callback that determines on a per-message basis whether background responses should be allowed.
 	// If both AllowBackgroundResponses and AllowBackgroundResponsesWhen are set, the callback takes precedence.
 	AllowBackgroundResponsesWhen func(context.Context, *a2asrv.ExecutorContext) (bool, error)
@@ -27,6 +32,7 @@ type executor struct {
 	cfg ExecutorConfig
 }
 
+// NewExecutor creates a new [a2asrv.AgentExecutor] using the provided configuration.
 func NewExecutor(cfg ExecutorConfig) a2asrv.AgentExecutor {
 	return &executor{cfg: cfg}
 }
@@ -42,89 +48,150 @@ func (e *executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 			return
 		}
 
-		allowBackground, err := e.shouldRunInBackground(ctx, execCtx)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		messagesIn, err := e.buildMessages(execCtx)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		session, err := e.cfg.Agent.CreateSession(ctx, agent.WithServiceID(execCtx.ContextID))
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		runOptions := []agent.Option{
-			agent.WithSession(session),
-			agent.AllowBackgroundResponses(allowBackground),
-		}
-
-		resp, runErr := e.cfg.Agent.Run(ctx, messagesIn, runOptions...).Collect()
-		if runErr != nil {
-			if execCtx.StoredTask != nil {
-				statusMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(runErr.Error()))
-				yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed, statusMsg), nil)
-				return
-			}
-			yield(nil, runErr)
-			return
-		}
-
-		if execCtx.StoredTask == nil && resp.ContinuationToken == "" {
-			msg, err := responseToMessage(execCtx, resp)
-			if err != nil {
+		if execCtx.StoredTask != nil {
+			if err := e.executeTaskUpdate(ctx, execCtx, yield); err != nil {
 				yield(nil, err)
-				return
 			}
-			yield(msg, nil)
 			return
 		}
 
-		if execCtx.StoredTask == nil {
-			if !yield(a2a.NewSubmittedTask(execCtx, execCtx.Message), nil) {
-				return
+		if e.isStreamingRequest(ctx) {
+			if err := e.executeNewMessageStreaming(ctx, execCtx, yield); err != nil {
+				yield(nil, err)
 			}
-			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateSubmitted, nil), nil) {
-				return
-			}
-		}
-
-		if resp.ContinuationToken != "" {
-			var progressMessage *a2a.Message
-			if len(resp.Messages) > 0 {
-				progressMessage, err = responseToMessage(execCtx, resp)
-				if err != nil {
-					yield(nil, err)
-					return
-				}
-			}
-
-			working := a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, progressMessage)
-			if working.Metadata == nil {
-				working.Metadata = map[string]any{}
-			}
-			working.Metadata[continuationTokenMetadataKey] = resp.ContinuationToken
-			yield(working, nil)
 			return
 		}
 
-		artifact, err := responseToArtifactEvent(execCtx, resp)
-		if err != nil {
+		if err := e.executeNewMessage(ctx, execCtx, yield); err != nil {
 			yield(nil, err)
-			return
 		}
-		if !yield(artifact, nil) {
-			return
+	}
+}
+
+func (e *executor) executeNewMessage(ctx context.Context, execCtx *a2asrv.ExecutorContext, yield func(a2a.Event, error) bool) error {
+	messagesIn, err := buildNewMessageInputs(execCtx.Message)
+	if err != nil {
+		return err
+	}
+
+	resp, err := e.runResponse(ctx, execCtx, messagesIn)
+	if err != nil {
+		return err
+	}
+
+	if resp.ContinuationToken == "" {
+		msg, err := responseToMessage(execCtx, resp)
+		if err != nil {
+			return err
+		}
+		yield(msg, nil)
+		return nil
+	}
+
+	if !yield(a2a.NewSubmittedTask(execCtx, execCtx.Message), nil) {
+		return nil
+	}
+	if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateSubmitted, nil), nil) {
+		return nil
+	}
+
+	return yieldWorkingStatusFromResponse(execCtx, resp, yield)
+}
+
+func (e *executor) executeTaskUpdate(ctx context.Context, execCtx *a2asrv.ExecutorContext, yield func(a2a.Event, error) bool) error {
+	messagesIn, err := buildTaskUpdateInputs(execCtx)
+	if err != nil {
+		return err
+	}
+
+	resp, runErr := e.runResponse(ctx, execCtx, messagesIn)
+	if runErr != nil {
+		statusMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(runErr.Error()))
+		yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed, statusMsg), nil)
+		return nil
+	}
+
+	if resp.ContinuationToken != "" {
+		return yieldWorkingStatusFromResponse(execCtx, resp, yield)
+	}
+
+	artifact, err := responseToArtifactEvent(execCtx, resp)
+	if err != nil {
+		return err
+	}
+	if !yield(artifact, nil) {
+		return nil
+	}
+
+	yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil), nil)
+	return nil
+}
+
+func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2asrv.ExecutorContext, yield func(a2a.Event, error) bool) error {
+	messagesIn, err := buildNewMessageInputs(execCtx.Message)
+	if err != nil {
+		return err
+	}
+
+	runOptions, err := e.newRunOptions(ctx, execCtx, true)
+	if err != nil {
+		return err
+	}
+
+	if !yield(a2a.NewSubmittedTask(execCtx, execCtx.Message), nil) {
+		return nil
+	}
+	if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateSubmitted, nil), nil) {
+		return nil
+	}
+
+	var artifactID a2a.ArtifactID
+	var yieldedWorking bool
+	for update, runErr := range e.cfg.Agent.Run(ctx, messagesIn, runOptions...) {
+		if runErr != nil {
+			statusMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(runErr.Error()))
+			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed, statusMsg), nil) {
+				return nil
+			}
+			return nil
+		}
+		if update == nil {
+			continue
+		}
+		if update.ContinuationToken != "" {
+			working, err := responseUpdateToWorkingStatusEvent(execCtx, update)
+			if err != nil {
+				return err
+			}
+			if !yield(working, nil) {
+				return nil
+			}
+			return nil
 		}
 
-		yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil), nil)
+		artifact, nextArtifactID, err := responseUpdateToArtifactEvent(execCtx, artifactID, update)
+		if err != nil {
+			return err
+		}
+		if artifact == nil {
+			continue
+		}
+		if !yieldedWorking {
+			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
+				return nil
+			}
+			yieldedWorking = true
+		}
+		artifactID = nextArtifactID
+		if !yield(artifact, nil) {
+			return nil
+		}
 	}
+
+	if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil), nil) {
+		return nil
+	}
+	return nil
 }
 
 func (e *executor) Cancel(_ context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
@@ -137,30 +204,90 @@ func (e *executor) Cancel(_ context.Context, execCtx *a2asrv.ExecutorContext) it
 	}
 }
 
-func (e *executor) buildMessages(execCtx *a2asrv.ExecutorContext) ([]*message.Message, error) {
-	messages := make([]*message.Message, 0, 1)
-
-	if execCtx != nil && execCtx.StoredTask != nil && len(execCtx.StoredTask.History) > 0 {
-		for _, m := range execCtx.StoredTask.History {
-			msg, err := toAgentMessage(m)
-			if err != nil {
-				return nil, err
-			}
-			if msg != nil {
-				messages = append(messages, msg)
-			}
-		}
-	}
-
-	incoming, err := toAgentMessage(execCtx.Message)
+func buildNewMessageInputs(in *a2a.Message) ([]*message.Message, error) {
+	incoming, err := toAgentMessage(in)
 	if err != nil {
 		return nil, err
 	}
-	if incoming != nil {
-		messages = append(messages, incoming)
+	if incoming == nil {
+		return nil, nil
+	}
+	return []*message.Message{incoming}, nil
+}
+
+func buildTaskUpdateInputs(execCtx *a2asrv.ExecutorContext) ([]*message.Message, error) {
+	messages := make([]*message.Message, 0, 1)
+	if len(execCtx.StoredTask.History) == 0 {
+		return messages, nil
+	}
+
+	for _, m := range execCtx.StoredTask.History {
+		if execCtx.Message != nil && m != nil && m.ID == execCtx.Message.ID {
+			continue
+		}
+		msg, err := toAgentMessage(m)
+		if err != nil {
+			return nil, err
+		}
+		if msg != nil {
+			messages = append(messages, msg)
+		}
 	}
 
 	return messages, nil
+}
+
+func yieldWorkingStatusFromResponse(execCtx *a2asrv.ExecutorContext, resp *message.Response, yield func(a2a.Event, error) bool) error {
+	var progressMessage *a2a.Message
+	var err error
+	if len(resp.Messages) > 0 {
+		progressMessage, err = responseToMessage(execCtx, resp)
+		if err != nil {
+			return err
+		}
+	}
+
+	working := a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, progressMessage)
+	if working.Metadata == nil {
+		working.Metadata = map[string]any{}
+	}
+	working.Metadata[continuationTokenMetadataKey] = resp.ContinuationToken
+	yield(working, nil)
+	return nil
+}
+
+func (e *executor) runResponse(ctx context.Context, execCtx *a2asrv.ExecutorContext, messagesIn []*message.Message) (*message.Response, error) {
+	runOptions, err := e.newRunOptions(ctx, execCtx, false)
+	if err != nil {
+		return nil, err
+	}
+	return e.cfg.Agent.Run(ctx, messagesIn, runOptions...).Collect()
+}
+
+func (e *executor) newRunOptions(ctx context.Context, execCtx *a2asrv.ExecutorContext, stream bool) ([]agent.Option, error) {
+	allowBackground, err := e.shouldRunInBackground(ctx, execCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := e.cfg.Agent.CreateSession(ctx, agent.WithServiceID(execCtx.ContextID))
+	if err != nil {
+		return nil, err
+	}
+
+	runOptions := []agent.Option{
+		agent.WithSession(session),
+		agent.AllowBackgroundResponses(allowBackground),
+	}
+	if stream {
+		runOptions = append(runOptions, agent.Stream(true))
+	}
+	return runOptions, nil
+}
+
+func (e *executor) isStreamingRequest(ctx context.Context) bool {
+	callCtx, ok := a2asrv.CallContextFrom(ctx)
+	return ok && callCtx.Method() == "SendStreamingMessage"
 }
 
 func (e *executor) shouldRunInBackground(ctx context.Context, decisionContext *a2asrv.ExecutorContext) (bool, error) {

--- a/agent/hosting/a2ahosting/executor.go
+++ b/agent/hosting/a2ahosting/executor.go
@@ -4,7 +4,7 @@ package a2ahosting
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"iter"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -40,11 +40,14 @@ func NewExecutor(cfg ExecutorConfig) a2asrv.AgentExecutor {
 func (e *executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
 		if execCtx == nil || execCtx.Message == nil {
-			yield(nil, fmt.Errorf("request message is required"))
+			yield(nil, errors.New("request message is required"))
 			return
 		}
 		if len(execCtx.Message.ReferenceTasks) > 0 {
-			yield(nil, fmt.Errorf("referenceTaskIds are not supported"))
+			// An agent does not support resuming from arbitrary prior tasks.
+			// Return an error explicitly so the client gets a clear error rather than a response
+			// that silently ignores the referenced task context.
+			yield(nil, errors.New("referenceTaskIds is not supported, an agent cannot resume from arbitrary prior task context"))
 			return
 		}
 

--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -67,9 +67,12 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 		session, _ := agent.GetOption(options, agent.WithSession)
 		stream, _ := agent.GetOption(options, agent.Stream)
 		if token, ok := agent.GetOption(options, agent.WithContinuationToken); ok && token != "" {
+			if len(messages) > 0 {
+				yield(nil, errors.New("messages are not allowed when continuing a background response using a continuation token"))
+				return
+			}
 			if stream {
-				// TODO: support resuming stream responses using continuation tokens.
-				yield(nil, errors.New("reconnecting to task streams using continuation tokens is not supported yet"))
+				sendMsg(session, a.subscribeToTaskWithFallback(ctx, a2a.TaskID(token)), yield)
 				return
 			}
 			task, err := a.client.GetTask(ctx, &a2a.GetTaskRequest{ID: a2a.TaskID(token)})
@@ -115,6 +118,36 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 				}
 			}
 			sendMsg(session, seq, yield)
+		}
+	}
+}
+
+// subscribeToTaskWithFallback resumes a task stream for a continuation token.
+// It falls back to GetTask when SubscribeToTask returns a2a.ErrUnsupportedOperation,
+// which can happen when the task has already reached a terminal state.
+func (a *a2aagent) subscribeToTaskWithFallback(ctx context.Context, taskID a2a.TaskID) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		for event, err := range a.client.SubscribeToTask(ctx, &a2a.SubscribeToTaskRequest{ID: taskID}) {
+			if err == nil {
+				if !yield(event, nil) {
+					return
+				}
+				continue
+			}
+
+			if !errors.Is(err, a2a.ErrUnsupportedOperation) {
+				yield(nil, err)
+				return
+			}
+
+			task, getTaskErr := a.client.GetTask(ctx, &a2a.GetTaskRequest{ID: taskID})
+			if getTaskErr != nil {
+				yield(nil, getTaskErr)
+				return
+			}
+
+			yield(task, nil)
+			return
 		}
 	}
 }

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -19,10 +19,17 @@ import (
 // mockA2ATransport is a stub that implements a2aclient.Transport for testing
 type mockA2ATransport struct {
 	capturedMessageSendParams  *a2a.SendMessageRequest
+	capturedSubscribeToTaskReq *a2a.SubscribeToTaskRequest
+	capturedGetTaskReq         *a2a.GetTaskRequest
 	responseToReturn           a2a.SendMessageResult
 	streamingResponseToReturn  a2a.Event
+	subscribeResponseToReturn  a2a.Event
+	subscribeErrToReturn       error
+	getTaskErrToReturn         error
 	sendMessageCalled          bool
 	sendStreamingMessageCalled bool
+	subscribeToTaskCalled      bool
+	getTaskCalled              bool
 }
 
 func (m *mockA2ATransport) SendMessage(ctx context.Context, _ a2aclient.ServiceParams, params *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
@@ -77,6 +84,11 @@ func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, _ a2aclient
 }
 
 func (m *mockA2ATransport) GetTask(ctx context.Context, _ a2aclient.ServiceParams, params *a2a.GetTaskRequest) (*a2a.Task, error) {
+	m.getTaskCalled = true
+	m.capturedGetTaskReq = params
+	if m.getTaskErrToReturn != nil {
+		return nil, m.getTaskErrToReturn
+	}
 	if m.responseToReturn != nil {
 		if task, ok := m.responseToReturn.(*a2a.Task); ok {
 			return task, nil
@@ -93,9 +105,45 @@ func (m *mockA2ATransport) CancelTask(ctx context.Context, _ a2aclient.ServicePa
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockA2ATransport) SubscribeToTask(ctx context.Context, _ a2aclient.ServiceParams, _ *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+func (m *mockA2ATransport) SubscribeToTask(ctx context.Context, _ a2aclient.ServiceParams, params *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+	m.subscribeToTaskCalled = true
+	m.capturedSubscribeToTaskReq = params
 	return func(yield func(a2a.Event, error) bool) {
-		yield(nil, errors.New("not implemented"))
+		if m.subscribeErrToReturn != nil {
+			yield(nil, m.subscribeErrToReturn)
+			return
+		}
+
+		responseToYield := m.subscribeResponseToReturn
+		if responseToYield == nil {
+			responseToYield = &a2a.Message{
+				ID:        "default-subscribe-id",
+				Role:      a2a.MessageRoleAgent,
+				TaskID:    params.ID,
+				ContextID: "default-subscribe-context",
+			}
+		}
+
+		switch resp := responseToYield.(type) {
+		case *a2a.Message:
+			if resp.TaskID == "" {
+				resp.TaskID = params.ID
+			}
+		case *a2a.Task:
+			if resp.ID == "" {
+				resp.ID = params.ID
+			}
+		case *a2a.TaskStatusUpdateEvent:
+			if resp.TaskID == "" {
+				resp.TaskID = params.ID
+			}
+		case *a2a.TaskArtifactUpdateEvent:
+			if resp.TaskID == "" {
+				resp.TaskID = params.ID
+			}
+		}
+
+		yield(responseToYield, nil)
 	}
 }
 
@@ -778,6 +826,200 @@ func TestRunStreamingWithContinuationTokenAndMessages(t *testing.T) {
 
 	if !gotError {
 		t.Error("expected error when continuation token used with streaming, got nil")
+	}
+}
+
+func TestRunStreamingWithContinuationToken_UsesSubscribeToTask(t *testing.T) {
+	transport := &mockA2ATransport{
+		subscribeResponseToReturn: &a2a.Message{
+			ID:        "response-123",
+			Role:      a2a.MessageRoleAgent,
+			TaskID:    "task-456",
+			ContextID: "ctx-456",
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Continuation response")},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var updates []*message.ResponseUpdate
+	for update, err := range a.Run(t.Context(), nil, agent.WithContinuationToken("task-456"), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+	if !transport.subscribeToTaskCalled {
+		t.Fatal("SubscribeToTask was not called")
+	}
+	if transport.sendStreamingMessageCalled {
+		t.Fatal("SendStreamingMessage was called, want SubscribeToTask only")
+	}
+	if got := updates[0].String(); got != "Continuation response" {
+		t.Errorf("update.String() = %q, want %q", got, "Continuation response")
+	}
+}
+
+func TestRunStreamingWithContinuationToken_PassesCorrectTaskID(t *testing.T) {
+	const expectedTaskID = "my-task-789"
+
+	transport := &mockA2ATransport{
+		subscribeResponseToReturn: &a2a.Message{
+			ID:        "response-123",
+			Role:      a2a.MessageRoleAgent,
+			TaskID:    a2a.TaskID(expectedTaskID),
+			ContextID: "ctx-456",
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Continuation response")},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(expectedTaskID), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+	}
+
+	if transport.capturedSubscribeToTaskReq == nil {
+		t.Fatal("capturedSubscribeToTaskReq is nil")
+	}
+	if got := string(transport.capturedSubscribeToTaskReq.ID); got != expectedTaskID {
+		t.Errorf("SubscribeToTaskRequest.ID = %q, want %q", got, expectedTaskID)
+	}
+}
+
+func TestRunStreamingWithContinuationTokenWhenSubscribeFailsWithUnsupportedOperationFallsBackToGetTask(t *testing.T) {
+	const taskID = "completed-task-123"
+	const contextID = "ctx-completed"
+
+	transport := &mockA2ATransport{
+		subscribeErrToReturn: a2a.ErrUnsupportedOperation,
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID(taskID),
+			ContextID: contextID,
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+			},
+			Artifacts: []*a2a.Artifact{{
+				ID:    a2a.ArtifactID("art-1"),
+				Parts: a2a.ContentParts{a2a.NewTextPart("Final result")},
+			}},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var updates []*message.ResponseUpdate
+	for update, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(taskID), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+	update := updates[0]
+	if update.ResponseID != taskID {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
+	}
+	if _, ok := update.RawRepresentation.(*a2a.Task); !ok {
+		t.Errorf("update.RawRepresentation type = %T, want *a2a.Task", update.RawRepresentation)
+	}
+	if !transport.subscribeToTaskCalled {
+		t.Fatal("SubscribeToTask was not called")
+	}
+	if !transport.getTaskCalled {
+		t.Fatal("GetTask was not called after SubscribeToTask fallback")
+	}
+}
+
+func TestRunStreamingWithContinuationTokenWhenSubscribeFailsWithUnsupportedOperationUpdatesSession(t *testing.T) {
+	const taskID = "completed-task-456"
+	const contextID = "ctx-completed-456"
+
+	transport := &mockA2ATransport{
+		subscribeErrToReturn: a2a.ErrUnsupportedOperation,
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID(taskID),
+			ContextID: contextID,
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range a.Run(t.Context(), nil, agent.WithSession(session), agent.WithContinuationToken(taskID), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+	}
+
+	if got := session.ServiceID; got != contextID {
+		t.Errorf("session.ContextID = %q, want %q", got, contextID)
+	}
+	if got := latestTaskID(session); got != taskID {
+		t.Errorf("session.TaskID = %q, want %q", got, taskID)
+	}
+}
+
+func TestRunStreamingWithContinuationTokenWhenSubscribeFailsWithNonUnsupportedErrorPropagatesWithoutFallback(t *testing.T) {
+	transport := &mockA2ATransport{
+		subscribeErrToReturn: a2a.ErrTaskNotFound,
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var gotErr error
+	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken("error-task-123"), agent.Stream(true)) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if !errors.Is(gotErr, a2a.ErrTaskNotFound) {
+		t.Fatalf("error = %v, want %v", gotErr, a2a.ErrTaskNotFound)
+	}
+	if !transport.subscribeToTaskCalled {
+		t.Fatal("SubscribeToTask was not called")
+	}
+	if transport.getTaskCalled {
+		t.Fatal("GetTask was called, want no fallback for non-unsupported errors")
+	}
+}
+
+func TestRunStreamingWithContinuationTokenWhenSubscribeAndGetTaskBothFailPropagatesError(t *testing.T) {
+	transport := &mockA2ATransport{
+		subscribeErrToReturn: a2a.ErrUnsupportedOperation,
+		getTaskErrToReturn:   a2a.ErrTaskNotFound,
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var gotErr error
+	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken("failed-task-789"), agent.Stream(true)) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if !errors.Is(gotErr, a2a.ErrTaskNotFound) {
+		t.Fatalf("error = %v, want %v", gotErr, a2a.ErrTaskNotFound)
+	}
+	if !transport.subscribeToTaskCalled {
+		t.Fatal("SubscribeToTask was not called")
+	}
+	if !transport.getTaskCalled {
+		t.Fatal("GetTask was not called after SubscribeToTask fallback")
 	}
 }
 

--- a/examples/02-agents/a2a/as_function_tools/main.go
+++ b/examples/02-agents/a2a/as_function_tools/main.go
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
+	"github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/tool"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/azure"
+)
+
+var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var cardURL = cmp.Or(os.Getenv("A2A_AGENT_HOST"), "http://127.0.0.1:5000")
+
+var invalidToolNameChars = regexp.MustCompile(`[^0-9A-Za-z]+`)
+
+var logger = demo.NewLogger(
+	"A2A Agent As Function Tools",
+	"Advertises the remote A2A agent's skills as function tools for a host agent.",
+	"Model", deployment,
+	"Agent", cardURL,
+)
+
+func main() {
+	ctx := context.Background()
+	demo.CheckAzureEndpoint(endpoint)
+
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		demo.Panicf("failed to create Azure credential: %v", err)
+	}
+
+	card, err := agentcard.DefaultResolver.Resolve(ctx, cardURL)
+	if err != nil {
+		demo.Panicf("failed to resolve agent card: %v", err)
+	}
+	if len(card.Skills) == 0 {
+		demo.Panic("resolved agent card does not advertise any skills")
+	}
+
+	client, err := a2aclient.NewFromCard(ctx, card)
+	if err != nil {
+		demo.Panicf("failed to create A2A client: %v", err)
+	}
+
+	remoteAgent := a2aagent.New(
+		client,
+		a2aagent.Config{
+			Config: agent.Config{
+				Name:        cmp.Or(card.Name, "RemoteA2AAgent"),
+				Description: card.Description,
+			},
+		},
+	)
+
+	hostAgent := openaichatagent.New(
+		openai.NewClient(
+			azure.WithEndpoint(endpoint, apiVersion),
+			azure.WithTokenCredential(token),
+		),
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Name:         "TravelPlanner",
+				Instructions: "You are a helpful assistant that helps people with travel planning.",
+				Middlewares:  []agent.Middleware{logger},
+				Tools:        createSkillTools(remoteAgent, card.Skills),
+			},
+		},
+	)
+
+	resp, err := hostAgent.RunText(
+		ctx,
+		"Plan a route from '1600 Amphitheatre Parkway, Mountain View, CA' to 'San Francisco International Airport' avoiding tolls.",
+	).Collect()
+	demo.Response(resp, err)
+}
+
+func createSkillTools(remoteAgent *agent.Agent, skills []a2a.AgentSkill) []tool.Tool {
+	tools := make([]tool.Tool, 0, len(skills))
+	for _, skill := range skills {
+		skill := skill
+		tools = append(tools, functool.MustNew(&functool.Func{
+			Name:        sanitizeToolName(cmp.Or(skill.Name, skill.ID, "a2a_skill")),
+			Description: formatSkillDescription(skill),
+		}, func(ctx tool.Context, query string) (string, error) {
+			resp, err := remoteAgent.RunText(ctx, skillPrompt(skill, query)).Collect()
+			if err != nil {
+				return "", err
+			}
+			return resp.String(), nil
+		}))
+	}
+	return tools
+}
+
+func sanitizeToolName(name string) string {
+	name = invalidToolNameChars.ReplaceAllString(name, "_")
+	name = strings.Trim(name, "_")
+	name = strings.ToLower(name)
+	if name == "" {
+		return "a2a_skill"
+	}
+	return name
+}
+
+func formatSkillDescription(skill a2a.AgentSkill) string {
+	lines := make([]string, 0, 6)
+	if skill.Description != "" {
+		lines = append(lines, skill.Description)
+	}
+	if skill.ID != "" {
+		lines = append(lines, fmt.Sprintf("Skill ID: %s", skill.ID))
+	}
+	if len(skill.Tags) > 0 {
+		lines = append(lines, fmt.Sprintf("Tags: %s", strings.Join(skill.Tags, ", ")))
+	}
+	if len(skill.Examples) > 0 {
+		lines = append(lines, fmt.Sprintf("Examples: %s", strings.Join(skill.Examples, " | ")))
+	}
+	if len(skill.InputModes) > 0 {
+		lines = append(lines, fmt.Sprintf("Input modes: %s", strings.Join(skill.InputModes, ", ")))
+	}
+	if len(skill.OutputModes) > 0 {
+		lines = append(lines, fmt.Sprintf("Output modes: %s", strings.Join(skill.OutputModes, ", ")))
+	}
+	if len(lines) == 0 {
+		return "Invoke the remote A2A skill with a user query."
+	}
+	return strings.Join(lines, "\n")
+}
+
+func skillPrompt(skill a2a.AgentSkill, query string) string {
+	if skill.Name == "" {
+		return query
+	}
+	return fmt.Sprintf("Use the %q skill for this request:\n%s", skill.Name, query)
+}

--- a/examples/02-agents/a2a/polling_for_task_completion/main.go
+++ b/examples/02-agents/a2a/polling_for_task_completion/main.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"cmp"
+	"context"
+	"os"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+)
+
+var cardURL = cmp.Or(os.Getenv("A2A_AGENT_HOST"), "http://127.0.0.1:5000")
+
+var logger = demo.NewLogger(
+	"A2A Agent Polling For Task Completion",
+	"Starts a background A2A task and polls it with continuation tokens until it finishes.",
+	"Agent", cardURL,
+)
+
+func main() {
+	ctx := context.Background()
+
+	card, err := agentcard.DefaultResolver.Resolve(ctx, cardURL)
+	if err != nil {
+		demo.Panicf("failed to resolve agent card: %v", err)
+	}
+
+	client, err := a2aclient.NewFromCard(ctx, card)
+	if err != nil {
+		demo.Panicf("failed to create A2A client: %v", err)
+	}
+
+	remoteAgent := a2aagent.New(
+		client,
+		a2aagent.Config{
+			Config: agent.Config{
+				Name:        cmp.Or(card.Name, "RemoteA2AAgent"),
+				Description: card.Description,
+				Middlewares: []agent.Middleware{logger},
+			},
+		},
+	)
+
+	session, err := remoteAgent.CreateSession(ctx)
+	if err != nil {
+		demo.Panicf("failed to create agent session: %v", err)
+	}
+
+	resp, err := remoteAgent.RunText(
+		ctx,
+		"Conduct a comprehensive analysis of quantum computing applications in cryptography, including recent breakthroughs, implementation challenges, and future roadmap. Please include diagrams and visual representations to illustrate complex concepts.",
+		agent.WithSession(session),
+		agent.AllowBackgroundResponses(true),
+	).Collect()
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	for resp.ContinuationToken != "" {
+		demo.Assistantf("Task %s is still running. Polling again in 2 seconds...", resp.ContinuationToken)
+		time.Sleep(2 * time.Second)
+
+		resp, err = remoteAgent.Run(
+			ctx,
+			nil,
+			agent.WithSession(session),
+			agent.WithContinuationToken(resp.ContinuationToken),
+		).Collect()
+		if err != nil {
+			demo.Panic(err)
+		}
+	}
+
+	demo.Response(resp, nil)
+}

--- a/examples/02-agents/a2a/protocol_selection/main.go
+++ b/examples/02-agents/a2a/protocol_selection/main.go
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"cmp"
+	"context"
+	"os"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+)
+
+var cardURL = cmp.Or(os.Getenv("A2A_AGENT_HOST"), "http://127.0.0.1:5000")
+
+// Change this to a2a.TransportProtocolJSONRPC to prefer JSON-RPC instead.
+var preferredTransport = a2a.TransportProtocolHTTPJSON
+
+var logger = demo.NewLogger(
+	"A2A Agent Protocol Selection",
+	"Creates an A2A client with an explicit preferred transport binding.",
+	"Agent", cardURL,
+	"Transport", string(preferredTransport),
+)
+
+func main() {
+	ctx := context.Background()
+
+	card, err := agentcard.DefaultResolver.Resolve(ctx, cardURL)
+	if err != nil {
+		demo.Panicf("failed to resolve agent card: %v", err)
+	}
+
+	client, err := a2aclient.NewFromCard(
+		ctx,
+		card,
+		a2aclient.WithConfig(a2aclient.Config{
+			PreferredTransports: []a2a.TransportProtocol{preferredTransport},
+		}),
+	)
+	if err != nil {
+		demo.Panicf("failed to create A2A client: %v", err)
+	}
+
+	remoteAgent := a2aagent.New(
+		client,
+		a2aagent.Config{
+			Config: agent.Config{
+				Name:        cmp.Or(card.Name, "RemoteA2AAgent"),
+				Description: card.Description,
+				Middlewares: []agent.Middleware{logger},
+			},
+		},
+	)
+
+	resp, err := remoteAgent.RunText(ctx, "Tell me a joke about a pirate.").Collect()
+	demo.Response(resp, err)
+}

--- a/examples/02-agents/a2a/stream_reconnection/main.go
+++ b/examples/02-agents/a2a/stream_reconnection/main.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"cmp"
+	"context"
+	"os"
+
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+)
+
+var cardURL = cmp.Or(os.Getenv("A2A_AGENT_HOST"), "http://127.0.0.1:5000")
+
+var logger = demo.NewLogger(
+	"A2A Agent Stream Reconnection",
+	"Starts a streamed agent run, captures the continuation token, and resumes the stream after an interruption.",
+	"Agent", cardURL,
+)
+
+func main() {
+	ctx := context.Background()
+
+	card, err := agentcard.DefaultResolver.Resolve(ctx, cardURL)
+	if err != nil {
+		demo.Panicf("failed to resolve agent card: %v", err)
+	}
+
+	client, err := a2aclient.NewFromCard(ctx, card)
+	if err != nil {
+		demo.Panicf("failed to create A2A client: %v", err)
+	}
+
+	remoteAgent := a2aagent.New(
+		client,
+		a2aagent.Config{
+			Config: agent.Config{
+				Name:        cmp.Or(card.Name, "RemoteA2AAgent"),
+				Description: card.Description,
+				Middlewares: []agent.Middleware{logger},
+			},
+		},
+	)
+
+	session, err := remoteAgent.CreateSession(ctx)
+	if err != nil {
+		demo.Panicf("failed to create agent session: %v", err)
+	}
+
+	query := "Conduct a comprehensive analysis of quantum computing applications in cryptography, including recent breakthroughs, implementation challenges, and future roadmap. Please include diagrams and visual representations to illustrate complex concepts."
+
+	var continuationToken string
+	for update, err := range remoteAgent.RunText(ctx, query, agent.WithSession(session), agent.Stream(true)) {
+		if err != nil {
+			demo.Panic(err)
+		}
+		if update != nil {
+			demo.Response(update, nil)
+			if update.ContinuationToken != "" {
+				continuationToken = update.ContinuationToken
+				demo.Assistantf("Captured continuation token %s. Simulating a stream interruption before completion.", continuationToken)
+				break
+			}
+		}
+	}
+
+	if continuationToken == "" {
+		demo.Assistant("The agent completed without issuing a continuation token. Stream reconnection is not applicable.")
+		return
+	}
+
+	demo.Assistantf("Reconnecting to task %s...", continuationToken)
+	for update, err := range remoteAgent.Run(
+		ctx,
+		nil,
+		agent.WithSession(session),
+		agent.WithContinuationToken(continuationToken),
+		agent.Stream(true),
+	) {
+		if err != nil {
+			demo.Panic(err)
+		}
+		if update != nil {
+			demo.Response(update, nil)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- refactor A2A hosting execution to split new-message, task-update, and streaming continuation paths
- add `SubscribeToTask` continuation fallback to `GetTask` to keep Go A2A task resumption aligned with `microsoft/agent-framework`
- add A2A examples for remote skills as function tools, protocol selection, polling for task completion, and stream reconnection
- expand A2A hosting and provider coverage for continuation, artifact, and task lifecycle behavior
- address PR feedback by preferring `MessageID` over `ResponseID` for streamed message IDs and by stopping the cancel-task test after the first task event

## Testing
- `go test -count=1 -timeout 120s ./agent/hosting/a2ahosting ./agent/provider/a2aagent`
