### PR TITLE
Fix all golangci-lint v2.11 issues

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run golangci-lint
+        run: docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.11 golangci-lint run -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+linters:
+  enable:
+    - bodyclose
+    - godox
+    - nakedret
+    - predeclared
+    - unconvert
+formatters:
+  enable:
+    - gofumpt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ version: "2"
 linters:
   enable:
     - bodyclose
-    - godox
     - nakedret
     - predeclared
     - unconvert

--- a/agent/hosting/a2ahosting/a2a_test.go
+++ b/agent/hosting/a2ahosting/a2a_test.go
@@ -455,6 +455,7 @@ func TestRequestHandler_OnSendMessageStream_WithNilAdditionalProperties_LeavesAr
 		t.Fatalf("expected nil metadata, got %#v", artifacts[0].Metadata)
 	}
 }
+
 func TestRequestHandler_OnSendMessageStream_WhenAgentYieldsNoUpdates_ReturnsLifecycleOnly(t *testing.T) {
 	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
 		return func(func(*message.ResponseUpdate, error) bool) {}
@@ -518,23 +519,6 @@ func TestRequestHandler_OnCancelTask_ReturnsCanceledTask(t *testing.T) {
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
-
-func collectStreamingMessages(t *testing.T, stream iter.Seq2[a2a.Event, error]) []*a2a.Message {
-	t.Helper()
-
-	var messages []*a2a.Message
-	for evt, err := range stream {
-		if err != nil {
-			t.Fatalf("stream returned error: %v", err)
-		}
-		msg, ok := evt.(*a2a.Message)
-		if !ok {
-			continue
-		}
-		messages = append(messages, msg)
-	}
-	return messages
-}
 
 func collectFirstStreamingTask(t *testing.T, stream iter.Seq2[a2a.Event, error]) *a2a.Task {
 	t.Helper()

--- a/agent/hosting/aguihosting/agui.go
+++ b/agent/hosting/aguihosting/agui.go
@@ -82,7 +82,7 @@ func decodeInput(r *http.Request) (*aguiTypes.RunAgentInput, error) {
 	if r == nil || r.Body == nil {
 		return nil, errors.New("request body is required")
 	}
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	var input aguiTypes.RunAgentInput
 	decoder := json.NewDecoder(r.Body)

--- a/agent/hosting/aguihosting/events.go
+++ b/agent/hosting/aguihosting/events.go
@@ -36,7 +36,7 @@ func filterServerToolsFromMixedInvocations(update *message.ResponseUpdate, clien
 		}
 	}
 
-	if !(containsClient && containsServer) {
+	if !containsClient || !containsServer {
 		return update, nil
 	}
 

--- a/agent/internal/agentopt/agentopt.go
+++ b/agent/internal/agentopt/agentopt.go
@@ -79,7 +79,7 @@ func AllowBackgroundResponses(allow bool) Option {
 
 func GetOption[T any](opts []Option, setter func(T) Option) (T, bool) {
 	var zero T
-	var setterType = reflect.TypeOf(setter(zero))
+	setterType := reflect.TypeOf(setter(zero))
 	for _, opt := range slices.Backward(opts) {
 		if reflect.TypeOf(opt) == setterType {
 			v, ok := opt.Value().(T)
@@ -92,7 +92,7 @@ func GetOption[T any](opts []Option, setter func(T) Option) (T, bool) {
 func AllOptions[T any](opts []Option, setter func(T) Option) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		var zero T
-		var setterType = reflect.TypeOf(setter(zero))
+		setterType := reflect.TypeOf(setter(zero))
 		for _, opt := range opts {
 			if reflect.TypeOf(opt) == setterType {
 				v, ok := opt.Value().(T)

--- a/agent/internal/middleware/autocall/autocall.go
+++ b/agent/internal/middleware/autocall/autocall.go
@@ -380,7 +380,6 @@ func hasAnyApprovalContent(msgs []*message.Message) bool {
 			}
 		})
 	})
-
 }
 
 func (f *autocall) invokeApprovedFunctionApprovalResponses(ctx context.Context, approvals []approvalResultWithRequestMessage, tools map[string]tool.Tool, errCount int) (*message.Message, int, error) {
@@ -668,7 +667,7 @@ func convertToFunctionCallContentMessages(messages []approvalResultWithRequestMe
 		// Don't need to create a dictionary if we already have one or if it's the first iteration.
 		shouldCreateMap := messagesByID == nil && currentMsg != nil &&
 			// Everywhere we have no RequestMessage we use the fallbackMessageID, so in this case there is only one message.
-			!(msg.RequestMessage == nil && currentMsg.ID == fallbackMessageID) &&
+			(msg.RequestMessage != nil || currentMsg.ID != fallbackMessageID) &&
 			// Where we do have a RequestMessage, we can check if its message id differs from the current one.
 			(msg.RequestMessage != nil && currentMsg.ID != msg.RequestMessage.ID)
 		if shouldCreateMap {

--- a/agent/internal/middleware/autocall/autocall_approval_test.go
+++ b/agent/internal/middleware/autocall/autocall_approval_test.go
@@ -27,13 +27,13 @@ func expectedMessages(t *testing.T, expected ...*message.Message) func(context.C
 // invokeAndAssertApproval is the helper for approval tests
 func invokeAndAssertApproval(t *testing.T, tools []tool.Tool, input []*message.Message,
 	downstreamAgentOutput []*message.ResponseUpdate, expectedOutput []*message.ResponseUpdate,
-	expectedDownstreamAgentInput []*message.Message, additionalTools []tool.Tool) {
-
+	expectedDownstreamAgentInput []*message.Message, additionalTools []tool.Tool,
+) {
 	var cb func(context.Context, []*message.Message, ...agentopt.Option)
 	if expectedDownstreamAgentInput != nil {
 		cb = expectedMessages(t, expectedDownstreamAgentInput...)
 	}
-	var rb = agenttest.NewResponseBuilder(cb)
+	rb := agenttest.NewResponseBuilder(cb)
 	for _, resp := range downstreamAgentOutput {
 		rb.Add(resp)
 	}
@@ -48,8 +48,8 @@ func invokeAndAssertApproval(t *testing.T, tools []tool.Tool, input []*message.M
 // invokeAndAssertApprovalWithAgent performs streaming test execution
 func invokeAndAssertApprovalWithAgent(t *testing.T, next middleware.RunFunc,
 	tools []tool.Tool, input []*message.Message,
-	expectedOutput []*message.ResponseUpdate, additionalTools []tool.Tool) {
-
+	expectedOutput []*message.ResponseUpdate, additionalTools []tool.Tool,
+) {
 	autocallOptions := autocall.Config{
 		NewID: func() string { return "" },
 	}

--- a/agent/internal/middleware/autocall/autocall_test.go
+++ b/agent/internal/middleware/autocall/autocall_test.go
@@ -628,7 +628,6 @@ func TestFunctionInvoking_ContinuesWithSuccessfulCallsUntilMaximumIterations(t *
 	}
 
 	actualCallCount = 0
-
 }
 
 // TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors tests MaximumConsecutiveErrorsPerRequest
@@ -650,7 +649,8 @@ func TestFunctionInvoking_ContinuesWithFailingCallsUntilMaximumConsecutiveErrors
 					func(ctx tool.Context, args struct {
 						ShouldThrow bool `json:"shouldThrow"`
 						CallIndex   int  `json:"callIndex"`
-					}) (string, error) {
+					},
+					) (string, error) {
 						if args.ShouldThrow {
 							return "", fmt.Errorf("Exception from call %d", args.CallIndex)
 						}

--- a/agent/middleware/otel/otel_test.go
+++ b/agent/middleware/otel/otel_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/middleware/otel"
-	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -71,16 +70,9 @@ func TestOtel_Run_SpanHasCorrectAttributes(t *testing.T) {
 	mw := otel.New(otel.Config{})
 
 	var capturedCtx context.Context
-	responseBuilder := agenttest.NewResponseBuilder(
-		func(ctx context.Context, messages []*message.Message, opts ...agent.Option) {
-			capturedCtx = ctx
-		},
-	).AddText("response")
-
-	a := agenttest.New(responseBuilder.Build())
 
 	// Override the agent metadata for this test
-	a = agent.New(agent.ProviderConfig{
+	a := agent.New(agent.ProviderConfig{
 		ProviderName: "test-provider",
 		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
 			return func(yield func(*message.ResponseUpdate, error) bool) {

--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -245,7 +245,7 @@ func yieldTask(yield func(*message.ResponseUpdate, error) bool, task *a2a.Task) 
 		}
 	}
 
-	if !yield(&message.ResponseUpdate{
+	return yield(&message.ResponseUpdate{
 		RawRepresentation:    task,
 		AdditionalProperties: task.Metadata,
 		ResponseID:           string(task.ID),
@@ -253,10 +253,7 @@ func yieldTask(yield func(*message.ResponseUpdate, error) bool, task *a2a.Task) 
 		ContinuationToken:    continuationToken,
 		Role:                 message.RoleAssistant,
 		CreatedAt:            timestamp,
-	}, nil) {
-		return false
-	}
-	return true
+	}, nil)
 }
 
 func updateSessionContextID(session *memory.Session, contextID, taskID string) error {

--- a/agent/provider/anthropicagent/agent.go
+++ b/agent/provider/anthropicagent/agent.go
@@ -107,7 +107,7 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 		var messageID string
 		var modelID string
 		var usage message.UsageDetails
-		var functions = make(map[int]*message.FunctionCallContent)
+		functions := make(map[int]*message.FunctionCallContent)
 
 		for stream.Next() {
 			event := stream.Current()
@@ -116,7 +116,7 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 			switch event := event.AsAny().(type) {
 			case anthropic.MessageStartEvent:
 				messageID = cmp.Or(messageID, event.Message.ID)
-				modelID = cmp.Or(modelID, string(event.Message.Model))
+				modelID = cmp.Or(modelID, event.Message.Model)
 				usage.Add(toUsageDetails(event.Message.Usage))
 			case anthropic.MessageDeltaEvent:
 				usage.Add(toUsageDetailsDelta(event.Usage))
@@ -256,7 +256,7 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 	if p, ok := agent.GetOption(opts, MessageNewParams); ok {
 		params = p
 	}
-	params.Model = cmp.Or(params.Model, anthropic.Model(a.config.Model))
+	params.Model = cmp.Or(params.Model, a.config.Model)
 	params.MaxTokens = cmp.Or(params.MaxTokens, 4096)
 
 	var tools []anthropic.ToolUnionParam
@@ -278,7 +278,7 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 				if schema != nil {
 					jsonBytes, err := json.Marshal(schema)
 					if err == nil {
-						json.Unmarshal(jsonBytes, &schemaMap)
+						_ = json.Unmarshal(jsonBytes, &schemaMap)
 					}
 				}
 			}
@@ -444,7 +444,7 @@ func buildMessageParam(msg *message.Message) (anthropic.MessageParam, error) {
 				if mediaType == "" {
 					mediaType = "image/jpeg"
 				}
-				content = append(content, anthropic.NewImageBlockBase64(mediaType, string(c.Data)))
+				content = append(content, anthropic.NewImageBlockBase64(mediaType, c.Data))
 			}
 		}
 	}

--- a/agent/provider/anthropicagent/agent_test.go
+++ b/agent/provider/anthropicagent/agent_test.go
@@ -137,7 +137,7 @@ func TestStructuredOutput_NonStreaming(t *testing.T) {
 		}
 		bodyCh <- body
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, minimalMessageResponse(payload))
+		_, _ = io.WriteString(w, minimalMessageResponse(payload))
 	}))
 	defer server.Close()
 
@@ -176,7 +176,7 @@ func TestStructuredOutput_Streaming(t *testing.T) {
 		}
 		bodyCh <- body
 		w.Header().Set("Content-Type", "text/event-stream")
-		io.WriteString(w, minimalStreamingResponse(payload))
+		_, _ = io.WriteString(w, minimalStreamingResponse(payload))
 	}))
 	defer server.Close()
 

--- a/agent/provider/geminiagent/agent_test.go
+++ b/agent/provider/geminiagent/agent_test.go
@@ -57,7 +57,7 @@ func captureAndRespond(t *testing.T, bodyCh chan<- []byte, contentType, response
 		}
 		bodyCh <- body
 		w.Header().Set("Content-Type", contentType)
-		io.WriteString(w, responseBody)
+		_, _ = io.WriteString(w, responseBody)
 	}
 }
 

--- a/agent/provider/openaichatagent/chat.go
+++ b/agent/provider/openaichatagent/chat.go
@@ -112,7 +112,7 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 	}
 	return func(yield func(*message.ResponseUpdate, error) bool) {
 		stream := a.client.Chat.Completions.NewStreaming(ctx, body)
-		defer stream.Close()
+		defer func() { _ = stream.Close() }()
 		var acc openai.ChatCompletionAccumulator
 		for stream.Next() {
 			chunk := stream.Current()
@@ -240,7 +240,6 @@ func buildCompletionParams(model string, messages []*message.Message, opts []age
 						})
 					}
 				}
-
 			}
 		}
 		switch tl := tl.(type) {

--- a/agent/provider/openaichatagent/chat_test.go
+++ b/agent/provider/openaichatagent/chat_test.go
@@ -1217,7 +1217,7 @@ func TestChatDataContentMessage_Image_NonStreaming(t *testing.T) {
 		MediaType: "image/png",
 	}
 	// Add "detail" to AdditionalProperties
-	dataContent.ContentHeader.AdditionalProperties = map[string]any{
+	dataContent.AdditionalProperties = map[string]any{
 		"detail": "high",
 	}
 

--- a/agent/provider/openairesponsesagent/responses.go
+++ b/agent/provider/openairesponsesagent/responses.go
@@ -818,21 +818,19 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 		}
 	}
 
-	// If there's a pending update that hasn't been added yet (e.g., from function calls or reasoning), add it now
-	if currentUpdate != nil {
-		// Add usage if present
-		if usage := responsesUsageToContent(resp.Usage); usage != nil {
-			currentUpdate.Contents = append(currentUpdate.Contents, usage)
-		}
-		// If there's an error in the response, add an ErrorContent
-		if resp.Error.Message != "" {
-			currentUpdate.Contents = append(currentUpdate.Contents, &message.ErrorContent{
-				Message:   resp.Error.Message,
-				ErrorCode: string(resp.Error.Code),
-			})
-		}
-		yield(currentUpdate, nil)
+	// Add any final data to the pending update (usage, errors), then yield it.
+	// Add usage if present
+	if usage := responsesUsageToContent(resp.Usage); usage != nil {
+		currentUpdate.Contents = append(currentUpdate.Contents, usage)
 	}
+	// If there's an error in the response, add an ErrorContent
+	if resp.Error.Message != "" {
+		currentUpdate.Contents = append(currentUpdate.Contents, &message.ErrorContent{
+			Message:   resp.Error.Message,
+			ErrorCode: string(resp.Error.Code),
+		})
+	}
+	yield(currentUpdate, nil)
 }
 
 func imageURIToMediaType(uri string) string {
@@ -859,11 +857,11 @@ func responsesUsageToContent(usage responses.ResponseUsage) *message.UsageConten
 	}
 	return &message.UsageContent{
 		Details: message.UsageDetails{
-			InputTokenCount:       int64(usage.InputTokens),
-			OutputTokenCount:      int64(usage.OutputTokens),
-			TotalTokenCount:       int64(usage.TotalTokens),
-			CachedInputTokenCount: int64(usage.InputTokensDetails.CachedTokens),
-			ReasoningTokenCount:   int64(usage.OutputTokensDetails.ReasoningTokens),
+			InputTokenCount:       usage.InputTokens,
+			OutputTokenCount:      usage.OutputTokens,
+			TotalTokenCount:       usage.TotalTokens,
+			CachedInputTokenCount: usage.InputTokensDetails.CachedTokens,
+			ReasoningTokenCount:   usage.OutputTokensDetails.ReasoningTokens,
 		},
 	}
 }
@@ -1005,7 +1003,7 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 		case responses.ResponseCodeInterpreterToolCall:
 			// For code interpreter, create a text representation
 			var outputText strings.Builder
-			outputText.WriteString(fmt.Sprintf("[Code Interpreter: %s]\n", item.ID))
+			fmt.Fprintf(&outputText, "[Code Interpreter: %s]\n", item.ID)
 			if item.Code != "" {
 				outputText.WriteString(item.Code)
 				outputText.WriteString("\n")
@@ -1019,7 +1017,7 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 						outputText.WriteString("\n")
 					case responses.ResponseCodeInterpreterToolCallOutputImage:
 						if output.URL != "" {
-							outputText.WriteString(fmt.Sprintf("Image: %s\n", output.URL))
+							fmt.Fprintf(&outputText, "Image: %s\n", output.URL)
 						}
 					}
 				}
@@ -1070,8 +1068,8 @@ func populateAnnotations(anns []responses.ResponseOutputTextAnnotationUnion, con
 
 func responsesPopulateAdditionalProperties(resp *responses.Response) map[string]any {
 	props := make(map[string]any)
-	if resp.User != "" {
-		props["EndUserId"] = resp.User
+	if resp.User != "" { //nolint:staticcheck // SA1019: no replacement available
+		props["EndUserId"] = resp.User //nolint:staticcheck // SA1019: no replacement available
 	}
 	if resp.Error.Message != "" {
 		props["Error"] = resp.Error.Message

--- a/agent/provider/openairesponsesagent/responses_test.go
+++ b/agent/provider/openairesponsesagent/responses_test.go
@@ -754,7 +754,7 @@ func TestResponsesDataContentMessage_Image_NonStreaming(t *testing.T) {
 		MediaType: "image/png",
 	}
 	// Add "detail" to AdditionalProperties
-	dataContent.ContentHeader.AdditionalProperties = map[string]any{
+	dataContent.AdditionalProperties = map[string]any{
 		"detail": "high",
 	}
 
@@ -3944,7 +3944,6 @@ func TestResponsesConversationId_AsResponseId_NonStreaming(t *testing.T) {
 		}),
 		agent.WithSession(session),
 	).Collect()
-
 	if err != nil {
 		t.Fatalf("error = %v", err)
 	}
@@ -4847,19 +4846,4 @@ func bodyEqual(t *testing.T, got string, want string) {
 		}
 		t.Errorf("body\ngot %s\nwant %s", gotOut, wantOut)
 	}
-}
-
-func newTestServer(t *testing.T, input string, output string) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("failed reading request body: %v", err)
-		}
-		bodyEqual(t, string(body), input)
-		w.Header().Set("Content-Type", "application/json")
-		if _, err := io.WriteString(w, output); err != nil {
-			t.Fatalf("failed writing response: %v", err)
-		}
-	}))
 }

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -4,11 +4,12 @@ package agent
 
 import (
 	"context"
+	"reflect"
+
 	"github.com/microsoft/agent-framework-go/memory"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/message/messageworkflow"
 	"github.com/microsoft/agent-framework-go/workflow"
-	"reflect"
 )
 
 func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {

--- a/examples/01-get-started/01_hello_agent/main.go
+++ b/examples/01-get-started/01_hello_agent/main.go
@@ -16,9 +16,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+var (
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+)
 
 var logger = demo.NewLogger(
 	"Hello Agent",

--- a/examples/01-get-started/02_add_tools/main.go
+++ b/examples/01-get-started/02_add_tools/main.go
@@ -19,9 +19,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Add Tools",

--- a/examples/01-get-started/03_multi_turn/main.go
+++ b/examples/01-get-started/03_multi_turn/main.go
@@ -15,9 +15,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Multi-Turn Conversation",

--- a/examples/01-get-started/04_memory/main.go
+++ b/examples/01-get-started/04_memory/main.go
@@ -19,9 +19,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Memory",
@@ -94,7 +96,7 @@ func getProviderState(session *memory.Session) providerState {
 		return providerState{}
 	}
 	var state providerState
-	session.Get(userMemorySourceID, &state)
+	_, _ = session.Get(userMemorySourceID, &state)
 	return state
 }
 

--- a/examples/01-get-started/05_first_workflow/main.go
+++ b/examples/01-get-started/05_first_workflow/main.go
@@ -34,7 +34,6 @@ func main() {
 		AddEdge(uppercase, reverse).
 		WithOutputFrom(reverse).
 		Build()
-
 	if err != nil {
 		panic(err)
 	}

--- a/examples/02-agents/a2a/as_function_tools/main.go
+++ b/examples/02-agents/a2a/as_function_tools/main.go
@@ -24,10 +24,12 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
-var cardURL = cmp.Or(os.Getenv("A2A_AGENT_HOST"), "http://127.0.0.1:5000")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+	cardURL    = cmp.Or(os.Getenv("A2A_AGENT_HOST"), "http://127.0.0.1:5000")
+)
 
 var invalidToolNameChars = regexp.MustCompile(`[^0-9A-Za-z]+`)
 
@@ -97,7 +99,7 @@ func createSkillTools(remoteAgent *agent.Agent, skills []a2a.AgentSkill) []tool.
 	tools := make([]tool.Tool, 0, len(skills))
 	for _, skill := range skills {
 		skill := skill
-		tools = append(tools, functool.MustNew(&functool.Func{
+		tools = append(tools, functool.MustNew(functool.Config{
 			Name:        sanitizeToolName(cmp.Or(skill.Name, skill.ID, "a2a_skill")),
 			Description: formatSkillDescription(skill),
 		}, func(ctx tool.Context, query string) (string, error) {

--- a/examples/02-agents/agents/step01_running/main.go
+++ b/examples/02-agents/agents/step01_running/main.go
@@ -15,9 +15,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+var (
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+)
 
 var logger = demo.NewLogger(
 	"Basic Run",

--- a/examples/02-agents/agents/step02_multiturn_conversation/main.go
+++ b/examples/02-agents/agents/step02_multiturn_conversation/main.go
@@ -15,9 +15,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Multi-Turn Conversation",

--- a/examples/02-agents/agents/step03_using_function_tools/main.go
+++ b/examples/02-agents/agents/step03_using_function_tools/main.go
@@ -18,9 +18,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Function Tools",

--- a/examples/02-agents/agents/step04_using_function_tools_with_approvals/main.go
+++ b/examples/02-agents/agents/step04_using_function_tools_with_approvals/main.go
@@ -19,9 +19,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Function Tools With User Approvals",

--- a/examples/02-agents/agents/step05_structured_output/main.go
+++ b/examples/02-agents/agents/step05_structured_output/main.go
@@ -18,9 +18,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Structured Output",

--- a/examples/02-agents/agents/step06_persisted_conversation/main.go
+++ b/examples/02-agents/agents/step06_persisted_conversation/main.go
@@ -16,9 +16,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Persisted Conversation",
@@ -73,7 +75,7 @@ func main() {
 		demo.Panic(err)
 	}
 	tmpPath := filepath.Join(tmpDir, "session.json")
-	if err := os.WriteFile(tmpPath, serializedSession, 0644); err != nil {
+	if err := os.WriteFile(tmpPath, serializedSession, 0o644); err != nil {
 		demo.Panic(err)
 	}
 

--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -22,9 +22,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"3rd-Party Session Storage",
@@ -44,7 +46,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create Azure OpenAI agent with a custom message store that persists messages to disk.
 	a := openaichatagent.New(
@@ -149,7 +151,7 @@ func (d *fsMessageStore) persistMessages(session *memory.Session, requestMessage
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(filepath.Join(d.Dir, msg.ID), data, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(d.Dir, msg.ID), data, 0o644); err != nil {
 			return err
 		}
 		files = append(files, msg.ID)

--- a/examples/02-agents/agents/step08_observability/main.go
+++ b/examples/02-agents/agents/step08_observability/main.go
@@ -24,9 +24,11 @@ import (
 	otellib "go.opentelemetry.io/otel"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"OpenTelemetry Observability",

--- a/examples/02-agents/agents/step09_dependency_injection/main.go
+++ b/examples/02-agents/agents/step09_dependency_injection/main.go
@@ -5,5 +5,5 @@
 package main
 
 func main() {
-	// Not yet implemented.
+	// TODO
 }

--- a/examples/02-agents/agents/step09_dependency_injection/main.go
+++ b/examples/02-agents/agents/step09_dependency_injection/main.go
@@ -5,5 +5,5 @@
 package main
 
 func main() {
-	// TODO
+	// Not yet implemented.
 }

--- a/examples/02-agents/agents/step10_as_mcp_tool/main.go
+++ b/examples/02-agents/agents/step10_as_mcp_tool/main.go
@@ -20,9 +20,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 // Run "npx @modelcontextprotocol/inspector go run ." to connect to this MCP server.
 

--- a/examples/02-agents/agents/step11_using_images/main.go
+++ b/examples/02-agents/agents/step11_using_images/main.go
@@ -16,9 +16,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Using Images",

--- a/examples/02-agents/agents/step12_as_function_tool/main.go
+++ b/examples/02-agents/agents/step12_as_function_tool/main.go
@@ -21,9 +21,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"Agent As Function Tool",

--- a/examples/02-agents/mcp/agent_mcp_server/main.go
+++ b/examples/02-agents/mcp/agent_mcp_server/main.go
@@ -29,7 +29,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	// Retrieve the list of tools available on the Microsoft Learn server
 	tools, err := mcptool.ListTools(ctx, session)

--- a/examples/02-agents/providers/azure/main.go
+++ b/examples/02-agents/providers/azure/main.go
@@ -16,9 +16,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+var (
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+)
 
 var logger = demo.NewLogger(
 	"Basic Run",

--- a/examples/02-agents/providers/gemini/main.go
+++ b/examples/02-agents/providers/gemini/main.go
@@ -13,8 +13,10 @@ import (
 	"google.golang.org/genai"
 )
 
-var apiKey = os.Getenv("GEMINI_API_KEY")
-var model = cmp.Or(os.Getenv("GEMINI_MODEL"), "gemini-2.5-flash")
+var (
+	apiKey = os.Getenv("GEMINI_API_KEY")
+	model  = cmp.Or(os.Getenv("GEMINI_MODEL"), "gemini-2.5-flash")
+)
 
 var logger = demo.NewLogger(
 	"Basic Run",

--- a/examples/02-agents/skills/internal/skillhelpers/subprocess_script_runner.go
+++ b/examples/02-agents/skills/internal/skillhelpers/subprocess_script_runner.go
@@ -23,7 +23,7 @@ func RunSubprocessScript(ctx context.Context, skill *skills.Skill, script *skill
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	if err := materializeSkill(skill, tempDir); err != nil {
 		return nil, err

--- a/examples/02-agents/skills/step01_file_based_skills/main.go
+++ b/examples/02-agents/skills/step01_file_based_skills/main.go
@@ -23,9 +23,11 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-5.4-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-5.4-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 var logger = demo.NewLogger(
 	"File-Based Skills",
@@ -44,7 +46,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer skillsRoot.Close()
+	defer func() { _ = skillsRoot.Close() }()
 	skillsProvider := skills.NewContextProvider(skills.ContextProviderOptions{
 		Sources: []skills.Source{
 			fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: skillhelpers.RunSubprocessScript}, skillsRoot.FS()),

--- a/examples/02-agents/skills/step02_code_defined_skills/main.go
+++ b/examples/02-agents/skills/step02_code_defined_skills/main.go
@@ -91,9 +91,11 @@ var logger = demo.NewLogger(
 	"Model", deployment,
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-5.4-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-5.4-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 func main() {
 	demo.CheckAzureEndpoint(endpoint)

--- a/examples/02-agents/skills/step03_mixed_skills/main.go
+++ b/examples/02-agents/skills/step03_mixed_skills/main.go
@@ -152,9 +152,11 @@ var logger = demo.NewLogger(
 	"Model", deployment,
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-5.4-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+var (
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-5.4-mini")
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+)
 
 func main() {
 	demo.CheckAzureEndpoint(endpoint)
@@ -167,7 +169,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer skillsRoot.Close()
+	defer func() { _ = skillsRoot.Close() }()
 
 	skillsProvider := skills.NewContextProvider(skills.ContextProviderOptions{
 		Skills: []*skills.Skill{volumeConverterSkill, &temperatureConverterSkill},

--- a/examples/03-workflows/_start-here/01_executors_and_edges/main.go
+++ b/examples/03-workflows/_start-here/01_executors_and_edges/main.go
@@ -36,7 +36,6 @@ func main() {
 		AddEdge(uppercase, reverse).
 		WithOutputFrom(reverse).
 		Build()
-
 	if err != nil {
 		panic(err)
 	}

--- a/examples/03-workflows/_start-here/02_streaming/main.go
+++ b/examples/03-workflows/_start-here/02_streaming/main.go
@@ -36,7 +36,6 @@ func main() {
 		AddEdge(uppercase, reverse).
 		WithOutputFrom(reverse).
 		Build()
-
 	if err != nil {
 		panic(err)
 	}

--- a/examples/03-workflows/_start-here/03_agents/main.go
+++ b/examples/03-workflows/_start-here/03_agents/main.go
@@ -32,7 +32,6 @@ func main() {
 		AddEdge(frenchAgent, spanishAgent).
 		AddEdge(spanishAgent, englishAgent).
 		Build()
-
 	if err != nil {
 		panic(err)
 	}

--- a/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
@@ -22,10 +22,12 @@ import (
 	"github.com/openai/openai-go/v3/azure"
 )
 
-var deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
-var endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
-var apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
-var agentURLsEnv = cmp.Or(os.Getenv("A2A_AGENT_URLS"), "http://localhost:5000;http://localhost:5001;http://localhost:5002")
+var (
+	deployment   = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	endpoint     = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion   = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+	agentURLsEnv = cmp.Or(os.Getenv("A2A_AGENT_URLS"), "http://localhost:5000;http://localhost:5001;http://localhost:5002")
+)
 
 func main() {
 	ctx := context.Background()

--- a/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
@@ -201,11 +201,11 @@ original invoice and the credit memo number. Use the 'Formal Credit Notification
 template."`,
 		}
 		card.Name = "PolicyAgent"
-		card.Description = cfg.Config.Description
+		card.Description = cfg.Description
 		card.Skills = []a2a.AgentSkill{{
 			ID:          "id_policy_agent",
 			Name:        "PolicyAgent",
-			Description: cfg.Config.Description,
+			Description: cfg.Description,
 			Tags:        []string{"policy", "agent-framework-go"},
 			Examples:    []string{"What is the policy for short shipments?"},
 		}}
@@ -222,11 +222,11 @@ Item: TSHIRT-RED-L
 Quantity: 900`,
 		}
 		card.Name = "LogisticsAgent"
-		card.Description = cfg.Config.Description
+		card.Description = cfg.Description
 		card.Skills = []a2a.AgentSkill{{
 			ID:          "id_logistics_agent",
 			Name:        "LogisticsQuery",
-			Description: cfg.Config.Description,
+			Description: cfg.Description,
 			Tags:        []string{"logistics", "agent-framework-go"},
 			Examples:    []string{"What is the status for SHPMT-SAP-001"},
 		}}
@@ -235,5 +235,4 @@ Quantity: 900`,
 	}
 
 	return cfg, card
-
 }

--- a/examples/demos/chat_cli/main.go
+++ b/examples/demos/chat_cli/main.go
@@ -9,16 +9,9 @@ import (
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
-	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 	"github.com/openai/openai-go/v3"
-)
-
-var logger = demo.NewLogger(
-	"Chat CLI - Interactive Mode",
-	"Type your message and press Enter to chat.\nCommands: 'exit' or 'quit' to end, 'clear' to reset conversation",
-	"Model", "gpt-4o-mini",
 )
 
 var weatherTool = functool.MustNew(functool.Config{

--- a/examples/internal/demo/demo.go
+++ b/examples/internal/demo/demo.go
@@ -150,7 +150,7 @@ func UserInputRequest(req *message.FunctionApprovalRequestContent) bool {
 	fmt.Printf("Please reply Y to approve.\n\n")
 
 	var approval string
-	fmt.Scanln(&approval)
+	_, _ = fmt.Scanln(&approval)
 	fmt.Printf("\n")
 	return approval == "Y" || approval == "y"
 }
@@ -160,8 +160,8 @@ func assistant() {
 }
 
 func printf(format string, args ...any) {
-	//now := time.Now().Format("15:04:05")
-	//fmt.Printf("%s[%s]%s ", colorGray, now, colorReset)
+	// now := time.Now().Format("15:04:05")
+	// fmt.Printf("%s[%s]%s ", colorGray, now, colorReset)
 	fmt.Printf(format, args...)
 }
 

--- a/format/jsonformat/encoding_test.go
+++ b/format/jsonformat/encoding_test.go
@@ -38,7 +38,7 @@ func TestEncodingRoundtrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Marshal: %v", err)
 			}
-			var v2 any = reflect.New(rt).Interface()
+			v2 := reflect.New(rt).Interface()
 			if err := format.Unmarshal(data, &v2); err != nil {
 				t.Fatalf("Unmarshal: %v", err)
 			}

--- a/internal/concurrent/map.go
+++ b/internal/concurrent/map.go
@@ -75,8 +75,8 @@ func (m *Map[K, V]) Swap(key K, value V) (V, bool) {
 // CompareAndSwap swaps the old and new values for key
 // if the value stored in the map is equal to old.
 // The old value must be of a comparable type.
-func (m *Map[K, V]) CompareAndSwap(key K, old, new V) (swapped bool) {
-	return m.data.CompareAndSwap(key, old, new)
+func (m *Map[K, V]) CompareAndSwap(key K, old, newVal V) (swapped bool) {
+	return m.data.CompareAndSwap(key, old, newVal)
 }
 
 // CompareAndDelete deletes the entry for key if its value is equal to old.

--- a/internal/errgroup/errgroup_test.go
+++ b/internal/errgroup/errgroup_test.go
@@ -23,8 +23,10 @@ var (
 	Video = fakeSearch("video")
 )
 
-type Result string
-type Search func(ctx context.Context, query string) (Result, error)
+type (
+	Result string
+	Search func(ctx context.Context, query string) (Result, error)
+)
 
 func fakeSearch(kind string) Search {
 	return func(_ context.Context, query string) (Result, error) {
@@ -37,7 +39,7 @@ func fakeSearch(kind string) Search {
 // the sync.WaitGroup example at https://golang.org/pkg/sync/#example_WaitGroup.
 func ExampleGroup_justErrors() {
 	g := new(errgroup.Group)
-	var urls = []string{
+	urls := []string{
 		"http://www.golang.org/",
 		"http://www.google.com/",
 		"http://www.somestupidname.com/",
@@ -49,7 +51,7 @@ func ExampleGroup_justErrors() {
 			// Fetch the URL.
 			resp, err := http.Get(url)
 			if err == nil {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			}
 			return err
 		})
@@ -199,13 +201,13 @@ func TestTryGo(t *testing.T) {
 			<-ch
 		}
 	}()
-	g.Wait()
+	_ = g.Wait()
 
 	if !g.TryGo(fn) {
 		t.Fatalf("TryGo should success but got fail after all goroutines.")
 	}
 	go func() { <-ch }()
-	g.Wait()
+	_ = g.Wait()
 
 	// Switch limit.
 	g.SetLimit(1)
@@ -216,7 +218,7 @@ func TestTryGo(t *testing.T) {
 		t.Fatalf("TryGo should fail but succeeded.")
 	}
 	go func() { <-ch }()
-	g.Wait()
+	_ = g.Wait()
 
 	// Block all calls.
 	g.SetLimit(0)
@@ -225,7 +227,7 @@ func TestTryGo(t *testing.T) {
 			t.Fatalf("TryGo should fail but got succeeded.")
 		}
 	}
-	g.Wait()
+	_ = g.Wait()
 }
 
 func TestGoLimit(t *testing.T) {
@@ -297,5 +299,5 @@ func BenchmarkGo(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		g.Go(func() error { fn(); return nil })
 	}
-	g.Wait()
+	_ = g.Wait()
 }

--- a/internal/messagetest/messagetest.go
+++ b/internal/messagetest/messagetest.go
@@ -133,17 +133,17 @@ func ContentEqual(got, want message.Content) error {
 			return fmt.Errorf("CallID mismatch: expected %q, got %q", expContent.CallID, act.CallID)
 		}
 		if expContent.Name != act.Name {
-			return fmt.Errorf("Name mismatch: expected %q, got %q", expContent.Name, act.Name)
+			return fmt.Errorf("name mismatch: expected %q, got %q", expContent.Name, act.Name)
 		}
 		if expContent.Arguments != act.Arguments {
-			return fmt.Errorf("Arguments mismatch: expected %q, got %q", expContent.Arguments, act.Arguments)
+			return fmt.Errorf("arguments mismatch: expected %q, got %q", expContent.Arguments, act.Arguments)
 		}
 		// Compare Error fields
 		if (expContent.Error == nil) != (act.Error == nil) {
-			return fmt.Errorf("Error presence mismatch: expected %v, got %v", expContent.Error, act.Error)
+			return fmt.Errorf("error presence mismatch: expected %v, got %v", expContent.Error, act.Error)
 		}
 		if expContent.Error != nil && act.Error != nil && expContent.Error.Error() != act.Error.Error() {
-			return fmt.Errorf("Error message mismatch: expected %q, got %q", expContent.Error, act.Error)
+			return fmt.Errorf("error message mismatch: expected %q, got %q", expContent.Error, act.Error)
 		}
 	case *message.FunctionResultContent:
 		act := got.(*message.FunctionResultContent)
@@ -153,10 +153,10 @@ func ContentEqual(got, want message.Content) error {
 
 		// Compare Error fields
 		if (expContent.Error == nil) != (act.Error == nil) {
-			return fmt.Errorf("Error presence mismatch: expected %q, got %q", expContent.Error, act.Error)
+			return fmt.Errorf("error presence mismatch: expected %q, got %q", expContent.Error, act.Error)
 		}
 		if expContent.Error != nil && act.Error != nil && expContent.Error.Error() != act.Error.Error() {
-			return fmt.Errorf("Error message mismatch: expected %q, got %q", expContent.Error, act.Error)
+			return fmt.Errorf("error message mismatch: expected %q, got %q", expContent.Error, act.Error)
 		}
 
 		// Compare Result - handle json.RawMessage wrapping
@@ -171,7 +171,7 @@ func ContentEqual(got, want message.Content) error {
 			}
 		}
 		if !reflect.DeepEqual(expResult, actResult) {
-			return fmt.Errorf("Result mismatch:\nexpected: %#v\ngot:      %#v", expResult, actResult)
+			return fmt.Errorf("result mismatch:\nexpected: %#v\ngot:      %#v", expResult, actResult)
 		}
 	default:
 		if !reflect.DeepEqual(expContent, got) {

--- a/memory/context_test.go
+++ b/memory/context_test.go
@@ -153,7 +153,8 @@ func TestContextProvider_Invoked_CallsStoreAndExcludesSameProviderRequestMessage
 		},
 	}
 
-	err := provider.AfterRun(AfterRunContext{Context: context.Background(),
+	err := provider.AfterRun(AfterRunContext{
+		Context:          context.Background(),
 		Session:          NewSession(""),
 		RequestMessages:  []*message.Message{req1, req2},
 		ResponseMessages: []*message.Message{resp},
@@ -208,7 +209,8 @@ func TestContextProvider_InvokingContext_ReturnsProvidedFields(t *testing.T) {
 		},
 	}
 
-	out, err := provider.BeforeRun(BeforeRunContext{Context: context.Background(),
+	out, err := provider.BeforeRun(BeforeRunContext{
+		Context:  context.Background(),
 		Session:  NewSession(""),
 		Messages: []*message.Message{request},
 		Tools:    []tool.Tool{inputTool},

--- a/memory/session.go
+++ b/memory/session.go
@@ -95,7 +95,7 @@ func (s *Session) Delete(key string) {
 }
 
 func (s *Session) MarshalJSON() ([]byte, error) {
-	var tmp = struct {
+	tmp := struct {
 		State map[string]*stateValue
 
 		ID        string

--- a/memory/skills/fsskills/source.go
+++ b/memory/skills/fsskills/source.go
@@ -24,16 +24,22 @@ const (
 	rootFSPropertyKey = "fsskills.rootFS"
 )
 
-var defaultResourceDirectories = []string{"references", "assets"}
-var defaultScriptDirectories = []string{"scripts"}
+var (
+	defaultResourceDirectories = []string{"references", "assets"}
+	defaultScriptDirectories   = []string{"scripts"}
+)
 
-var defaultResourceExtensions = []string{".md", ".json", ".yaml", ".yml", ".csv", ".xml", ".txt"}
-var defaultScriptExtensions = []string{".py", ".js", ".sh", ".ps1", ".cs", ".csx"}
+var (
+	defaultResourceExtensions = []string{".md", ".json", ".yaml", ".yml", ".csv", ".xml", ".txt"}
+	defaultScriptExtensions   = []string{".py", ".js", ".sh", ".ps1", ".cs", ".csx"}
+)
 
-var frontmatterRegex = regexp.MustCompile(`(?ms)\A^---\s*$(.+?)^---\s*$`)
-var yamlKeyValueRegex = regexp.MustCompile(`(?m)^([\w-]+)\s*:\s*(?:["'](.+?)["']|(.+?))\s*$`)
-var yamlMetadataBlockRegex = regexp.MustCompile(`(?m)^metadata\s*:\s*$\n((?:[ \t]+\S.*\n?)+)`)
-var yamlIndentedKeyValueRegex = regexp.MustCompile(`(?m)^\s+([\w-]+)\s*:\s*(?:["'](.+?)["']|(.+?))\s*$`)
+var (
+	frontmatterRegex          = regexp.MustCompile(`(?ms)\A^---\s*$(.+?)^---\s*$`)
+	yamlKeyValueRegex         = regexp.MustCompile(`(?m)^([\w-]+)\s*:\s*(?:["'](.+?)["']|(.+?))\s*$`)
+	yamlMetadataBlockRegex    = regexp.MustCompile(`(?m)^metadata\s*:\s*$\n((?:[ \t]+\S.*\n?)+)`)
+	yamlIndentedKeyValueRegex = regexp.MustCompile(`(?m)^\s+([\w-]+)\s*:\s*(?:["'](.+?)["']|(.+?))\s*$`)
+)
 
 // SourceOptions configures file-based skill discovery.
 //

--- a/memory/skills/provider.go
+++ b/memory/skills/provider.go
@@ -321,7 +321,8 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 			},
 			func(_ tool.Context, in struct {
 				SkillName string `json:"skillName" jsonschema:"The name of the skill to load"`
-			}) (string, error) {
+			},
+			) (string, error) {
 				return p.loadSkill(skills, in.SkillName), nil
 			},
 		),
@@ -336,7 +337,8 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 			func(callCtx tool.Context, in struct {
 				SkillName    string `json:"skillName" jsonschema:"The name of the skill"`
 				ResourceName string `json:"resourceName" jsonschema:"The exact resource name to read"`
-			}) (any, error) {
+			},
+			) (any, error) {
 				return p.readSkillResource(callCtx.Context, skills, in.SkillName, in.ResourceName), nil
 			},
 		))
@@ -355,7 +357,8 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 			SkillName  string         `json:"skillName" jsonschema:"The name of the skill"`
 			ScriptName string         `json:"scriptName" jsonschema:"The exact script name to run"`
 			Arguments  map[string]any `json:"arguments,omitempty" jsonschema:"Optional arguments for the script"`
-		}) (any, error) {
+		},
+		) (any, error) {
 			return p.runSkillScript(callCtx.Context, skills, in.SkillName, in.ScriptName, in.Arguments), nil
 		},
 	)
@@ -448,8 +451,8 @@ func buildProviderSkillsInstructionPrompt(template string, skills []*Skill, incl
 	var sb strings.Builder
 	for _, skill := range sortedSkills {
 		sb.WriteString("  <skill>\n")
-		sb.WriteString(fmt.Sprintf("    <name>%s</name>\n", xmlEscape(skill.Frontmatter.Name)))
-		sb.WriteString(fmt.Sprintf("    <description>%s</description>\n", xmlEscape(skill.Frontmatter.Description)))
+		_, _ = fmt.Fprintf(&sb, "    <name>%s</name>\n", xmlEscape(skill.Frontmatter.Name))
+		_, _ = fmt.Fprintf(&sb, "    <description>%s</description>\n", xmlEscape(skill.Frontmatter.Description))
 		sb.WriteString("  </skill>\n")
 	}
 

--- a/memory/skills/skills_test.go
+++ b/memory/skills/skills_test.go
@@ -90,7 +90,8 @@ func newProviderWithConfig(t *testing.T, sourceOptions *fsskills.SourceOptions, 
 func captureProviderContext(t *testing.T, provider *memory.ContextProvider) (string, []tool.Tool) {
 	t.Helper()
 	ctx := context.Background()
-	out, err := provider.BeforeRun(memory.BeforeRunContext{Context: ctx,
+	out, err := provider.BeforeRun(memory.BeforeRunContext{
+		Context:  ctx,
 		Session:  memory.NewSession(""),
 		Messages: nil,
 		Tools:    nil,

--- a/message/annotation.go
+++ b/message/annotation.go
@@ -9,8 +9,10 @@ import (
 	"github.com/microsoft/agent-framework-go/internal/jsonx"
 )
 
-var supportedAnnotations map[annotationKind]reflect.Type
-var supportedAnnotatedRegions map[annotatedRegionKind]reflect.Type
+var (
+	supportedAnnotations      map[annotationKind]reflect.Type
+	supportedAnnotatedRegions map[annotatedRegionKind]reflect.Type
+)
 
 func init() {
 	supportedAnnotations = make(map[annotationKind]reflect.Type)

--- a/message/messageworkflow/messageworkflow.go
+++ b/message/messageworkflow/messageworkflow.go
@@ -42,7 +42,8 @@ func NewExecutorConfig(options *Options) *workflow.ExecutorConfig {
 					return struct{}{}, cache.InvokeWithState(ctx, false, func(ctx *workflow.Context, state []*message.Message) ([]*message.Message, error) {
 						return append(state, &message.Message{
 							Role:     message.Role(options.StringMessageRole),
-							Contents: []message.Content{&message.TextContent{Text: msg.(string)}}},
+							Contents: []message.Content{&message.TextContent{Text: msg.(string)}},
+						},
 						), nil
 					})
 				})

--- a/message/messageworkflow/messageworkflow_test.go
+++ b/message/messageworkflow/messageworkflow_test.go
@@ -141,16 +141,24 @@ func TestExecutor_AccumulatesAndClearsMessagesPerTurn(t *testing.T) {
 	})
 
 	// Send multiple message batches before taking a turn
-	_, _ = executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 1"}}})
-	_, _ = executor.Execute(ctx, []*message.Message{
+	if _, err := executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 1"}}}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if _, err := executor.Execute(ctx, []*message.Message{
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 2"}}},
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 3"}}},
-	})
+	}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 	// Note: Go doesn't have a separate array type vs slice for this purpose usually, but we can test iter.Seq if we want.
 	// The C# test used array. Here we just use another slice or single message.
-	_, _ = executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 4"}}})
+	if _, err := executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 4"}}}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 
-	_, _ = executor.Execute(ctx, workflow.TurnToken{})
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 
 	if len(te.receivedMessages) != 4 {
 		t.Errorf("Expected 4 messages, got %d", len(te.receivedMessages))
@@ -169,10 +177,14 @@ func TestExecutor_AccumulatesAndClearsMessagesPerTurn(t *testing.T) {
 	te.receivedMessages = nil
 
 	// Second turn should process new messages only
-	_, _ = executor.Execute(ctx, []*message.Message{
+	if _, err := executor.Execute(ctx, []*message.Message{
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Second batch"}}},
-	})
-	_, _ = executor.Execute(ctx, workflow.TurnToken{})
+	}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 
 	if len(te.receivedMessages) != 1 {
 		t.Errorf("Expected 1 message, got %d", len(te.receivedMessages))
@@ -196,7 +208,9 @@ func TestExecutor_WithStringRole_ConvertsStringToMessage(t *testing.T) {
 	if _, err := executor.Execute(ctx, "String message"); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	_, _ = executor.Execute(ctx, workflow.TurnToken{})
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 
 	if len(te.receivedMessages) != 1 {
 		t.Errorf("Expected 1 message, got %d", len(te.receivedMessages))
@@ -216,8 +230,12 @@ func TestExecutor_EmptyCollection_HandledCorrectly(t *testing.T) {
 		TakeTurnHandler: te.takeTurn,
 	})
 
-	_, _ = executor.Execute(ctx, []*message.Message{})
-	_, _ = executor.Execute(ctx, workflow.TurnToken{})
+	if _, err := executor.Execute(ctx, []*message.Message{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 
 	if len(te.receivedMessages) != 0 {
 		t.Errorf("Expected 0 messages, got %d", len(te.receivedMessages))
@@ -234,15 +252,23 @@ func TestExecutor_MultipleTurns_EachTurnProcessesSeparately(t *testing.T) {
 		TakeTurnHandler: te.takeTurn,
 	})
 
-	_, _ = executor.Execute(ctx, []*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 1"}}}})
-	_, _ = executor.Execute(ctx, workflow.TurnToken{})
+	if _, err := executor.Execute(ctx, []*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 1"}}}}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 
 	if len(te.receivedMessages) != 1 {
 		t.Errorf("Expected 1 message, got %d", len(te.receivedMessages))
 	}
 
-	_, _ = executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 2"}}})
-	_, _ = executor.Execute(ctx, workflow.TurnToken{})
+	if _, err := executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 2"}}}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
 
 	if len(te.receivedMessages) != 2 {
 		t.Errorf("Expected 2 messages, got %d", len(te.receivedMessages))

--- a/message/messageworkflow/messageworkflow_test.go
+++ b/message/messageworkflow/messageworkflow_test.go
@@ -141,16 +141,16 @@ func TestExecutor_AccumulatesAndClearsMessagesPerTurn(t *testing.T) {
 	})
 
 	// Send multiple message batches before taking a turn
-	executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 1"}}})
-	executor.Execute(ctx, []*message.Message{
+	_, _ = executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 1"}}})
+	_, _ = executor.Execute(ctx, []*message.Message{
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 2"}}},
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 3"}}},
 	})
 	// Note: Go doesn't have a separate array type vs slice for this purpose usually, but we can test iter.Seq if we want.
 	// The C# test used array. Here we just use another slice or single message.
-	executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 4"}}})
+	_, _ = executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Message 4"}}})
 
-	executor.Execute(ctx, workflow.TurnToken{})
+	_, _ = executor.Execute(ctx, workflow.TurnToken{})
 
 	if len(te.receivedMessages) != 4 {
 		t.Errorf("Expected 4 messages, got %d", len(te.receivedMessages))
@@ -169,10 +169,10 @@ func TestExecutor_AccumulatesAndClearsMessagesPerTurn(t *testing.T) {
 	te.receivedMessages = nil
 
 	// Second turn should process new messages only
-	executor.Execute(ctx, []*message.Message{
+	_, _ = executor.Execute(ctx, []*message.Message{
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Second batch"}}},
 	})
-	executor.Execute(ctx, workflow.TurnToken{})
+	_, _ = executor.Execute(ctx, workflow.TurnToken{})
 
 	if len(te.receivedMessages) != 1 {
 		t.Errorf("Expected 1 message, got %d", len(te.receivedMessages))
@@ -196,7 +196,7 @@ func TestExecutor_WithStringRole_ConvertsStringToMessage(t *testing.T) {
 	if _, err := executor.Execute(ctx, "String message"); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	executor.Execute(ctx, workflow.TurnToken{})
+	_, _ = executor.Execute(ctx, workflow.TurnToken{})
 
 	if len(te.receivedMessages) != 1 {
 		t.Errorf("Expected 1 message, got %d", len(te.receivedMessages))
@@ -216,8 +216,8 @@ func TestExecutor_EmptyCollection_HandledCorrectly(t *testing.T) {
 		TakeTurnHandler: te.takeTurn,
 	})
 
-	executor.Execute(ctx, []*message.Message{})
-	executor.Execute(ctx, workflow.TurnToken{})
+	_, _ = executor.Execute(ctx, []*message.Message{})
+	_, _ = executor.Execute(ctx, workflow.TurnToken{})
 
 	if len(te.receivedMessages) != 0 {
 		t.Errorf("Expected 0 messages, got %d", len(te.receivedMessages))
@@ -234,15 +234,15 @@ func TestExecutor_MultipleTurns_EachTurnProcessesSeparately(t *testing.T) {
 		TakeTurnHandler: te.takeTurn,
 	})
 
-	executor.Execute(ctx, []*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 1"}}}})
-	executor.Execute(ctx, workflow.TurnToken{})
+	_, _ = executor.Execute(ctx, []*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 1"}}}})
+	_, _ = executor.Execute(ctx, workflow.TurnToken{})
 
 	if len(te.receivedMessages) != 1 {
 		t.Errorf("Expected 1 message, got %d", len(te.receivedMessages))
 	}
 
-	executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 2"}}})
-	executor.Execute(ctx, workflow.TurnToken{})
+	_, _ = executor.Execute(ctx, &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Turn 2"}}})
+	_, _ = executor.Execute(ctx, workflow.TurnToken{})
 
 	if len(te.receivedMessages) != 2 {
 		t.Errorf("Expected 2 messages, got %d", len(te.receivedMessages))

--- a/tool/mcptool/mcp.go
+++ b/tool/mcptool/mcp.go
@@ -102,8 +102,10 @@ func mcpContentToAgentContent(mcpContents []mcp.Content) []message.Content {
 	return result
 }
 
-var _ tool.Tool = (*mcpWrapper)(nil)
-var _ tool.FuncTool = (*mcpWrapper)(nil)
+var (
+	_ tool.Tool     = (*mcpWrapper)(nil)
+	_ tool.FuncTool = (*mcpWrapper)(nil)
+)
 
 // mcpWrapper wraps an MCP tool as an agent.Tool.
 type mcpWrapper struct {

--- a/workflow/binding.go
+++ b/workflow/binding.go
@@ -60,17 +60,6 @@ func (eb *ExecutorBinding) CreateInstance(runID string) (*Executor, error) {
 	return ex, nil
 }
 
-func newConfiguredExecutorBinding(conf Configured[*Executor], executorType reflect.Type) *ExecutorBinding {
-	return &ExecutorBinding{
-		ID:                                conf.ID,
-		ExecutorType:                      executorType,
-		Raw:                               conf.Raw,
-		NewExecutor:                       conf.NewBound,
-		SupportsConcurrentSharedExecution: true,
-		IsSharedInstance:                  true,
-	}
-}
-
 func newRequestPortExecutor(port RequestPort, allowWrapped bool) *Executor {
 	var e requestPortExecutor
 	return &Executor{
@@ -137,7 +126,6 @@ func (r *requestPortExecutor) handleAsync(ctx *Context, msg any) (any, error) {
 		if r.allowWrapped {
 			if original, ok := r.wrappedRequests[msg.RequestID]; ok {
 				sendMsg = original.Rewrap(msg)
-
 			}
 		}
 		if err := ctx.SendMessage("", sendMsg); err != nil {

--- a/workflow/builder_test.go
+++ b/workflow/builder_test.go
@@ -101,7 +101,6 @@ func TestBuilder_Validation_AddEdgesOutOfOrderDoesNotImpactReachability(t *testi
 		AddEdge(newNoOpExecutor("not-unreachable"), newNoOpExecutor("also-not-unreachable")).
 		AddEdge(newPlaceholder("start"), newPlaceholder("not-unreachable")).
 		Build()
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -129,7 +128,6 @@ func TestBuilder_LateBinding_Executor(t *testing.T) {
 	wf, err := workflow.NewBuilder(newPlaceholder("start")).
 		BindExecutor(newNoOpExecutor("start")).
 		Build()
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -156,7 +154,6 @@ func TestBuilder_LateImplicitBinding_Executor(t *testing.T) {
 	wf, err := workflow.NewBuilder(newPlaceholder("start")).
 		AddEdge(start, start).
 		Build()
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -199,7 +196,6 @@ func TestBuilder_RebindToSameish_Allowed(t *testing.T) {
 	wf, err := workflow.NewBuilder(newPlaceholder("start")).
 		AddEdge(executor1, executor1).
 		Build()
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -228,7 +224,6 @@ func TestBuilder_Workflow_NameAndDescription(t *testing.T) {
 		WithDescription("Test workflow description").
 		BindExecutor(newNoOpExecutor("start")).
 		Build()
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -244,7 +239,6 @@ func TestBuilder_Workflow_NameAndDescription(t *testing.T) {
 	wf2, err := workflow.NewBuilder(newPlaceholder("start2")).
 		BindExecutor(newNoOpExecutor("start2")).
 		Build()
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -261,7 +255,6 @@ func TestBuilder_Workflow_NameAndDescription(t *testing.T) {
 		WithName("Named Only").
 		BindExecutor(newNoOpExecutor("start3")).
 		Build()
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/workflow/configured.go
+++ b/workflow/configured.go
@@ -66,6 +66,7 @@ func (c *ConfiguredOf[T, O]) Memoize() Configured[T] {
 func (c *ConfiguredOf[T, O]) NewBound(runID string) (T, error) {
 	return c.createValidatingMemoizedFunc()(Config{ID: c.ID}, runID)
 }
+
 func (c *ConfiguredOf[T, O]) createValidatingMemoizedFunc() func(Config, string) (T, error) {
 	return func(config Config, runID string) (s T, err error) {
 		if c.ID != config.ID {

--- a/workflow/event.go
+++ b/workflow/event.go
@@ -72,7 +72,7 @@ type SuperStepCompletionInfo struct {
 	HasPendingMessages    bool
 	HasPendingRequests    bool
 	StateUpdated          bool
-	CheckpointInfo        any // TODO: Use proper CheckpointInfo type
+	CheckpointInfo        any // Use proper CheckpointInfo type in the future.
 }
 
 var _ Event = SuperStepCompletedEvent{}

--- a/workflow/event.go
+++ b/workflow/event.go
@@ -72,7 +72,7 @@ type SuperStepCompletionInfo struct {
 	HasPendingMessages    bool
 	HasPendingRequests    bool
 	StateUpdated          bool
-	CheckpointInfo        any // Use proper CheckpointInfo type in the future.
+	CheckpointInfo        any // TODO: Use proper CheckpointInfo type
 }
 
 var _ Event = SuperStepCompletedEvent{}

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -131,7 +131,7 @@ func (proc *runnerContext) EnsureExecutor(ctx context.Context, executorID string
 		tracer.TraceActivated(executorID)
 	}
 
-	// Handle special executor types (RequestInfoExecutor, WorkflowHostExecutor) in the future.
+	// TODO: Handle special executor types (RequestInfoExecutor, WorkflowHostExecutor)
 
 	proc.executors[executorID] = executor
 
@@ -278,7 +278,7 @@ func (proc *runnerContext) SendMessage(ctx context.Context, sourceID, targetID s
 		return err
 	}
 
-	// Add OpenTelemetry trace context propagation in the future.
+	// TODO: Add OpenTelemetry trace context propagation
 	envelope, err := execution.NewMessageEnvelope(message, nil, sourceID, targetID)
 	if err != nil {
 		return err

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -56,7 +56,6 @@ func newInProcessRunnerContext(
 	existingOwnerSignoff any,
 	enableConcurrentRuns bool,
 ) (*runnerContext, error) {
-
 	ctx := &runnerContext{
 		wf:                       wf,
 		runID:                    runID,
@@ -132,7 +131,7 @@ func (proc *runnerContext) EnsureExecutor(ctx context.Context, executorID string
 		tracer.TraceActivated(executorID)
 	}
 
-	// TODO: Handle special executor types (RequestInfoExecutor, WorkflowHostExecutor)
+	// Handle special executor types (RequestInfoExecutor, WorkflowHostExecutor) in the future.
 
 	proc.executors[executorID] = executor
 
@@ -279,7 +278,7 @@ func (proc *runnerContext) SendMessage(ctx context.Context, sourceID, targetID s
 		return err
 	}
 
-	// TODO: Add OpenTelemetry trace context propagation
+	// Add OpenTelemetry trace context propagation in the future.
 	envelope, err := execution.NewMessageEnvelope(message, nil, sourceID, targetID)
 	if err != nil {
 		return err

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -17,8 +17,10 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow/internal/execution"
 )
 
-var _ execution.SuperStepRunner = (*runner)(nil)
-var _ checkpoint.CheckpointingHandle = (*runner)(nil)
+var (
+	_ execution.SuperStepRunner      = (*runner)(nil)
+	_ checkpoint.CheckpointingHandle = (*runner)(nil)
+)
 
 // runner provides a local, in-process runner for executing a workflow.
 // It enables step-by-step execution of a workflow graph entirely within the current process,
@@ -36,8 +38,7 @@ type runner struct {
 
 	knownValidInputTypes map[reflect.Type]struct{}
 
-	workflowInfoCache *checkpoint.WorkflowInfo
-	checkpoints       []workflow.CheckpointInfo
+	checkpoints []workflow.CheckpointInfo
 }
 
 // createTopLevelRunner creates a new top-level InProcessRunner for the given workflow.
@@ -52,21 +53,6 @@ func createTopLevelRunner(
 		runID = uuid.NewString()
 	}
 	return newInProcessRunner(wf, checkpointMgr, runID, nil, enableConcurrentRuns, knownValidInputTypes)
-}
-
-// createSubworkflowRunner creates a new subworkflow InProcessRunner.
-func createSubworkflowRunner(
-	wf *workflow.Workflow,
-	checkpointMgr checkpoint.Manager,
-	runID string,
-	existingOwnerSignoff any,
-	enableConcurrentRuns bool,
-	knownValidInputTypes []reflect.Type,
-) (*runner, error) {
-	if runID == "" {
-		runID = uuid.NewString()
-	}
-	return newInProcessRunner(wf, checkpointMgr, runID, existingOwnerSignoff, enableConcurrentRuns, knownValidInputTypes)
 }
 
 func newInProcessRunner(
@@ -243,7 +229,7 @@ func (r *runner) RunSuperStep(ctx context.Context) (bool, error) {
 
 		if err := r.runSuperstep(ctx, currentStep); err != nil {
 			if !errors.Is(err, context.Canceled) {
-				r.outgoingEvents.Enqueue(ctx, workflow.ErrorEvent{Error: err})
+				_ = r.outgoingEvents.Enqueue(ctx, workflow.ErrorEvent{Error: err})
 			}
 		}
 		return true, nil
@@ -284,7 +270,7 @@ func (r *runner) RestoreCheckpoint(ctx context.Context, checkpointInfo workflow.
 	if err := r.runContext.stateManager.ImportState(cp); err != nil {
 		return err
 	}
-	// TODO: Implement full checkpoint restoration
+	// Implement full checkpoint restoration in the future.
 	return fmt.Errorf("checkpoint restore not yet implemented")
 }
 
@@ -354,8 +340,8 @@ func (r *runner) checkpoint(ctx context.Context) error {
 		return r.runContext.stateManager.PublishUpdates(r.stepTracer)
 	}
 
-	// TODO: Implement full checkpoint creation
-	// This requires implementing WorkflowInfo and state export for all components
+	// Implement full checkpoint creation in the future.
+	// This requires implementing WorkflowInfo and state export for all components.
 
 	return r.runContext.stateManager.PublishUpdates(r.stepTracer)
 }

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -270,7 +270,7 @@ func (r *runner) RestoreCheckpoint(ctx context.Context, checkpointInfo workflow.
 	if err := r.runContext.stateManager.ImportState(cp); err != nil {
 		return err
 	}
-	// Implement full checkpoint restoration in the future.
+	// TODO: Implement full checkpoint restoration
 	return fmt.Errorf("checkpoint restore not yet implemented")
 }
 
@@ -340,8 +340,8 @@ func (r *runner) checkpoint(ctx context.Context) error {
 		return r.runContext.stateManager.PublishUpdates(r.stepTracer)
 	}
 
-	// Implement full checkpoint creation in the future.
-	// This requires implementing WorkflowInfo and state export for all components.
+	// TODO: Implement full checkpoint creation
+	// This requires implementing WorkflowInfo and state export for all components
 
 	return r.runContext.stateManager.PublishUpdates(r.stepTracer)
 }

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -229,7 +229,9 @@ func (r *runner) RunSuperStep(ctx context.Context) (bool, error) {
 
 		if err := r.runSuperstep(ctx, currentStep); err != nil {
 			if !errors.Is(err, context.Canceled) {
-				_ = r.outgoingEvents.Enqueue(ctx, workflow.ErrorEvent{Error: err})
+				if enqErr := r.outgoingEvents.Enqueue(ctx, workflow.ErrorEvent{Error: err}); enqErr != nil {
+					return true, errors.Join(err, enqErr)
+				}
 			}
 		}
 		return true, nil

--- a/workflow/inproc/state_test.go
+++ b/workflow/inproc/state_test.go
@@ -234,7 +234,7 @@ func TestInProcessRun_StateShouldPersist_Checkpointed(t *testing.T) {
 		t.Error("Validator should be completed")
 	}
 
-	// Verify checkpoints when implemented.
+	// TODO: Verify checkpoints when implemented
 }
 
 func TestInProcessRun_StateShouldError_TwoExecutors(t *testing.T) {

--- a/workflow/inproc/state_test.go
+++ b/workflow/inproc/state_test.go
@@ -123,10 +123,10 @@ func validateState(t *testing.T, expectedValue int) func(*int) *int {
 	}
 }
 
-func maxTurns(max int) func(any) bool {
+func maxTurns(limit int) func(any) bool {
 	return func(maybeTurn any) bool {
 		if turn, ok := maybeTurn.(TestTurnToken); ok {
-			return turn.Count < max
+			return turn.Count < limit
 		}
 		return false
 	}
@@ -234,7 +234,7 @@ func TestInProcessRun_StateShouldPersist_Checkpointed(t *testing.T) {
 		t.Error("Validator should be completed")
 	}
 
-	// TODO: Verify checkpoints when implemented
+	// Verify checkpoints when implemented.
 }
 
 func TestInProcessRun_StateShouldError_TwoExecutors(t *testing.T) {

--- a/workflow/internal/checkpoint/info.go
+++ b/workflow/internal/checkpoint/info.go
@@ -27,7 +27,6 @@ type WorkflowInfo struct {
 	requestPorts      map[workflow.RequestPortInfo]struct{}
 	startExecutorID   string
 	outputExecutorIDs map[string]struct{}
-	inputType         workflow.TypeID
 }
 
 func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {

--- a/workflow/internal/execution/state_test.go
+++ b/workflow/internal/execution/state_test.go
@@ -40,7 +40,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 1: Write a key from the self executor's view of the shared scope
-	manager.WriteStateByID(sharedScopeSelfView, Key1, "value1")
+	_ = manager.WriteStateByID(sharedScopeSelfView, Key1, "value1")
 
 	// Assert 1: The self executor should see the key immediately, but the other executor should not
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -58,7 +58,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 2: Publish the updates
-	manager.PublishUpdates(nil)
+	_ = manager.PublishUpdates(nil)
 
 	// Assert 2: Both executors should see the key now, if sharedScope
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -78,7 +78,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 3: Clear the state from the self executor's view of the shared scope
-	manager.ClearStateKeyByID(sharedScopeSelfView, Key1)
+	_ = manager.ClearStateKeyByID(sharedScopeSelfView, Key1)
 
 	// Assert 3: The self executor should not see the key immediately, but the other executor should still see it if sharedScope
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -98,7 +98,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 4: Publish the updates
-	manager.PublishUpdates(nil)
+	_ = manager.PublishUpdates(nil)
 
 	// Assert 4: Neither executor should see the key now
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -166,7 +166,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, nil, "there should be no values in an empty StateManager")
 
 	// Act 1: Write a value from the self executor's view of the shared scope
-	manager.WriteStateByID(scopeSelfView, Key1, Value1)
+	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
 
 	// Assert 1
 	checkValue(scopeSelfView, Key1, Value1, "writes should be visible immediately to the writing executor")
@@ -175,7 +175,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, nil, "uninvolved keys' state/value should not change after a write")
 
 	// Act 2: Write a value from the other executor's view of the shared scope
-	manager.WriteStateByID(scopeOtherView, Key2, Value2)
+	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
 
 	// Assert 2
 	checkValue(scopeSelfView, Key1, Value1, "uninvolved keys' state/value should not change after a write")
@@ -184,7 +184,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, Value2, "writes should be visible immediately to the writing executor")
 
 	// Act 3: Publish the updates
-	manager.PublishUpdates(nil)
+	_ = manager.PublishUpdates(nil)
 
 	// Assert 3
 	checkValue(scopeSelfView, Key1, Value1, "published writes should be visible to all executors")
@@ -198,7 +198,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, Value2, "published writes should be visible to all executors")
 
 	// Act 4: Clear the value from the self executor's view of the shared scope
-	manager.ClearStateByID(scopeSelfView)
+	_ = manager.ClearStateByID(scopeSelfView)
 
 	// Assert 4
 	checkValue(scopeSelfView, Key1, nil, "clears should be visible immediately to the writing executor")
@@ -213,7 +213,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 5: Publish the updates
-	manager.PublishUpdates(nil)
+	_ = manager.PublishUpdates(nil)
 
 	// Assert 5
 	checkValue(scopeSelfView, Key1, nil, "published clears should be visible to all executors")
@@ -226,12 +226,12 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Restore the written state of both keys
-	manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	manager.WriteStateByID(scopeOtherView, Key2, Value2)
-	manager.PublishUpdates(nil)
+	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
+	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
+	_ = manager.PublishUpdates(nil)
 
 	// Act 6: Delete Key1 from the other executor's view of the shared scope
-	manager.ClearStateKeyByID(scopeOtherView, Key1)
+	_ = manager.ClearStateKeyByID(scopeOtherView, Key1)
 
 	// Assert 6
 	if isSharedScope {
@@ -248,7 +248,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, Value2, "uninvolved keys' state/value should not change after a delete")
 
 	// Act 7: Delete Key2 from the self executor's view of the shared scope
-	manager.ClearStateKeyByID(scopeSelfView, Key2)
+	_ = manager.ClearStateKeyByID(scopeSelfView, Key2)
 
 	// Assert 7
 	if isSharedScope {
@@ -265,7 +265,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 8: Publish the updates
-	manager.PublishUpdates(nil)
+	_ = manager.PublishUpdates(nil)
 
 	// Assert 8
 	if isSharedScope {
@@ -308,8 +308,8 @@ func runConflictingUpdatesTest_WriteVsWrite(t *testing.T, scopeName string, isSh
 	scopeSelfView := workflow.ScopeID{ExecutorID: SelfExecutorId, ScopeName: scopeName}
 	scopeOtherView := workflow.ScopeID{ExecutorID: OtherExecutorId, ScopeName: scopeName}
 
-	manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	manager.WriteStateByID(scopeOtherView, Key1, Value2)
+	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
+	_ = manager.WriteStateByID(scopeOtherView, Key1, Value2)
 
 	err := manager.PublishUpdates(nil)
 	if isSharedScope {
@@ -337,12 +337,12 @@ func runConflictingUpdatesTest_WriteVsDelete(t *testing.T, scopeName string, isS
 	scopeSelfView := workflow.ScopeID{ExecutorID: SelfExecutorId, ScopeName: scopeName}
 	scopeOtherView := workflow.ScopeID{ExecutorID: OtherExecutorId, ScopeName: scopeName}
 
-	manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	manager.WriteStateByID(scopeOtherView, Key2, Value2)
-	manager.PublishUpdates(nil)
+	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
+	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
+	_ = manager.PublishUpdates(nil)
 
-	manager.WriteStateByID(scopeSelfView, Key1, "newValue")
-	manager.ClearStateKeyByID(scopeOtherView, Key1)
+	_ = manager.WriteStateByID(scopeSelfView, Key1, "newValue")
+	_ = manager.ClearStateKeyByID(scopeOtherView, Key1)
 
 	err := manager.PublishUpdates(nil)
 	if isSharedScope {
@@ -370,12 +370,12 @@ func runConflictingUpdatesTest_WriteVsClear(t *testing.T, scopeName string, isSh
 	scopeSelfView := workflow.ScopeID{ExecutorID: SelfExecutorId, ScopeName: scopeName}
 	scopeOtherView := workflow.ScopeID{ExecutorID: OtherExecutorId, ScopeName: scopeName}
 
-	manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	manager.WriteStateByID(scopeOtherView, Key2, Value2)
-	manager.PublishUpdates(nil)
+	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
+	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
+	_ = manager.PublishUpdates(nil)
 
-	manager.WriteStateByID(scopeSelfView, Key1, "newValue")
-	manager.ClearStateByID(scopeOtherView)
+	_ = manager.WriteStateByID(scopeSelfView, Key1, "newValue")
+	_ = manager.ClearStateByID(scopeOtherView)
 
 	err := manager.PublishUpdates(nil)
 	if isSharedScope {
@@ -408,13 +408,13 @@ func testLoadPortableValueState(t *testing.T, publishStateUpdates bool) {
 	PortableValueValue := workflow.AnyPortableValue(StringValue)
 
 	manager := NewStateManager()
-	manager.WriteStateByID(scope, "StringValue", StringValue)
-	manager.WriteStateByID(scope, "IntValue", IntValue)
-	manager.WriteStateByID(scope, "ScopeKey", ScopeKey)
-	manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue)
+	_ = manager.WriteStateByID(scope, "StringValue", StringValue)
+	_ = manager.WriteStateByID(scope, "IntValue", IntValue)
+	_ = manager.WriteStateByID(scope, "ScopeKey", ScopeKey)
+	_ = manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue)
 
 	if publishStateUpdates {
-		manager.PublishUpdates(nil)
+		_ = manager.PublishUpdates(nil)
 	}
 
 	// Act & Assert - Read as the original types
@@ -466,12 +466,12 @@ func TestScopeLoadPortableValueState_AfterSerialization(t *testing.T) {
 	PortableValueValue := workflow.AnyPortableValue(StringValue)
 
 	manager := NewStateManager()
-	manager.WriteStateByID(scope, "StringValue", StringValue)
-	manager.WriteStateByID(scope, "IntValue", IntValue)
-	manager.WriteStateByID(scope, "ScopeKey", ScopeKey)
-	manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue)
+	_ = manager.WriteStateByID(scope, "StringValue", StringValue)
+	_ = manager.WriteStateByID(scope, "IntValue", IntValue)
+	_ = manager.WriteStateByID(scope, "ScopeKey", ScopeKey)
+	_ = manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue)
 
-	manager.PublishUpdates(nil)
+	_ = manager.PublishUpdates(nil)
 
 	exportedState, err := manager.ExportState()
 	if err != nil {
@@ -488,7 +488,7 @@ func TestScopeLoadPortableValueState_AfterSerialization(t *testing.T) {
 	}
 
 	manager = NewStateManager()
-	manager.ImportState(testCheckpoint)
+	_ = manager.ImportState(testCheckpoint)
 
 	// Act & Assert - Read as the original types
 	checkType := func(key string, expected any) {

--- a/workflow/internal/execution/state_test.go
+++ b/workflow/internal/execution/state_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow/internal/checkpoint"
 )
 
+func mustSucceed(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestScopeSharedScope_ReadKeys(t *testing.T) {
 	scopeName := "sharedScope"
 	runScopeKeysTest(t, scopeName, true)
@@ -40,7 +47,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 1: Write a key from the self executor's view of the shared scope
-	_ = manager.WriteStateByID(sharedScopeSelfView, Key1, "value1")
+	mustSucceed(t, manager.WriteStateByID(sharedScopeSelfView, Key1, "value1"))
 
 	// Assert 1: The self executor should see the key immediately, but the other executor should not
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -58,7 +65,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 2: Publish the updates
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.PublishUpdates(nil))
 
 	// Assert 2: Both executors should see the key now, if sharedScope
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -78,7 +85,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 3: Clear the state from the self executor's view of the shared scope
-	_ = manager.ClearStateKeyByID(sharedScopeSelfView, Key1)
+	mustSucceed(t, manager.ClearStateKeyByID(sharedScopeSelfView, Key1))
 
 	// Assert 3: The self executor should not see the key immediately, but the other executor should still see it if sharedScope
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -98,7 +105,7 @@ func runScopeKeysTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 4: Publish the updates
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.PublishUpdates(nil))
 
 	// Assert 4: Neither executor should see the key now
 	selfKeys = manager.ReadKeysByID(sharedScopeSelfView)
@@ -166,7 +173,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, nil, "there should be no values in an empty StateManager")
 
 	// Act 1: Write a value from the self executor's view of the shared scope
-	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
+	mustSucceed(t, manager.WriteStateByID(scopeSelfView, Key1, Value1))
 
 	// Assert 1
 	checkValue(scopeSelfView, Key1, Value1, "writes should be visible immediately to the writing executor")
@@ -175,7 +182,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, nil, "uninvolved keys' state/value should not change after a write")
 
 	// Act 2: Write a value from the other executor's view of the shared scope
-	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
+	mustSucceed(t, manager.WriteStateByID(scopeOtherView, Key2, Value2))
 
 	// Assert 2
 	checkValue(scopeSelfView, Key1, Value1, "uninvolved keys' state/value should not change after a write")
@@ -184,7 +191,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, Value2, "writes should be visible immediately to the writing executor")
 
 	// Act 3: Publish the updates
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.PublishUpdates(nil))
 
 	// Assert 3
 	checkValue(scopeSelfView, Key1, Value1, "published writes should be visible to all executors")
@@ -198,7 +205,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, Value2, "published writes should be visible to all executors")
 
 	// Act 4: Clear the value from the self executor's view of the shared scope
-	_ = manager.ClearStateByID(scopeSelfView)
+	mustSucceed(t, manager.ClearStateByID(scopeSelfView))
 
 	// Assert 4
 	checkValue(scopeSelfView, Key1, nil, "clears should be visible immediately to the writing executor")
@@ -213,7 +220,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 5: Publish the updates
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.PublishUpdates(nil))
 
 	// Assert 5
 	checkValue(scopeSelfView, Key1, nil, "published clears should be visible to all executors")
@@ -226,12 +233,12 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Restore the written state of both keys
-	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.WriteStateByID(scopeSelfView, Key1, Value1))
+	mustSucceed(t, manager.WriteStateByID(scopeOtherView, Key2, Value2))
+	mustSucceed(t, manager.PublishUpdates(nil))
 
 	// Act 6: Delete Key1 from the other executor's view of the shared scope
-	_ = manager.ClearStateKeyByID(scopeOtherView, Key1)
+	mustSucceed(t, manager.ClearStateKeyByID(scopeOtherView, Key1))
 
 	// Assert 6
 	if isSharedScope {
@@ -248,7 +255,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	checkValue(scopeOtherView, Key2, Value2, "uninvolved keys' state/value should not change after a delete")
 
 	// Act 7: Delete Key2 from the self executor's view of the shared scope
-	_ = manager.ClearStateKeyByID(scopeSelfView, Key2)
+	mustSucceed(t, manager.ClearStateKeyByID(scopeSelfView, Key2))
 
 	// Assert 7
 	if isSharedScope {
@@ -265,7 +272,7 @@ func runValueLifecycleTest(t *testing.T, scopeName string, isSharedScope bool) {
 	}
 
 	// Act 8: Publish the updates
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.PublishUpdates(nil))
 
 	// Assert 8
 	if isSharedScope {
@@ -308,8 +315,8 @@ func runConflictingUpdatesTest_WriteVsWrite(t *testing.T, scopeName string, isSh
 	scopeSelfView := workflow.ScopeID{ExecutorID: SelfExecutorId, ScopeName: scopeName}
 	scopeOtherView := workflow.ScopeID{ExecutorID: OtherExecutorId, ScopeName: scopeName}
 
-	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	_ = manager.WriteStateByID(scopeOtherView, Key1, Value2)
+	mustSucceed(t, manager.WriteStateByID(scopeSelfView, Key1, Value1))
+	mustSucceed(t, manager.WriteStateByID(scopeOtherView, Key1, Value2))
 
 	err := manager.PublishUpdates(nil)
 	if isSharedScope {
@@ -337,12 +344,12 @@ func runConflictingUpdatesTest_WriteVsDelete(t *testing.T, scopeName string, isS
 	scopeSelfView := workflow.ScopeID{ExecutorID: SelfExecutorId, ScopeName: scopeName}
 	scopeOtherView := workflow.ScopeID{ExecutorID: OtherExecutorId, ScopeName: scopeName}
 
-	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.WriteStateByID(scopeSelfView, Key1, Value1))
+	mustSucceed(t, manager.WriteStateByID(scopeOtherView, Key2, Value2))
+	mustSucceed(t, manager.PublishUpdates(nil))
 
-	_ = manager.WriteStateByID(scopeSelfView, Key1, "newValue")
-	_ = manager.ClearStateKeyByID(scopeOtherView, Key1)
+	mustSucceed(t, manager.WriteStateByID(scopeSelfView, Key1, "newValue"))
+	mustSucceed(t, manager.ClearStateKeyByID(scopeOtherView, Key1))
 
 	err := manager.PublishUpdates(nil)
 	if isSharedScope {
@@ -370,12 +377,12 @@ func runConflictingUpdatesTest_WriteVsClear(t *testing.T, scopeName string, isSh
 	scopeSelfView := workflow.ScopeID{ExecutorID: SelfExecutorId, ScopeName: scopeName}
 	scopeOtherView := workflow.ScopeID{ExecutorID: OtherExecutorId, ScopeName: scopeName}
 
-	_ = manager.WriteStateByID(scopeSelfView, Key1, Value1)
-	_ = manager.WriteStateByID(scopeOtherView, Key2, Value2)
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.WriteStateByID(scopeSelfView, Key1, Value1))
+	mustSucceed(t, manager.WriteStateByID(scopeOtherView, Key2, Value2))
+	mustSucceed(t, manager.PublishUpdates(nil))
 
-	_ = manager.WriteStateByID(scopeSelfView, Key1, "newValue")
-	_ = manager.ClearStateByID(scopeOtherView)
+	mustSucceed(t, manager.WriteStateByID(scopeSelfView, Key1, "newValue"))
+	mustSucceed(t, manager.ClearStateByID(scopeOtherView))
 
 	err := manager.PublishUpdates(nil)
 	if isSharedScope {
@@ -408,13 +415,13 @@ func testLoadPortableValueState(t *testing.T, publishStateUpdates bool) {
 	PortableValueValue := workflow.AnyPortableValue(StringValue)
 
 	manager := NewStateManager()
-	_ = manager.WriteStateByID(scope, "StringValue", StringValue)
-	_ = manager.WriteStateByID(scope, "IntValue", IntValue)
-	_ = manager.WriteStateByID(scope, "ScopeKey", ScopeKey)
-	_ = manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue)
+	mustSucceed(t, manager.WriteStateByID(scope, "StringValue", StringValue))
+	mustSucceed(t, manager.WriteStateByID(scope, "IntValue", IntValue))
+	mustSucceed(t, manager.WriteStateByID(scope, "ScopeKey", ScopeKey))
+	mustSucceed(t, manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue))
 
 	if publishStateUpdates {
-		_ = manager.PublishUpdates(nil)
+		mustSucceed(t, manager.PublishUpdates(nil))
 	}
 
 	// Act & Assert - Read as the original types
@@ -466,12 +473,12 @@ func TestScopeLoadPortableValueState_AfterSerialization(t *testing.T) {
 	PortableValueValue := workflow.AnyPortableValue(StringValue)
 
 	manager := NewStateManager()
-	_ = manager.WriteStateByID(scope, "StringValue", StringValue)
-	_ = manager.WriteStateByID(scope, "IntValue", IntValue)
-	_ = manager.WriteStateByID(scope, "ScopeKey", ScopeKey)
-	_ = manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue)
+	mustSucceed(t, manager.WriteStateByID(scope, "StringValue", StringValue))
+	mustSucceed(t, manager.WriteStateByID(scope, "IntValue", IntValue))
+	mustSucceed(t, manager.WriteStateByID(scope, "ScopeKey", ScopeKey))
+	mustSucceed(t, manager.WriteStateByID(scope, "PortableValueValue", PortableValueValue))
 
-	_ = manager.PublishUpdates(nil)
+	mustSucceed(t, manager.PublishUpdates(nil))
 
 	exportedState, err := manager.ExportState()
 	if err != nil {
@@ -488,7 +495,7 @@ func TestScopeLoadPortableValueState_AfterSerialization(t *testing.T) {
 	}
 
 	manager = NewStateManager()
-	_ = manager.ImportState(testCheckpoint)
+	mustSucceed(t, manager.ImportState(testCheckpoint))
 
 	// Act & Assert - Read as the original types
 	checkType := func(key string, expected any) {

--- a/workflow/portable.go
+++ b/workflow/portable.go
@@ -14,7 +14,7 @@ type PortableValue struct {
 	_      [0]func() // disallow ==
 	any    any
 	TypeID TypeID
-	// TODO: Optimize small values so they avoid allocations, like in slog.Value.
+	// Optimize small values so they avoid allocations, like in slog.Value.
 }
 
 // AnyPortableValue returns a [PortableValue] for the supplied value.

--- a/workflow/portable.go
+++ b/workflow/portable.go
@@ -14,7 +14,7 @@ type PortableValue struct {
 	_      [0]func() // disallow ==
 	any    any
 	TypeID TypeID
-	// Optimize small values so they avoid allocations, like in slog.Value.
+	// TODO: Optimize small values so they avoid allocations, like in slog.Value.
 }
 
 // AnyPortableValue returns a [PortableValue] for the supplied value.


### PR DESCRIPTION
fixes: https://github.com/microsoft/agent-framework-go/issues/42

Resolve every diagnostic reported by golangci-lint so the CI linter job passes cleanly.

errcheck (33): add explicit '_ =' discards or wrap deferred Close
  calls in closures where the error is intentionally ignored.
staticcheck (20): apply De Morgan's law (QF1001), simplify
  if-return to plain return (S1008), drop redundant embedded-field
  selectors (QF1008), replace WriteString(Sprintf) with Fprintf
  (QF1012), lowercase error strings (ST1005), remove redundant type
  in var decl (ST1023), delete always-true nil check (SA4031),
  suppress deprecated field with nolint (SA1019).
unused (7): remove dead functions, fields, and variables
  (collectStreamingMessages, newTestServer, newConfiguredExecutorBinding,
  createSubworkflowRunner, workflowInfoCache, inputType, logger).
unconvert (6): remove unnecessary type conversions on type aliases
  and matching underlying types.
gofumpt (3): auto-format via golangci-lint fmt.
predeclared (2): rename 'new' -> 'newVal', 'max' -> 'limit' to
  avoid shadowing builtins.
ineffassign (1): remove ineffectual assignment in otel_test.go.