### PR TITLE
Improve agent.Session API

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"iter"
 	"log/slog"
@@ -29,12 +28,12 @@ type ProviderConfig struct {
 	// Run executes a request and streams response updates.
 	Run RunFunc
 
-	// CreateSession creates a provider-specific session.
-	CreateSession func(ctx context.Context, options ...Option) (*Session, error)
-	// MarshalSession serializes a provider-specific session.
-	MarshalSession func(ctx context.Context, session *Session) ([]byte, error)
-	// UnmarshalSession deserializes a provider-specific session.
-	UnmarshalSession func(ctx context.Context, data []byte) (*Session, error)
+	// CreateSession configures a provider-specific session.
+	CreateSession func(ctx context.Context, session Session, options ...Option) error
+	// BeforeMarshalSession configures a provider-specific session before serialization.
+	BeforeMarshalSession func(ctx context.Context, session Session, options ...Option) error
+	// AfterUnmarshalSession configures a deserialized provider-specific session.
+	AfterUnmarshalSession func(ctx context.Context, session Session, options ...Option) error
 	// FormatOfFn returns the response format for a structured output destination.
 	FormatOfFn func(v any) (format.Format, error)
 	// UnmarshalFn unmarshals provider output into a structured output destination.
@@ -122,17 +121,13 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 	cfg.Middlewares = append(prefixedMiddlewares, cfg.Middlewares...)
 	cfg.Middlewares = append(cfg.Middlewares, authorMiddleware(cfg.ID, cfg.Name))
 	return &Agent{
-		id:               cfg.ID,
-		name:             cfg.Name,
-		description:      cfg.Description,
-		providerName:     prov.ProviderName,
-		instructions:     cfg.Instructions,
-		createSession:    prov.CreateSession,
-		marshalSession:   prov.MarshalSession,
-		unmarshalSession: prov.UnmarshalSession,
-		run:              prov.Run,
-		runOptions:       cfg.RunOptions,
-		middlewares:      cfg.Middlewares,
+		id:           cfg.ID,
+		name:         cfg.Name,
+		description:  cfg.Description,
+		provider:     prov,
+		instructions: cfg.Instructions,
+		runOptions:   cfg.RunOptions,
+		middlewares:  cfg.Middlewares,
 	}
 }
 
@@ -154,20 +149,15 @@ func (r ResponseStream) Collect() (*message.Response, error) {
 
 // Agent coordinates message preparation, middleware, sessions, and provider execution.
 type Agent struct {
-	id           string
-	name         string
-	description  string
-	providerName string
+	id          string
+	name        string
+	description string
+	provider    ProviderConfig
 
 	instructions string
 
 	middlewares []Middleware
 	runOptions  []Option
-
-	createSession    func(ctx context.Context, options ...Option) (*Session, error)
-	marshalSession   func(ctx context.Context, session *Session) ([]byte, error)
-	unmarshalSession func(ctx context.Context, data []byte) (*Session, error)
-	run              func(ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*message.ResponseUpdate, error]
 }
 
 // ID returns the agent's unique identifier.
@@ -199,40 +189,48 @@ func (a *Agent) ProviderName() string {
 	if a == nil {
 		return ""
 	}
-	return a.providerName
+	return a.provider.ProviderName
 }
 
 // CreateSession creates a session for this agent.
-func (a *Agent) CreateSession(ctx context.Context, options ...Option) (*Session, error) {
-	if a.createSession == nil {
-		session := NewSession("")
-		session.ServiceID, _ = GetOption(options, WithServiceID)
-		return session, nil
+func (a *Agent) CreateSession(ctx context.Context, options ...Option) (Session, error) {
+	session := &session{}
+	serviceID, _ := GetOption(options, WithServiceID)
+	session.SetServiceID(serviceID)
+	if a.provider.CreateSession != nil {
+		if err := a.provider.CreateSession(ctx, session, options...); err != nil {
+			return nil, err
+		}
 	}
-	return a.createSession(ctx, options...)
+	return session, nil
 }
 
 // MarshalSession serializes a session created for this agent.
-func (a *Agent) MarshalSession(ctx context.Context, session *Session) ([]byte, error) {
-	if a.marshalSession == nil {
-		if session == nil {
-			return nil, errors.New("the provided session is nil")
+//
+// Any provided options are forwarded to the provider's BeforeMarshalSession hook.
+func (a *Agent) MarshalSession(ctx context.Context, session Session, options ...Option) ([]byte, error) {
+	if a.provider.BeforeMarshalSession != nil {
+		if err := a.provider.BeforeMarshalSession(ctx, session, options...); err != nil {
+			return nil, err
 		}
-		return json.Marshal(session)
 	}
-	return a.marshalSession(ctx, session)
+	return marshalSession(session)
 }
 
 // UnmarshalSession deserializes a session for this agent.
-func (a *Agent) UnmarshalSession(ctx context.Context, data []byte) (*Session, error) {
-	if a.unmarshalSession == nil {
-		var session Session
-		if err := json.Unmarshal(data, &session); err != nil {
+//
+// Any provided options are forwarded to the provider's AfterUnmarshalSession hook.
+func (a *Agent) UnmarshalSession(ctx context.Context, data []byte, options ...Option) (Session, error) {
+	session, err := unmarshalSession(data)
+	if err != nil {
+		return nil, err
+	}
+	if a.provider.AfterUnmarshalSession != nil {
+		if err := a.provider.AfterUnmarshalSession(ctx, session, options...); err != nil {
 			return nil, err
 		}
-		return &session, nil
 	}
-	return a.unmarshalSession(ctx, data)
+	return session, nil
 }
 
 // RunText runs the agent with a single user text message.
@@ -253,7 +251,7 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 			yield(nil, err)
 		}
 	}
-	return ResponseStream(runChain(ctx, a.run, a.middlewares, preparedMessages, options...))
+	return ResponseStream(runChain(ctx, a.provider.Run, a.middlewares, preparedMessages, options...))
 }
 
 func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, options []Option) (context.Context, []*message.Message, []Option, error) {
@@ -269,7 +267,7 @@ func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, opt
 			return nil, nil, nil, errors.New("a session must be provided when AllowBackgroundResponses is enabled")
 		}
 		// Ensure a session is provided in the options.
-		session, err := a.CreateSession(ctx)
+		session, err := a.CreateSession(ctx, options...)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -312,7 +310,7 @@ func defaultLocalHistoryMiddleware() Middleware {
 		session, _ := GetOption(options, WithSession)
 		noSession, _ := GetOption(options, noSessionProvided)
 		contToken, _ := GetOption(options, WithContinuationToken)
-		if noSession || contToken != "" || session.ServiceID != "" {
+		if noSession || contToken != "" || session == nil || session.ServiceID() != "" {
 			return next(ctx, messages, options...)
 		}
 		return history.Run(next, ctx, messages, options...)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -31,7 +31,7 @@ type prependMiddleware struct {
 	prependMessages []*message.Message
 	instructions    string
 	runCalls        int
-	lastSession     *agent.Session
+	lastSession     agent.Session
 }
 
 func (m *prependMiddleware) Run(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
@@ -99,6 +99,89 @@ func newGenericTestAgent(runFn func(context.Context, []*message.Message, ...agen
 		Middlewares:  middlewares,
 		RunOptions:   runOptions,
 	})
+}
+
+func TestAgent_UnmarshalSession_CallsAfterUnmarshalSession(t *testing.T) {
+	called := false
+	a := agent.New(agent.ProviderConfig{
+		Run: func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+			return func(yield func(*message.ResponseUpdate, error) bool) {}
+		},
+		AfterUnmarshalSession: func(_ context.Context, session agent.Session, opts ...agent.Option) error {
+			called = true
+			serviceID, ok := agent.GetOption(opts, agent.WithServiceID)
+			if !ok || serviceID != "hook-option" {
+				t.Fatalf("expected hook option service id hook-option, got %q (present=%v)", serviceID, ok)
+			}
+			if got := session.ServiceID(); got != "service-123" {
+				t.Fatalf("session.ServiceID() = %q, want %q", got, "service-123")
+			}
+
+			var value string
+			ok, err := session.Get("key", &value)
+			if err != nil || !ok || value != "value" {
+				t.Fatalf("session.Get() = ok %v, value %q, err %v", ok, value, err)
+			}
+
+			session.Set("provider", "configured")
+			return nil
+		},
+	}, agent.Config{})
+
+	session, err := a.UnmarshalSession(t.Context(), []byte(`{"ServiceID":"service-123","State":{"key":"value"}}`), agent.WithServiceID("hook-option"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected provider AfterUnmarshalSession to be called")
+	}
+
+	var providerValue string
+	if ok, err := session.Get("provider", &providerValue); err != nil || !ok || providerValue != "configured" {
+		t.Fatalf("session.Get(provider) = ok %v, value %q, err %v", ok, providerValue, err)
+	}
+}
+
+func TestAgent_MarshalSession_CallsBeforeMarshalSession(t *testing.T) {
+	called := false
+	a := agent.New(agent.ProviderConfig{
+		Run: func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
+			return func(yield func(*message.ResponseUpdate, error) bool) {}
+		},
+		BeforeMarshalSession: func(_ context.Context, session agent.Session, opts ...agent.Option) error {
+			called = true
+			serviceID, ok := agent.GetOption(opts, agent.WithServiceID)
+			if !ok || serviceID != "hook-option" {
+				t.Fatalf("expected hook option service id hook-option, got %q (present=%v)", serviceID, ok)
+			}
+			session.Set("provider", "configured")
+			return nil
+		},
+	}, agent.Config{})
+
+	session, err := a.CreateSession(t.Context(), agent.WithServiceID("service-123"))
+	if err != nil {
+		t.Fatalf("unexpected create session error: %v", err)
+	}
+	data, err := a.MarshalSession(t.Context(), session, agent.WithServiceID("hook-option"))
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected provider BeforeMarshalSession to be called")
+	}
+
+	restored, err := a.UnmarshalSession(t.Context(), data)
+	if err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if got := restored.ServiceID(); got != "service-123" {
+		t.Fatalf("restored.ServiceID() = %q, want %q", got, "service-123")
+	}
+	var providerValue string
+	if ok, err := restored.Get("provider", &providerValue); err != nil || !ok || providerValue != "configured" {
+		t.Fatalf("restored.Get(provider) = ok %v, value %q, err %v", ok, providerValue, err)
+	}
 }
 
 func TestAgent_RunText(t *testing.T) {
@@ -699,7 +782,7 @@ func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionHasServiceID(t *te
 	})
 
 	session := agenttest.CreateSession()
-	session.ServiceID = "server-managed"
+	session.SetServiceID("server-managed")
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -4,13 +4,13 @@ package compaction_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"slices"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/compaction"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -370,7 +370,7 @@ func TestSummarizationStrategy_PropagatesCancellation(t *testing.T) {
 }
 
 func TestNewProvider_CompactsAndPersistsIndex(t *testing.T) {
-	session := agent.NewSession("session")
+	session := agenttest.CreateSession()
 	provider := compaction.NewContextProvider(compaction.ContextProviderConfig{
 		Strategy: &compaction.TruncationStrategy{
 			Trigger:                compaction.GroupsExceed(2),
@@ -390,12 +390,13 @@ func TestNewProvider_CompactsAndPersistsIndex(t *testing.T) {
 	var state struct {
 		MessageGroups []*compaction.MessageGroup `json:"messagegroups,omitempty"`
 	}
-	data, err := json.Marshal(session)
+	a := agenttest.New(nil)
+	data, err := a.MarshalSession(t.Context(), session)
 	if err != nil {
 		t.Fatalf("unexpected marshal error: %v", err)
 	}
-	var restored agent.Session
-	if err := json.Unmarshal(data, &restored); err != nil {
+	restored, err := a.UnmarshalSession(t.Context(), data)
+	if err != nil {
 		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 	if ok, err := restored.Get("compaction-test", &state); err != nil || !ok {

--- a/agent/compaction/provider.go
+++ b/agent/compaction/provider.go
@@ -66,7 +66,7 @@ func NewContextProvider(cfg ContextProviderConfig) *agent.ContextProvider {
 				}
 				return index.IncludedMessages(), options, nil
 			}
-			if session.ServiceID != "" {
+			if session.ServiceID() != "" {
 				if cfg.Logger != nil {
 					cfg.Logger.DebugContext(ctx, "compaction provider skipped", slog.String("reason", "session managed by remote service"))
 				}

--- a/agent/context.go
+++ b/agent/context.go
@@ -164,7 +164,7 @@ func (r *contextProviderRunner) Run(next RunFunc, ctx context.Context, messages 
 		}
 		var resp message.Response
 		for update, err := range next(ctx, messages, options...) {
-			if update != nil && (session == nil || session.ServiceID == "") {
+			if update != nil && (session == nil || session.ServiceID() == "") {
 				resp.Update(update)
 			}
 			if !yield(update, err) {

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
@@ -18,7 +19,7 @@ func TestContextProvider_Invoking_WithoutProvide_ReturnsNoAdditions(t *testing.T
 	request := message.NewText("r1")
 	provider := &agent.ContextProvider{SourceID: "ctx"}
 
-	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agent.NewSession("")))
+	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -37,7 +38,7 @@ func TestContextProvider_Invoking_PanicsWithoutSourceID(t *testing.T) {
 			t.Fatal("expected panic")
 		}
 	}()
-	_, _, _ = provider.BeforeRun(t.Context(), nil, agent.WithSession(agent.NewSession("")))
+	_, _, _ = provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 }
 
 func TestContextProvider_Invoking_PassesAllMessagesToProvide(t *testing.T) {
@@ -54,7 +55,7 @@ func TestContextProvider_Invoking_PassesAllMessagesToProvide(t *testing.T) {
 		},
 	}
 
-	_, _, err := provider.BeforeRun(t.Context(), []*message.Message{external, history}, agent.WithSession(agent.NewSession("")))
+	_, _, err := provider.BeforeRun(t.Context(), []*message.Message{external, history}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestContextProvider_Invoking_PropagatesProvideError(t *testing.T) {
 		},
 	}
 
-	_, _, err := provider.BeforeRun(t.Context(), []*message.Message{message.NewText("r1")}, agent.WithSession(agent.NewSession("")))
+	_, _, err := provider.BeforeRun(t.Context(), []*message.Message{message.NewText("r1")}, agent.WithSession(agenttest.CreateSession()))
 	if !errors.Is(err, expected) {
 		t.Fatalf("expected Provide error, got %v", err)
 	}
@@ -89,7 +90,7 @@ func TestContextProvider_Invoking_ReturnsProvidedMessagesAndSetsSourceID(t *test
 		},
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agent.NewSession("")))
+	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -121,7 +122,7 @@ func TestContextProvider_Invoking_SetsSourceIDOnPrependedMessages(t *testing.T) 
 		},
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agent.NewSession("")))
+	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,7 +148,7 @@ func TestContextProvider_Invoking_UsesCustomSourceID(t *testing.T) {
 		},
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agent.NewSession("")))
+	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestContextProvider_Invoked_PanicsWithoutSourceID(t *testing.T) {
 			t.Fatal("expected panic")
 		}
 	}()
-	_ = provider.AfterRun(t.Context(), nil, nil, agent.WithSession(agent.NewSession("")))
+	_ = provider.AfterRun(t.Context(), nil, nil, agent.WithSession(agenttest.CreateSession()))
 }
 
 func TestContextProvider_Invoked_CallsStoreAndExcludesSameProviderRequestMessagesByDefault(t *testing.T) {
@@ -189,7 +190,7 @@ func TestContextProvider_Invoked_CallsStoreAndExcludesSameProviderRequestMessage
 		},
 	}
 
-	err := provider.AfterRun(t.Context(), []*message.Message{req1, req2}, []*message.Message{resp}, agent.WithSession(agent.NewSession("")))
+	err := provider.AfterRun(t.Context(), []*message.Message{req1, req2}, []*message.Message{resp}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -213,7 +214,7 @@ func TestContextProvider_Invoked_PropagatesStoreError(t *testing.T) {
 		},
 	}
 
-	err := provider.AfterRun(t.Context(), []*message.Message{message.NewText("r1")}, nil, agent.WithSession(agent.NewSession("")))
+	err := provider.AfterRun(t.Context(), []*message.Message{message.NewText("r1")}, nil, agent.WithSession(agenttest.CreateSession()))
 	if !errors.Is(err, expected) {
 		t.Fatalf("expected store error, got %v", err)
 	}
@@ -236,7 +237,7 @@ func TestContextProvider_InvokingContext_ReturnsProvidedFields(t *testing.T) {
 		},
 	}
 
-	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agent.NewSession("")), agent.WithTool(inputTool))
+	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()), agent.WithTool(inputTool))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/agent/history_test.go
+++ b/agent/history_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -16,7 +17,7 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 		t.Fatalf("expected SourceID=in-memory, got %q", provider.SourceID)
 	}
 
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
@@ -60,7 +61,7 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 
 func TestNewInMemoryHistoryProvider_ProvidePrependsHistory(t *testing.T) {
 	provider := agent.NewInMemoryHistoryProvider("InMemoryHistoryProvider")
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
@@ -88,7 +89,7 @@ func TestNewInMemoryHistoryProvider_ProvidePrependsHistory(t *testing.T) {
 }
 
 func TestNewInMemoryHistoryProvider_SourceID_MapsToSessionStateKey(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	customProvider := agent.NewInMemoryHistoryProvider("custom")
 	defaultProvider := agent.NewInMemoryHistoryProvider("InMemoryHistoryProvider")
 
@@ -114,7 +115,7 @@ func TestNewInMemoryHistoryProvider_SourceID_MapsToSessionStateKey(t *testing.T)
 
 func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesContextProviderMessages(t *testing.T) {
 	provider := agent.NewInMemoryHistoryProvider("k")
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 
 	user := message.NewText("user")
 	ctxMsg := message.NewText("ctx")
@@ -138,7 +139,7 @@ func TestNewInMemoryHistoryProvider_SkipStoreRequestMessages(t *testing.T) {
 	provider.StoreRequestFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
 		return nil, nil
 	}
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
@@ -160,7 +161,7 @@ func TestNewInMemoryHistoryProvider_SkipStoreResponseMessages(t *testing.T) {
 	provider.StoreResponseFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
 		return nil, nil
 	}
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
@@ -188,7 +189,7 @@ func TestNewInMemoryHistoryProvider_StoreContextMessages(t *testing.T) {
 		}
 		return filtered, nil
 	}
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	user := message.NewText("user")
 	ctxMsg := message.NewText("ctx")
 	ctxMsg.SourceID = "provider-A"
@@ -217,7 +218,7 @@ func TestNewInMemoryHistoryProvider_StoreContextMessagesFrom(t *testing.T) {
 		}
 		return filtered, nil
 	}
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	ctxA := message.NewText("ctx-a")
 	ctxA.SourceID = "provider-A"
 	ctxB := message.NewText("ctx-b")
@@ -236,24 +237,38 @@ func TestNewInMemoryHistoryProvider_StoreContextMessagesFrom(t *testing.T) {
 	}
 }
 
-func TestNewInMemoryHistoryProvider_Invoking_ReturnsErrorOnStateDecodeFailure(t *testing.T) {
+func TestNewInMemoryHistoryProvider_Invoking_IgnoresUnreadableState(t *testing.T) {
 	provider := agent.NewInMemoryHistoryProvider("k")
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("k", "not-a-history-state")
+	request := []*message.Message{message.NewText("req")}
 
-	_, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
-	if err == nil {
-		t.Fatal("expected decode error when state cannot be read as inmemoryState")
+	messages, _, err := provider.BeforeRun(t.Context(), request, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("unexpected error when state is unreadable: %v", err)
+	}
+	if len(messages) != 1 || messages[0].String() != "req" {
+		t.Fatal("expected unreadable state to be ignored")
 	}
 }
 
-func TestNewInMemoryHistoryProvider_Invoked_ReturnsErrorOnStateDecodeFailure(t *testing.T) {
+func TestNewInMemoryHistoryProvider_Invoked_OverwritesUnreadableState(t *testing.T) {
 	provider := agent.NewInMemoryHistoryProvider("k")
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("k", "not-a-history-state")
+	request := message.NewText("r1")
+	response := message.NewText("a1")
 
-	err := provider.AfterRun(t.Context(), []*message.Message{message.NewText("r1")}, nil, agent.WithSession(session))
-	if err == nil {
-		t.Fatal("expected decode error when state cannot be read as inmemoryState")
+	err := provider.AfterRun(t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("unexpected error when state is unreadable: %v", err)
+	}
+
+	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("unexpected error reading stored history: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 stored messages, got %d", len(messages))
 	}
 }

--- a/agent/middleware/contextprovider/contextprovider.go
+++ b/agent/middleware/contextprovider/contextprovider.go
@@ -45,7 +45,7 @@ func (r *contextProviderRunner) Run(next agent.RunFunc, ctx context.Context, mes
 		}
 		var resp message.Response
 		for update, err := range next(ctx, messages, options...) {
-			if update != nil && (session == nil || session.ServiceID == "") {
+			if update != nil && (session == nil || session.ServiceID() == "") {
 				resp.Update(update)
 			}
 			if !yield(update, err) {

--- a/agent/middleware/contextprovider/contextprovider_test.go
+++ b/agent/middleware/contextprovider/contextprovider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/middleware/contextprovider"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 )
@@ -42,7 +43,7 @@ func TestContextProviderMiddleware_Run_ProviderOptionsEnrichTools(t *testing.T) 
 		},
 		context.Background(),
 		[]*message.Message{message.NewText("hello")},
-		agent.WithSession(agent.NewSession("")),
+		agent.WithSession(agenttest.CreateSession()),
 		agent.WithTool(baselineTool),
 	))
 	if err != nil {
@@ -63,7 +64,7 @@ func TestContextProviderMiddleware_Run_SharedOptions_ProviderToolsDoNotAccumulat
 		},
 	}
 	sharedOptions := []agent.Option{
-		agent.WithSession(agent.NewSession("")),
+		agent.WithSession(agenttest.CreateSession()),
 		agent.WithTool(stubTool{name: "baseline"}),
 	}
 
@@ -96,7 +97,7 @@ func TestContextProviderMiddleware_Run_SharedOptions_OriginalToolsNotMutated(t *
 		},
 	}
 	sharedOptions := []agent.Option{
-		agent.WithSession(agent.NewSession("")),
+		agent.WithSession(agenttest.CreateSession()),
 		agent.WithTool(baselineTool),
 	}
 

--- a/agent/options.go
+++ b/agent/options.go
@@ -17,7 +17,7 @@ import (
 // to uniquely identify each option.
 type Option = agentopt.Option
 
-type sessionOpt struct{ *Session }
+type sessionOpt struct{ Session }
 
 func (o sessionOpt) Value() any { return o.Session }
 
@@ -73,7 +73,7 @@ func WithResponseFormat(format format.Format) Option {
 }
 
 // WithSession sets the session to use during the agent run.
-func WithSession(session *Session) Option {
+func WithSession(session Session) Option {
 	return sessionOpt{session}
 }
 

--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -53,12 +53,9 @@ func New(aclient *a2aclient.Client, config Config) *agent.Agent {
 	}, config.Config)
 }
 
-func (a *a2aagent) createSession(ctx context.Context, options ...agent.Option) (*agent.Session, error) {
-	serviceID, _ := agent.GetOption(options, agent.WithServiceID)
-	session := agent.NewSession("")
-	setContextID(session, serviceID)
+func (a *a2aagent) createSession(ctx context.Context, session agent.Session, options ...agent.Option) error {
 	setTaskIDs(session, slices.Collect(agent.AllOptions(options, TaskID)))
-	return session, nil
+	return nil
 }
 
 func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
@@ -151,7 +148,7 @@ func (a *a2aagent) subscribeToTaskWithFallback(ctx context.Context, taskID a2a.T
 	}
 }
 
-func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func(*message.ResponseUpdate, error) bool) {
+func sendMsg(session agent.Session, seq iter.Seq2[a2a.Event, error], yield func(*message.ResponseUpdate, error) bool) {
 	for e, err := range seq {
 		if err != nil {
 			yield(nil, err)
@@ -255,7 +252,7 @@ func yieldTask(yield func(*message.ResponseUpdate, error) bool, task *a2a.Task) 
 	}, nil)
 }
 
-func updateSessionContextID(session *agent.Session, contextID, taskID string) error {
+func updateSessionContextID(session agent.Session, contextID, taskID string) error {
 	if session == nil {
 		return nil
 	}

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -194,7 +194,7 @@ func newTestAgent(transport a2aclient.Transport, config agent.Config) *agent.Age
 	return a2a1.New(client, a2a1.Config{Config: config})
 }
 
-func latestTaskID(session *agent.Session) string {
+func latestTaskID(session agent.Session) string {
 	taskIDs := a2a1.TaskIDsFromSession(session)
 	if len(taskIDs) == 0 {
 		return ""
@@ -312,7 +312,7 @@ func TestRunWithCreateSession(t *testing.T) {
 		t.Fatalf("error = %v, want nil", err)
 	}
 
-	if got := session.ServiceID; got != "new-context-id" {
+	if got := session.ServiceID(); got != "new-context-id" {
 		t.Errorf("session.ServiceID = %q, want %q", got, "new-context-id")
 	}
 }
@@ -462,7 +462,7 @@ func TestRunStreamingWithSession(t *testing.T) {
 		}
 	}
 
-	if got := session.ServiceID; got != "new-stream-context" {
+	if got := session.ServiceID(); got != "new-stream-context" {
 		t.Errorf("session.ContextID = %q, want %q", got, "new-stream-context")
 	}
 }
@@ -755,7 +755,7 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 		t.Errorf("continuation token = %q, want %q", result.ContinuationToken, "task-789")
 	}
 
-	if got := session.ServiceID; got != "context-456" {
+	if got := session.ServiceID(); got != "context-456" {
 		t.Errorf("session.ContextID = %q, want %q", got, "context-456")
 	}
 	if got := latestTaskID(session); got != "task-789" {
@@ -963,7 +963,7 @@ func TestRunStreamingWithContinuationTokenWhenSubscribeFailsWithUnsupportedOpera
 		}
 	}
 
-	if got := session.ServiceID; got != contextID {
+	if got := session.ServiceID(); got != contextID {
 		t.Errorf("session.ContextID = %q, want %q", got, contextID)
 	}
 	if got := latestTaskID(session); got != taskID {
@@ -1186,7 +1186,7 @@ func TestRunStreamingWithAgentTaskYieldsUpdate(t *testing.T) {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.Task", update.RawRepresentation)
 	}
 
-	if got := session.ServiceID; got != contextID {
+	if got := session.ServiceID(); got != contextID {
 		t.Errorf("session.ContextID = %q, want %q", got, contextID)
 	}
 	if got := latestTaskID(session); got != taskID {
@@ -1238,7 +1238,7 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
 	}
 
-	if got := session.ServiceID; got != contextID {
+	if got := session.ServiceID(); got != contextID {
 		t.Errorf("session.ContextID = %q, want %q", got, contextID)
 	}
 	if got := latestTaskID(session); got != taskID {
@@ -1299,7 +1299,7 @@ func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 		t.Errorf("update.String() = %q, want %q", update.String(), artifactContent)
 	}
 
-	if got := session.ServiceID; got != contextID {
+	if got := session.ServiceID(); got != contextID {
 		t.Errorf("session.ContextID = %q, want %q", got, contextID)
 	}
 	if got := latestTaskID(session); got != taskID {

--- a/agent/provider/a2aagent/session.go
+++ b/agent/provider/a2aagent/session.go
@@ -8,29 +8,29 @@ const (
 	taskIDsStateKey = "a2aagent.taskIDs"
 )
 
-func setContextID(session *agent.Session, contextID string) {
-	session.ServiceID = contextID
+func setContextID(session agent.Session, contextID string) {
+	session.SetServiceID(contextID)
 }
 
-func getContextID(session *agent.Session) string {
-	return session.ServiceID
+func getContextID(session agent.Session) string {
+	return session.ServiceID()
 }
 
-func setTaskID(session *agent.Session, taskID string) {
+func setTaskID(session agent.Session, taskID string) {
 	if taskID == "" {
 		return
 	}
 	setTaskIDs(session, append(getTaskIDs(session), taskID))
 }
 
-func setTaskIDs(session *agent.Session, taskIDs []string) {
+func setTaskIDs(session agent.Session, taskIDs []string) {
 	if len(taskIDs) == 0 {
 		return
 	}
 	session.Set(taskIDsStateKey, taskIDs)
 }
 
-func getTaskIDs(session *agent.Session) []string {
+func getTaskIDs(session agent.Session) []string {
 	var taskIDs []string
 	if ok, err := session.Get(taskIDsStateKey, &taskIDs); err != nil || !ok {
 		return nil
@@ -39,6 +39,6 @@ func getTaskIDs(session *agent.Session) []string {
 }
 
 // TaskIDsFromSession returns all known A2A task IDs stored in session state.
-func TaskIDsFromSession(session *agent.Session) []string {
+func TaskIDsFromSession(session agent.Session) []string {
 	return getTaskIDs(session)
 }

--- a/agent/provider/aguiagent/agui.go
+++ b/agent/provider/aguiagent/agui.go
@@ -133,13 +133,13 @@ func decodeFrame(decoder *aguiEvents.EventDecoder, data []byte) (aguiEvents.Even
 	return decoder.DecodeEvent(envelope.Type, data)
 }
 
-func getOrCreateThreadID(session *agent.Session) string {
-	if session != nil && session.ServiceID != "" {
-		return session.ServiceID
+func getOrCreateThreadID(session agent.Session) string {
+	if session != nil && session.ServiceID() != "" {
+		return session.ServiceID()
 	}
 	threadID := aguiEvents.GenerateThreadID()
 	if session != nil {
-		session.ServiceID = threadID
+		session.SetServiceID(threadID)
 	}
 	return threadID
 }

--- a/agent/provider/aguiagent/agui_test.go
+++ b/agent/provider/aguiagent/agui_test.go
@@ -73,7 +73,7 @@ func TestAGUIAgentCreateSession_UsesServiceIDAsThreadID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create session error: %v", err)
 	}
-	if got := s.ServiceID; got != "thread-existing" {
+	if got := s.ServiceID(); got != "thread-existing" {
 		t.Fatalf("session.ServiceID = %q, want %q", got, "thread-existing")
 	}
 }

--- a/agent/provider/openairesponsesagent/responses.go
+++ b/agent/provider/openairesponsesagent/responses.go
@@ -78,17 +78,17 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 		stream, _ := agent.GetOption(options, agent.Stream)
 
 		// Get session for conversation ID management
-		var session *agent.Session
+		var session agent.Session
 		var keepConversationID bool // true if we should keep the conversation ID unchanged (it's a "conv_" ID)
 		if t, ok := agent.GetOption(options, agent.WithSession); ok && t != nil {
 			session = t
-			keepConversationID = session.ServiceID != "" && strings.HasPrefix(session.ServiceID, "conv_")
+			keepConversationID = session.ServiceID() != "" && strings.HasPrefix(session.ServiceID(), "conv_")
 		}
 
 		// Helper to update conversation ID after response completes
 		updateConversationID := func(responseID string) {
-			if !keepConversationID && responseID != "" {
-				session.ServiceID = responseID
+			if session != nil && !keepConversationID && responseID != "" {
+				session.SetServiceID(responseID)
 			}
 		}
 
@@ -209,15 +209,15 @@ func responsesBuildCompletionParams(model string, messages []*message.Message, o
 		params.Background = openai.Bool(v)
 	}
 	if session, ok := agent.GetOption(opts, agent.WithSession); ok && session != nil {
-		if session.ServiceID != "" {
+		if session.ServiceID() != "" {
 			// Technically, OpenAI's IDs are opaque. However, by convention conversation IDs start with "conv_" and
 			// we can use that to disambiguate whether we're looking at a conversation ID or a response ID.
-			if strings.HasPrefix(session.ServiceID, "conv_") {
+			if strings.HasPrefix(session.ServiceID(), "conv_") {
 				params.Conversation = responses.ResponseNewParamsConversationUnion{
-					OfString: openai.String(session.ServiceID),
+					OfString: openai.String(session.ServiceID()),
 				}
 			} else {
-				params.PreviousResponseID = openai.String(session.ServiceID)
+				params.PreviousResponseID = openai.String(session.ServiceID())
 			}
 		}
 	}

--- a/agent/provider/openairesponsesagent/responses_test.go
+++ b/agent/provider/openairesponsesagent/responses_test.go
@@ -3949,7 +3949,7 @@ func TestResponsesConversationId_AsResponseId_NonStreaming(t *testing.T) {
 	}
 
 	// After the call, session conversation id should be updated to the new response ID
-	if got := session.ServiceID; got != "resp_67890" {
+	if got := session.ServiceID(); got != "resp_67890" {
 		t.Errorf("expected ConversationId resp_67890, got %s", got)
 	}
 }
@@ -4015,7 +4015,7 @@ func TestResponsesConversationId_AsConversationId_NonStreaming(t *testing.T) {
 	}
 
 	// When using a conversation ID, it should remain unchanged
-	if got := session.ServiceID; got != "conv_12345" {
+	if got := session.ServiceID(); got != "conv_12345" {
 		t.Errorf("expected ConversationId conv_12345, got %s", got)
 	}
 }
@@ -4094,7 +4094,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 		}
 	}
 
-	if got := session.ServiceID; got != "resp_67890" {
+	if got := session.ServiceID(); got != "resp_67890" {
 		t.Errorf("expected ConversationId resp_67890, got %s", got)
 	}
 }
@@ -4173,7 +4173,7 @@ data: {"type":"response.completed","response":{"id":"resp_67890","object":"respo
 		}
 	}
 
-	if got := session.ServiceID; got != "conv_12345" {
+	if got := session.ServiceID(); got != "conv_12345" {
 		t.Errorf("expected ConversationId conv_12345, got %s", got)
 	}
 }

--- a/agent/session.go
+++ b/agent/session.go
@@ -4,8 +4,7 @@ package agent
 
 import (
 	"encoding/json"
-
-	"github.com/google/uuid"
+	"errors"
 )
 
 // Session contains the state of a specific conversation with an agent which may include:
@@ -27,34 +26,46 @@ import (
 // behaviors to the Session it creates.
 //
 // To support conversations that may need to survive application restarts or separate service requests,
-// a Session can be serialized and deserialized, so that it can be saved in a persistent store.
-type Session struct {
-	ServiceID string
+// a Session can be serialized and deserialized through [Agent.MarshalSession] and
+// [Agent.UnmarshalSession], so that it can be saved in a persistent store.
+type Session interface {
+	// Get attempts to read the value associated with key into value.
+	//
+	// It returns ok=true only when the value exists and can be read into the destination type.
+	// It returns ok=false with a nil error when the key is missing or the stored value cannot be read as the
+	// requested type.
+	//
+	// value must be a non-nil pointer to the desired destination type.
+	Get(key string, value any) (ok bool, err error)
 
-	id    string
+	// Set stores a value in the session state under the given key.
+	// If the key already exists, its value is overwritten.
+	Set(key string, value any)
+
+	// Delete removes the value with the given key.
+	Delete(key string)
+
+	// ServiceID returns the provider-specific identifier associated with the session.
+	ServiceID() string
+
+	// SetServiceID sets the provider-specific identifier associated with the session.
+	SetServiceID(id string)
+
+	// sealedSession prevents implementations outside this package so sessions can only
+	// be created by an Agent. This also allows Session to grow with new methods without
+	// breaking existing implementations.
+	sealedSession()
+}
+
+type session struct {
+	serviceID string
+
 	state map[string]*stateValue
 }
 
-// NewSession creates a new Session with the given ID. If the ID is empty, a new UUID is generated.
-//
-// This function is intended to be used by an [Agent] provider.
-// Consumers of the agent framework should use [Agent.CreateSession] to create sessions.
-func NewSession(id string) *Session {
-	if id == "" {
-		id = uuid.NewString()
-	}
-	return &Session{
-		id: id,
-	}
-}
+func (s *session) sealedSession() {}
 
-func (s *Session) ID() string {
-	return s.id
-}
-
-// Get decodes the value associated with key into value and reports whether the key was present.
-// value must be a non-nil pointer to the desired destination type.
-func (s *Session) Get(key string, value any) (bool, error) {
+func (s *session) Get(key string, value any) (bool, error) {
 	if s == nil {
 		return false, nil
 	}
@@ -62,12 +73,10 @@ func (s *Session) Get(key string, value any) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	return true, wrapped.readInto(value)
+	return wrapped.readInto(value)
 }
 
-// Set stores a value in the session state under the given key.
-// If the key already exists, its value is overwritten.
-func (s *Session) Set(key string, value any) {
+func (s *session) Set(key string, value any) {
 	if s == nil {
 		return
 	}
@@ -82,23 +91,52 @@ func (s *Session) Set(key string, value any) {
 	s.state[key] = wrapped
 }
 
-// Delete removes the value with the given key.
-func (s *Session) Delete(key string) {
+func (s *session) Delete(key string) {
 	if s == nil {
 		return
 	}
 	delete(s.state, key)
 }
 
-func (s *Session) MarshalJSON() ([]byte, error) {
+func (s *session) ServiceID() string {
+	if s == nil {
+		return ""
+	}
+	return s.serviceID
+}
+
+func (s *session) SetServiceID(id string) {
+	if s == nil {
+		return
+	}
+	s.serviceID = id
+}
+
+func (s *session) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("sessions must be marshaled with Agent.MarshalSession")
+}
+
+func (s *session) UnmarshalJSON([]byte) error {
+	return errors.New("sessions must be unmarshaled with Agent.UnmarshalSession")
+}
+
+type sessionData struct {
+	State map[string]*stateValue
+
+	ServiceID string
+}
+
+func marshalSession(sess Session) ([]byte, error) {
+	s, ok := sess.(*session)
+	if !ok || s == nil {
+		return nil, errors.New("the provided session is nil")
+	}
 	tmp := struct {
 		State map[string]*stateValue
 
-		ID        string
 		ServiceID string
 	}{
-		ID:        s.id,
-		ServiceID: s.ServiceID,
+		ServiceID: s.serviceID,
 	}
 	if s.state == nil {
 		tmp.State = make(map[string]*stateValue)
@@ -108,20 +146,16 @@ func (s *Session) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
-func (s *Session) UnmarshalJSON(data []byte) error {
-	var tmp struct {
-		State     map[string]*stateValue
-		ID        string
-		ServiceID string
-	}
+func unmarshalSession(data []byte) (Session, error) {
+	var tmp sessionData
 	if err := json.Unmarshal(data, &tmp); err != nil {
-		return err
+		return nil, err
 	}
-	s.id = tmp.ID
-	s.ServiceID = tmp.ServiceID
 	if tmp.State == nil {
 		tmp.State = make(map[string]*stateValue)
 	}
-	s.state = tmp.State
-	return nil
+	return &session{
+		serviceID: tmp.ServiceID,
+		state:     tmp.State,
+	}, nil
 }

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -8,14 +8,19 @@ import (
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 )
 
 type person struct {
 	Name string
 }
 
+type nullablePerson struct {
+	Name string
+}
+
 func TestSessionState_Get_NonexistentKey_ReturnsNotFound(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	var v string
 	ok, err := session.Get("nonexistent", &v)
 	if err != nil {
@@ -27,7 +32,7 @@ func TestSessionState_Get_NonexistentKey_ReturnsNotFound(t *testing.T) {
 }
 
 func TestSessionState_Set_And_Get_Roundtrips(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("key1", "value1")
 
 	var v string
@@ -44,7 +49,7 @@ func TestSessionState_Set_And_Get_Roundtrips(t *testing.T) {
 }
 
 func TestSessionState_Set_OverwritesExistingValue(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("key1", "original")
 	session.Set("key1", "updated")
 
@@ -62,7 +67,7 @@ func TestSessionState_Set_OverwritesExistingValue(t *testing.T) {
 }
 
 func TestSessionState_Delete_ExistingKey(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("key1", "value1")
 	session.Delete("key1")
 
@@ -77,7 +82,7 @@ func TestSessionState_Delete_ExistingKey(t *testing.T) {
 }
 
 func TestSessionState_Set_DifferentValueTypes(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("string", "hello")
 	session.Set("int", 42)
 	session.Set("bool", true)
@@ -96,28 +101,46 @@ func TestSessionState_Set_DifferentValueTypes(t *testing.T) {
 	}
 }
 
+func TestSessionState_Set_NilPointerValue_RoundtripsForSameType(t *testing.T) {
+	session := agenttest.CreateSession()
+	var p *nullablePerson
+	session.Set("person", p)
+
+	var out *nullablePerson
+	ok, err := session.Get("person", &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected key to be found")
+	}
+	if out != nil {
+		t.Fatalf("expected nil pointer, got %#v", out)
+	}
+}
+
 func TestSessionState_Get_TypeMismatchReturnsError(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("count", 42)
 
 	var s string
 	ok, err := session.Get("count", &s)
-	if !ok {
-		t.Fatal("expected key to exist")
+	if ok {
+		t.Fatal("expected type mismatch to report not found")
 	}
-	if err == nil {
-		t.Fatal("expected type mismatch error")
+	if err != nil {
+		t.Fatalf("expected no error on type mismatch, got %v", err)
 	}
 }
 
 func TestSessionState_Get_InvalidDestinationReturnsError(t *testing.T) {
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	session.Set("count", 42)
 
 	var nonPtr int
 	ok, err := session.Get("count", nonPtr)
-	if !ok {
-		t.Fatal("expected key to exist")
+	if ok {
+		t.Fatal("expected unreadable destination to report not found")
 	}
 	if err == nil {
 		t.Fatal("expected destination error")
@@ -125,8 +148,8 @@ func TestSessionState_Get_InvalidDestinationReturnsError(t *testing.T) {
 }
 
 func TestSession_MarshalJSON_EmptyState(t *testing.T) {
-	session := agent.NewSession("")
-	data, err := json.Marshal(session)
+	session := agenttest.CreateSession()
+	data, err := agenttest.New(nil).MarshalSession(t.Context(), session)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -135,9 +158,34 @@ func TestSession_MarshalJSON_EmptyState(t *testing.T) {
 	}
 }
 
-func TestSession_UnmarshalJSON_WithStateValues(t *testing.T) {
+func TestSession_MarshalJSON_DirectMarshalReturnsError(t *testing.T) {
+	session := agenttest.CreateSession()
+	if _, err := json.Marshal(session); err == nil {
+		t.Fatal("expected direct JSON marshaling to fail")
+	}
+}
+
+func TestSession_UnmarshalJSON_DirectUnmarshalReturnsError(t *testing.T) {
 	var session agent.Session
-	if err := json.Unmarshal([]byte(`{"State":{"key1":"value1","key2":42}}`), &session); err != nil {
+	if err := json.Unmarshal([]byte(`{"State":{"key1":"value1"}}`), &session); err == nil {
+		t.Fatal("expected direct JSON unmarshaling to fail")
+	}
+}
+
+func TestSession_UnmarshalJSON_IntoCreatedSessionReturnsGuardError(t *testing.T) {
+	session := agenttest.CreateSession()
+	err := json.Unmarshal([]byte(`{"State":{"key1":"value1"}}`), session)
+	if err == nil {
+		t.Fatal("expected direct JSON unmarshaling to fail")
+	}
+	if !strings.Contains(err.Error(), "sessions must be unmarshaled with Agent.UnmarshalSession") {
+		t.Fatalf("expected guard error, got %v", err)
+	}
+}
+
+func TestSession_UnmarshalSession_WithStateValues(t *testing.T) {
+	session, err := agenttest.New(nil).UnmarshalSession(t.Context(), []byte(`{"State":{"key1":"value1","key2":42}}`))
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -152,8 +200,8 @@ func TestSession_UnmarshalJSON_WithStateValues(t *testing.T) {
 }
 
 func TestSessionState_Get_LazyDecodesAndCaches(t *testing.T) {
-	var session agent.Session
-	if err := json.Unmarshal([]byte(`{"State":{"person":{"Name":"Ada"}}}`), &session); err != nil {
+	session, err := agenttest.New(nil).UnmarshalSession(t.Context(), []byte(`{"State":{"person":{"Name":"Ada"}}}`))
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -168,8 +216,8 @@ func TestSessionState_Get_LazyDecodesAndCaches(t *testing.T) {
 }
 
 func TestSessionState_Get_LazyDecodedValueTypeMismatchReturnsError(t *testing.T) {
-	var session agent.Session
-	if err := json.Unmarshal([]byte(`{"State":{"person":{"Name":"Ada"}}}`), &session); err != nil {
+	session, err := agenttest.New(nil).UnmarshalSession(t.Context(), []byte(`{"State":{"person":{"Name":"Ada"}}}`))
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -183,10 +231,10 @@ func TestSessionState_Get_LazyDecodedValueTypeMismatchReturnsError(t *testing.T)
 
 	var n int
 	ok, err := session.Get("person", &n)
-	if !ok {
-		t.Fatal("expected key to exist")
+	if ok {
+		t.Fatal("expected type mismatch to report not found")
 	}
-	if err == nil {
-		t.Fatal("expected decode failure for incompatible type")
+	if err != nil {
+		t.Fatalf("expected no error on type mismatch, got %v", err)
 	}
 }

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/skills"
 	"github.com/microsoft/agent-framework-go/agent/skills/fsskills"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 )
@@ -256,7 +257,7 @@ func TestProvider_RecoversFromPanickingSourceAndResetsLoading(t *testing.T) {
 	source := &panicOnceSource{skill: skill}
 	provider := skills.NewContextProvider(skills.ContextProviderOptions{Sources: []skills.Source{source}})
 
-	_, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agent.NewSession("")))
+	_, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 	if err == nil {
 		t.Fatal("expected provider to return an error after source panic")
 	}
@@ -270,7 +271,7 @@ func TestProvider_RecoversFromPanickingSourceAndResetsLoading(t *testing.T) {
 	}
 	resultCh := make(chan result, 1)
 	go func() {
-		messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agent.NewSession("")))
+		messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 		resultCh <- result{messageCount: len(messages), err: err}
 	}()
 
@@ -483,7 +484,7 @@ func TestNewProvider_ProvideExtendsInput(t *testing.T) {
 		nil,
 	)
 	provider := skills.NewContextProvider(skills.ContextProviderOptions{Skills: []*skills.Skill{skill}})
-	session := agent.NewSession("")
+	session := agenttest.CreateSession()
 	input := message.NewText("input")
 
 	messages, options, err := provider.Provide(t.Context(), []*message.Message{input}, agent.WithSession(session))
@@ -511,7 +512,7 @@ func TestNewProvider_ProvideExtendsInput(t *testing.T) {
 func TestProvider_WithEmptySource_ReturnsEmptyProvider(t *testing.T) {
 	provider := skills.NewContextProvider(skills.ContextProviderOptions{})
 	ctx := context.Background()
-	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agent.NewSession("")))
+	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -601,7 +602,7 @@ func TestProvider_SkillFilter_CanFilterOutAllSkills(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agent.NewSession("")))
+	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/skills"
 	"github.com/microsoft/agent-framework-go/agent/skills/fsskills"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 )
@@ -91,7 +92,7 @@ func newProviderWithConfig(t *testing.T, sourceOptions *fsskills.SourceOptions, 
 func captureProviderContext(t *testing.T, provider *agent.ContextProvider) (string, []tool.Tool) {
 	t.Helper()
 	ctx := context.Background()
-	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agent.NewSession("")))
+	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/value.go
+++ b/agent/value.go
@@ -14,48 +14,50 @@ type stateValue struct {
 	raw       json.RawMessage
 	cached    any
 	cachedTyp reflect.Type
+	hasCached bool
 }
 
 // newStateValue creates a new state value from a deserialized value.
 func newStateValue(value any) *stateValue {
-	return &stateValue{cached: value, cachedTyp: reflect.TypeOf(value)}
+	return &stateValue{cached: value, cachedTyp: reflect.TypeOf(value), hasCached: true}
 }
 
-func (v *stateValue) readInto(out any) error {
+func (v *stateValue) readInto(out any) (bool, error) {
 	if out == nil {
-		return fmt.Errorf("out must be a non-nil pointer")
+		return false, fmt.Errorf("out must be a non-nil pointer")
 	}
 	outValue := reflect.ValueOf(out)
 	if outValue.Kind() != reflect.Pointer || outValue.IsNil() {
-		return fmt.Errorf("out must be a non-nil pointer")
+		return false, fmt.Errorf("out must be a non-nil pointer")
 	}
 	requestedType := outValue.Elem().Type()
 
-	if v.cachedTyp != nil {
+	if v.hasCached {
 		if v.cachedTyp != requestedType {
-			return fmt.Errorf("cached value type is %v, requested %v", v.cachedTyp, requestedType)
+			return false, nil
 		}
 		cachedValue := reflect.ValueOf(v.cached)
 		if !cachedValue.IsValid() {
 			outValue.Elem().SetZero()
-			return nil
+			return true, nil
 		}
 		outValue.Elem().Set(cachedValue)
-		return nil
+		return true, nil
 	}
 	if v.raw == nil {
-		return fmt.Errorf("value is undefined")
+		return false, nil
 	}
 	if err := json.Unmarshal(v.raw, out); err != nil {
-		return err
+		return false, nil
 	}
 	v.cached = outValue.Elem().Interface()
 	v.cachedTyp = requestedType
-	return nil
+	v.hasCached = true
+	return true, nil
 }
 
 func (v *stateValue) MarshalJSON() ([]byte, error) {
-	if v.cachedTyp != nil {
+	if v.hasCached {
 		return json.Marshal(v.cached)
 	}
 	if v.raw != nil {
@@ -68,5 +70,6 @@ func (v *stateValue) UnmarshalJSON(data []byte) error {
 	v.raw = append(json.RawMessage(nil), data...)
 	v.cached = nil
 	v.cachedTyp = nil
+	v.hasCached = false
 	return nil
 }

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -11,10 +11,11 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow"
 )
 
+const agentSessionStateKey = "agent_session"
+
 func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {
-	var session *Session
-	var sessionStateKey string
-	ensureSession := func(ctx context.Context) (*Session, error) {
+	var session Session
+	ensureSession := func(ctx context.Context) (Session, error) {
 		if session == nil {
 			var err error
 			session, err = a.CreateSession(ctx)
@@ -22,7 +23,6 @@ func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {
 				return nil, err
 			}
 		}
-		sessionStateKey = session.ID()
 		return session, nil
 	}
 	id := agentDescriptiveID(a)
@@ -38,10 +38,10 @@ func newExecutor(a *Agent, emitEvents bool) *workflow.Executor {
 					if err != nil {
 						return err
 					}
-					return wctx.QueueStateUpdate(sessionStateKey, "", data)
+					return wctx.QueueStateUpdate(agentSessionStateKey, "", data)
 				},
 				OnCheckpointRestored: func(wctx *workflow.Context) error {
-					data, err := wctx.ReadState(sessionStateKey, "")
+					data, err := wctx.ReadState(agentSessionStateKey, "")
 					if err != nil {
 						return err
 					}

--- a/examples/01-get-started/04_memory/main.go
+++ b/examples/01-get-started/04_memory/main.go
@@ -86,7 +86,7 @@ type providerState struct {
 	UserName string `json:"user_name,omitempty"`
 }
 
-func getProviderState(session *agent.Session) providerState {
+func getProviderState(session agent.Session) providerState {
 	if session == nil {
 		return providerState{}
 	}

--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -101,7 +101,7 @@ type fsMessageStore struct {
 	Dir string
 }
 
-func (d *fsMessageStore) getFiles(session *agent.Session) []string {
+func (d *fsMessageStore) getFiles(session agent.Session) []string {
 	if session == nil {
 		return nil
 	}
@@ -113,7 +113,7 @@ func (d *fsMessageStore) getFiles(session *agent.Session) []string {
 	return files
 }
 
-func (d *fsMessageStore) loadMessages(session *agent.Session) ([]*message.Message, error) {
+func (d *fsMessageStore) loadMessages(session agent.Session) ([]*message.Message, error) {
 	var msgs []*message.Message
 	for _, file := range d.getFiles(session) {
 		data, err := os.ReadFile(filepath.Join(d.Dir, file))
@@ -130,7 +130,7 @@ func (d *fsMessageStore) loadMessages(session *agent.Session) ([]*message.Messag
 	return msgs, nil
 }
 
-func (d *fsMessageStore) persistMessages(session *agent.Session, requestMessages, responseMessages []*message.Message) error {
+func (d *fsMessageStore) persistMessages(session agent.Session, requestMessages, responseMessages []*message.Message) error {
 	var files []string
 	_, _ = session.Get("fsMessageStore.files", &files)
 	persist := func(msg *message.Message) error {
@@ -166,7 +166,7 @@ func (d *fsMessageStore) persistMessages(session *agent.Session, requestMessages
 }
 
 func (d *fsMessageStore) Run(next agent.RunFunc, ctx context.Context, msgs []*message.Message, opts ...agent.Option) iter.Seq2[*message.ResponseUpdate, error] {
-	var session *agent.Session
+	var session agent.Session
 	if v, ok := agent.GetOption(opts, agent.WithSession); ok {
 		session = v
 	} else {

--- a/examples/02-agents/agui/step04_human_in_loop/client/main.go
+++ b/examples/02-agents/agui/step04_human_in_loop/client/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 }
 
-func runWithApprovals(ctx context.Context, a *agent.Agent, session *agent.Session, input *message.Message) error {
+func runWithApprovals(ctx context.Context, a *agent.Agent, session agent.Session, input *message.Message) error {
 	current := input
 	for {
 		resp, err := a.RunMessage(ctx, current, agent.WithSession(session)).Collect()

--- a/internal/agenttest/agenttest.go
+++ b/internal/agenttest/agenttest.go
@@ -4,7 +4,6 @@ package agenttest
 
 import (
 	"context"
-	"encoding/json"
 	"iter"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -95,11 +94,9 @@ func New(responses []Turn) *agent.Agent {
 		responses: responses,
 	}
 	return agent.New(agent.ProviderConfig{
-		ProviderName:     "agenttest",
-		CreateSession:    a.createSession,
-		MarshalSession:   a.marshalSession,
-		UnmarshalSession: a.unmarshalSession,
-		Run:              a.run,
+		ProviderName:  "agenttest",
+		CreateSession: a.createSession,
+		Run:           a.run,
 	}, agent.Config{
 		ID:          "test-agent-id",
 		Name:        "TestAgent",
@@ -125,28 +122,20 @@ func (a *testagent) run(ctx context.Context, messages []*message.Message, opts .
 	}
 }
 
-func (a *testagent) createSession(_ context.Context, opts ...agent.Option) (*agent.Session, error) {
-	return agent.NewSession(""), nil
+func (a *testagent) createSession(_ context.Context, _ agent.Session, opts ...agent.Option) error {
+	return nil
 }
 
-func (a *testagent) marshalSession(_ context.Context, session *agent.Session) ([]byte, error) {
-	return json.Marshal(session)
-}
-
-func (a *testagent) unmarshalSession(_ context.Context, data []byte) (*agent.Session, error) {
-	var session agent.Session
-	if err := json.Unmarshal(data, &session); err != nil {
-		return nil, err
+func CreateSession(options ...agent.Option) agent.Session {
+	session, err := New(nil).CreateSession(context.Background(), options...)
+	if err != nil {
+		panic(err)
 	}
-	return &session, nil
+	return session
 }
 
-func CreateSession() *agent.Session {
-	return agent.NewSession("")
-}
-
-func MarshalSession(session *agent.Session) ([]byte, error) {
-	return json.Marshal(session)
+func MarshalSession(session agent.Session) ([]byte, error) {
+	return New(nil).MarshalSession(context.Background(), session)
 }
 
 // Middleware is a test implementation of the Middleware interface


### PR DESCRIPTION
`agent.Session` should only be instantiated via an `agent.CreateSession`, so exposing `agent.NewSession` is misleading. Also, it should not be possible to instantiate a new session by doing `s := agent.Session{}`.

To fix this issues, `agent.Session` is now an interface that can only be implemented in the `agent` package. The provider callbacks have been updated to account for this change.

While here, improve the session state handling so that is more similar to the .NET one, and also allow passing options to `agent.MarshalSession` and `agent.UnmarshalSession`.