### PR TITLE
Unify agent workflow responses as output events

### DIFF
--- a/agent/hosting/workflowhosting/inprocess_execution_test.go
+++ b/agent/hosting/workflowhosting/inprocess_execution_test.go
@@ -98,11 +98,48 @@ func TestRunAsync_ExecutesWorkflow(t *testing.T) {
 	if len(events) == 0 {
 		t.Fatalf("expected events, got 0")
 	}
-	if !containsType[workflow.ResponseUpdateEvent](events) {
-		t.Errorf("expected at least one ResponseUpdateEvent")
+	if !containsOutputPayloadType[*agent.ResponseUpdate](events) {
+		t.Errorf("expected at least one OutputEvent carrying *agent.ResponseUpdate")
 	}
-	if !containsType[workflow.ResponseEvent](events) {
-		t.Errorf("expected at least one ResponseEvent")
+	if !containsOutputPayloadType[*agent.Response](events) {
+		t.Errorf("expected at least one OutputEvent carrying *agent.Response")
+	}
+}
+
+func TestWorkflowBuilderWithHostedAgentsEmitsOutputEventWithoutWithOutputFrom(t *testing.T) {
+	agent1 := workflowhosting.New(newEchoAgent("agent-1"), workflowhosting.Config{})
+	agent2 := workflowhosting.New(newEchoAgent("agent-2"), workflowhosting.Config{})
+	wf, err := workflow.NewBuilder(agent1).
+		AddEdge(agent1, agent2).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx := context.Background()
+	stream, err := inproc.Default.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.CancelRun() }()
+
+	sendStreamMessage(t, stream, ctx, []*message.Message{{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: "Hello"}},
+	}})
+	emit := true
+	sendStreamMessage(t, stream, ctx, workflow.TurnToken{EmitEvents: &emit})
+
+	var events []workflow.Event
+	for evt, err := range stream.WatchStream(ctx) {
+		if err != nil {
+			t.Fatalf("watch: %v", err)
+		}
+		events = append(events, evt)
+	}
+
+	if !containsOutputPayloadType[*agent.ResponseUpdate](events) {
+		t.Fatalf("expected at least one OutputEvent carrying *agent.ResponseUpdate")
 	}
 }
 
@@ -139,11 +176,11 @@ func TestStreamAsync_ExecutesWorkflowWithTurnToken(t *testing.T) {
 	if status != inproc.RunStatusIdle {
 		t.Errorf("status = %v, want Idle", status)
 	}
-	if !containsType[workflow.ResponseUpdateEvent](events) {
-		t.Errorf("expected at least one ResponseUpdateEvent")
+	if !containsOutputPayloadType[*agent.ResponseUpdate](events) {
+		t.Errorf("expected at least one OutputEvent carrying *agent.ResponseUpdate")
 	}
-	if !containsType[workflow.ResponseEvent](events) {
-		t.Errorf("expected at least one ResponseEvent")
+	if !containsOutputPayloadType[*agent.Response](events) {
+		t.Errorf("expected at least one OutputEvent carrying *agent.Response")
 	}
 }
 
@@ -187,7 +224,7 @@ func TestRunAsyncAndStreamAsync_ProduceSimilarResults(t *testing.T) {
 	if len(nonStreamingEvents) == 0 {
 		t.Fatalf("non-streaming version produced no events")
 	}
-	if got, want := countType[workflow.ResponseUpdateEvent](nonStreamingEvents), countType[workflow.ResponseUpdateEvent](streamingEvents); got != want {
+	if got, want := countOutputPayloadType[*agent.ResponseUpdate](nonStreamingEvents), countOutputPayloadType[*agent.ResponseUpdate](streamingEvents); got != want {
 		t.Errorf("agent update count: non-streaming=%d, streaming=%d", got, want)
 	}
 }
@@ -241,26 +278,25 @@ func TestRunStreamingAsync_StatusReachesIdleBeforeWatch(t *testing.T) {
 	if len(events) == 0 {
 		t.Fatalf("expected events even after run reached Idle, got 0")
 	}
-	if !containsType[workflow.ResponseUpdateEvent](events) {
-		t.Errorf("expected at least one ResponseUpdateEvent")
+	if !containsOutputPayloadType[*agent.ResponseUpdate](events) {
+		t.Errorf("expected at least one OutputEvent carrying *agent.ResponseUpdate")
 	}
 }
 
-// containsType reports whether any element of events is of type T.
-func containsType[T any](events []workflow.Event) bool {
-	for _, e := range events {
-		if _, ok := e.(T); ok {
-			return true
-		}
-	}
-	return false
+// containsOutputPayloadType reports whether any OutputEvent has payload type T.
+func containsOutputPayloadType[T any](events []workflow.Event) bool {
+	return countOutputPayloadType[T](events) > 0
 }
 
-// countType returns the number of events of type T in events.
-func countType[T any](events []workflow.Event) int {
+// countOutputPayloadType returns the number of OutputEvents with payload type T.
+func countOutputPayloadType[T any](events []workflow.Event) int {
 	n := 0
 	for _, e := range events {
-		if _, ok := e.(T); ok {
+		out, ok := e.(workflow.OutputEvent)
+		if !ok {
+			continue
+		}
+		if _, ok := out.Output.(T); ok {
 			n++
 		}
 	}

--- a/agent/hosting/workflowhosting/workflow.go
+++ b/agent/hosting/workflowhosting/workflow.go
@@ -29,13 +29,13 @@ const (
 // Config configures how an [agent.Agent] is hosted as a workflow
 // [workflow.Executor].
 type Config struct {
-	// EmitUpdateEvents controls whether streaming [workflow.ResponseUpdateEvent]s
+	// EmitUpdateEvents controls whether streaming [agent.ResponseUpdate] outputs
 	// are emitted as the agent runs. A [workflow.TurnToken] with
 	// [workflow.TurnToken.EmitEvents] set overrides this default for that turn.
 	EmitUpdateEvents bool
 
-	// EmitResponseEvents controls whether an aggregated [workflow.ResponseEvent]
-	// is emitted at the end of each turn.
+	// EmitResponseEvents controls whether an aggregated [agent.Response] output is
+	// emitted at the end of each turn.
 	EmitResponseEvents bool
 
 	// DisableMessageForwarding disables forwarding of incoming messages
@@ -442,7 +442,7 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 			return err
 		}
 		if emitUpdates {
-			if err := wctx.AddEvent(workflow.ResponseUpdateEvent{ExecutorID: h.id, Update: update}); err != nil {
+			if err := wctx.AddEvent(workflow.OutputEvent{ExecutorID: h.id, Output: update}); err != nil {
 				return err
 			}
 		}
@@ -458,7 +458,7 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 	}
 
 	if h.cfg.EmitResponseEvents {
-		if err := wctx.AddEvent(workflow.ResponseEvent{ExecutorID: h.id, Response: &resp}); err != nil {
+		if err := wctx.AddEvent(workflow.OutputEvent{ExecutorID: h.id, Output: &resp}); err != nil {
 			return err
 		}
 	}

--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -186,7 +186,7 @@ func runHostedAgent(t *testing.T, a *agent.Agent, cfg workflowhosting.Config, to
 func boolPtr(b bool) *bool { return &b }
 
 // TestHostedAgent_EmitsStreamingUpdatesIfConfigured exercises the matrix
-// (executorSetting × turnSetting) for ResponseUpdateEvent emission. The rule:
+// (executorSetting × turnSetting) for streaming response update output emission. The rule:
 // the TurnToken's EmitEvents flag overrides the executor's EmitUpdateEvents
 // when set; otherwise the executor setting applies (default false).
 func TestHostedAgent_EmitsStreamingUpdatesIfConfigured(t *testing.T) {
@@ -220,12 +220,7 @@ func TestHostedAgent_EmitsStreamingUpdatesIfConfigured(t *testing.T) {
 				{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "hi"}}},
 			})
 
-			var updates []workflow.ResponseUpdateEvent
-			for _, e := range events {
-				if u, ok := e.(workflow.ResponseUpdateEvent); ok {
-					updates = append(updates, u)
-				}
-			}
+			updates := collectOutputPayloads[*agent.ResponseUpdate](events)
 
 			expecting := false
 			switch {
@@ -243,14 +238,14 @@ func TestHostedAgent_EmitsStreamingUpdatesIfConfigured(t *testing.T) {
 					if u.ExecutorID == "" {
 						t.Errorf("update[%d] missing ExecutorID", i)
 					}
-					if u.Update.AuthorName != testAgentName {
-						t.Errorf("update[%d] AuthorName = %q, want %q", i, u.Update.AuthorName, testAgentName)
+					if u.Payload.AuthorName != testAgentName {
+						t.Errorf("update[%d] AuthorName = %q, want %q", i, u.Payload.AuthorName, testAgentName)
 					}
-					if len(u.Update.Contents) != 1 {
-						t.Errorf("update[%d] expected 1 content, got %d", i, len(u.Update.Contents))
+					if len(u.Payload.Contents) != 1 {
+						t.Errorf("update[%d] expected 1 content, got %d", i, len(u.Payload.Contents))
 						continue
 					}
-					gotText := u.Update.Contents[0].(*message.TextContent).Text
+					gotText := u.Payload.Contents[0].(*message.TextContent).Text
 					if gotText != expectedContents[i].Text {
 						t.Errorf("update[%d] text = %q, want %q", i, gotText, expectedContents[i].Text)
 					}
@@ -273,7 +268,7 @@ func boolPtrStr(b *bool) string {
 }
 
 // TestHostedAgent_EmitsResponseIfConfigured verifies that the EmitResponseEvents
-// flag controls whether a single aggregated ResponseEvent is produced.
+// flag controls whether a single aggregated response output is produced.
 func TestHostedAgent_EmitsResponseIfConfigured(t *testing.T) {
 	for _, executorSetting := range []bool{true, false} {
 		t.Run(fmt.Sprintf("emit=%v", executorSetting), func(t *testing.T) {
@@ -282,38 +277,33 @@ func TestHostedAgent_EmitsResponseIfConfigured(t *testing.T) {
 				workflow.TurnToken{},
 				[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "hi"}}}})
 
-			var responses []workflow.ResponseEvent
-			for _, e := range events {
-				if r, ok := e.(workflow.ResponseEvent); ok {
-					responses = append(responses, r)
-				}
-			}
+			responses := collectOutputPayloads[*agent.Response](events)
 
 			if executorSetting {
 				if len(responses) != 1 {
-					t.Fatalf("expected 1 ResponseEvent, got %d", len(responses))
+					t.Fatalf("expected 1 response output, got %d", len(responses))
 				}
 				resp := responses[0]
 				if resp.ExecutorID == "" {
-					t.Error("ResponseEvent missing ExecutorID")
+					t.Error("response output missing ExecutorID")
 				}
-				if resp.Response == nil {
-					t.Fatal("ResponseEvent.Response is nil")
+				if resp.Payload == nil {
+					t.Fatal("response output payload is nil")
 				}
 				// One *Message per non-empty source message: 3 in the
 				// reference data (the first is empty and produces no updates,
 				// hence no message).
-				if len(resp.Response.Messages) != len(testReplayMessages)-1 {
+				if len(resp.Payload.Messages) != len(testReplayMessages)-1 {
 					t.Errorf("Response.Messages count = %d, want %d",
-						len(resp.Response.Messages), len(testReplayMessages)-1)
+						len(resp.Payload.Messages), len(testReplayMessages)-1)
 				}
-				for _, msg := range resp.Response.Messages {
+				for _, msg := range resp.Payload.Messages {
 					if msg.AuthorName != testAgentName {
 						t.Errorf("message AuthorName = %q, want %q", msg.AuthorName, testAgentName)
 					}
 				}
 			} else if len(responses) != 0 {
-				t.Errorf("expected no ResponseEvents, got %d", len(responses))
+				t.Errorf("expected no response outputs, got %d", len(responses))
 			}
 		})
 	}
@@ -631,13 +621,31 @@ func resultExecutor(target *workflow.ExecutorBinding, result any) *workflow.Exec
 	return binding
 }
 
-func collectResponseEvents(t *testing.T, ev []workflow.Event) []*agent.Response {
+type outputPayload[T any] struct {
+	ExecutorID string
+	Payload    T
+}
+
+func collectOutputPayloads[T any](ev []workflow.Event) []outputPayload[T] {
+	var out []outputPayload[T]
+	for _, e := range ev {
+		o, ok := e.(workflow.OutputEvent)
+		if !ok {
+			continue
+		}
+		payload, ok := o.Output.(T)
+		if ok {
+			out = append(out, outputPayload[T]{ExecutorID: o.ExecutorID, Payload: payload})
+		}
+	}
+	return out
+}
+
+func collectResponseOutputs(t *testing.T, ev []workflow.Event) []*agent.Response {
 	t.Helper()
 	var out []*agent.Response
-	for _, e := range ev {
-		if r, ok := e.(workflow.ResponseEvent); ok {
-			out = append(out, r.Response)
-		}
+	for _, response := range collectOutputPayloads[*agent.Response](ev) {
+		out = append(out, response.Payload)
 	}
 	return out
 }
@@ -681,9 +689,9 @@ func TestHostedAgent_InterceptUserInputRequests(t *testing.T) {
 		events = append(events, evt)
 	}
 
-	responses := collectResponseEvents(t, events)
+	responses := collectResponseOutputs(t, events)
 	if len(responses) < 2 {
-		t.Fatalf("expected >=2 ResponseEvents (initial + post-approval), got %d", len(responses))
+		t.Fatalf("expected >=2 response outputs (initial + post-approval), got %d", len(responses))
 	}
 	last := responses[len(responses)-1]
 	if len(last.Messages) == 0 || last.Messages[0].Contents.Text() != "approved" {
@@ -730,9 +738,9 @@ func TestHostedAgent_InterceptUnterminatedFunctionCalls(t *testing.T) {
 		events = append(events, evt)
 	}
 
-	responses := collectResponseEvents(t, events)
+	responses := collectResponseOutputs(t, events)
 	if len(responses) < 2 {
-		t.Fatalf("expected >=2 ResponseEvents, got %d", len(responses))
+		t.Fatalf("expected >=2 response outputs, got %d", len(responses))
 	}
 	last := responses[len(responses)-1]
 	if last.Messages[0].Contents.Text() != "got:42" {
@@ -854,12 +862,14 @@ func TestHostedAgent_InterceptDisabled_ResumesWithExternalResponse(t *testing.T)
 
 	var responses []*agent.Response
 	for evt := range run.OutgoingEvents() {
-		if r, ok := evt.(workflow.ResponseEvent); ok {
-			responses = append(responses, r.Response)
+		if o, ok := evt.(workflow.OutputEvent); ok {
+			if response, ok := o.Output.(*agent.Response); ok {
+				responses = append(responses, response)
+			}
 		}
 	}
 	if len(responses) == 0 {
-		t.Fatalf("expected at least one ResponseEvent after resume, got 0")
+		t.Fatalf("expected at least one response output after resume, got 0")
 	}
 	last := responses[len(responses)-1]
 	if last.Messages[0].Contents.Text() != "approved" {
@@ -1010,13 +1020,15 @@ func TestHostedAgent_InterceptsOnlyUnpairedFunctionCalls_PortMode(t *testing.T) 
 }
 
 // lastResponseText drains all currently-available events from the run and
-// returns the text of the last ResponseEvent observed (or "" if none).
+// returns the text of the last response output observed (or "" if none).
 func lastResponseText(t *testing.T, run *inproc.Run) string {
 	t.Helper()
 	var text string
 	for evt := range run.OutgoingEvents() {
-		if r, ok := evt.(workflow.ResponseEvent); ok && r.Response != nil && len(r.Response.Messages) > 0 {
-			text = r.Response.Messages[len(r.Response.Messages)-1].Contents.Text()
+		if o, ok := evt.(workflow.OutputEvent); ok {
+			if response, ok := o.Output.(*agent.Response); ok && response != nil && len(response.Messages) > 0 {
+				text = response.Messages[len(response.Messages)-1].Contents.Text()
+			}
 		}
 	}
 	return text

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -51,8 +51,8 @@ type Config struct {
 	// IncludeOutputsInResponse, if true, surfaces [workflow.OutputEvent]
 	// payloads in the agent response stream when the payload is a
 	// [*message.Message] or [[]*message.Message]. By default outputs are
-	// observed only via [workflow.ResponseUpdateEvent]s emitted by hosted
-	// agents inside the workflow.
+	// observed only when they contain [*agent.ResponseUpdate] or [*agent.Response]
+	// payloads emitted by hosted agents inside the workflow.
 	IncludeOutputsInResponse bool
 
 	// IncludeErrorDetails, if true, surfaces the full error message from
@@ -167,29 +167,32 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 					return
 				}
 				switch e := evt.(type) {
-				case workflow.ResponseUpdateEvent:
-					if !yield(stampUpdate(e.Update, responseID, e), nil) {
-						return
-					}
-				case workflow.ResponseEvent:
-					if e.Response == nil {
-						continue
-					}
-					for _, update := range e.Response.ToUpdates() {
-						if !yield(stampUpdate(update, responseID, e), nil) {
+				case workflow.OutputEvent:
+					switch out := e.Output.(type) {
+					case *agent.ResponseUpdate:
+						if !yield(stampUpdate(out, responseID, e), nil) {
 							return
 						}
-					}
-				case workflow.OutputEvent:
-					if !cfg.IncludeOutputsInResponse {
-						continue
-					}
-					switch out := e.Output.(type) {
+					case *agent.Response:
+						if out == nil {
+							continue
+						}
+						for _, update := range out.ToUpdates() {
+							if !yield(stampUpdate(update, responseID, e), nil) {
+								return
+							}
+						}
 					case *message.Message:
+						if !cfg.IncludeOutputsInResponse {
+							continue
+						}
 						if !yield(messageToUpdate(out, responseID, e), nil) {
 							return
 						}
 					case []*message.Message:
+						if !cfg.IncludeOutputsInResponse {
+							continue
+						}
 						for _, msg := range out {
 							if !yield(messageToUpdate(msg, responseID, e), nil) {
 								return

--- a/agent/provider/workflowprovider/workflow_test.go
+++ b/agent/provider/workflowprovider/workflow_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 // echoExecutorBinding builds a workflow executor that, on each TurnToken,
-// emits a single ResponseUpdate echoing the last user message and yields a
-// final aggregated message as workflow output.
+// emits a single response update output echoing the last user message and
+// yields a final aggregated message as workflow output.
 func echoExecutorBinding(id string) *workflow.ExecutorBinding {
 	binding := &workflow.ExecutorBinding{
 		ID:           id,
@@ -48,9 +48,9 @@ func echoExecutorBinding(id string) *workflow.ExecutorBinding {
 							AgentID:    id,
 							AuthorName: id,
 						}
-						if err := ctx.AddEvent(workflow.ResponseUpdateEvent{
+						if err := ctx.AddEvent(workflow.OutputEvent{
 							ExecutorID: id,
-							Update:     update,
+							Output:     update,
 						}); err != nil {
 							return err
 						}
@@ -193,13 +193,13 @@ func TestNew_IncludeOutputsInResponse(t *testing.T) {
 	for range ag.RunText(context.Background(), "ping") {
 		updates++
 	}
-	// One update from ResponseUpdateEvent, one from OutputEvent translation.
+	// One update from *agent.ResponseUpdate output, one from message output translation.
 	if updates < 2 {
 		t.Errorf("expected at least 2 updates with IncludeOutputsInResponse, got %d", updates)
 	}
 }
 
-func TestNew_ConvertsResponseEventsWithResponseMetadata(t *testing.T) {
+func TestNew_ConvertsResponseOutputWithResponseMetadata(t *testing.T) {
 	createdAt := time.Date(2024, 11, 10, 9, 20, 0, 0, time.UTC)
 	binding := &workflow.ExecutorBinding{
 		ID:           "response-yielder",
@@ -234,7 +234,9 @@ func TestNew_ConvertsResponseEventsWithResponseMetadata(t *testing.T) {
 			},
 		}, nil
 	}
-	wf, err := workflow.NewBuilder(binding).Build()
+	wf, err := workflow.NewBuilder(binding).
+		WithOutputFrom(binding).
+		Build()
 	if err != nil {
 		t.Fatalf("build workflow: %v", err)
 	}
@@ -922,7 +924,7 @@ func TestNew_MatchingResponse_DoesNotCauseExtraTurn(t *testing.T) {
 			}
 		}
 	}
-	// One agent turn yields the same FCC via both ResponseUpdateEvent and
+	// One agent turn yields the same FCC via both *agent.ResponseUpdate output and
 	// RequestInfoEvent, so first-turn count is the baseline. An extra
 	// TurnToken-driven turn would double the second-turn count.
 	if secondCount != firstCount {

--- a/examples/03-workflows/_start-here/02_agents_in_workflows/main.go
+++ b/examples/03-workflows/_start-here/02_agents_in_workflows/main.go
@@ -65,8 +65,10 @@ func main() {
 		if err != nil {
 			demo.Panic(err)
 		}
-		if update, ok := evt.(workflow.ResponseUpdateEvent); ok {
-			demo.Assistantf("%s: %s", update.ExecutorID, update.Update.String())
+		if out, ok := evt.(workflow.OutputEvent); ok {
+			if update, ok := out.Output.(*agent.ResponseUpdate); ok {
+				demo.Assistantf("%s: %s", out.ExecutorID, update.String())
+			}
 		}
 	}
 }

--- a/examples/03-workflows/_start-here/03_agent_workflow_patterns/main.go
+++ b/examples/03-workflows/_start-here/03_agent_workflow_patterns/main.go
@@ -53,10 +53,12 @@ func main() {
 			demo.Panic(err)
 		}
 		switch e := evt.(type) {
-		case workflow.ResponseUpdateEvent:
-			demo.Assistantf("%s: %s", e.ExecutorID, e.Update.String())
 		case workflow.OutputEvent:
-			demo.Assistantf("Output: %v", e.Output)
+			if update, ok := e.Output.(*agent.ResponseUpdate); ok {
+				demo.Assistantf("%s: %s", e.ExecutorID, update.String())
+			} else {
+				demo.Assistantf("Output: %v", e.Output)
+			}
 		}
 	}
 }

--- a/workflow/event.go
+++ b/workflow/event.go
@@ -2,8 +2,6 @@
 
 package workflow
 
-import "github.com/microsoft/agent-framework-go/agent"
-
 type Event interface {
 	Data() any
 }
@@ -149,30 +147,4 @@ type RequestInfoEvent struct {
 
 func (e RequestInfoEvent) Data() any {
 	return e.Request
-}
-
-var _ Event = ResponseUpdateEvent{}
-
-// ResponseUpdateEvent is an event triggered when an agent run produces a streaming response update.
-// This event is also automatically emitted when an executor yields a *agent.ResponseUpdate via YieldOutput.
-type ResponseUpdateEvent struct {
-	ExecutorID string
-	Update     *agent.ResponseUpdate
-}
-
-func (e ResponseUpdateEvent) Data() any {
-	return e.Update
-}
-
-var _ Event = ResponseEvent{}
-
-// ResponseEvent is an event triggered when an agent produces a complete response.
-// This event is automatically emitted when an executor yields a *agent.Response via YieldOutput.
-type ResponseEvent struct {
-	ExecutorID string
-	Response   *agent.Response
-}
-
-func (e ResponseEvent) Data() any {
-	return e.Response
 }

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 
 	"github.com/google/uuid"
-	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/workflow"
 	"github.com/microsoft/agent-framework-go/workflow/internal/checkpoint"
 	"github.com/microsoft/agent-framework-go/workflow/internal/execution"
@@ -489,15 +488,6 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 		},
 
 		YieldOutput: func(output any) error {
-			// Special-case agent response types so they get translated into typed
-			// events regardless of whether this executor is registered as an
-			// output executor.
-			switch v := output.(type) {
-			case *agent.ResponseUpdate:
-				return proc.AddEvent(ctx, workflow.ResponseUpdateEvent{ExecutorID: executorID, Update: v})
-			case *agent.Response:
-				return proc.AddEvent(ctx, workflow.ResponseEvent{ExecutorID: executorID, Response: v})
-			}
 			// Check if this executor can output
 			if _, ok := proc.wf.OutputExecutors[executorID]; ok {
 				return proc.AddEvent(ctx, workflow.OutputEvent{


### PR DESCRIPTION
## Summary
- remove workflow ResponseUpdateEvent and ResponseEvent in favor of OutputEvent payloads
- emit hosted-agent response updates and aggregated responses as OutputEvent values
- update workflow provider, examples, and tests
- port https://github.com/microsoft/agent-framework/pull/3441

## Tests
- go test ./...