### PR TITLE
Add history provider and additional context sample

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -42,12 +42,18 @@ type Config struct {
 	// Description describes the agent's purpose.
 	Description string
 
-	// Instructions are prepended as a system message for each non-continuation run.
-	Instructions string
-
 	// HistoryProvider injects and persists conversation history around each agent run.
 	// When nil, New uses a default in-memory history provider for local sessions.
 	HistoryProvider *HistoryProvider
+	// AllowHistoryProviderConflict prevents returning an error when a configured
+	// HistoryProvider conflicts with service-managed history.
+	AllowHistoryProviderConflict bool
+	// SuppressHistoryProviderConflictWarning prevents logging a warning when a
+	// configured HistoryProvider conflicts with service-managed history.
+	SuppressHistoryProviderConflictWarning bool
+	// KeepHistoryProviderOnConflict prevents clearing the configured HistoryProvider
+	// when it conflicts with service-managed history. Returning an error takes precedence.
+	KeepHistoryProviderOnConflict bool
 
 	// ContextProviders inject and persist context around each agent run.
 	ContextProviders []*ContextProvider
@@ -79,42 +85,40 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 	}
 
 	cfg.RunOptions = slices.Clone(cfg.RunOptions)
-	cfg.Tools = slices.Clone(cfg.Tools)
 	for _, tool := range cfg.Tools {
 		if tool != nil {
 			cfg.RunOptions = append(cfg.RunOptions, WithTool(tool))
 		}
 	}
 	cfg.Middlewares = slices.Clone(cfg.Middlewares)
-	providers := make([]*ContextProvider, 0, len(cfg.ContextProviders)+1)
+	contextProviders := make([]*ContextProvider, 0, len(cfg.ContextProviders))
 	for _, provider := range cfg.ContextProviders {
 		if provider != nil {
-			providers = append(providers, provider)
+			contextProviders = append(contextProviders, provider)
 		}
 	}
-	prefixedMiddlewares := make([]Middleware, 0, 2)
 	historyProvider := cfg.HistoryProvider
-	var useDefaultHistoryHeuristics bool
+	var hasDefaultHistoryProvider bool
 	if historyProvider == nil {
 		historyProvider = NewInMemoryHistoryProvider("")
-		useDefaultHistoryHeuristics = true
+		hasDefaultHistoryProvider = true
 	}
-	if historyProvider != nil {
-		prefixedMiddlewares = append(prefixedMiddlewares, newHistoryProviderMiddleware(historyProvider, useDefaultHistoryHeuristics))
-	}
-	if len(providers) > 0 {
-		prefixedMiddlewares = append(prefixedMiddlewares, newContextProviderMiddleware(providers...))
-	}
-	cfg.Middlewares = append(prefixedMiddlewares, cfg.Middlewares...)
 	cfg.Middlewares = append(cfg.Middlewares, authorMiddleware(cfg.ID, cfg.Name))
 	return &Agent{
-		id:           cfg.ID,
-		name:         cfg.Name,
-		description:  cfg.Description,
-		provider:     prov,
-		instructions: cfg.Instructions,
-		runOptions:   cfg.RunOptions,
-		middlewares:  cfg.Middlewares,
+		id:                        cfg.ID,
+		name:                      cfg.Name,
+		description:               cfg.Description,
+		provider:                  prov,
+		runOptions:                cfg.RunOptions,
+		middlewares:               cfg.Middlewares,
+		logger:                    cfg.Logger,
+		historyProvider:           historyProvider,
+		hasConfiguredHistory:      cfg.HistoryProvider != nil,
+		hasDefaultHistoryProvider: hasDefaultHistoryProvider,
+		allowHistoryConflict:      cfg.AllowHistoryProviderConflict,
+		suppressHistoryWarning:    cfg.SuppressHistoryProviderConflictWarning,
+		keepHistoryOnConflict:     cfg.KeepHistoryProviderOnConflict,
+		contextProviders:          contextProviders,
 	}
 }
 
@@ -125,10 +129,21 @@ type Agent struct {
 	description string
 	provider    ProviderConfig
 
-	instructions string
-
 	middlewares []Middleware
 	runOptions  []Option
+	logger      *slog.Logger
+
+	historyProvider      *HistoryProvider
+	hasConfiguredHistory bool
+	// hasDefaultHistoryProvider is true when New synthesized the in-memory
+	// history provider because Config.HistoryProvider was nil. The synthesized
+	// provider is a local-session convenience and backs off for implicit per-run
+	// sessions and service-managed sessions.
+	hasDefaultHistoryProvider bool
+	allowHistoryConflict      bool
+	suppressHistoryWarning    bool
+	keepHistoryOnConflict     bool
+	contextProviders          []*ContextProvider
 }
 
 // ID returns the agent's unique identifier.
@@ -222,7 +237,225 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 			yield(nil, err)
 		}
 	}
-	return ResponseStream(runChain(ctx, a.provider.Run, a.middlewares, preparedMessages, options...))
+	return ResponseStream(a.run(ctx, preparedMessages, options...))
+}
+
+func (a *Agent) run(ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
+	return func(yield func(*ResponseUpdate, error) bool) {
+		session, _ := GetOption(options, WithSession)
+		rawContinuationToken, _ := GetOption(options, WithContinuationToken)
+		continuationState, err := parseContinuationToken(rawContinuationToken)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		continuationToken := continuationState.InnerToken
+		if rawContinuationToken != "" && continuationToken != rawContinuationToken {
+			options = append(slices.Clone(options), WithContinuationToken(continuationToken))
+		}
+		noSession, _ := GetOption(options, noSessionProvided)
+		stream, _ := GetOption(options, Stream)
+		inputMessages := slices.Clone(messages)
+		lifecycleOptions := withoutContinuationToken(options)
+
+		historyProvider := a.historyProviderForRun(session, continuationToken, noSession)
+		runContextProviders := continuationToken == "" && len(a.contextProviders) > 0
+		if historyProvider != nil {
+			var err error
+			messages, err = historyProvider.BeforeRun(ctx, messages, lifecycleOptions...)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+		}
+
+		if runContextProviders {
+			options = slices.Clone(lifecycleOptions)
+			for _, provider := range a.contextProviders {
+				var err error
+				messages, options, err = provider.BeforeRun(ctx, messages, options...)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+			}
+		}
+
+		requestMessages := slices.Clone(messages)
+		var contextResponse Response
+		var historyResponse Response
+		continuationUpdates := cloneResponseUpdates(continuationState.ResponseUpdates)
+		var runErr error
+		var stopped bool
+
+		for update, err := range runChain(ctx, a.provider.Run, a.middlewares, messages, options...) {
+			if update != nil {
+				continuationUpdates = append(continuationUpdates, cloneResponseUpdate(update))
+				historyResponse.Update(update)
+				if runContextProviders {
+					contextResponse.Update(update)
+				}
+				if update.ContinuationToken != "" {
+					var tokenInputMessages []*message.Message
+					var tokenResponseUpdates []*ResponseUpdate
+					if stream {
+						tokenInputMessages = inputMessagesForContinuation(inputMessages, continuationState)
+						tokenResponseUpdates = continuationUpdates
+					}
+					wrappedToken, err := wrapContinuationToken(update.ContinuationToken, tokenInputMessages, tokenResponseUpdates)
+					if err != nil {
+						if !stopped {
+							yield(nil, err)
+						}
+						return
+					}
+					update.ContinuationToken = wrappedToken
+				}
+			}
+			if err != nil {
+				runErr = err
+				stopped = !yield(update, err)
+				break
+			}
+			if !yield(update, nil) {
+				stopped = true
+				break
+			}
+		}
+
+		historyStoreProvider := historyProvider
+		storeRequestMessages := requestMessages
+		storeResponseMessages := historyResponse.Messages
+		if continuationToken != "" {
+			historyStoreProvider = a.historyProviderForContinuationStore(session, noSession)
+			storeRequestMessages = inputMessagesForContinuation(nil, continuationState)
+			continuationResponse := responseFromUpdates(continuationUpdates)
+			storeResponseMessages = continuationResponse.Messages
+		}
+
+		if runErr == nil && historyStoreProvider != nil {
+			storeHistory, err := a.handleHistoryProviderConflict(ctx, historyStoreProvider, session)
+			if err != nil {
+				if !stopped {
+					yield(nil, err)
+				}
+				return
+			}
+			if storeHistory && a.shouldStoreHistoryProvider(historyStoreProvider, session) {
+				if continuationToken == "" {
+					historyResponse.Coalesce()
+					storeResponseMessages = historyResponse.Messages
+				}
+				if err := historyStoreProvider.AfterRun(ctx, slices.Clone(storeRequestMessages), slices.Clone(storeResponseMessages), withoutContinuationToken(options)...); err != nil {
+					if !stopped {
+						yield(nil, err)
+					}
+					return
+				}
+			}
+		}
+
+		if runContextProviders || continuationToken != "" && len(a.contextProviders) > 0 {
+			contextStoreResponseMessages := contextResponse.Messages
+			if continuationToken != "" {
+				continuationResponse := responseFromUpdates(continuationUpdates)
+				contextStoreResponseMessages = continuationResponse.Messages
+			} else {
+				contextResponse.Coalesce()
+				contextStoreResponseMessages = contextResponse.Messages
+			}
+			for _, provider := range a.contextProviders {
+				if err := provider.AfterRun(ctx, slices.Clone(storeRequestMessages), slices.Clone(contextStoreResponseMessages), withoutContinuationToken(options)...); err != nil {
+					if !stopped {
+						yield(nil, err)
+					}
+					return
+				}
+			}
+		}
+	}
+}
+
+func withoutContinuationToken(options []Option) []Option {
+	if !slices.ContainsFunc(options, func(opt Option) bool {
+		_, ok := opt.(continuationTokenOpt)
+		return ok
+	}) {
+		return options
+	}
+	return slices.DeleteFunc(slices.Clone(options), func(opt Option) bool {
+		_, ok := opt.(continuationTokenOpt)
+		return ok
+	})
+}
+
+func (a *Agent) historyProviderForRun(session Session, continuationToken string, noSession bool) *HistoryProvider {
+	if a.historyProvider == nil || continuationToken != "" || session == nil {
+		return nil
+	}
+	if !a.hasDefaultHistoryProvider {
+		if session.ServiceID() != "" {
+			return nil
+		}
+		return a.historyProvider
+	}
+
+	// The default in-memory provider only owns caller-provided local sessions.
+	// Auto-created sessions are per-run and cannot preserve history across calls;
+	// service-managed sessions use the provider service as the source of history.
+	if noSession || session.ServiceID() != "" {
+		return nil
+	}
+	return a.historyProvider
+}
+
+func (a *Agent) historyProviderForContinuationStore(session Session, noSession bool) *HistoryProvider {
+	if a.historyProvider == nil || session == nil {
+		return nil
+	}
+	if !a.hasDefaultHistoryProvider {
+		if session.ServiceID() != "" {
+			return nil
+		}
+		return a.historyProvider
+	}
+	if noSession || session.ServiceID() != "" {
+		return nil
+	}
+	return a.historyProvider
+}
+
+func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session Session) bool {
+	if provider == nil {
+		return false
+	}
+	if !a.hasDefaultHistoryProvider {
+		return true
+	}
+
+	// A provider can promote a local session to a service-managed one during the
+	// run. Once that happens, the default in-memory provider should stop storing.
+	return session != nil && session.ServiceID() == ""
+}
+
+func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider *HistoryProvider, session Session) (bool, error) {
+	if provider == nil || !a.hasConfiguredHistory || session == nil || session.ServiceID() == "" {
+		return true, nil
+	}
+
+	if !a.suppressHistoryWarning && a.logger != nil {
+		a.logger.WarnContext(ctx, "history provider conflicts with service-managed history", slog.String("service_id", session.ServiceID()))
+	}
+	if !a.allowHistoryConflict {
+		return false, errors.New("only Session.ServiceID or HistoryProvider may be used, but not both; the service returned an ID indicating service-managed history while the agent has a HistoryProvider configured")
+	}
+	if !a.keepHistoryOnConflict {
+		if a.historyProvider == provider {
+			a.historyProvider = nil
+		}
+		return false, nil
+	}
+	return true, nil
 }
 
 func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, options []Option) (context.Context, []*message.Message, []Option, error) {
@@ -246,23 +479,14 @@ func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, opt
 	}
 
 	continuationToken, _ := GetOption(options, WithContinuationToken)
+	if continuationToken != "" {
+		if _, err := parseContinuationToken(continuationToken); err != nil {
+			return nil, nil, nil, err
+		}
+	}
 	if continuationToken != "" && len(messages) > 0 {
 		return nil, nil, nil, errors.New("messages are not allowed when continuing a background response using a continuation token")
 	}
-	if continuationToken == "" {
-		if a.instructions != "" {
-			preparedMessages := make([]*message.Message, 0, len(messages)+1)
-			preparedMessages = append(preparedMessages, &message.Message{
-				Role: message.RoleSystem,
-				Contents: []message.Content{
-					&message.TextContent{Text: a.instructions},
-				},
-			})
-			preparedMessages = append(preparedMessages, messages...)
-			messages = preparedMessages
-		}
-	}
-
 	// Add agent identity to context so that middlewares can log it.
 	ctx = context.WithValue(ctx, agentKey{}, a)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -45,6 +45,10 @@ type Config struct {
 	// Instructions are prepended as a system message for each non-continuation run.
 	Instructions string
 
+	// HistoryProvider injects and persists conversation history around each agent run.
+	// When nil, New uses a default in-memory history provider for local sessions.
+	HistoryProvider *HistoryProvider
+
 	// ContextProviders inject and persist context around each agent run.
 	ContextProviders []*ContextProvider
 
@@ -89,8 +93,14 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 		}
 	}
 	prefixedMiddlewares := make([]Middleware, 0, 2)
-	if len(providers) == 0 {
-		prefixedMiddlewares = append(prefixedMiddlewares, defaultLocalHistoryMiddleware())
+	historyProvider := cfg.HistoryProvider
+	var useDefaultHistoryHeuristics bool
+	if historyProvider == nil {
+		historyProvider = NewInMemoryHistoryProvider("")
+		useDefaultHistoryHeuristics = true
+	}
+	if historyProvider != nil {
+		prefixedMiddlewares = append(prefixedMiddlewares, newHistoryProviderMiddleware(historyProvider, useDefaultHistoryHeuristics))
 	}
 	if len(providers) > 0 {
 		prefixedMiddlewares = append(prefixedMiddlewares, newContextProviderMiddleware(providers...))
@@ -257,25 +267,6 @@ func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, opt
 	ctx = context.WithValue(ctx, agentKey{}, a)
 
 	return ctx, messages, options, nil
-}
-
-// defaultLocalHistoryMiddleware attaches an in-memory history provider for local
-// sessions so multi-turn runs keep prior messages without requiring explicit
-// configuration. New prepends it only when Config.ContextProviders is empty.
-// It is bypassed for auto-created sessions on the first run, service-managed
-// sessions, and continuation-token resumes.
-func defaultLocalHistoryMiddleware() Middleware {
-	history := newContextProviderMiddleware(NewInMemoryHistoryProvider(""))
-
-	return MiddlewareFunc(func(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
-		session, _ := GetOption(options, WithSession)
-		noSession, _ := GetOption(options, noSessionProvided)
-		contToken, _ := GetOption(options, WithContinuationToken)
-		if noSession || contToken != "" || session == nil || session.ServiceID() != "" {
-			return next(ctx, messages, options...)
-		}
-		return history.Run(next, ctx, messages, options...)
-	})
 }
 
 func authorMiddleware(id, name string) Middleware {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -356,7 +356,7 @@ func (a *Agent) run(ctx context.Context, messages []*message.Message, options ..
 		}
 
 		if runContextProviders || continuationToken != "" && len(a.contextProviders) > 0 {
-			contextStoreResponseMessages := contextResponse.Messages
+			var contextStoreResponseMessages []*message.Message
 			if continuationToken != "" {
 				continuationResponse := responseFromUpdates(continuationUpdates)
 				contextStoreResponseMessages = continuationResponse.Messages

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -99,14 +99,21 @@ func messageStrings(messages []*message.Message) []string {
 	return strings
 }
 
-func newGenericTestAgent(runFn func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error], instructions string, middlewares []agent.Middleware, runOptions ...agent.Option) *agent.Agent {
+func updateStrings(updates []*agent.ResponseUpdate) []string {
+	strings := make([]string, 0, len(updates))
+	for _, update := range updates {
+		strings = append(strings, update.String())
+	}
+	return strings
+}
+
+func newGenericTestAgent(runFn func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error], middlewares []agent.Middleware, runOptions ...agent.Option) *agent.Agent {
 	return agent.New(agent.ProviderConfig{
 		Run: runFn,
 	}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		Instructions: instructions,
-		Middlewares:  middlewares,
-		RunOptions:   runOptions,
+		Middlewares: middlewares,
+		RunOptions:  runOptions,
 	})
 }
 
@@ -329,12 +336,33 @@ func TestAgent_Run_RejectsMessagesWithContinuationToken(t *testing.T) {
 	a := agenttest.New(responseBuilder.Build())
 
 	ctx := t.Context()
-	_, err := a.RunText(ctx, "test", agent.WithContinuationToken("token-123")).Collect()
+	token := agenttest.NewContinuationToken(t, "token-123")
+	_, err := a.RunText(ctx, "test", agent.WithContinuationToken(token)).Collect()
 	if err == nil {
 		t.Fatal("expected error when continuation token and messages are both provided")
 	}
 	if runCalled {
 		t.Fatal("expected run function not to be called when validation fails")
+	}
+}
+
+func TestAgent_Run_RejectsRawContinuationToken(t *testing.T) {
+	runCalled := false
+	runFn := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		runCalled = true
+		return func(yield func(*agent.ResponseUpdate, error) bool) {}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{ID: "test-agent", Name: "test-agent"})
+
+	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken("raw-token")).Collect()
+	if err == nil {
+		t.Fatal("expected error for raw continuation token")
+	}
+	if err.Error() != "continuation token is not a valid agent continuation token" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runCalled {
+		t.Fatal("expected run function not to be called")
 	}
 }
 
@@ -593,7 +621,7 @@ func TestAgent_Run_InvokesSingleContextMiddleware(t *testing.T) {
 		}
 	}
 
-	a := newGenericTestAgent(runFn, "", []agent.Middleware{mw})
+	a := newGenericTestAgent(runFn, []agent.Middleware{mw})
 
 	ctx := t.Context()
 	session := agenttest.CreateSession()
@@ -626,7 +654,7 @@ func TestAgent_Run_ContextMiddlewareReceivesSession(t *testing.T) {
 			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "response"}}}, nil)
 		}
 	}
-	a := newGenericTestAgent(runFn, "", []agent.Middleware{mw})
+	a := newGenericTestAgent(runFn, []agent.Middleware{mw})
 
 	ctx := t.Context()
 	session := agenttest.CreateSession()
@@ -647,7 +675,7 @@ func TestAgent_Run_ContextMiddlewareCanFailBeforeRun(t *testing.T) {
 			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "response"}}}, nil)
 		}
 	}
-	a := newGenericTestAgent(runFn, "", []agent.Middleware{&errorMiddleware{err: middlewareErr}})
+	a := newGenericTestAgent(runFn, []agent.Middleware{&errorMiddleware{err: middlewareErr}})
 
 	ctx := t.Context()
 	_, err := a.RunText(ctx, "test", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -659,7 +687,7 @@ func TestAgent_Run_ContextMiddlewareCanFailBeforeRun(t *testing.T) {
 func TestAgent_Run_MiddlewareObservesRunFailure(t *testing.T) {
 	runErr := errors.New("run failed")
 	tracker := &trackingMiddleware{}
-	a := newGenericTestAgent(failRunFunc(runErr), "", []agent.Middleware{tracker})
+	a := newGenericTestAgent(failRunFunc(runErr), []agent.Middleware{tracker})
 
 	ctx := t.Context()
 	_, err := a.RunText(ctx, "test", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -675,15 +703,17 @@ func TestAgent_Run_MiddlewareObservesRunFailure(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_IncludesInstructions(t *testing.T) {
+func TestAgent_Run_IncludesInstructionsRunOption(t *testing.T) {
 	var capturedMessages []*message.Message
-	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+	var capturedInstructions []string
+	runFn := func(_ context.Context, msgs []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		capturedMessages = msgs
+		capturedInstructions = slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
 			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "response"}}}, nil)
 		}
 	}
-	a := newGenericTestAgent(runFn, "You are a helpful assistant.", nil)
+	a := newGenericTestAgent(runFn, nil, agent.WithInstructions("  You are a helpful assistant.  "))
 
 	ctx := t.Context()
 	_, err := a.RunText(ctx, "hello", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -691,15 +721,30 @@ func TestAgent_Run_IncludesInstructions(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(capturedMessages) == 0 {
-		t.Fatal("expected at least 1 message")
+	if got := messageStrings(capturedMessages); !slices.Equal(got, []string{"hello"}) {
+		t.Fatalf("messages = %v, want [hello]", got)
 	}
-	if capturedMessages[0].Role != message.RoleSystem {
-		t.Errorf("expected first message to be system role, got %s", capturedMessages[0].Role)
+	if !slices.Equal(capturedInstructions, []string{"You are a helpful assistant."}) {
+		t.Fatalf("instructions = %q, want %q", capturedInstructions, []string{"You are a helpful assistant."})
 	}
-	tc, ok := capturedMessages[0].Contents[0].(*message.TextContent)
-	if !ok || tc.Text != "You are a helpful assistant." {
-		t.Error("expected instructions message as first message")
+}
+
+func TestAgent_Run_CombinesInstructionOptions(t *testing.T) {
+	var capturedInstructions []string
+	runFn := func(_ context.Context, _ []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		capturedInstructions = slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "response"}}}, nil)
+		}
+	}
+	a := newGenericTestAgent(runFn, nil, agent.WithInstructions(" base instructions "))
+
+	_, err := a.RunText(t.Context(), "hello", agent.WithSession(agenttest.CreateSession()), agent.WithInstructions(" run instructions ")).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Equal(capturedInstructions, []string{"base instructions", "run instructions"}) {
+		t.Fatalf("instructions = %q, want combined instruction options", capturedInstructions)
 	}
 }
 
@@ -803,12 +848,17 @@ func TestRun_All_WithError(t *testing.T) {
 func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionHasServiceID(t *testing.T) {
 	provideCalled := false
 	var capturedMessages []*message.Message
+	var storedResponseMessages []*message.Message
 
 	historyProvider := &agent.ContextProvider{
 		SourceID: "history",
 		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
 			provideCalled = true
 			return append(messages, message.NewText("history")), options, nil
+		},
+		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, _ ...agent.Option) error {
+			storedResponseMessages = responseMessages
+			return nil
 		},
 	}
 
@@ -840,9 +890,12 @@ func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionHasServiceID(t *te
 	if capturedMessages[0].String() != "input" || capturedMessages[1].String() != "history" {
 		t.Fatalf("expected message order [input history], got [%s %s]", capturedMessages[0].String(), capturedMessages[1].String())
 	}
+	if got := messageStrings(storedResponseMessages); !slices.Equal(got, []string{"ok"}) {
+		t.Fatalf("stored response messages = %v, want [ok]", got)
+	}
 }
 
-func TestAgent_Run_ProviderMiddleware_RunsProvidersWithContinuationToken(t *testing.T) {
+func TestAgent_Run_ContextProviders_SkipWithContinuationToken(t *testing.T) {
 	provideCalled := false
 	runCalled := false
 
@@ -869,7 +922,8 @@ func TestAgent_Run_ProviderMiddleware_RunsProvidersWithContinuationToken(t *test
 		ContextProviders: []*agent.ContextProvider{historyProvider},
 	})
 
-	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken("ct-1")).Collect()
+	token := agenttest.NewContinuationToken(t, "ct-1")
+	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken(token)).Collect()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -877,8 +931,201 @@ func TestAgent_Run_ProviderMiddleware_RunsProvidersWithContinuationToken(t *test
 	if !runCalled {
 		t.Fatal("expected provider run function to be called")
 	}
-	if !provideCalled {
-		t.Fatal("expected history provider to be used with continuation token")
+	if provideCalled {
+		t.Fatal("expected context provider to be skipped with continuation token")
+	}
+}
+
+func TestAgent_Run_StreamingContinuationToken_SavesInputMessagesAndUpdates(t *testing.T) {
+	runCalls := 0
+	runFn := func(_ context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		runCalls++
+		if runCalls == 1 {
+			if got := messageStrings(messages); !slices.Equal(got, []string{"Tell me a story"}) {
+				t.Fatalf("initial messages = %v, want [Tell me a story]", got)
+			}
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "Once"}}, ContinuationToken: "inner-1"}, nil)
+			}
+		}
+
+		if len(messages) != 0 {
+			t.Fatalf("resume messages = %v, want none", messageStrings(messages))
+		}
+		if token, _ := agent.GetOption(options, agent.WithContinuationToken); token != "inner-1" {
+			t.Fatalf("resume continuation token = %q, want inner-1", token)
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			if !yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: " upon"}}, ContinuationToken: "inner-2"}, nil) {
+				return
+			}
+			if !yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: " a"}}, ContinuationToken: "inner-3"}, nil) {
+				return
+			}
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: " time"}}, ContinuationToken: "inner-4"}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{ID: "test-agent", Name: "test-agent"})
+	session := agenttest.CreateSession()
+
+	var firstToken string
+	for update, err := range a.RunText(t.Context(), "Tell me a story", agent.WithSession(session), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("unexpected initial error: %v", err)
+		}
+		firstToken = update.ContinuationToken
+		break
+	}
+	first := agenttest.DecodeContinuationToken(t, firstToken)
+	if first.Type != agenttest.ContinuationTokenType || first.InnerToken != "inner-1" {
+		t.Fatalf("first token = %#v, want wrapped inner-1", first)
+	}
+	if got := messageStrings(first.InputMessages); !slices.Equal(got, []string{"Tell me a story"}) {
+		t.Fatalf("first token input messages = %v, want [Tell me a story]", got)
+	}
+	if len(first.ResponseUpdates) != 1 || first.ResponseUpdates[0].String() != "Once" {
+		t.Fatalf("first token updates = %v, want [Once]", updateStrings(first.ResponseUpdates))
+	}
+
+	var tokens []agenttest.ContinuationToken
+	for update, err := range a.Run(t.Context(), nil, agent.WithSession(session), agent.WithContinuationToken(firstToken), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("unexpected resume error: %v", err)
+		}
+		tokens = append(tokens, agenttest.DecodeContinuationToken(t, update.ContinuationToken))
+	}
+	if len(tokens) != 3 {
+		t.Fatalf("resume token count = %d, want 3", len(tokens))
+	}
+	last := tokens[len(tokens)-1]
+	if last.InnerToken != "inner-4" {
+		t.Fatalf("last inner token = %q, want inner-4", last.InnerToken)
+	}
+	if got := messageStrings(last.InputMessages); !slices.Equal(got, []string{"Tell me a story"}) {
+		t.Fatalf("last token input messages = %v, want [Tell me a story]", got)
+	}
+	if got := updateStrings(last.ResponseUpdates); !slices.Equal(got, []string{"Once", " upon", " a", " time"}) {
+		t.Fatalf("last token updates = %v, want [Once  upon  a  time]", got)
+	}
+}
+
+func TestAgent_Run_ContinuationToken_PersistsSavedResponseUpdates(t *testing.T) {
+	var historyResponseMessages []*message.Message
+	var contextResponseMessages []*message.Message
+	var historyStoreSawContinuationToken bool
+	var contextStoreSawContinuationToken bool
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, options ...agent.Option) error {
+			historyResponseMessages = responseMessages
+			_, historyStoreSawContinuationToken = agent.GetOption(options, agent.WithContinuationToken)
+			return nil
+		},
+	}
+	contextProvider := &agent.ContextProvider{
+		SourceID: "ctx",
+		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, options ...agent.Option) error {
+			contextResponseMessages = responseMessages
+			_, contextStoreSawContinuationToken = agent.GetOption(options, agent.WithContinuationToken)
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		if len(messages) != 0 {
+			t.Fatalf("resume messages = %v, want none", messageStrings(messages))
+		}
+		if token, _ := agent.GetOption(options, agent.WithContinuationToken); token != "inner" {
+			t.Fatalf("provider continuation token = %q, want inner", token)
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			if !yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: " upon"}}}, nil) {
+				return
+			}
+			if !yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: " a"}}}, nil) {
+				return
+			}
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: " time"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:               "test-agent",
+		Name:             "test-agent",
+		HistoryProvider:  historyProvider,
+		ContextProviders: []*agent.ContextProvider{contextProvider},
+	})
+	token := agenttest.EncodeContinuationToken(t, agenttest.ContinuationToken{
+		Type:       agenttest.ContinuationTokenType,
+		InnerToken: "inner",
+		ResponseUpdates: []*agent.ResponseUpdate{
+			{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "once"}}},
+		},
+	})
+
+	_, err := a.Run(t.Context(), nil, agent.WithSession(agenttest.CreateSession()), agent.WithContinuationToken(token), agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := messageStrings(historyResponseMessages); !slices.Equal(got, []string{"once upon a time"}) {
+		t.Fatalf("history response messages = %v, want [once upon a time]", got)
+	}
+	if got := messageStrings(contextResponseMessages); !slices.Equal(got, []string{"once upon a time"}) {
+		t.Fatalf("context response messages = %v, want [once upon a time]", got)
+	}
+	if historyStoreSawContinuationToken {
+		t.Fatal("history provider Store saw continuation token option")
+	}
+	if contextStoreSawContinuationToken {
+		t.Fatal("context provider Store saw continuation token option")
+	}
+}
+
+func TestAgent_Run_ContinuationToken_PersistsSavedInputMessages(t *testing.T) {
+	var historyRequestMessages []*message.Message
+	var contextRequestMessages []*message.Message
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
+			historyRequestMessages = requestMessages
+			return nil
+		},
+	}
+	contextProvider := &agent.ContextProvider{
+		SourceID: "ctx",
+		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
+			contextRequestMessages = requestMessages
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		if len(messages) != 0 {
+			t.Fatalf("resume messages = %v, want none", messageStrings(messages))
+		}
+		if token, _ := agent.GetOption(options, agent.WithContinuationToken); token != "inner" {
+			t.Fatalf("provider continuation token = %q, want inner", token)
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:               "test-agent",
+		Name:             "test-agent",
+		HistoryProvider:  historyProvider,
+		ContextProviders: []*agent.ContextProvider{contextProvider},
+	})
+	token := agenttest.EncodeContinuationToken(t, agenttest.ContinuationToken{
+		Type:          agenttest.ContinuationTokenType,
+		InnerToken:    "inner",
+		InputMessages: []*message.Message{message.NewText("Tell me a story")},
+	})
+
+	_, err := a.Run(t.Context(), nil, agent.WithSession(agenttest.CreateSession()), agent.WithContinuationToken(token), agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := messageStrings(historyRequestMessages); !slices.Equal(got, []string{"Tell me a story"}) {
+		t.Fatalf("history request messages = %v, want [Tell me a story]", got)
+	}
+	if got := messageStrings(contextRequestMessages); !slices.Equal(got, []string{"Tell me a story"}) {
+		t.Fatalf("context request messages = %v, want [Tell me a story]", got)
 	}
 }
 
@@ -953,6 +1200,71 @@ func TestAgent_Run_DefaultHistoryProvider_SkipsAutoCreatedSession(t *testing.T) 
 	}
 }
 
+func TestAgent_Run_DefaultHistoryProvider_SkipsServiceManagedSession(t *testing.T) {
+	runner := &agenttest.Runner{
+		Responses: []agenttest.Turn{
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first"}) {
+							t.Fatalf("first turn messages = %v, want [first]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "one"}}}}},
+			},
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"second"}) {
+							t.Fatalf("second turn messages = %v, want [second]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "two"}}}}},
+			},
+		},
+	}
+	a := agent.New(agent.ProviderConfig{Run: runner.Run}, agent.Config{ID: "test-agent", Name: "test-agent"})
+	session := agenttest.CreateSession()
+	session.SetServiceID("server-managed")
+
+	if _, err := a.RunText(t.Context(), "first", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected first turn error: %v", err)
+	}
+	if _, err := a.RunText(t.Context(), "second", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected second turn error: %v", err)
+	}
+}
+
+func TestAgent_Run_DefaultHistoryProvider_SkipsWhenSessionBecomesServiceManaged(t *testing.T) {
+	turn := 0
+	runFn := func(_ context.Context, msgs []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		turn++
+		want := []string{"first"}
+		if turn == 2 {
+			want = []string{"second"}
+		}
+		if got := messageStrings(msgs); !slices.Equal(got, want) {
+			t.Fatalf("turn %d messages = %v, want %v", turn, got, want)
+		}
+		session, _ := agent.GetOption(options, agent.WithSession)
+		session.SetServiceID("server-managed")
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{ID: "test-agent", Name: "test-agent"})
+	session := agenttest.CreateSession()
+
+	if _, err := a.RunText(t.Context(), "first", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected first turn error: %v", err)
+	}
+	if _, err := a.RunText(t.Context(), "second", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected second turn error: %v", err)
+	}
+}
+
 func TestAgent_Run_DefaultHistoryProvider_UsesExplicitLocalSession(t *testing.T) {
 	runner := &agenttest.Runner{
 		Responses: []agenttest.Turn{
@@ -1011,8 +1323,8 @@ func TestAgent_Run_DefaultHistoryProvider_RunsWithContextProviders(t *testing.T)
 			{
 				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
 					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
-						if got := messageStrings(messages); !slices.Equal(got, []string{"first", "one", "second", "context"}) {
-							t.Fatalf("second turn messages = %v, want [first one second context]", got)
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first", "context", "one", "second", "context"}) {
+							t.Fatalf("second turn messages = %v, want [first context one second context]", got)
 						}
 					},
 				},
@@ -1108,10 +1420,145 @@ func TestAgent_Run_HistoryProvider_SkipsWhenSessionHasServiceID(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if provideCalled || storeCalled {
-		t.Fatal("expected history provider to be skipped for service-managed sessions")
+		t.Fatal("expected configured history provider to be skipped for service-managed sessions")
 	}
 	if got := messageStrings(capturedMessages); !slices.Equal(got, []string{"input"}) {
 		t.Fatalf("messages = %v, want [input]", got)
+	}
+}
+
+func TestAgent_Run_HistoryProvider_ThrowsWhenServiceIDReturnedByDefault(t *testing.T) {
+	provideCalled := false
+	storeCalled := false
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+			provideCalled = true
+			return messages, nil
+		},
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			storeCalled = true
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		session, _ := agent.GetOption(options, agent.WithSession)
+		session.SetServiceID("server-managed")
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{ID: "test-agent", Name: "test-agent", HistoryProvider: historyProvider})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if err == nil {
+		t.Fatal("expected history provider conflict error")
+	}
+	if err.Error() != "only Session.ServiceID or HistoryProvider may be used, but not both; the service returned an ID indicating service-managed history while the agent has a HistoryProvider configured" {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if !provideCalled {
+		t.Fatal("expected history provider to run before the service returned an ID")
+	}
+	if storeCalled {
+		t.Fatal("expected history provider store to be skipped on conflict")
+	}
+}
+
+func TestAgent_Run_HistoryProvider_ClearsWhenThrowDisabledAndClearEnabled(t *testing.T) {
+	provideCalls := 0
+	storeCalled := false
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+			provideCalls++
+			return messages, nil
+		},
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			storeCalled = true
+			return nil
+		},
+	}
+	runCalls := 0
+	runFn := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		runCalls++
+		if runCalls == 1 {
+			session, _ := agent.GetOption(options, agent.WithSession)
+			session.SetServiceID("server-managed")
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:                           "test-agent",
+		Name:                         "test-agent",
+		HistoryProvider:              historyProvider,
+		AllowHistoryProviderConflict: true,
+	})
+
+	if _, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect(); err != nil {
+		t.Fatalf("unexpected first run error: %v", err)
+	}
+	if storeCalled {
+		t.Fatal("expected cleared history provider not to store conflict run")
+	}
+	if provideCalls != 1 {
+		t.Fatalf("provide calls = %d, want 1", provideCalls)
+	}
+	if _, err := a.RunText(t.Context(), "next", agent.WithSession(agenttest.CreateSession())).Collect(); err != nil {
+		t.Fatalf("unexpected second run error: %v", err)
+	}
+	if provideCalls != 1 {
+		t.Fatalf("expected cleared history provider not to run again, got %d calls", provideCalls)
+	}
+}
+
+func TestAgent_Run_HistoryProvider_KeepsWhenThrowAndClearDisabled(t *testing.T) {
+	provideCalls := 0
+	storeCalls := 0
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+			provideCalls++
+			return messages, nil
+		},
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			storeCalls++
+			return nil
+		},
+	}
+	runCalls := 0
+	runFn := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		runCalls++
+		if runCalls == 1 {
+			session, _ := agent.GetOption(options, agent.WithSession)
+			session.SetServiceID("server-managed")
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:                                     "test-agent",
+		Name:                                   "test-agent",
+		HistoryProvider:                        historyProvider,
+		AllowHistoryProviderConflict:           true,
+		SuppressHistoryProviderConflictWarning: true,
+		KeepHistoryProviderOnConflict:          true,
+	})
+
+	if _, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect(); err != nil {
+		t.Fatalf("unexpected first run error: %v", err)
+	}
+	if provideCalls != 1 || storeCalls != 1 {
+		t.Fatalf("after first run provide/store = %d/%d, want 1/1", provideCalls, storeCalls)
+	}
+	if _, err := a.RunText(t.Context(), "next", agent.WithSession(agenttest.CreateSession())).Collect(); err != nil {
+		t.Fatalf("unexpected second run error: %v", err)
+	}
+	if provideCalls != 2 || storeCalls != 2 {
+		t.Fatalf("after second run provide/store = %d/%d, want 2/2", provideCalls, storeCalls)
 	}
 }
 
@@ -1136,7 +1583,8 @@ func TestAgent_Run_HistoryProvider_SkipsWithContinuationToken(t *testing.T) {
 	}
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{ID: "test-agent", Name: "test-agent", HistoryProvider: historyProvider})
 
-	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken("ct-1")).Collect()
+	token := agenttest.NewContinuationToken(t, "ct-1")
+	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken(token)).Collect()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1150,14 +1598,16 @@ func TestAgent_Run_HistoryProvider_SkipsWithContinuationToken(t *testing.T) {
 
 func TestAgent_Run_UsesHistoryBeforeContextProviders(t *testing.T) {
 	sequence := make([]string, 0, 5)
+	var storedRequestMessages []*message.Message
 	historyProvider := &agent.HistoryProvider{
 		SourceID: "history",
 		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
 			sequence = append(sequence, "history-before")
 			return append([]*message.Message{message.NewText("history")}, messages...), nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
 			sequence = append(sequence, "history-after")
+			storedRequestMessages = requestMessages
 			return nil
 		},
 	}
@@ -1195,9 +1645,50 @@ func TestAgent_Run_UsesHistoryBeforeContextProviders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := []string{"history-before", "context-before", "run", "context-after", "history-after"}
+	expected := []string{"history-before", "context-before", "run", "history-after", "context-after"}
 	if !slices.Equal(sequence, expected) {
 		t.Fatalf("sequence = %v, want %v", sequence, expected)
+	}
+	if got := messageStrings(storedRequestMessages); !slices.Equal(got, []string{"input", "context"}) {
+		t.Fatalf("stored request messages = %v, want [input context]", got)
+	}
+}
+
+func TestAgent_Run_HistoryProvider_DoesNotStoreInstructions(t *testing.T) {
+	var storedRequestMessages []*message.Message
+	var capturedInstructions []string
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
+			storedRequestMessages = requestMessages
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, msgs []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		capturedInstructions = slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
+		if got := messageStrings(msgs); !slices.Equal(got, []string{"input"}) {
+			t.Fatalf("messages = %v, want [input]", got)
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:              "test-agent",
+		Name:            "test-agent",
+		HistoryProvider: historyProvider,
+		RunOptions:      []agent.Option{agent.WithInstructions(" instructions ")},
+	})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Equal(capturedInstructions, []string{"instructions"}) {
+		t.Fatalf("instructions = %q, want instructions", capturedInstructions)
+	}
+	if got := messageStrings(storedRequestMessages); !slices.Equal(got, []string{"input"}) {
+		t.Fatalf("stored request messages = %v, want [input]", got)
 	}
 }
 
@@ -1539,7 +2030,7 @@ func TestAgent_Run_UsesContextProvidersInOrder(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := []string{"before-a", "before-b", "after-b", "after-a"}
+	expected := []string{"before-a", "before-b", "after-a", "after-b"}
 	if !slices.Equal(sequence, expected) {
 		t.Fatalf("expected sequence %v, got %v", expected, sequence)
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -91,6 +91,14 @@ func failRunFunc(runErr error) func(_ context.Context, _ []*message.Message, _ .
 	}
 }
 
+func messageStrings(messages []*message.Message) []string {
+	strings := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		strings = append(strings, msg.String())
+	}
+	return strings
+}
+
 func newGenericTestAgent(runFn func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error], instructions string, middlewares []agent.Middleware, runOptions ...agent.Option) *agent.Agent {
 	return agent.New(agent.ProviderConfig{
 		Run: runFn,
@@ -907,6 +915,322 @@ func TestAgent_Run_UsesConfigContextProvider(t *testing.T) {
 	}
 	if !provideCalled {
 		t.Fatal("expected context provider to be used")
+	}
+}
+
+func TestAgent_Run_DefaultHistoryProvider_SkipsAutoCreatedSession(t *testing.T) {
+	runner := &agenttest.Runner{
+		Responses: []agenttest.Turn{
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first"}) {
+							t.Fatalf("first turn messages = %v, want [first]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "one"}}}}},
+			},
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"second"}) {
+							t.Fatalf("second turn messages = %v, want [second]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "two"}}}}},
+			},
+		},
+	}
+	a := agent.New(agent.ProviderConfig{Run: runner.Run}, agent.Config{ID: "test-agent", Name: "test-agent"})
+
+	if _, err := a.RunText(t.Context(), "first").Collect(); err != nil {
+		t.Fatalf("unexpected first turn error: %v", err)
+	}
+	if _, err := a.RunText(t.Context(), "second").Collect(); err != nil {
+		t.Fatalf("unexpected second turn error: %v", err)
+	}
+}
+
+func TestAgent_Run_DefaultHistoryProvider_UsesExplicitLocalSession(t *testing.T) {
+	runner := &agenttest.Runner{
+		Responses: []agenttest.Turn{
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first"}) {
+							t.Fatalf("first turn messages = %v, want [first]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "one"}}}}},
+			},
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first", "one", "second"}) {
+							t.Fatalf("second turn messages = %v, want [first one second]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "two"}}}}},
+			},
+		},
+	}
+	a := agent.New(agent.ProviderConfig{Run: runner.Run}, agent.Config{ID: "test-agent", Name: "test-agent"})
+	session := agenttest.CreateSession()
+
+	if _, err := a.RunText(t.Context(), "first", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected first turn error: %v", err)
+	}
+	if _, err := a.RunText(t.Context(), "second", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected second turn error: %v", err)
+	}
+}
+
+func TestAgent_Run_DefaultHistoryProvider_RunsWithContextProviders(t *testing.T) {
+	contextProvider := &agent.ContextProvider{
+		SourceID: "ctx",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+			return append(messages, message.NewText("context")), options, nil
+		},
+	}
+	runner := &agenttest.Runner{
+		Responses: []agenttest.Turn{
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first", "context"}) {
+							t.Fatalf("first turn messages = %v, want [first context]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "one"}}}}},
+			},
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first", "one", "second", "context"}) {
+							t.Fatalf("second turn messages = %v, want [first one second context]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "two"}}}}},
+			},
+		},
+	}
+	a := agent.New(agent.ProviderConfig{Run: runner.Run}, agent.Config{
+		ID:               "test-agent",
+		Name:             "test-agent",
+		ContextProviders: []*agent.ContextProvider{contextProvider},
+	})
+	session := agenttest.CreateSession()
+
+	if _, err := a.RunText(t.Context(), "first", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected first turn error: %v", err)
+	}
+	if _, err := a.RunText(t.Context(), "second", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected second turn error: %v", err)
+	}
+}
+
+func TestAgent_Run_UsesConfigHistoryProvider(t *testing.T) {
+	runner := &agenttest.Runner{
+		Responses: []agenttest.Turn{
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first"}) {
+							t.Fatalf("first turn messages = %v, want [first]", got)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "one"}}}}},
+			},
+			{
+				Callbacks: []func(context.Context, []*message.Message, ...agent.Option){
+					func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						if got := messageStrings(messages); !slices.Equal(got, []string{"first", "one", "second"}) {
+							t.Fatalf("second turn messages = %v, want [first one second]", got)
+						}
+						if messages[0].SourceID != "in-memory" || messages[1].SourceID != "in-memory" || messages[2].SourceID != "" {
+							t.Fatalf("unexpected source IDs: [%q %q %q]", messages[0].SourceID, messages[1].SourceID, messages[2].SourceID)
+						}
+					},
+				},
+				Responses: []agenttest.Response{{Response: &agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "two"}}}}},
+			},
+		},
+	}
+	a := agent.New(agent.ProviderConfig{Run: runner.Run}, agent.Config{
+		ID:              "test-agent",
+		Name:            "test-agent",
+		HistoryProvider: agent.NewInMemoryHistoryProvider(""),
+	})
+	session := agenttest.CreateSession()
+
+	if _, err := a.RunText(t.Context(), "first", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected first turn error: %v", err)
+	}
+	if _, err := a.RunText(t.Context(), "second", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("unexpected second turn error: %v", err)
+	}
+}
+
+func TestAgent_Run_HistoryProvider_SkipsWhenSessionHasServiceID(t *testing.T) {
+	provideCalled := false
+	storeCalled := false
+	var capturedMessages []*message.Message
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+			provideCalled = true
+			return append([]*message.Message{message.NewText("history")}, messages...), nil
+		},
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			storeCalled = true
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		capturedMessages = msgs
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{ID: "test-agent", Name: "test-agent", HistoryProvider: historyProvider})
+	session := agenttest.CreateSession()
+	session.SetServiceID("server-managed")
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provideCalled || storeCalled {
+		t.Fatal("expected history provider to be skipped for service-managed sessions")
+	}
+	if got := messageStrings(capturedMessages); !slices.Equal(got, []string{"input"}) {
+		t.Fatalf("messages = %v, want [input]", got)
+	}
+}
+
+func TestAgent_Run_HistoryProvider_SkipsWithContinuationToken(t *testing.T) {
+	provideCalled := false
+	runCalled := false
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+			provideCalled = true
+			return messages, nil
+		},
+	}
+	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		runCalled = true
+		if len(msgs) != 0 {
+			t.Fatalf("expected no messages with continuation token run, got %d", len(msgs))
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{ID: "test-agent", Name: "test-agent", HistoryProvider: historyProvider})
+
+	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken("ct-1")).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !runCalled {
+		t.Fatal("expected provider run function to be called")
+	}
+	if provideCalled {
+		t.Fatal("expected history provider to be skipped with continuation token")
+	}
+}
+
+func TestAgent_Run_UsesHistoryBeforeContextProviders(t *testing.T) {
+	sequence := make([]string, 0, 5)
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+			sequence = append(sequence, "history-before")
+			return append([]*message.Message{message.NewText("history")}, messages...), nil
+		},
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			sequence = append(sequence, "history-after")
+			return nil
+		},
+	}
+	contextProvider := &agent.ContextProvider{
+		SourceID: "ctx",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+			sequence = append(sequence, "context-before")
+			return append(messages, message.NewText("context")), options, nil
+		},
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			sequence = append(sequence, "context-after")
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		sequence = append(sequence, "run")
+		if got := messageStrings(msgs); !slices.Equal(got, []string{"history", "input", "context"}) {
+			t.Fatalf("messages = %v, want [history input context]", got)
+		}
+		if msgs[0].SourceID != "history" || msgs[1].SourceID != "" || msgs[2].SourceID != "ctx" {
+			t.Fatalf("unexpected source IDs: [%q %q %q]", msgs[0].SourceID, msgs[1].SourceID, msgs[2].SourceID)
+		}
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:               "test-agent",
+		Name:             "test-agent",
+		HistoryProvider:  historyProvider,
+		ContextProviders: []*agent.ContextProvider{contextProvider},
+	})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []string{"history-before", "context-before", "run", "context-after", "history-after"}
+	if !slices.Equal(sequence, expected) {
+		t.Fatalf("sequence = %v, want %v", sequence, expected)
+	}
+}
+
+func TestAgent_Run_HistoryProvider_SkipsStoreAfterRunError(t *testing.T) {
+	expected := errors.New("run failed")
+	storeCalled := false
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+			return messages, nil
+		},
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			storeCalled = true
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(nil, expected)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:              "test-agent",
+		Name:            "test-agent",
+		HistoryProvider: historyProvider,
+	})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if !errors.Is(err, expected) {
+		t.Fatalf("error = %v, want %v", err, expected)
+	}
+	if storeCalled {
+		t.Fatal("expected history provider store to be skipped after run error")
 	}
 }
 

--- a/agent/context.go
+++ b/agent/context.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"context"
-	"iter"
 	"slices"
 
 	"github.com/microsoft/agent-framework-go/message"
@@ -128,58 +127,4 @@ func (p *ContextProvider) withAgentRequestMessageSource(msg *message.Message) *m
 	out := msg.Clone()
 	out.SourceID = p.SourceID
 	return out
-}
-
-// newContextProviderMiddleware returns a middleware that invokes the provided context providers in order
-// before the wrapped run and persists them in reverse order after the run.
-func newContextProviderMiddleware(providers ...*ContextProvider) Middleware {
-	activeProviders := make([]*ContextProvider, 0, len(providers))
-	for _, provider := range providers {
-		if provider != nil {
-			activeProviders = append(activeProviders, provider)
-		}
-	}
-	if len(activeProviders) == 0 {
-		panic("at least one context provider is required")
-	}
-	return &contextProviderRunner{providers: activeProviders}
-}
-
-type contextProviderRunner struct {
-	providers []*ContextProvider
-}
-
-func (r *contextProviderRunner) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
-	session, _ := GetOption(options, WithSession)
-
-	return func(yield func(*ResponseUpdate, error) bool) {
-		options = slices.Clone(options)
-		for _, provider := range r.providers {
-			var err error
-			messages, options, err = provider.BeforeRun(ctx, messages, options...)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-		}
-		var resp Response
-		for update, err := range next(ctx, messages, options...) {
-			if update != nil && (session == nil || session.ServiceID() == "") {
-				resp.Update(update)
-			}
-			if !yield(update, err) {
-				break
-			}
-		}
-		resp.Coalesce()
-		requestMessages := slices.Clone(messages)
-		responseMessages := slices.Clone(resp.Messages)
-
-		for _, provider := range slices.Backward(r.providers) {
-			if err := provider.AfterRun(ctx, requestMessages, responseMessages, options...); err != nil {
-				yield(nil, err)
-				return
-			}
-		}
-	}
 }

--- a/agent/continuation.go
+++ b/agent/continuation.go
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+const continuationTokenType = "agentContinuationToken"
+
+var errInvalidContinuationToken = errors.New("continuation token is not a valid agent continuation token")
+
+type continuationTokenState struct {
+	Type            string             `json:"type"`
+	InnerToken      string             `json:"innerToken"`
+	InputMessages   []*message.Message `json:"inputMessages,omitempty"`
+	ResponseUpdates []*ResponseUpdate  `json:"responseUpdates,omitempty"`
+}
+
+func parseContinuationToken(token string) (continuationTokenState, error) {
+	if token == "" {
+		return continuationTokenState{}, nil
+	}
+	var state continuationTokenState
+	if err := json.Unmarshal([]byte(token), &state); err != nil || state.Type != continuationTokenType || state.InnerToken == "" {
+		return continuationTokenState{}, errInvalidContinuationToken
+	}
+	return state, nil
+}
+
+func wrapContinuationToken(innerToken string, inputMessages []*message.Message, responseUpdates []*ResponseUpdate) (string, error) {
+	if innerToken == "" {
+		return "", nil
+	}
+	state := continuationTokenState{
+		Type:            continuationTokenType,
+		InnerToken:      innerToken,
+		InputMessages:   cloneMessages(inputMessages),
+		ResponseUpdates: cloneResponseUpdates(responseUpdates),
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func inputMessagesForContinuation(inputMessages []*message.Message, state continuationTokenState) []*message.Message {
+	if len(inputMessages) > 0 {
+		return inputMessages
+	}
+	return state.InputMessages
+}
+
+func cloneMessages(messages []*message.Message) []*message.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]*message.Message, 0, len(messages))
+	for _, msg := range messages {
+		out = append(out, msg.Clone())
+	}
+	return out
+}
+
+func cloneResponseUpdate(update *ResponseUpdate) *ResponseUpdate {
+	if update == nil {
+		return nil
+	}
+	out := *update
+	out.Contents = slices.Clone(update.Contents)
+	return &out
+}
+
+func cloneResponseUpdates(updates []*ResponseUpdate) []*ResponseUpdate {
+	if len(updates) == 0 {
+		return nil
+	}
+	out := make([]*ResponseUpdate, 0, len(updates))
+	for _, update := range updates {
+		out = append(out, cloneResponseUpdate(update))
+	}
+	return out
+}
+
+func responseFromUpdates(updates []*ResponseUpdate) Response {
+	var resp Response
+	for _, update := range updates {
+		resp.Update(update)
+	}
+	resp.Coalesce()
+	return resp
+}

--- a/agent/history.go
+++ b/agent/history.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"context"
-	"iter"
 	"slices"
 
 	"github.com/microsoft/agent-framework-go/message"
@@ -155,55 +154,6 @@ func (p *HistoryProvider) withHistorySource(outMessages, inMessages []*message.M
 		return cloned
 	}
 	return outMessages
-}
-
-func newHistoryProviderMiddleware(provider *HistoryProvider, skipAutoCreatedSession bool) Middleware {
-	if provider == nil {
-		panic("history provider is required")
-	}
-	return &historyProviderRunner{provider: provider, skipAutoCreatedSession: skipAutoCreatedSession}
-}
-
-type historyProviderRunner struct {
-	provider               *HistoryProvider
-	skipAutoCreatedSession bool
-}
-
-func (r *historyProviderRunner) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
-	session, _ := GetOption(options, WithSession)
-	continuationToken, _ := GetOption(options, WithContinuationToken)
-	noSession, _ := GetOption(options, noSessionProvided)
-	if continuationToken != "" || session == nil || session.ServiceID() != "" || r.skipAutoCreatedSession && noSession {
-		return next(ctx, messages, options...)
-	}
-
-	return func(yield func(*ResponseUpdate, error) bool) {
-		var err error
-		messages, err = r.provider.BeforeRun(ctx, messages, options...)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		var resp Response
-		for update, err := range next(ctx, messages, options...) {
-			if err != nil {
-				yield(update, err)
-				return
-			}
-			resp.Update(update)
-			if !yield(update, nil) {
-				break
-			}
-		}
-		resp.Coalesce()
-		requestMessages := slices.Clone(messages)
-		responseMessages := slices.Clone(resp.Messages)
-
-		if err := r.provider.AfterRun(ctx, requestMessages, responseMessages, options...); err != nil {
-			yield(nil, err)
-		}
-	}
 }
 
 // NewInMemoryHistoryProvider creates a history provider that stores conversation history in the session.

--- a/agent/history.go
+++ b/agent/history.go
@@ -4,6 +4,8 @@ package agent
 
 import (
 	"context"
+	"iter"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/message/messagefilter"
@@ -11,31 +13,223 @@ import (
 
 const defaultInMemoryHistorySourceID = "in-memory"
 
-// NewInMemoryHistoryProvider creates a context provider that stores conversation history in the session.
+// HistoryProvider injects and persists conversation history around an agent invocation.
+type HistoryProvider struct {
+	// Unique identifier for this provider instance (required).
+	SourceID string
+
+	// Optional filter applied to messages added by Provide before they are included.
+	// Defaults to passing all added messages through.
+	ProvideFilter messagefilter.Filter
+
+	// Optional filter applied to request messages before Store.
+	// Defaults to messages that did not come from this history provider.
+	StoreRequestFilter messagefilter.Filter
+
+	// Optional filter applied to response messages before Store.
+	// Defaults to passing all response messages through.
+	StoreResponseFilter messagefilter.Filter
+
+	// Optional retrieval hook that returns updated history and request messages.
+	// Messages that are not pointer-identical to the original input messages are marked with SourceID.
+	// Defaults to returning the original messages unchanged.
+	Provide func(context.Context, []*message.Message, ...Option) ([]*message.Message, error)
+
+	// Optional storage hook. Defaults to no-op.
+	Store func(context.Context, []*message.Message, []*message.Message, ...Option) error
+}
+
+// BeforeRun returns the input messages with this provider's history applied.
+func (p *HistoryProvider) BeforeRun(ctx context.Context, messages []*message.Message, options ...Option) ([]*message.Message, error) {
+	if p.SourceID == "" {
+		panic("SourceID is required")
+	}
+	if p.Provide == nil {
+		return messages, nil
+	}
+
+	outMessages, err := p.Provide(ctx, messages, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	if outMessages == nil {
+		outMessages = messages
+	}
+
+	if p.ProvideFilter != nil {
+		outMessages, err = p.filterProvidedMessages(ctx, outMessages, messages)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	outMessages = p.withHistorySource(outMessages, messages)
+
+	return outMessages, nil
+}
+
+// AfterRun persists history after an agent invocation finishes.
+func (p *HistoryProvider) AfterRun(ctx context.Context, requestMessages, responseMessages []*message.Message, options ...Option) error {
+	if p.SourceID == "" {
+		panic("SourceID is required")
+	}
+	if p.Store == nil {
+		return nil
+	}
+	requestFilter := p.StoreRequestFilter
+	if requestFilter == nil {
+		requestFilter = messagefilter.NotSources(p.SourceID)
+	}
+	filteredRequestMessages, err := requestFilter(ctx, requestMessages)
+	if err != nil {
+		return err
+	}
+
+	responseFilter := p.StoreResponseFilter
+	if responseFilter == nil {
+		responseFilter = messagefilter.PassThrough
+	}
+	filteredResponseMessages, err := responseFilter(ctx, responseMessages)
+	if err != nil {
+		return err
+	}
+
+	return p.Store(ctx, filteredRequestMessages, filteredResponseMessages, options...)
+}
+
+func (p *HistoryProvider) filterProvidedMessages(ctx context.Context, outMessages, inMessages []*message.Message) ([]*message.Message, error) {
+	originals := make(map[*message.Message]struct{}, len(inMessages))
+	for _, msg := range inMessages {
+		originals[msg] = struct{}{}
+	}
+	provided := make([]*message.Message, 0, len(outMessages))
+	for _, msg := range outMessages {
+		if _, ok := originals[msg]; ok {
+			continue
+		}
+		provided = append(provided, msg)
+	}
+	filtered, err := p.ProvideFilter(ctx, provided)
+	if err != nil {
+		return nil, err
+	}
+	kept := make(map[*message.Message]struct{}, len(filtered))
+	for _, msg := range filtered {
+		kept[msg] = struct{}{}
+	}
+	return slices.DeleteFunc(outMessages, func(msg *message.Message) bool {
+		if _, ok := originals[msg]; ok {
+			return false
+		}
+		_, ok := kept[msg]
+		return !ok
+	}), nil
+}
+
+func (p *HistoryProvider) withHistorySource(outMessages, inMessages []*message.Message) []*message.Message {
+	if len(outMessages) == 0 {
+		return outMessages
+	}
+	originals := make(map[*message.Message]struct{}, len(inMessages))
+	for _, msg := range inMessages {
+		originals[msg] = struct{}{}
+	}
+
+	var cloned []*message.Message
+	for i, msg := range outMessages {
+		if _, ok := originals[msg]; ok {
+			continue
+		}
+		if msg == nil || msg.SourceID == p.SourceID {
+			continue
+		}
+		if cloned == nil {
+			cloned = slices.Clone(outMessages)
+		}
+		marked := msg.Clone()
+		marked.SourceID = p.SourceID
+		cloned[i] = marked
+	}
+	if cloned != nil {
+		return cloned
+	}
+	return outMessages
+}
+
+func newHistoryProviderMiddleware(provider *HistoryProvider, skipAutoCreatedSession bool) Middleware {
+	if provider == nil {
+		panic("history provider is required")
+	}
+	return &historyProviderRunner{provider: provider, skipAutoCreatedSession: skipAutoCreatedSession}
+}
+
+type historyProviderRunner struct {
+	provider               *HistoryProvider
+	skipAutoCreatedSession bool
+}
+
+func (r *historyProviderRunner) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
+	session, _ := GetOption(options, WithSession)
+	continuationToken, _ := GetOption(options, WithContinuationToken)
+	noSession, _ := GetOption(options, noSessionProvided)
+	if continuationToken != "" || session == nil || session.ServiceID() != "" || r.skipAutoCreatedSession && noSession {
+		return next(ctx, messages, options...)
+	}
+
+	return func(yield func(*ResponseUpdate, error) bool) {
+		var err error
+		messages, err = r.provider.BeforeRun(ctx, messages, options...)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		var resp Response
+		for update, err := range next(ctx, messages, options...) {
+			if err != nil {
+				yield(update, err)
+				return
+			}
+			resp.Update(update)
+			if !yield(update, nil) {
+				break
+			}
+		}
+		resp.Coalesce()
+		requestMessages := slices.Clone(messages)
+		responseMessages := slices.Clone(resp.Messages)
+
+		if err := r.provider.AfterRun(ctx, requestMessages, responseMessages, options...); err != nil {
+			yield(nil, err)
+		}
+	}
+}
+
+// NewInMemoryHistoryProvider creates a history provider that stores conversation history in the session.
 // If sourceID is empty, it defaults to "in-memory".
-func NewInMemoryHistoryProvider(sourceID string) *ContextProvider {
+func NewInMemoryHistoryProvider(sourceID string) *HistoryProvider {
 	if sourceID == "" {
 		sourceID = defaultInMemoryHistorySourceID
 	}
-	return &ContextProvider{
-		SourceID:           sourceID,
-		StoreRequestFilter: messagefilter.ExternalOnly,
-		Provide: func(_ context.Context, msgs []*message.Message, options ...Option) ([]*message.Message, []Option, error) {
+	return &HistoryProvider{
+		SourceID: sourceID,
+		Provide: func(_ context.Context, msgs []*message.Message, options ...Option) ([]*message.Message, error) {
 			session, _ := GetOption(options, WithSession)
 			if session == nil {
-				return msgs, options, nil
+				return msgs, nil
 			}
 			var state inmemoryState
 			if _, err := session.Get(sourceID, &state); err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			if len(state.Messages) == 0 {
-				return msgs, options, nil
+				return msgs, nil
 			}
 			messages := make([]*message.Message, 0, len(state.Messages)+len(msgs))
 			messages = append(messages, state.Messages...)
 			messages = append(messages, msgs...)
-			return messages, options, nil
+			return messages, nil
 		},
 		Store: func(_ context.Context, requestMessages, responseMessages []*message.Message, options ...Option) error {
 			session, _ := GetOption(options, WithSession)

--- a/agent/history_test.go
+++ b/agent/history_test.go
@@ -26,7 +26,7 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 	}
 
 	newRequest := message.NewText("new request")
-	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error loading history: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 	if err := provider.AfterRun(t.Context(), messages, []*message.Message{newResponse}, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error storing next turn: %v", err)
 	}
-	messages, _, err = provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err = provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error loading updated history: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 	}
 }
 
-func TestNewInMemoryHistoryProvider_ProvidePrependsHistory(t *testing.T) {
+func TestNewInMemoryHistoryProvider_ProvidePassesOriginalMessages(t *testing.T) {
 	provider := agent.NewInMemoryHistoryProvider("InMemoryHistoryProvider")
 	session := agenttest.CreateSession()
 	request := message.NewText("request")
@@ -70,7 +70,7 @@ func TestNewInMemoryHistoryProvider_ProvidePrependsHistory(t *testing.T) {
 	}
 
 	newRequest := message.NewText("new request")
-	messages, options, err := provider.Provide(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
+	messages, err := provider.Provide(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error loading history: %v", err)
 	}
@@ -83,8 +83,21 @@ func TestNewInMemoryHistoryProvider_ProvidePrependsHistory(t *testing.T) {
 	if messages[0].String() != "request" || messages[1].String() != "response" {
 		t.Fatalf("unexpected output order/content")
 	}
-	if gotSession, ok := agent.GetOption(options, agent.WithSession); !ok || gotSession != session {
-		t.Fatal("expected original session option to be preserved")
+	messages, err = provider.BeforeRun(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("unexpected error loading history: %v", err)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("expected 2 history messages plus request, got %d", len(messages))
+	}
+	if messages[2] != newRequest {
+		t.Fatal("expected original request message to be preserved last")
+	}
+	if messages[0].String() != "request" || messages[1].String() != "response" {
+		t.Fatalf("unexpected output order/content")
+	}
+	if messages[0].SourceID != "InMemoryHistoryProvider" || messages[1].SourceID != "InMemoryHistoryProvider" {
+		t.Fatal("expected history messages to have provider source ID")
 	}
 }
 
@@ -101,7 +114,7 @@ func TestNewInMemoryHistoryProvider_SourceID_MapsToSessionStateKey(t *testing.T)
 	}
 
 	provider := agent.NewInMemoryHistoryProvider("custom")
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -113,24 +126,26 @@ func TestNewInMemoryHistoryProvider_SourceID_MapsToSessionStateKey(t *testing.T)
 	}
 }
 
-func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesContextProviderMessages(t *testing.T) {
+func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesHistoryMessages(t *testing.T) {
 	provider := agent.NewInMemoryHistoryProvider("k")
 	session := agenttest.CreateSession()
 
 	user := message.NewText("user")
+	historyMsg := message.NewText("history")
+	historyMsg.SourceID = "k"
 	ctxMsg := message.NewText("ctx")
 	ctxMsg.SourceID = "provider-A"
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{user, ctxMsg}, nil, agent.WithSession(session)); err != nil {
+	if err := provider.AfterRun(t.Context(), []*message.Message{user, historyMsg, ctxMsg}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(messages) != 1 || messages[0].String() != "user" {
-		t.Fatal("expected default request filter to exclude context-provider messages")
+	if len(messages) != 2 || messages[0].String() != "user" || messages[1].String() != "ctx" {
+		t.Fatal("expected default request filter to exclude only history messages")
 	}
 }
 
@@ -147,7 +162,7 @@ func TestNewInMemoryHistoryProvider_SkipStoreRequestMessages(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,7 +184,7 @@ func TestNewInMemoryHistoryProvider_SkipStoreResponseMessages(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -198,7 +213,7 @@ func TestNewInMemoryHistoryProvider_StoreContextMessages(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,7 +243,7 @@ func TestNewInMemoryHistoryProvider_StoreContextMessagesFrom(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -243,7 +258,7 @@ func TestNewInMemoryHistoryProvider_Invoking_IgnoresUnreadableState(t *testing.T
 	session.Set("k", "not-a-history-state")
 	request := []*message.Message{message.NewText("req")}
 
-	messages, _, err := provider.BeforeRun(t.Context(), request, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), request, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error when state is unreadable: %v", err)
 	}
@@ -264,7 +279,7 @@ func TestNewInMemoryHistoryProvider_Invoked_OverwritesUnreadableState(t *testing
 		t.Fatalf("unexpected error when state is unreadable: %v", err)
 	}
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error reading stored history: %v", err)
 	}

--- a/agent/middleware/contextprovider/contextprovider.go
+++ b/agent/middleware/contextprovider/contextprovider.go
@@ -11,8 +11,9 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-// New returns a middleware that invokes the provided context providers in order
-// before the wrapped run and persists them in reverse order after the run.
+// New adapts context providers into middleware for callers that explicitly need
+// middleware composition. Agents configured with agent.Config.ContextProviders
+// run providers through the agent lifecycle rather than through this adapter.
 func New(providers ...*agent.ContextProvider) agent.Middleware {
 	activeProviders := make([]*agent.ContextProvider, 0, len(providers))
 	for _, provider := range providers {
@@ -31,8 +32,6 @@ type contextProviderRunner struct {
 }
 
 func (r *contextProviderRunner) Run(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
-	session, _ := agent.GetOption(options, agent.WithSession)
-
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		options = slices.Clone(options)
 		for _, provider := range r.providers {
@@ -43,9 +42,11 @@ func (r *contextProviderRunner) Run(next agent.RunFunc, ctx context.Context, mes
 				return
 			}
 		}
+
+		requestMessages := slices.Clone(messages)
 		var resp agent.Response
 		for update, err := range next(ctx, messages, options...) {
-			if update != nil && (session == nil || session.ServiceID() == "") {
+			if update != nil {
 				resp.Update(update)
 			}
 			if !yield(update, err) {
@@ -53,11 +54,9 @@ func (r *contextProviderRunner) Run(next agent.RunFunc, ctx context.Context, mes
 			}
 		}
 		resp.Coalesce()
-		requestMessages := slices.Clone(messages)
-		responseMessages := slices.Clone(resp.Messages)
 
-		for _, provider := range slices.Backward(r.providers) {
-			if err := provider.AfterRun(ctx, requestMessages, responseMessages, options...); err != nil {
+		for _, provider := range r.providers {
+			if err := provider.AfterRun(ctx, slices.Clone(requestMessages), slices.Clone(resp.Messages), options...); err != nil {
 				yield(nil, err)
 				return
 			}

--- a/agent/middleware/contextprovider/contextprovider_test.go
+++ b/agent/middleware/contextprovider/contextprovider_test.go
@@ -122,6 +122,34 @@ func TestContextProviderMiddleware_Run_SharedOptions_OriginalToolsNotMutated(t *
 	}
 }
 
+func TestContextProviderMiddleware_Run_PassesResponseMessagesWithServiceManagedSession(t *testing.T) {
+	session := agenttest.CreateSession()
+	session.SetServiceID("server-managed")
+	var storedResponseMessages []*message.Message
+	provider := &agent.ContextProvider{
+		SourceID: "provider-a",
+		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, _ ...agent.Option) error {
+			storedResponseMessages = responseMessages
+			return nil
+		},
+	}
+
+	_, err := collectMiddlewareResponse(contextprovider.New(provider).Run(
+		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return middlewareSingleUpdate("ok")
+		},
+		context.Background(),
+		[]*message.Message{message.NewText("hello")},
+		agent.WithSession(session),
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := messageStrings(storedResponseMessages); !slices.Equal(got, []string{"ok"}) {
+		t.Fatalf("stored response messages = %v, want [ok]", got)
+	}
+}
+
 func middlewareSingleUpdate(text string) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: text}}}, nil)
@@ -138,6 +166,14 @@ func collectMiddlewareResponse(seq iter.Seq2[*agent.ResponseUpdate, error]) (*ag
 	}
 	resp.Coalesce()
 	return &resp, nil
+}
+
+func messageStrings(messages []*message.Message) []string {
+	strings := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		strings = append(strings, msg.String())
+	}
+	return strings
 }
 
 type stubTool struct {

--- a/agent/options.go
+++ b/agent/options.go
@@ -6,6 +6,7 @@ import (
 	"iter"
 	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/microsoft/agent-framework-go/tool"
 )
@@ -22,6 +23,7 @@ type Option interface {
 type (
 	responseFormatOpt    struct{ ResponseFormat }
 	continuationTokenOpt string
+	instructionsOpt      string
 	serviceIDOpt         string
 
 	toolOpt struct{ tool.Tool }
@@ -36,6 +38,7 @@ type (
 func (o responseFormatOpt) Value() any           { return o.ResponseFormat }
 func (o streamOpt) Value() any                   { return bool(o) }
 func (o continuationTokenOpt) Value() any        { return string(o) }
+func (o instructionsOpt) Value() any             { return string(o) }
 func (o allowBackgroundResponsesOpt) Value() any { return bool(o) }
 func (o toolModeOpt) Value() any                 { return tool.ToolMode(o) }
 func (o toolOpt) Value() any                     { return o.Tool }
@@ -135,6 +138,12 @@ func WithSession(session Session) Option {
 // completion by obtaining the token from the [RunResponse] continuation token.
 func WithContinuationToken(token string) Option {
 	return continuationTokenOpt(token)
+}
+
+// WithInstructions sets system instructions for an agent run when supported by the provider.
+// Use [AllOptions] to access instructions because multiple instruction values can be supplied.
+func WithInstructions(instructions string) Option {
+	return instructionsOpt(strings.TrimSpace(instructions))
 }
 
 // AllowBackgroundResponses sets whether to allow background responses during the agent run.

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2aclient"
 	"github.com/microsoft/agent-framework-go/agent"
 	a2a1 "github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -288,6 +289,29 @@ func TestRunWithValidUserMessage(t *testing.T) {
 	}
 	if msg.String() != "Hello! How can I help you today?" {
 		t.Errorf("String() = %q, want %q", msg.String(), "Hello! How can I help you today?")
+	}
+}
+
+func TestRunIgnoresInstructions(t *testing.T) {
+	transport := &mockA2ATransport{}
+	a := newTestAgent(transport, agent.Config{})
+
+	_, err := a.RunText(t.Context(), "Hello, world!", agent.WithInstructions("Be concise.")).Collect()
+	if err != nil {
+		t.Fatalf("error = %v, want nil", err)
+	}
+	if !transport.sendMessageCalled {
+		t.Fatal("SendMessage was not called")
+	}
+	inputMessage := transport.capturedMessageSendParams.Message
+	if inputMessage == nil {
+		t.Fatal("captured message is nil")
+	}
+	if len(inputMessage.Parts) != 1 {
+		t.Fatalf("captured message parts count = %d, want 1", len(inputMessage.Parts))
+	}
+	if got := inputMessage.Parts[0].Text(); got != "Hello, world!" {
+		t.Errorf("captured message text = %q, want %q", got, "Hello, world!")
 	}
 }
 
@@ -594,7 +618,7 @@ func TestRunWithContinuationTokenAndMessages(t *testing.T) {
 	transport := &mockA2ATransport{}
 	a := newTestAgent(transport, agent.Config{})
 
-	_, err := a.RunText(t.Context(), "Test message", agent.WithContinuationToken("task-123")).Collect()
+	_, err := a.RunText(t.Context(), "Test message", agent.WithContinuationToken(agenttest.NewContinuationToken(t, "task-123"))).Collect()
 	if err == nil {
 		t.Error("error = nil, want error when continuation token and messages are provided")
 	}
@@ -610,7 +634,7 @@ func TestRunWithContinuationToken(t *testing.T) {
 	}
 	a := newTestAgent(transport, agent.Config{})
 
-	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken("task-123")).Collect()
+	_, err := a.Run(t.Context(), nil, agent.WithContinuationToken(agenttest.NewContinuationToken(t, "task-123"))).Collect()
 	if err != nil {
 		t.Fatalf("error = %v, want nil", err)
 	}
@@ -751,8 +775,8 @@ func TestRunWithAgentTaskResponse(t *testing.T) {
 		t.Errorf("ID = %q, want empty", msg.ID)
 	}
 
-	if result.ContinuationToken != "task-789" {
-		t.Errorf("continuation token = %q, want %q", result.ContinuationToken, "task-789")
+	if result.ContinuationToken == "" {
+		t.Error("ContinuationToken is empty, want non-empty")
 	}
 
 	if got := session.ServiceID(); got != "context-456" {
@@ -816,7 +840,7 @@ func TestRunStreamingWithContinuationTokenAndMessages(t *testing.T) {
 	a := newTestAgent(transport, agent.Config{})
 
 	gotError := false
-	for _, err := range a.RunText(t.Context(), "Test message", agent.WithContinuationToken("task-123"), agent.Stream(true)) {
+	for _, err := range a.RunText(t.Context(), "Test message", agent.WithContinuationToken(agenttest.NewContinuationToken(t, "task-123")), agent.Stream(true)) {
 		if err != nil {
 			gotError = true
 			break
@@ -841,7 +865,7 @@ func TestRunStreamingWithContinuationToken_UsesSubscribeToTask(t *testing.T) {
 	a := newTestAgent(transport, agent.Config{})
 
 	var updates []*agent.ResponseUpdate
-	for update, err := range a.Run(t.Context(), nil, agent.WithContinuationToken("task-456"), agent.Stream(true)) {
+	for update, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(agenttest.NewContinuationToken(t, "task-456")), agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("error = %v, want nil", err)
 		}
@@ -876,7 +900,7 @@ func TestRunStreamingWithContinuationToken_PassesCorrectTaskID(t *testing.T) {
 	}
 	a := newTestAgent(transport, agent.Config{})
 
-	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(expectedTaskID), agent.Stream(true)) {
+	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(agenttest.NewContinuationToken(t, expectedTaskID)), agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("error = %v, want nil", err)
 		}
@@ -911,7 +935,7 @@ func TestRunStreamingWithContinuationTokenWhenSubscribeFailsWithUnsupportedOpera
 	a := newTestAgent(transport, agent.Config{})
 
 	var updates []*agent.ResponseUpdate
-	for update, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(taskID), agent.Stream(true)) {
+	for update, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(agenttest.NewContinuationToken(t, taskID)), agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("error = %v, want nil", err)
 		}
@@ -957,7 +981,7 @@ func TestRunStreamingWithContinuationTokenWhenSubscribeFailsWithUnsupportedOpera
 		t.Fatal(err)
 	}
 
-	for _, err := range a.Run(t.Context(), nil, agent.WithSession(session), agent.WithContinuationToken(taskID), agent.Stream(true)) {
+	for _, err := range a.Run(t.Context(), nil, agent.WithSession(session), agent.WithContinuationToken(agenttest.NewContinuationToken(t, taskID)), agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("error = %v, want nil", err)
 		}
@@ -978,7 +1002,7 @@ func TestRunStreamingWithContinuationTokenWhenSubscribeFailsWithNonUnsupportedEr
 	a := newTestAgent(transport, agent.Config{})
 
 	var gotErr error
-	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken("error-task-123"), agent.Stream(true)) {
+	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(agenttest.NewContinuationToken(t, "error-task-123")), agent.Stream(true)) {
 		if err != nil {
 			gotErr = err
 			break
@@ -1004,7 +1028,7 @@ func TestRunStreamingWithContinuationTokenWhenSubscribeAndGetTaskBothFailPropaga
 	a := newTestAgent(transport, agent.Config{})
 
 	var gotErr error
-	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken("failed-task-789"), agent.Stream(true)) {
+	for _, err := range a.Run(t.Context(), nil, agent.WithContinuationToken(agenttest.NewContinuationToken(t, "failed-task-789")), agent.Stream(true)) {
 		if err != nil {
 			gotErr = err
 			break

--- a/agent/provider/aguiagent/agui.go
+++ b/agent/provider/aguiagent/agui.go
@@ -25,6 +25,9 @@ import (
 type Config struct {
 	agent.Config
 
+	// Instructions are sent to AG-UI as a leading system message for each run.
+	Instructions string
+
 	Decoder *aguiEvents.EventDecoder
 }
 
@@ -38,6 +41,9 @@ func New(aclient *aguiSSEClient.Client, config Config) *agent.Agent {
 	p := &provider{
 		cfg:    config,
 		client: aclient,
+	}
+	if config.Instructions != "" {
+		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
 	if config.Decoder != nil {
 		p.decoder = config.Decoder
@@ -67,6 +73,14 @@ func (p *provider) run(ctx context.Context, messages []*message.Message, options
 		if err != nil {
 			yield(nil, err)
 			return
+		}
+		instructions := slices.Collect(agent.AllOptions(options, agent.WithInstructions))
+		if len(instructions) > 0 {
+			convertedMessages = append([]aguiTypes.Message{{
+				ID:      aguiEvents.GenerateMessageID(),
+				Role:    aguiTypes.RoleSystem,
+				Content: strings.Join(instructions, "\n"),
+			}}, convertedMessages...)
 		}
 
 		payload := aguiTypes.RunAgentInput{

--- a/agent/provider/aguiagent/agui_test.go
+++ b/agent/provider/aguiagent/agui_test.go
@@ -44,6 +44,33 @@ func TestAGUIAgentRun_AggregatesStreamingText(t *testing.T) {
 	}
 }
 
+func TestAGUIAgentRun_ConfigInstructionsBecomeSystemMessage(t *testing.T) {
+	var captured aguiTypes.RunAgentInput
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent(captured.ThreadID, captured.RunID))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent(captured.ThreadID, captured.RunID))
+	}))
+	defer server.Close()
+
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{Instructions: "Be concise."})
+	if _, err := a.RunText(context.Background(), "hi").Collect(); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if len(captured.Messages) < 2 {
+		t.Fatalf("messages length = %d, want at least 2", len(captured.Messages))
+	}
+	if captured.Messages[0].Role != aguiTypes.RoleSystem || captured.Messages[0].Content != "Be concise." {
+		t.Fatalf("first message = %#v, want system instructions", captured.Messages[0])
+	}
+	if captured.Messages[1].Role != aguiTypes.RoleUser || captured.Messages[1].Content != "hi" {
+		t.Fatalf("second message = %#v, want user input", captured.Messages[1])
+	}
+}
+
 func TestAGUIAgentRun_WithEmptyEventStream_EmitsMetadataUpdate(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/agent/provider/anthropicagent/agent.go
+++ b/agent/provider/anthropicagent/agent.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -40,6 +41,9 @@ type client struct {
 type Config struct {
 	agent.Config
 
+	// Instructions are provided to Anthropic as system instructions for each run.
+	Instructions string
+
 	Model string
 }
 
@@ -47,6 +51,9 @@ func New(aclient anthropic.Client, config Config) *agent.Agent {
 	c := &client{
 		client: aclient,
 		config: config,
+	}
+	if config.Instructions != "" {
+		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
 	config.Middlewares = slices.Clone(config.Middlewares)
 	if !config.DisableFuncAutoCall {
@@ -272,6 +279,10 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 	}
 	params.Model = cmp.Or(params.Model, a.config.Model)
 	params.MaxTokens = cmp.Or(params.MaxTokens, 4096)
+	instructions := slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
+	if len(instructions) > 0 {
+		params.System = append(params.System, anthropic.TextBlockParam{Text: strings.Join(instructions, "\n")})
+	}
 
 	var tools []anthropic.ToolUnionParam
 	for tl := range agent.AllOptions(opts, agent.WithTool) {

--- a/agent/provider/anthropicagent/agent_test.go
+++ b/agent/provider/anthropicagent/agent_test.go
@@ -119,6 +119,55 @@ func minimalStreamingResponse(payload string) string {
 		`data: {"type":"message_stop"}` + "\n\n"
 }
 
+func TestConfigInstructions(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		bodyCh <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, minimalMessageResponse("ok"))
+	}))
+	defer server.Close()
+
+	a := anthropicagent.New(
+		anthropic.NewClient(
+			option.WithBaseURL(server.URL),
+			option.WithAPIKey("test"),
+		),
+		anthropicagent.Config{
+			Model:        "claude-3-5-sonnet-20241022",
+			Instructions: "You are helpful.",
+			Config: agent.Config{
+				DisableFuncAutoCall: true,
+			},
+		})
+
+	if _, err := a.RunText(t.Context(), "hi").Collect(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var req map[string]any
+	if err := json.Unmarshal(<-bodyCh, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	system, ok := req["system"].([]any)
+	if !ok || len(system) != 1 {
+		t.Fatalf("system = %#v, want one text block", req["system"])
+	}
+	block, _ := system[0].(map[string]any)
+	if block["text"] != "You are helpful." {
+		t.Fatalf("system text = %q, want %q", block["text"], "You are helpful.")
+	}
+	messages, _ := req["messages"].([]any)
+	if len(messages) != 1 {
+		t.Fatalf("messages length = %d, want 1", len(messages))
+	}
+}
+
 // TestStructuredOutput_NonStreaming verifies that passing agent.WithStructuredOutput
 // with a typed struct causes the provider to:
 //  1. Send output_config.format with type "json_schema" and a schema derived

--- a/agent/provider/geminiagent/agent.go
+++ b/agent/provider/geminiagent/agent.go
@@ -10,6 +10,7 @@ import (
 	"iter"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -39,6 +40,9 @@ type client struct {
 type Config struct {
 	agent.Config
 
+	// Instructions are provided to Gemini as system instructions for each run.
+	Instructions string
+
 	Model string
 }
 
@@ -47,6 +51,9 @@ func New(gclient *genai.Client, config Config) *agent.Agent {
 	c := &client{
 		client: gclient,
 		config: config,
+	}
+	if config.Instructions != "" {
+		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
 	config.Middlewares = slices.Clone(config.Middlewares)
 	if !config.DisableFuncAutoCall {
@@ -172,6 +179,10 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 			cfg.SystemInstruction = &si
 		}
 	}
+	instructions := slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
+	if len(instructions) > 0 {
+		appendSystemInstruction(cfg, strings.Join(instructions, "\n"))
+	}
 
 	// Collect tools from options.
 	var funcDecls []*genai.FunctionDeclaration
@@ -240,12 +251,9 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 		case message.RoleSystem:
 			// Gemini uses a single system instruction content that can hold multiple parts.
 			// Add each non-empty system text content as its own part.
-			if cfg.SystemInstruction == nil {
-				cfg.SystemInstruction = &genai.Content{Role: genai.RoleUser}
-			}
 			for _, c := range msg.Contents {
 				if tc, ok := c.(*message.TextContent); ok && tc.Text != "" {
-					cfg.SystemInstruction.Parts = append(cfg.SystemInstruction.Parts, &genai.Part{Text: tc.Text})
+					appendSystemInstruction(cfg, tc.Text)
 				}
 			}
 		case message.RoleUser, message.RoleTool:
@@ -274,6 +282,16 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 	}
 
 	return contents, cfg, nil
+}
+
+func appendSystemInstruction(cfg *genai.GenerateContentConfig, text string) {
+	if text == "" {
+		return
+	}
+	if cfg.SystemInstruction == nil {
+		cfg.SystemInstruction = &genai.Content{Role: genai.RoleUser}
+	}
+	cfg.SystemInstruction.Parts = append(cfg.SystemInstruction.Parts, &genai.Part{Text: text})
 }
 
 // buildRequestParts converts a framework message's contents into genai Parts.

--- a/agent/provider/geminiagent/agent_test.go
+++ b/agent/provider/geminiagent/agent_test.go
@@ -291,6 +291,56 @@ func TestSystemInstruction(t *testing.T) {
 	}
 }
 
+func TestConfigInstructions(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	server := httptest.NewServer(captureAndRespond(t, bodyCh, "application/json", minimalTextResponse("ok")))
+	defer server.Close()
+
+	client, err := genai.NewClient(t.Context(), &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		APIKey:  "test",
+		HTTPOptions: genai.HTTPOptions{
+			BaseURL: server.URL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("genai.NewClient: %v", err)
+	}
+	a := geminiagent.New(client, geminiagent.Config{
+		Model:        testModel,
+		Instructions: "You are helpful.",
+		Config: agent.Config{
+			DisableFuncAutoCall: true,
+		},
+	})
+
+	_, err = a.RunText(t.Context(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(<-bodyCh, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	si, hasSI := nestedKey(req, "systemInstruction", "parts")
+	if !hasSI {
+		t.Fatal("request missing systemInstruction.parts")
+	}
+	parts, _ := si.([]any)
+	if len(parts) != 1 {
+		t.Fatalf("systemInstruction.parts length = %d, want 1", len(parts))
+	}
+	firstPart, _ := parts[0].(map[string]any)
+	if text, _ := nestedKey(firstPart, "text"); text != "You are helpful." {
+		t.Fatalf("systemInstruction text = %q, want %q", text, "You are helpful.")
+	}
+	contents, _ := req["contents"].([]any)
+	if len(contents) != 1 {
+		t.Fatalf("contents length = %d, want 1", len(contents))
+	}
+}
+
 // TestToolCall_NonStreaming verifies that tool definitions are sent in the
 // request and that a functionCall part in the response is translated into a
 // FunctionCallContent.

--- a/agent/provider/openaiagent/chat.go
+++ b/agent/provider/openaiagent/chat.go
@@ -10,6 +10,7 @@ import (
 	"iter"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -43,6 +44,9 @@ func ChatCompletionNewParams(params openai.ChatCompletionNewParams) agent.Option
 type Config struct {
 	agent.Config
 
+	// Instructions are provided to OpenAI as system instructions for each run.
+	Instructions string
+
 	Model string
 }
 
@@ -51,6 +55,9 @@ func NewChatCompletions(oclient openai.Client, config Config) *agent.Agent {
 	c := &chatClient{
 		client: oclient,
 		config: config,
+	}
+	if config.Instructions != "" {
+		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
 	config.Middlewares = slices.Clone(config.Middlewares)
 	if !config.DisableFuncAutoCall {
@@ -315,6 +322,10 @@ func buildCompletionParams(model string, messages []*message.Message, opts []age
 				},
 			})
 		}
+	}
+	instructions := slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
+	if len(instructions) > 0 {
+		params.Messages = append(params.Messages, openai.SystemMessage(strings.Join(instructions, "\n")))
 	}
 	for _, msg := range messages {
 		omsg, err := buildMessageParam(msg)

--- a/agent/provider/openaiagent/chat_test.go
+++ b/agent/provider/openaiagent/chat_test.go
@@ -70,6 +70,48 @@ func newTestClient(server *httptest.Server) *agent.Agent {
 	)
 }
 
+func TestChatConfigInstructions_NonStreaming(t *testing.T) {
+	const input = `
+						{
+								"messages":[
+										{"role":"system","content":"Be concise.\nAnswer warmly."},
+										{"role":"user","content":"hello"}
+								],
+								"model":"gpt-4o-mini"
+						}
+						`
+	const output = `
+						{
+							"id": "chatcmpl-test",
+							"object": "chat.completion",
+							"created": 1727888631,
+							"model": "gpt-4o-mini-2024-07-18",
+							"choices": [{
+								"index": 0,
+								"message": {"role": "assistant", "content": "Hello", "refusal": null},
+								"finish_reason": "stop"
+							}]
+						}
+						`
+	server := newTestServer(t, input, output)
+	defer server.Close()
+
+	a := openaiagent.NewChatCompletions(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiagent.Config{
+			Model:        "gpt-4o-mini",
+			Instructions: "Be concise.",
+			Config: agent.Config{
+				DisableFuncAutoCall: true,
+			},
+		},
+	)
+
+	if _, err := a.RunText(t.Context(), "hello", agent.WithInstructions("Answer warmly.")).Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestChatBasicRequestResponse_NonStreaming(t *testing.T) {
 	const input = `
             {

--- a/agent/provider/openaiagent/responses.go
+++ b/agent/provider/openaiagent/responses.go
@@ -36,6 +36,9 @@ func NewResponses(oclient openai.Client, config Config) *agent.Agent {
 		client: oclient,
 		config: config,
 	}
+	if config.Instructions != "" {
+		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
+	}
 	config.Middlewares = slices.Clone(config.Middlewares)
 	if !config.DisableFuncAutoCall {
 		config.Middlewares = append(config.Middlewares, autocall.New(autocall.Config{
@@ -214,6 +217,10 @@ func responsesBuildCompletionParams(model string, messages []*message.Message, o
 		params = p
 	}
 	params.Model = cmp.Or(params.Model, model)
+	instructions := slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
+	if len(instructions) > 0 {
+		params.Instructions = openai.String(strings.Join(instructions, "\n"))
+	}
 	if v, ok := agent.GetOption(opts, agent.AllowBackgroundResponses); ok {
 		params.Background = openai.Bool(v)
 	}

--- a/agent/provider/openaiagent/responses_test.go
+++ b/agent/provider/openaiagent/responses_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/format/jsonformat"
 	"github.com/microsoft/agent-framework-go/agent/provider/openaiagent"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/internal/messagetest"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
@@ -70,6 +71,56 @@ func newTestResponsesClient(server *httptest.Server, model string) *agent.Agent 
 			Config: agent.Config{DisableFuncAutoCall: true},
 		},
 	)
+}
+
+func TestResponsesConfigInstructions_NonStreaming(t *testing.T) {
+	const input = `
+						{
+								"instructions":"Be concise.",
+								"model":"gpt-4o-mini",
+								"input": [{
+										"type":"message",
+										"role":"user",
+										"content":[{"type":"input_text","text":"hello"}]
+								}]
+						}
+						`
+	const output = `
+						{
+							"id": "resp_test",
+							"object": "response",
+							"created_at": 1741891428,
+							"status": "completed",
+							"error": null,
+							"incomplete_details": null,
+							"instructions": "Be concise.",
+							"model": "gpt-4o-mini",
+							"output": [{
+								"type": "message",
+								"id": "msg_test",
+								"status": "completed",
+								"role": "assistant",
+								"content": [{"type": "output_text", "text": "Hello", "annotations": []}]
+							}]
+						}
+						`
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := openaiagent.NewResponses(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiagent.Config{
+			Model:        "gpt-4o-mini",
+			Instructions: "Be concise.",
+			Config: agent.Config{
+				DisableFuncAutoCall: true,
+			},
+		},
+	)
+
+	if _, err := a.RunText(t.Context(), "hello").Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
 }
 
 func TestResponsesBasicRequestResponse_NonStreaming(t *testing.T) {
@@ -4271,18 +4322,8 @@ func TestResponsesBackgroundResponses_FirstCall(t *testing.T) {
 	if resp.ContinuationToken == "" {
 		t.Fatal("expected ContinuationToken to be set")
 	}
-
-	// Continuation token is already a JSON string, unmarshal it directly
-	var ct continuationToken
-	if err := json.Unmarshal([]byte(resp.ContinuationToken), &ct); err != nil {
-		t.Fatalf("failed to unmarshal continuation token: %v", err)
-	}
-
-	if ct.ResponseID != "resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7" {
-		t.Errorf("expected continuation token ResponseID resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7, got %s", ct.ResponseID)
-	}
-	if ct.SequenceNumber != 0 {
-		t.Errorf("expected continuation token SequenceNumber 0, got %d", ct.SequenceNumber)
+	if got := session.ServiceID(); got != "resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7" {
+		t.Errorf("expected session ServiceID resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7, got %s", got)
 	}
 }
 
@@ -4346,7 +4387,7 @@ func testResponsesBackgroundPolling(t *testing.T, status string) {
 	ctJSON, _ := json.Marshal(ct)
 
 	resp, err := a.Run(t.Context(), nil,
-		agent.WithContinuationToken(string(ctJSON)),
+		agent.WithContinuationToken(agenttest.NewContinuationToken(t, string(ctJSON))),
 		agent.AllowBackgroundResponses(true),
 		agent.WithSession(session),
 	).Collect()
@@ -4358,13 +4399,6 @@ func testResponsesBackgroundPolling(t *testing.T, status string) {
 	case "queued", "in_progress":
 		if resp.ContinuationToken == "" {
 			t.Error("expected ContinuationToken to be set for queued/in_progress status")
-		} else {
-			var parsedToken continuationToken
-			if err := json.Unmarshal([]byte(resp.ContinuationToken), &parsedToken); err == nil {
-				if parsedToken.ResponseID != "resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8" {
-					t.Errorf("expected continuation token ResponseID, got %s", parsedToken.ResponseID)
-				}
-			}
 		}
 
 		if len(resp.Messages) != 1 {
@@ -4383,6 +4417,9 @@ func testResponsesBackgroundPolling(t *testing.T, status string) {
 		if len(resp.Messages) != 1 {
 			t.Fatalf("expected 1 message, got %d", len(resp.Messages))
 		}
+	}
+	if got := session.ServiceID(); got != "resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8" {
+		t.Errorf("expected session ServiceID resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8, got %s", got)
 	}
 }
 
@@ -4492,6 +4529,9 @@ data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_6
 	if len(updates) != 18 {
 		t.Errorf("expected 18 updates, got %d", len(updates))
 	}
+	if got := session.ServiceID(); got != "resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559" {
+		t.Errorf("expected session ServiceID resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559, got %s", got)
+	}
 
 	// Verify continuation tokens
 	for i := 0; i < len(updates); i++ {
@@ -4503,16 +4543,6 @@ data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_6
 			// All updates except the last should have continuation token
 			if updates[i].ContinuationToken == "" {
 				t.Errorf("update %d: expected ContinuationToken to be set", i)
-			} else {
-				var ct continuationToken
-				if err := json.Unmarshal([]byte(updates[i].ContinuationToken), &ct); err == nil {
-					if ct.ResponseID != "resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559" {
-						t.Errorf("update %d: expected continuation token ResponseID, got %s", i, ct.ResponseID)
-					}
-					if ct.SequenceNumber != int64(i) {
-						t.Errorf("update %d: expected continuation token SequenceNumber %d, got %d", i, i, ct.SequenceNumber)
-					}
-				}
 			}
 		} else {
 			// Last update should not have continuation token
@@ -4571,7 +4601,7 @@ data: {"type":"response.completed","sequence_number":17,"response":{"truncation"
 	a := newTestResponsesClient(server, "gpt-4o-2024-08-06")
 
 	// Emulating resumption of the stream after receiving the first 9 updates that provided the text "Hello! How can I"
-	token := `{"response_id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","sequence_number":9}`
+	token := agenttest.NewContinuationToken(t, `{"response_id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","sequence_number":9}`)
 
 	// Create session with ConversationID to allow continuation
 	session, err := a.CreateSession(t.Context(), agent.WithServiceID("resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b"))
@@ -4609,6 +4639,9 @@ data: {"type":"response.completed","sequence_number":17,"response":{"truncation"
 	if fullText.String() != " assist you today?" {
 		t.Errorf("expected text ' assist you today?', got %q", fullText.String())
 	}
+	if got := session.ServiceID(); got != "resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b" {
+		t.Errorf("expected session ServiceID resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b, got %s", got)
+	}
 
 	// Verify all updates have correct ResponseID
 	for i, update := range updates {
@@ -4617,20 +4650,9 @@ data: {"type":"response.completed","sequence_number":17,"response":{"truncation"
 		}
 
 		// Verify continuation tokens for all but last update
-		sequenceNumber := i + 10
 		if i < len(updates)-1 {
 			if update.ContinuationToken == "" {
 				t.Errorf("update %d: expected ContinuationToken to be set", i)
-			} else {
-				var ct continuationToken
-				if err := json.Unmarshal([]byte(update.ContinuationToken), &ct); err == nil {
-					if ct.ResponseID != "resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b" {
-						t.Errorf("update %d: expected continuation token ResponseID, got %s", i, ct.ResponseID)
-					}
-					if ct.SequenceNumber != int64(sequenceNumber) {
-						t.Errorf("update %d: expected continuation token SequenceNumber %d, got %d", i, sequenceNumber, ct.SequenceNumber)
-					}
-				}
 			}
 		} else {
 			// Last update should not have continuation token
@@ -4646,7 +4668,7 @@ func TestResponsesGetContinuationToken_WithMessages_ThrowsException(t *testing.T
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	token := `{"response_id":"resp_123","sequence_number":0}`
+	token := agenttest.NewContinuationToken(t, `{"response_id":"resp_123","sequence_number":0}`)
 
 	// Attempt to use continuation token with messages should error
 	_, err := a.RunText(t.Context(), "test",
@@ -4671,7 +4693,7 @@ func TestResponsesBackgroundResponses_PollingCall_WithMessages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
-	token := `{"response_id":"resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8","sequence_number":0}`
+	token := agenttest.NewContinuationToken(t, `{"response_id":"resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8","sequence_number":0}`)
 
 	// A try to update a background response with new messages should fail
 	_, err = a.RunText(t.Context(), "Please book hotel as well",
@@ -4698,7 +4720,7 @@ func TestResponsesBackgroundResponses_StreamResumption_WithMessages(t *testing.T
 	if err != nil {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
-	token := `{"response_id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","sequence_number":9}`
+	token := agenttest.NewContinuationToken(t, `{"response_id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","sequence_number":9}`)
 
 	// Attempt to resume stream with messages should fail
 	for _, err := range a.RunText(t.Context(), "Please book a hotel for me",

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -35,8 +35,9 @@ const sessionStateKey = "workflowprovider_state"
 
 // providerServiceID marks sessions managed by this provider. Setting a
 // non-empty ServiceID on the session opts out of the agent package's
-// default history provider on subsequent calls. The workflow itself owns
-// conversational state across turns.
+// default history provider on subsequent calls. Explicitly configured
+// history providers still run. The workflow itself owns conversational
+// state across turns.
 const providerServiceID = "workflowprovider"
 
 // Config configures a [workflow.Workflow] hosted as an [agent.Agent] via [New].

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -35,9 +35,8 @@ const sessionStateKey = "workflowprovider_state"
 
 // providerServiceID marks sessions managed by this provider. Setting a
 // non-empty ServiceID on the session opts out of the agent package's
-// default in-memory chat history middleware, which would otherwise
-// replay prior messages into the workflow on every call. The workflow
-// itself owns conversational state across turns.
+// default history provider on subsequent calls. The workflow itself owns
+// conversational state across turns.
 const providerServiceID = "workflowprovider"
 
 // Config configures a [workflow.Workflow] hosted as an [agent.Agent] via [New].

--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -96,8 +96,9 @@ type providerState struct {
 }
 
 type providerContext struct {
-	Messages []*message.Message
-	Options  []agent.Option
+	Messages     []*message.Message
+	Options      []agent.Option
+	Instructions string
 }
 
 // NewContextProvider creates a skills context provider from the configured in-memory skills and sources.
@@ -237,6 +238,9 @@ func extendProviderContext(messages []*message.Message, options []agent.Option, 
 	if len(result.Options) > 0 {
 		outOptions = append(options, result.Options...)
 	}
+	if strings.TrimSpace(result.Instructions) != "" {
+		outOptions = append(outOptions, agent.WithInstructions(result.Instructions))
+	}
 
 	return outMessages, outOptions
 }
@@ -258,12 +262,7 @@ func (p *providerState) buildContext(ctx context.Context) (providerContext, erro
 
 	instructions := buildProviderSkillsInstructionPrompt(p.options.SkillsInstructionPrompt, skills, hasResources, hasScripts)
 	if instructions != "" {
-		out.Messages = []*message.Message{{
-			Role: message.RoleSystem,
-			Contents: []message.Content{
-				&message.TextContent{Text: instructions},
-			},
-		}}
+		out.Instructions = instructions
 	}
 
 	return out, nil

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -266,13 +266,14 @@ func TestProvider_RecoversFromPanickingSourceAndResetsLoading(t *testing.T) {
 	}
 
 	type result struct {
-		messageCount int
-		err          error
+		hasInstructions bool
+		err             error
 	}
 	resultCh := make(chan result, 1)
 	go func() {
-		messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
-		resultCh <- result{messageCount: len(messages), err: err}
+		_, options, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
+		instructions, _ := agent.GetOption(options, agent.WithInstructions)
+		resultCh <- result{hasInstructions: strings.Contains(instructions, "recovered-skill"), err: err}
 	}()
 
 	select {
@@ -280,8 +281,8 @@ func TestProvider_RecoversFromPanickingSourceAndResetsLoading(t *testing.T) {
 		if outcome.err != nil {
 			t.Fatalf("expected second provider call to succeed, got %v", outcome.err)
 		}
-		if outcome.messageCount == 0 {
-			t.Fatal("expected provider to recover and return messages on the second call")
+		if !outcome.hasInstructions {
+			t.Fatal("expected provider to recover and return instructions on the second call")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for provider to recover after panic")
@@ -491,14 +492,14 @@ func TestNewProvider_ProvideExtendsInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(messages) != 2 {
-		t.Fatalf("expected input plus skills message, got %d", len(messages))
+	if len(messages) != 1 {
+		t.Fatalf("expected only input message, got %d", len(messages))
 	}
 	if messages[0] != input {
 		t.Fatal("expected original input message to be preserved first")
 	}
-	if messages[1].Role != message.RoleSystem {
-		t.Fatalf("expected skills message to be a system message, got %q", messages[1].Role)
+	if instructions, ok := agent.GetOption(options, agent.WithInstructions); !ok || !strings.Contains(instructions, "inline-skill") {
+		t.Fatalf("expected skills instructions option, got %q", instructions)
 	}
 	if gotSession, ok := agent.GetOption(options, agent.WithSession); !ok || gotSession != session {
 		t.Fatal("expected original session option to be preserved")

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/microsoft/agent-framework-go/agent/skills"
 	"github.com/microsoft/agent-framework-go/agent/skills/fsskills"
 	"github.com/microsoft/agent-framework-go/internal/agenttest"
-	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 )
 
@@ -97,15 +96,11 @@ func captureProviderContext(t *testing.T, provider *agent.ContextProvider) (stri
 		t.Fatal(err)
 	}
 	tools := slices.Collect(agent.AllOptions(options, agent.WithTool))
-	if len(messages) == 0 {
-		return "", tools
+	instructions, _ := agent.GetOption(options, agent.WithInstructions)
+	if len(messages) != 0 {
+		t.Fatalf("expected skills provider not to add messages, got %d", len(messages))
 	}
-	for _, content := range messages[0].Contents {
-		if txt, ok := content.(*message.TextContent); ok {
-			return txt.Text, tools
-		}
-	}
-	return "", tools
+	return instructions, tools
 }
 
 func findTool(t *testing.T, tools []tool.Tool, name string) tool.FuncTool {

--- a/examples/01-get-started/01_hello_agent/main.go
+++ b/examples/01-get-started/01_hello_agent/main.go
@@ -38,11 +38,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/01-get-started/02_add_tools/main.go
+++ b/examples/01-get-started/02_add_tools/main.go
@@ -48,11 +48,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant",
 			Config: agent.Config{
-				Instructions: "You are a helpful assistant",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
-				Tools:        []tool.Tool{weatherTool},
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
+				Tools:       []tool.Tool{weatherTool},
 			},
 		},
 	)

--- a/examples/01-get-started/03_multi_turn/main.go
+++ b/examples/01-get-started/03_multi_turn/main.go
@@ -37,11 +37,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/01-get-started/04_memory/main.go
+++ b/examples/01-get-started/04_memory/main.go
@@ -39,9 +39,9 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a friendly assistant.",
 			Config: agent.Config{
-				Instructions:     "You are a friendly assistant.",
 				Name:             "MemoryAgent",
 				Middlewares:      []agent.Middleware{logger}, // for logging agent interactions
 				ContextProviders: []*agent.ContextProvider{newUserMemoryProvider()},
@@ -102,12 +102,7 @@ func provideUserMemory(ctx context.Context, messages []*message.Message, options
 	if strings.TrimSpace(state.UserName) != "" {
 		instructions = fmt.Sprintf("The user's name is %s. Always address them by name.", state.UserName)
 	}
-	return append(messages, &message.Message{
-		Role: message.RoleSystem,
-		Contents: []message.Content{
-			&message.TextContent{Text: instructions},
-		},
-	}), options, nil
+	return messages, append(options, agent.WithInstructions(instructions)), nil
 }
 
 func storeUserMemory(ctx context.Context, requestMessages, _ []*message.Message, options ...agent.Option) error {

--- a/examples/02-agents/a2a/as_function_tools/main.go
+++ b/examples/02-agents/a2a/as_function_tools/main.go
@@ -73,12 +73,12 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant that helps people with travel planning.",
 			Config: agent.Config{
-				Name:         "TravelPlanner",
-				Instructions: "You are a helpful assistant that helps people with travel planning.",
-				Middlewares:  []agent.Middleware{logger},
-				Tools:        createSkillTools(remoteAgent, card.Skills),
+				Name:        "TravelPlanner",
+				Middlewares: []agent.Middleware{logger},
+				Tools:       createSkillTools(remoteAgent, card.Skills),
 			},
 		},
 	)

--- a/examples/02-agents/agents/step01_running/main.go
+++ b/examples/02-agents/agents/step01_running/main.go
@@ -37,11 +37,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/agents/step02_multiturn_conversation/main.go
+++ b/examples/02-agents/agents/step02_multiturn_conversation/main.go
@@ -37,11 +37,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/agents/step03_using_function_tools/main.go
+++ b/examples/02-agents/agents/step03_using_function_tools/main.go
@@ -47,11 +47,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant",
 			Config: agent.Config{
-				Instructions: "You are a helpful assistant",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
-				Tools:        []tool.Tool{weatherTool},
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
+				Tools:       []tool.Tool{weatherTool},
 			},
 		},
 	)

--- a/examples/02-agents/agents/step04_using_function_tools_with_approvals/main.go
+++ b/examples/02-agents/agents/step04_using_function_tools_with_approvals/main.go
@@ -49,11 +49,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant",
 			Config: agent.Config{
-				Instructions: "You are a helpful assistant",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
-				Tools:        []tool.Tool{tool.ApprovalRequiredFunc(weatherTool)},
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
+				Tools:       []tool.Tool{tool.ApprovalRequiredFunc(weatherTool)},
 			},
 		},
 	)

--- a/examples/02-agents/agents/step05_structured_output/main.go
+++ b/examples/02-agents/agents/step05_structured_output/main.go
@@ -58,11 +58,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant.",
 			Config: agent.Config{
-				Instructions: "You are a helpful assistant.",
-				Name:         "HelpfulAssistant",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "HelpfulAssistant",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)
@@ -88,11 +88,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant.",
 			Config: agent.Config{
-				Instructions: "You are a helpful assistant.",
-				Name:         "HelpfulAssistant",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "HelpfulAssistant",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 				RunOptions: []agent.Option{
 					agent.WithResponseFormat(jsonformat.MustFor[PersonInfo]()),
 				},

--- a/examples/02-agents/agents/step06_persisted_conversation/main.go
+++ b/examples/02-agents/agents/step06_persisted_conversation/main.go
@@ -38,11 +38,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"iter"
 	"os"
 	"path/filepath"
 	"slices"
@@ -52,12 +51,10 @@ func main() {
 		openaiagent.Config{
 			Model: deployment,
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares: []agent.Middleware{
-					logger,                       // for logging agent interactions
-					&fsMessageStore{Dir: tmpDir}, // for persistent message history
-				},
+				Instructions:    "You are good at telling jokes.",
+				Name:            "Joker",
+				HistoryProvider: newFSHistoryProvider(tmpDir),
+				Middlewares:     []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)
@@ -77,7 +74,7 @@ func main() {
 	// Serialize the session state, so it can be stored for later use.
 	// The disk store holds the chat history.
 	// The serialized session only contains the message-store ID.
-	serializedSession, err := json.MarshalIndent(session, "", "\t")
+	serializedSession, err := a.MarshalSession(ctx, session)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -99,6 +96,15 @@ func main() {
 
 type fsMessageStore struct {
 	Dir string
+}
+
+func newFSHistoryProvider(dir string) *agent.HistoryProvider {
+	store := &fsMessageStore{Dir: dir}
+	return &agent.HistoryProvider{
+		SourceID: "fsMessageStore",
+		Provide:  store.provideMessages,
+		Store:    store.persistMessages,
+	}
 }
 
 func (d *fsMessageStore) getFiles(session agent.Session) []string {
@@ -130,7 +136,29 @@ func (d *fsMessageStore) loadMessages(session agent.Session) ([]*message.Message
 	return msgs, nil
 }
 
-func (d *fsMessageStore) persistMessages(session agent.Session, requestMessages, responseMessages []*message.Message) error {
+func (d *fsMessageStore) provideMessages(_ context.Context, msgs []*message.Message, opts ...agent.Option) ([]*message.Message, error) {
+	session, _ := agent.GetOption(opts, agent.WithSession)
+	if session == nil {
+		return msgs, nil
+	}
+	history, err := d.loadMessages(session)
+	if err != nil {
+		return nil, err
+	}
+	if len(history) == 0 {
+		return msgs, nil
+	}
+	messages := make([]*message.Message, 0, len(history)+len(msgs))
+	messages = append(messages, history...)
+	messages = append(messages, msgs...)
+	return messages, nil
+}
+
+func (d *fsMessageStore) persistMessages(_ context.Context, requestMessages, responseMessages []*message.Message, opts ...agent.Option) error {
+	session, _ := agent.GetOption(opts, agent.WithSession)
+	if session == nil {
+		return nil
+	}
 	var files []string
 	_, _ = session.Get("fsMessageStore.files", &files)
 	persist := func(msg *message.Message) error {
@@ -163,39 +191,4 @@ func (d *fsMessageStore) persistMessages(session agent.Session, requestMessages,
 	}
 	session.Set("fsMessageStore.files", files)
 	return nil
-}
-
-func (d *fsMessageStore) Run(next agent.RunFunc, ctx context.Context, msgs []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
-	var session agent.Session
-	if v, ok := agent.GetOption(opts, agent.WithSession); ok {
-		session = v
-	} else {
-		// If no session is provided, we cannot persist messages, so just pass through to next middleware.
-		return next(ctx, msgs, opts...)
-	}
-	history, err := d.loadMessages(session)
-	if err != nil {
-		return func(yield func(*agent.ResponseUpdate, error) bool) {
-			yield(nil, err)
-		}
-	}
-	messagesForClient := append(history, msgs...)
-
-	return func(yield func(*agent.ResponseUpdate, error) bool) {
-		var resp agent.Response
-		for update, err := range next(ctx, messagesForClient, opts...) {
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-			resp.Update(update)
-			if !yield(update, nil) {
-				return
-			}
-		}
-		resp.Coalesce()
-		if err := d.persistMessages(session, msgs, resp.Messages); err != nil {
-			yield(nil, err)
-		}
-	}
 }

--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -49,9 +49,9 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions:    "You are good at telling jokes.",
 				Name:            "Joker",
 				HistoryProvider: newFSHistoryProvider(tmpDir),
 				Middlewares:     []agent.Middleware{logger}, // for logging agent interactions

--- a/examples/02-agents/agents/step08_observability/main.go
+++ b/examples/02-agents/agents/step08_observability/main.go
@@ -63,10 +63,10 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
+				Name: "Joker",
 				Middlewares: []agent.Middleware{
 					otel.New(otel.Config{}), // for OpenTelemetry observability
 					logger,                  // for logging agent interactions

--- a/examples/02-agents/agents/step10_as_mcp_tool/main.go
+++ b/examples/02-agents/agents/step10_as_mcp_tool/main.go
@@ -38,11 +38,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes, and you always start each joke with 'Aye aye, captain!'.",
 			Config: agent.Config{
-				Name:         "Joker",
-				Description:  "An agent that tells jokes.",
-				Instructions: "You are good at telling jokes, and you always start each joke with 'Aye aye, captain!'.",
+				Name:        "Joker",
+				Description: "An agent that tells jokes.",
 			},
 		},
 	)

--- a/examples/02-agents/agents/step11_using_images/main.go
+++ b/examples/02-agents/agents/step11_using_images/main.go
@@ -38,11 +38,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful agent that can analyze images.",
 			Config: agent.Config{
-				Instructions: "You are a helpful agent that can analyze images.",
-				Name:         "VisionAgent",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "VisionAgent",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/agents/step12_as_function_tool/main.go
+++ b/examples/02-agents/agents/step12_as_function_tool/main.go
@@ -50,13 +50,13 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You answer questions about the weather.",
 			Config: agent.Config{
-				Instructions: "You answer questions about the weather.",
-				Name:         "WeatherAgent",
-				Description:  "An agent that answers questions about the weather.",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
-				Tools:        []tool.Tool{weatherTool},
+				Name:        "WeatherAgent",
+				Description: "An agent that answers questions about the weather.",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
+				Tools:       []tool.Tool{weatherTool},
 			},
 		},
 	)
@@ -69,10 +69,10 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant who responds in French.",
 			Config: agent.Config{
-				Instructions: "You are a helpful assistant who responds in French.",
-				Tools:        []tool.Tool{agenttool.New(weatherAgent, agenttool.Config{})},
+				Tools: []tool.Tool{agenttool.New(weatherAgent, agenttool.Config{})},
 			},
 		},
 	)

--- a/examples/02-agents/agents/step17_additional_ai_context/main.go
+++ b/examples/02-agents/agents/step17_additional_ai_context/main.go
@@ -51,10 +51,10 @@ func main() {
 		),
 		openaiagent.Config{
 			Model: deployment,
-			Config: agent.Config{
-				Instructions: `You are a helpful personal assistant.
+			Instructions: `You are a helpful personal assistant.
 You manage a TODO list for the user. When the user has completed one of the tasks it can be removed from the TODO list. Only provide the list of TODO items if asked.
 You remind users of upcoming calendar events when the user interacts with you.`,
+			Config: agent.Config{
 				Name:            "PersonalAssistant",
 				HistoryProvider: newChatHistoryProvider(),
 				ContextProviders: []*agent.ContextProvider{

--- a/examples/02-agents/agents/step17_additional_ai_context/main.go
+++ b/examples/02-agents/agents/step17_additional_ai_context/main.go
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to inject additional AI context into an agent using custom ContextProvider components.
+// Multiple providers can be attached to an agent, and they will be called in sequence, each receiving the
+// accumulated context from the previous one. This mechanism can be used for various purposes, such as injecting
+// RAG search results or memories into the agent's context.
+
+package main
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/provider/openaiagent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/message/messagefilter"
+	"github.com/microsoft/agent-framework-go/tool"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/azure"
+)
+
+var (
+	endpoint   = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	apiVersion = cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+	deployment = cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+)
+
+var logger = demo.NewLogger(
+	"Additional AI Context",
+	"Demonstrates how to use context providers to inject todo-list and calendar context.",
+	"Model", deployment,
+)
+
+func main() {
+	// Get Azure token credential for authentication with Azure OpenAI.
+	token := demo.AzureTokenCredential()
+
+	// Create Azure OpenAI agent with multiple context providers.
+	a := openaiagent.NewChatCompletions(
+		openai.NewClient(
+			azure.WithEndpoint(endpoint, apiVersion),
+			azure.WithTokenCredential(token),
+		),
+		openaiagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: `You are a helpful personal assistant.
+You manage a TODO list for the user. When the user has completed one of the tasks it can be removed from the TODO list. Only provide the list of TODO items if asked.
+You remind users of upcoming calendar events when the user interacts with you.`,
+				Name:            "PersonalAssistant",
+				HistoryProvider: newChatHistoryProvider(),
+				ContextProviders: []*agent.ContextProvider{
+					newTodoListContextProvider(),
+					newCalendarSearchContextProvider(loadNextThreeCalendarEvents),
+				},
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
+			},
+		},
+	)
+
+	ctx := context.Background()
+
+	// Invoke the agent and output the text result.
+	session, err := a.CreateSession(ctx)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	prompts := []string{
+		"I need to pick up milk from the supermarket.",
+		"I need to take Sally for soccer practice.",
+		"I need to make a dentist appointment for Jimmy.",
+		"I've taken Sally to soccer practice.",
+	}
+	for _, prompt := range prompts {
+		resp, err := a.RunText(ctx, prompt, agent.WithSession(session)).Collect()
+		demo.Response(resp, err)
+	}
+
+	// Serialize the session. It contains the chat history plus state serialized by the context providers.
+	serializedSession, err := a.MarshalSession(ctx, session)
+	if err != nil {
+		demo.Panic(err)
+	}
+	var prettySession bytes.Buffer
+	if err := json.Indent(&prettySession, serializedSession, "", "  "); err != nil {
+		demo.Panic(err)
+	}
+	fmt.Println(prettySession.String())
+
+	// The serialized session can be stored long term in a persistent store. Here we deserialize it and continue.
+	session, err = a.UnmarshalSession(ctx, serializedSession)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	resp, err := a.RunText(ctx, "Considering my appointments, can you create a plan for my day that plans out when I should complete the items on my todo list?", agent.WithSession(session)).Collect()
+	demo.Response(resp, err)
+}
+
+func loadNextThreeCalendarEvents(context.Context) ([]string, error) {
+	// In a real implementation, this function would connect to a calendar service.
+	return []string{
+		"Doctor's appointment today at 15:00",
+		"Team meeting today at 17:00",
+		"Birthday party today at 20:00",
+	}, nil
+}
+
+const (
+	chatHistorySourceID    = "chat_history"
+	todoListSourceID       = "todo_list"
+	calendarSearchSourceID = "calendar_search"
+)
+
+func newChatHistoryProvider() *agent.HistoryProvider {
+	historyProvider := agent.NewInMemoryHistoryProvider(chatHistorySourceID)
+	// Use StoreRequestFilter to provide a custom filter for request messages stored in chat history.
+	// By default, the history provider stores request messages that did not come from chat history.
+	// In this case, we explicitly exclude messages from chat history and AI context providers.
+	// You may want to store these messages, depending on their content and your requirements.
+	historyProvider.StoreRequestFilter = messagefilter.NotSources(
+		chatHistorySourceID,
+		todoListSourceID,
+		calendarSearchSourceID,
+	)
+	return historyProvider
+}
+
+type todoListState struct {
+	Items []string `json:"items,omitempty"`
+}
+
+type addTodoItemArgs struct {
+	Item string `json:"item"`
+}
+
+type removeTodoItemArgs struct {
+	Index int `json:"index"`
+}
+
+func newTodoListContextProvider() *agent.ContextProvider {
+	return &agent.ContextProvider{
+		SourceID: todoListSourceID,
+		Provide:  provideTodoListContext,
+	}
+}
+
+func getTodoListState(session agent.Session) todoListState {
+	if session == nil {
+		return todoListState{}
+	}
+	var state todoListState
+	_, _ = session.Get(todoListSourceID, &state)
+	return state
+}
+
+func setTodoListState(session agent.Session, state todoListState) {
+	if session != nil {
+		session.Set(todoListSourceID, state)
+	}
+}
+
+func provideTodoListContext(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+	session, _ := agent.GetOption(options, agent.WithSession)
+	state := getTodoListState(session)
+
+	var output strings.Builder
+	output.WriteString("Your todo list contains the following items:\n")
+	if len(state.Items) == 0 {
+		output.WriteString("  (no items)\n")
+	} else {
+		for i, item := range state.Items {
+			_, _ = fmt.Fprintf(&output, "%d. %s\n", i, item)
+		}
+	}
+
+	addTodoItemTool := functool.MustNew(functool.Config{
+		Name:        "AddTodoItem",
+		Description: "Adds an item to the todo list.",
+	}, func(_ tool.Context, args addTodoItemArgs) (string, error) {
+		if strings.TrimSpace(args.Item) == "" {
+			return "", fmt.Errorf("item must have a value")
+		}
+		state := getTodoListState(session)
+		state.Items = append(state.Items, args.Item)
+		setTodoListState(session, state)
+		return fmt.Sprintf("Added todo item: %s", args.Item), nil
+	})
+	removeTodoItemTool := functool.MustNew(functool.Config{
+		Name:        "RemoveTodoItem",
+		Description: "Removes an item from the todo list. Index is zero based.",
+	}, func(_ tool.Context, args removeTodoItemArgs) (string, error) {
+		state := getTodoListState(session)
+		if args.Index < 0 || args.Index >= len(state.Items) {
+			return "", fmt.Errorf("todo item index %d is out of range", args.Index)
+		}
+		removed := state.Items[args.Index]
+		state.Items = append(state.Items[:args.Index], state.Items[args.Index+1:]...)
+		setTodoListState(session, state)
+		return fmt.Sprintf("Removed todo item: %s", removed), nil
+	})
+
+	messages = append(messages, &message.Message{
+		Role: message.RoleUser,
+		Contents: []message.Content{
+			&message.TextContent{Text: output.String()},
+		},
+	})
+	options = append(options, agent.WithTool(addTodoItemTool), agent.WithTool(removeTodoItemTool))
+	return messages, options, nil
+}
+
+func newCalendarSearchContextProvider(loadNextThreeCalendarEvents func(context.Context) ([]string, error)) *agent.ContextProvider {
+	return &agent.ContextProvider{
+		SourceID: calendarSearchSourceID,
+		Provide: func(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+			events, err := loadNextThreeCalendarEvents(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			var output strings.Builder
+			output.WriteString("You have the following upcoming calendar events:\n")
+			for _, calendarEvent := range events {
+				_, _ = fmt.Fprintf(&output, " - %s\n", calendarEvent)
+			}
+
+			messages = append(messages, &message.Message{
+				Role: message.RoleUser,
+				Contents: []message.Content{
+					&message.TextContent{Text: output.String()},
+				},
+			})
+			return messages, options, nil
+		},
+	}
+}

--- a/examples/02-agents/agents/step18_compaction_pipeline/main.go
+++ b/examples/02-agents/agents/step18_compaction_pipeline/main.go
@@ -104,7 +104,6 @@ Help the user look up prices and compare products.
 When responding, be extra descriptive and use as many words as possible without sounding ridiculous.`,
 				Name: "ShoppingAssistant",
 				ContextProviders: []*agent.ContextProvider{
-					agent.NewInMemoryHistoryProvider(""),
 					compaction.NewContextProvider(compaction.ContextProviderConfig{
 						Strategy: compactionPipeline,
 						Logger:   slog.New(logger),

--- a/examples/02-agents/agents/step18_compaction_pipeline/main.go
+++ b/examples/02-agents/agents/step18_compaction_pipeline/main.go
@@ -98,10 +98,10 @@ func main() {
 		client,
 		openaiagent.Config{
 			Model: deployment,
-			Config: agent.Config{
-				Instructions: `You are a helpful, but long-winded, shopping assistant.
+			Instructions: `You are a helpful, but long-winded, shopping assistant.
 Help the user look up prices and compare products.
 When responding, be extra descriptive and use as many words as possible without sounding ridiculous.`,
+			Config: agent.Config{
 				Name: "ShoppingAssistant",
 				ContextProviders: []*agent.ContextProvider{
 					compaction.NewContextProvider(compaction.ContextProviderConfig{

--- a/examples/02-agents/agui/step01_getting_started/server/main.go
+++ b/examples/02-agents/agui/step01_getting_started/server/main.go
@@ -32,10 +32,10 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant.",
 			Config: agent.Config{
-				Name:         "AGUIAssistant",
-				Instructions: "You are a helpful assistant.",
+				Name: "AGUIAssistant",
 			},
 		},
 	)

--- a/examples/02-agents/agui/step02_backend_tools/server/main.go
+++ b/examples/02-agents/agui/step02_backend_tools/server/main.go
@@ -71,11 +71,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant with access to restaurant information.",
 			Config: agent.Config{
-				Name:         "AGUIAssistant",
-				Instructions: "You are a helpful assistant with access to restaurant information.",
-				Tools:        []tool.Tool{searchRestaurants},
+				Name:  "AGUIAssistant",
+				Tools: []tool.Tool{searchRestaurants},
 			},
 		},
 	)

--- a/examples/02-agents/agui/step03_frontend_tools/server/main.go
+++ b/examples/02-agents/agui/step03_frontend_tools/server/main.go
@@ -32,10 +32,10 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant.",
 			Config: agent.Config{
 				Name:                "AGUIAssistant",
-				Instructions:        "You are a helpful assistant.",
 				DisableFuncAutoCall: true,
 			},
 		},

--- a/examples/02-agents/agui/step04_human_in_loop/server/main.go
+++ b/examples/02-agents/agui/step04_human_in_loop/server/main.go
@@ -42,11 +42,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant in charge of approving expenses.",
 			Config: agent.Config{
-				Name:         "AGUIAssistant",
-				Instructions: "You are a helpful assistant in charge of approving expenses.",
-				Tools:        []tool.Tool{tool.ApprovalRequiredFunc(approveExpense)},
+				Name:  "AGUIAssistant",
+				Tools: []tool.Tool{tool.ApprovalRequiredFunc(approveExpense)},
 			},
 		},
 	)

--- a/examples/02-agents/agui/step05_state_management/server/main.go
+++ b/examples/02-agents/agui/step05_state_management/server/main.go
@@ -72,21 +72,21 @@ func main() {
 		),
 		openaiagent.Config{
 			Model: deployment,
-			Config: agent.Config{
-				Name: "RecipeAgent",
-				Instructions: `You are a helpful recipe assistant. When users ask for recipes, respond with a JSON object in this shape:
+			Instructions: `You are a helpful recipe assistant. When users ask for recipes, respond with a JSON object in this shape:
 {
-  "recipe": {
-    "title": "...",
-    "cuisine": "...",
-    "ingredients": ["..."],
-    "steps": ["..."],
-    "prep_time_minutes": 10,
-    "cook_time_minutes": 20,
-    "skill_level": "beginner"
-  }
+	"recipe": {
+		"title": "...",
+		"cuisine": "...",
+		"ingredients": ["..."],
+		"steps": ["..."],
+		"prep_time_minutes": 10,
+		"cook_time_minutes": 20,
+		"skill_level": "beginner"
+	}
 }
 Then also provide a concise summary in one sentence.`,
+			Config: agent.Config{
+				Name:        "RecipeAgent",
 				Middlewares: []agent.Middleware{stateSnapshotMiddleware},
 			},
 		},

--- a/examples/02-agents/mcp/agent_mcp_server/main.go
+++ b/examples/02-agents/mcp/agent_mcp_server/main.go
@@ -41,12 +41,12 @@ func main() {
 	a := openaiagent.NewChatCompletions(
 		openai.NewClient(),
 		openaiagent.Config{
-			Model: "gpt-4o-mini",
+			Model:        "gpt-4o-mini",
+			Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
 			Config: agent.Config{
-				Name:         "DocsAgent",
-				Instructions: "You are a helpful assistant that can help with microsoft documentation questions.",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
-				Tools:        tools,
+				Name:        "DocsAgent",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
+				Tools:       tools,
 			},
 		},
 	)

--- a/examples/02-agents/providers/a2a/main.go
+++ b/examples/02-agents/providers/a2a/main.go
@@ -47,9 +47,8 @@ func main() {
 		client,
 		a2aagent.Config{
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/providers/anthrophic/main.go
+++ b/examples/02-agents/providers/anthrophic/main.go
@@ -22,11 +22,11 @@ func main() {
 	a := anthropicagent.New(
 		anthropic.NewClient(),
 		anthropicagent.Config{
-			Model: "claude-sonnet-4-5",
+			Model:        "claude-sonnet-4-5",
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/providers/azure/main.go
+++ b/examples/02-agents/providers/azure/main.go
@@ -38,11 +38,11 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/providers/gemini/main.go
+++ b/examples/02-agents/providers/gemini/main.go
@@ -38,11 +38,11 @@ func main() {
 	a := geminiagent.New(
 		client,
 		geminiagent.Config{
-			Model: model,
+			Model:        model,
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/providers/openai/main.go
+++ b/examples/02-agents/providers/openai/main.go
@@ -22,11 +22,11 @@ func main() {
 	a := openaiagent.NewChatCompletions(
 		openai.NewClient(),
 		openaiagent.Config{
-			Model: "gpt-4o-mini",
+			Model:        "gpt-4o-mini",
+			Instructions: "You are good at telling jokes.",
 			Config: agent.Config{
-				Instructions: "You are good at telling jokes.",
-				Name:         "Joker",
-				Middlewares:  []agent.Middleware{logger}, // for logging agent interactions
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
 			},
 		},
 	)

--- a/examples/02-agents/skills/step01_file_based_skills/main.go
+++ b/examples/02-agents/skills/step01_file_based_skills/main.go
@@ -54,10 +54,10 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant that can convert units.",
 			Config: agent.Config{
 				Name:             "UnitConverterAgent",
-				Instructions:     "You are a helpful assistant that can convert units.",
 				Middlewares:      []agent.Middleware{logger},
 				ContextProviders: []*agent.ContextProvider{skillsProvider},
 			},

--- a/examples/02-agents/skills/step02_code_defined_skills/main.go
+++ b/examples/02-agents/skills/step02_code_defined_skills/main.go
@@ -106,10 +106,10 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant that can convert units.",
 			Config: agent.Config{
 				Name:             "UnitConverterAgent",
-				Instructions:     "You are a helpful assistant that can convert units.",
 				Middlewares:      []agent.Middleware{logger},
 				ContextProviders: []*agent.ContextProvider{skillsProvider},
 			},

--- a/examples/02-agents/skills/step03_mixed_skills/main.go
+++ b/examples/02-agents/skills/step03_mixed_skills/main.go
@@ -179,10 +179,10 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You are a helpful assistant that can convert units, volumes, and temperatures.",
 			Config: agent.Config{
 				Name:             "MultiConverterAgent",
-				Instructions:     "You are a helpful assistant that can convert units, volumes, and temperatures.",
 				Middlewares:      []agent.Middleware{logger},
 				ContextProviders: []*agent.ContextProvider{skillsProvider},
 			},

--- a/examples/03-workflows/_start-here/02_agents_in_workflows/main.go
+++ b/examples/03-workflows/_start-here/02_agents_in_workflows/main.go
@@ -79,11 +79,11 @@ func newTranslationAgent(language string) *agent.Agent {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: fmt.Sprintf("Translate the user's text to %s. Return only the translation.", language),
 			Config: agent.Config{
-				Name:         language,
-				Instructions: fmt.Sprintf("Translate the user's text to %s. Return only the translation.", language),
-				Middlewares:  []agent.Middleware{logger},
+				Name:        language,
+				Middlewares: []agent.Middleware{logger},
 			},
 		},
 	)

--- a/examples/03-workflows/_start-here/03_agent_workflow_patterns/main.go
+++ b/examples/03-workflows/_start-here/03_agent_workflow_patterns/main.go
@@ -92,11 +92,11 @@ func newTranslationAgent(language string) *agent.Agent {
 			azure.WithTokenCredential(token),
 		),
 		openaichatagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: fmt.Sprintf("Translate the user's text to %s. Return only the translation.", language),
 			Config: agent.Config{
-				Name:         language,
-				Instructions: fmt.Sprintf("Translate the user's text to %s. Return only the translation.", language),
-				Middlewares:  []agent.Middleware{logger},
+				Name:        language,
+				Middlewares: []agent.Middleware{logger},
 			},
 		},
 	)

--- a/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_client/main.go
@@ -71,12 +71,12 @@ func main() {
 			azure.WithTokenCredential(token),
 		),
 		openaiagent.Config{
-			Model: deployment,
+			Model:        deployment,
+			Instructions: "You specialize in handling user queries and using your tools to provide answers.",
 			Config: agent.Config{
-				Name:         "HostClient",
-				Instructions: "You specialize in handling user queries and using your tools to provide answers.",
-				Middlewares:  []agent.Middleware{logger},
-				Tools:        tools,
+				Name:        "HostClient",
+				Middlewares: []agent.Middleware{logger},
+				Tools:       tools,
 			},
 		},
 	)

--- a/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
+++ b/examples/05-end-to-end/a2a_client_server/a2a_server/main.go
@@ -162,10 +162,10 @@ func buildAgent(agentType, model string) (openaiagent.Config, *a2a.AgentCard) {
 			return q.QueryByInvoiceID(invoiceID), nil
 		})
 
+		cfg.Instructions = "You specialize in handling queries related to invoices."
 		cfg.Config = agent.Config{
-			Name:         "InvoiceAgent",
-			Description:  "Handles requests relating to invoices.",
-			Instructions: "You specialize in handling queries related to invoices.",
+			Name:        "InvoiceAgent",
+			Description: "Handles requests relating to invoices.",
 			Tools: []tool.Tool{
 				queryInvoices,
 				queryByTransactionID,
@@ -182,10 +182,7 @@ func buildAgent(agentType, model string) (openaiagent.Config, *a2a.AgentCard) {
 			Examples:    []string{"List the latest invoices for Contoso."},
 		}}
 	case "POLICY":
-		cfg.Config = agent.Config{
-			Name:        "PolicyAgent",
-			Description: "Handles requests relating to policies and customer communications.",
-			Instructions: `You specialize in handling queries related to policies and customer communications.
+		cfg.Instructions = `You specialize in handling queries related to policies and customer communications.
 
 Always reply with exactly this text:
 
@@ -196,7 +193,10 @@ Summary: "For short shipments reported by customers, first verify internal shipm
 shows fewer items packed than invoiced, issue a credit for the missing items. Document the
 resolution in SAP CRM and notify the customer via email within 2 business days, referencing the
 original invoice and the credit memo number. Use the 'Formal Credit Notification' email
-template."`,
+template."`
+		cfg.Config = agent.Config{
+			Name:        "PolicyAgent",
+			Description: "Handles requests relating to policies and customer communications.",
 		}
 		card.Name = "PolicyAgent"
 		card.Description = cfg.Description
@@ -208,16 +208,16 @@ template."`,
 			Examples:    []string{"What is the policy for short shipments?"},
 		}}
 	case "LOGISTICS":
-		cfg.Config = agent.Config{
-			Name:        "LogisticsAgent",
-			Description: "Handles requests relating to logistics.",
-			Instructions: `You specialize in handling queries related to logistics.
+		cfg.Instructions = `You specialize in handling queries related to logistics.
 
 Always reply with exactly:
 
 Shipment number: SHPMT-SAP-001
 Item: TSHIRT-RED-L
-Quantity: 900`,
+Quantity: 900`
+		cfg.Config = agent.Config{
+			Name:        "LogisticsAgent",
+			Description: "Handles requests relating to logistics.",
 		}
 		card.Name = "LogisticsAgent"
 		card.Description = cfg.Description

--- a/examples/demos/chat_cli/main.go
+++ b/examples/demos/chat_cli/main.go
@@ -25,10 +25,10 @@ func main() {
 	a := openaiagent.NewChatCompletions(
 		openai.NewClient(),
 		openaiagent.Config{
-			Model: "gpt-4o-mini",
+			Model:        "gpt-4o-mini",
+			Instructions: "You are a helpful assistant with access to weather information. Be concise and friendly.",
 			Config: agent.Config{
-				Instructions: "You are a helpful assistant with access to weather information. Be concise and friendly.",
-				Tools:        []tool.Tool{weatherTool},
+				Tools: []tool.Tool{weatherTool},
 			},
 		},
 	)

--- a/internal/agenttest/continuation.go
+++ b/internal/agenttest/continuation.go
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package agenttest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+const ContinuationTokenType = "agentContinuationToken"
+
+type ContinuationToken struct {
+	Type            string                  `json:"type"`
+	InnerToken      string                  `json:"innerToken"`
+	InputMessages   []*message.Message      `json:"inputMessages,omitempty"`
+	ResponseUpdates []*agent.ResponseUpdate `json:"responseUpdates,omitempty"`
+}
+
+func NewContinuationToken(t testing.TB, innerToken string) string {
+	t.Helper()
+	return EncodeContinuationToken(t, ContinuationToken{
+		Type:       ContinuationTokenType,
+		InnerToken: innerToken,
+	})
+}
+
+func DecodeContinuationToken(t testing.TB, token string) ContinuationToken {
+	t.Helper()
+	var out ContinuationToken
+	if err := json.Unmarshal([]byte(token), &out); err != nil {
+		t.Fatalf("failed to unmarshal continuation token: %v", err)
+	}
+	return out
+}
+
+func EncodeContinuationToken(t testing.TB, token ContinuationToken) string {
+	t.Helper()
+	data, err := json.Marshal(token)
+	if err != nil {
+		t.Fatalf("failed to marshal continuation token: %v", err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary

Adds explicit agent history handling and aligns the agent run lifecycle with the .NET model:

- Introduces `HistoryProvider` with a default in-memory provider for local sessions.
- Keeps context providers separate from core middleware while preserving the public `agent/middleware/contextprovider` adapter.
- Moves instructions out of base `agent.Config` and into provider configs / `agent.WithInstructions` run options.
- Adds configurable history-provider conflict behavior using inline zero-value-friendly config flags.
- Adds agent-owned continuation token wrapping for background/streaming resumptions, including saved input messages and response updates for interrupted streams.
- Rejects raw provider continuation tokens at the agent boundary; providers only see the unwrapped inner token.
- Updates providers, tests, examples, and shared test helpers for the new history/instruction/continuation behavior.

## Validation

- `go test ./...`