### PR TITLE
Port .NET skill and workflow fixes

### DIFF
--- a/agent/hosting/workflowhosting/workflow.go
+++ b/agent/hosting/workflowhosting/workflow.go
@@ -463,8 +463,14 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 		}
 	}
 
-	if err := wctx.SendMessage("", resp.Messages); err != nil {
-		return err
+	// Filter out server-side artifacts (reasoning tokens, web search calls, etc.)
+	// that are internal to this agent. Forwarding them to other agents in the
+	// workflow can cause invalid request errors when the receiving agent uses an
+	// API that does not accept those output-only item types as input.
+	if forwardableMessages := filterForwardableMessages(resp.Messages); len(forwardableMessages) > 0 {
+		if err := wctx.SendMessage("", forwardableMessages); err != nil {
+			return err
+		}
 	}
 
 	if err := h.dispatchRequests(wctx, resp.Messages); err != nil {
@@ -489,6 +495,51 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 		}
 	}
 	return nil
+}
+
+// filterForwardableMessages filters response messages to only include portable
+// conversational content, and strips Message.RawRepresentation so
+// provider-specific output items (for example mcp_list_tools, reasoning, or
+// web_search_call payloads) are not round-tripped as input to another agent.
+func filterForwardableMessages(messages []*message.Message) []*message.Message {
+	result := make([]*message.Message, 0, len(messages))
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		contents := filterForwardableContents(msg.Contents)
+		if len(contents) == 0 {
+			continue
+		}
+		clone := msg.Clone()
+		clone.RawRepresentation = nil
+		clone.Contents = contents
+		result = append(result, clone)
+	}
+	return result
+}
+
+// filterForwardableContents keeps content types that represent meaningful
+// conversational content portable across agents. Messages containing only
+// content types outside this set, such as reasoning tokens or usage metadata,
+// are dropped before forwarding.
+func filterForwardableContents(contents message.Contents) message.Contents {
+	result := make(message.Contents, 0, len(contents))
+	for _, content := range contents {
+		switch content.(type) {
+		case *message.TextContent,
+			*message.DataContent,
+			*message.URIContent,
+			*message.FunctionCallContent,
+			*message.FunctionResultContent,
+			*message.FunctionApprovalRequestContent,
+			*message.FunctionApprovalResponseContent,
+			*message.HostedFileContent,
+			*message.ErrorContent:
+			result = append(result, content)
+		}
+	}
+	return result
 }
 
 // dispatchRequests scans the agent's response for request content and

--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -149,6 +149,78 @@ func newRoleCheckAgent() *agent.Agent {
 	)
 }
 
+func newContentAgent(updates ...*agent.ResponseUpdate) *agent.Agent {
+	run := func(ctx context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			for _, update := range updates {
+				if !yield(update, nil) {
+					return
+				}
+			}
+		}
+	}
+	return agent.New(
+		agent.ProviderConfig{ProviderName: "content", Run: run},
+		agent.Config{ID: testAgentID, Name: testAgentName, DisableFuncAutoCall: true},
+	)
+}
+
+func collectForwardedResponseMessages(t *testing.T, a *agent.Agent, cfg workflowhosting.Config) []*message.Message {
+	t.Helper()
+	var observed []*message.Message
+	sinkID := "sink"
+	sink := &workflow.ExecutorBinding{
+		ID:           sinkID,
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+	}
+	sink.NewExecutor = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: sinkID,
+			Options: workflow.ExecutorOptions{
+				DisableAutoSendMessageHandlerResultObject: true,
+				DisableAutoYieldOutputHandlerResultObject: true,
+			},
+			Config: []*workflow.ExecutorConfig{{
+				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
+					return rb.AddHandler(reflect.TypeFor[[]*message.Message](), nil, false, func(_ *workflow.Context, msg any) (any, error) {
+						observed = append(observed, msg.([]*message.Message)...)
+						return nil, nil
+					}), nil
+				},
+			}},
+		}, nil
+	}
+
+	hostCfg := cfg
+	hostCfg.DisableMessageForwarding = true
+	binding := workflowhosting.New(a, hostCfg)
+	wf, err := workflow.NewBuilder(binding).
+		AddEdge(binding, sink).
+		Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	ctx := context.Background()
+	stream, err := inproc.Default.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.CancelRun() }()
+
+	sendStreamMessage(t, stream, ctx, []*message.Message{{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: "go"}},
+	}})
+	sendStreamMessage(t, stream, ctx, workflow.TurnToken{})
+	for _, err := range stream.WatchUntilHalt(ctx) {
+		if err != nil {
+			t.Fatalf("watch: %v", err)
+		}
+	}
+	return observed
+}
+
 // runHostedAgent builds a single-node workflow hosting the agent under cfg,
 // drives it with the given input messages and a TurnToken, and returns the
 // collected workflow events.
@@ -470,6 +542,135 @@ func TestHostedAgent_ForwardsIncomingMessages(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHostedAgent_FiltersNonPortableContentFromForwardedResponseMessages(t *testing.T) {
+	agent := newContentAgent(
+		&agent.ResponseUpdate{
+			Role:              message.RoleAssistant,
+			MessageID:         "text-message",
+			RawRepresentation: "provider-text",
+			Contents: message.Contents{
+				&message.TextContent{Text: "Useful response text"},
+			},
+		},
+		&agent.ResponseUpdate{
+			Role:              message.RoleAssistant,
+			MessageID:         "reasoning-message",
+			RawRepresentation: "provider-reasoning",
+			Contents: message.Contents{
+				&message.TextReasoningContent{Text: "internal reasoning"},
+			},
+		},
+		&agent.ResponseUpdate{
+			Role:              message.RoleAssistant,
+			MessageID:         "usage-message",
+			RawRepresentation: "provider-usage",
+			Contents: message.Contents{
+				&message.UsageContent{Details: message.UsageDetails{TotalTokenCount: 10}},
+			},
+		},
+	)
+
+	forwarded := collectForwardedResponseMessages(t, agent, workflowhosting.Config{})
+	if len(forwarded) != 1 {
+		t.Fatalf("expected 1 forwarded message, got %d", len(forwarded))
+	}
+	if forwarded[0].ID != "text-message" {
+		t.Fatalf("expected text-message to be forwarded, got %q", forwarded[0].ID)
+	}
+	if len(forwarded[0].Contents) != 1 {
+		t.Fatalf("expected 1 forwarded content item, got %d", len(forwarded[0].Contents))
+	}
+	text, ok := forwarded[0].Contents[0].(*message.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", forwarded[0].Contents[0])
+	}
+	if text.Text != "Useful response text" {
+		t.Fatalf("unexpected forwarded text: %q", text.Text)
+	}
+}
+
+func TestHostedAgent_StripsRawRepresentationFromForwardedResponseMessages(t *testing.T) {
+	text := &message.TextContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: "content-raw"},
+		Text:          "Response",
+	}
+	agent := newContentAgent(&agent.ResponseUpdate{
+		Role:              message.RoleAssistant,
+		MessageID:         "raw-message",
+		RawRepresentation: "message-raw",
+		Contents:          message.Contents{text},
+	})
+
+	forwarded := collectForwardedResponseMessages(t, agent, workflowhosting.Config{})
+	if len(forwarded) != 1 {
+		t.Fatalf("expected 1 forwarded message, got %d", len(forwarded))
+	}
+	if forwarded[0].RawRepresentation != nil {
+		t.Fatalf("expected forwarded message RawRepresentation to be nil, got %#v", forwarded[0].RawRepresentation)
+	}
+	if forwarded[0].AuthorName != testAgentName {
+		t.Fatalf("expected AuthorName %q, got %q", testAgentName, forwarded[0].AuthorName)
+	}
+	forwardedText := forwarded[0].Contents[0].(*message.TextContent)
+	if forwardedText.RawRepresentation != "content-raw" {
+		t.Fatalf("expected content RawRepresentation to be preserved, got %#v", forwardedText.RawRepresentation)
+	}
+}
+
+func TestHostedAgent_PreservesForwardableContentInMixedForwardedResponseMessages(t *testing.T) {
+	agent := newContentAgent(&agent.ResponseUpdate{
+		Role:              message.RoleAssistant,
+		MessageID:         "mixed-message",
+		RawRepresentation: "mixed-raw",
+		Contents: message.Contents{
+			&message.TextContent{Text: "Visible text"},
+			&message.TextReasoningContent{Text: "Hidden reasoning"},
+			&message.FunctionCallContent{CallID: "call-1", Name: "my_function", Arguments: `{"arg":"val"}`},
+		},
+	})
+
+	forwarded := collectForwardedResponseMessages(t, agent, workflowhosting.Config{})
+	if len(forwarded) != 1 {
+		t.Fatalf("expected 1 forwarded message, got %d", len(forwarded))
+	}
+	if len(forwarded[0].Contents) != 2 {
+		t.Fatalf("expected 2 forwarded content items, got %d", len(forwarded[0].Contents))
+	}
+	if _, ok := forwarded[0].Contents[0].(*message.TextContent); !ok {
+		t.Fatalf("expected first content to be TextContent, got %T", forwarded[0].Contents[0])
+	}
+	if _, ok := forwarded[0].Contents[1].(*message.FunctionCallContent); !ok {
+		t.Fatalf("expected second content to be FunctionCallContent, got %T", forwarded[0].Contents[1])
+	}
+	if forwarded[0].RawRepresentation != nil {
+		t.Fatalf("expected forwarded message RawRepresentation to be nil, got %#v", forwarded[0].RawRepresentation)
+	}
+}
+
+func TestHostedAgent_DropsResponseMessagesWithOnlyNonPortableContent(t *testing.T) {
+	agent := newContentAgent(
+		&agent.ResponseUpdate{
+			Role:      message.RoleAssistant,
+			MessageID: "reasoning-message",
+			Contents: message.Contents{
+				&message.TextReasoningContent{Text: "reasoning only"},
+			},
+		},
+		&agent.ResponseUpdate{
+			Role:      message.RoleAssistant,
+			MessageID: "vector-store-message",
+			Contents: message.Contents{
+				&message.HostedVectorStoreContent{VectorStoreID: "vs-1"},
+			},
+		},
+	)
+
+	forwarded := collectForwardedResponseMessages(t, agent, workflowhosting.Config{})
+	if len(forwarded) != 0 {
+		t.Fatalf("expected no forwarded messages, got %d", len(forwarded))
 	}
 }
 

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -352,19 +352,35 @@ func parseYamlScalarValue(yamlContent string, kv []int) string {
 	if scalarStyle == '|' {
 		parsedValue = strings.Join(normalizedLines, "\n")
 	} else {
-		foldedLines := normalizedLines[:0]
-		for _, line := range normalizedLines {
-			if line != "" {
-				foldedLines = append(foldedLines, line)
-			}
-		}
-		parsedValue = strings.Join(foldedLines, " ")
+		parsedValue = foldYamlLines(normalizedLines)
 	}
 
 	if keepTrailingNewline {
 		return parsedValue + "\n"
 	}
 	return parsedValue
+}
+
+func foldYamlLines(lines []string) string {
+	var builder strings.Builder
+	blankLines := 0
+	for _, line := range lines {
+		if line == "" {
+			blankLines++
+			continue
+		}
+
+		if builder.Len() > 0 {
+			if blankLines > 0 {
+				builder.WriteString(strings.Repeat("\n", blankLines))
+			} else {
+				builder.WriteByte(' ')
+			}
+		}
+		builder.WriteString(line)
+		blankLines = 0
+	}
+	return builder.String()
 }
 
 func leadingWhitespaceCount(line string) int {

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -237,12 +237,15 @@ func (s *Source) tryParseFrontmatter(content, skillFilePath string) (skills.Fron
 	yamlContent := strings.TrimSpace(contentForParsing[match[2]:match[3]])
 	frontmatter := skills.Frontmatter{}
 
-	for _, kv := range yamlKeyValueRegex.FindAllStringSubmatch(yamlContent, -1) {
-		value := kv[2]
-		if value == "" {
-			value = kv[3]
+	for _, kv := range yamlKeyValueRegex.FindAllStringSubmatchIndex(yamlContent, -1) {
+		key := yamlContent[kv[2]:kv[3]]
+		value := ""
+		if kv[4] >= 0 {
+			value = yamlContent[kv[4]:kv[5]]
+		} else if kv[6] >= 0 {
+			value = parseYamlScalarValue(yamlContent, kv)
 		}
-		switch strings.ToLower(kv[1]) {
+		switch strings.ToLower(key) {
 		case "name":
 			frontmatter.Name = value
 		case "description":
@@ -284,6 +287,92 @@ func (s *Source) tryParseFrontmatter(content, skillFilePath string) (skills.Fron
 	}
 
 	return frontmatter, true
+}
+
+func parseYamlScalarValue(yamlContent string, kv []int) string {
+	value := yamlContent[kv[6]:kv[7]]
+	if value == "" || (value[0] != '|' && value[0] != '>') {
+		return value
+	}
+
+	scalarStyle := value[0]
+	keepTrailingNewline := len(value) > 1 && value[1] == '+'
+	lineBreak := strings.IndexByte(yamlContent[kv[1]:], '\n')
+	if lineBreak < 0 {
+		return value
+	}
+
+	remaining := yamlContent[kv[1]+lineBreak+1:]
+	if strings.HasSuffix(remaining, "\n") {
+		remaining = strings.TrimSuffix(remaining, "\n")
+	}
+
+	var blockLines []string
+	for _, line := range strings.Split(remaining, "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			blockLines = append(blockLines, "")
+			continue
+		}
+		if line[0] != ' ' && line[0] != '\t' {
+			break
+		}
+		blockLines = append(blockLines, line)
+	}
+
+	if len(blockLines) == 0 {
+		return ""
+	}
+
+	commonIndent := -1
+	for _, line := range blockLines {
+		if line == "" {
+			continue
+		}
+		indent := leadingWhitespaceCount(line)
+		if commonIndent < 0 || indent < commonIndent {
+			commonIndent = indent
+		}
+	}
+	if commonIndent < 0 {
+		commonIndent = 0
+	}
+
+	normalizedLines := make([]string, len(blockLines))
+	for i, line := range blockLines {
+		if line == "" {
+			continue
+		}
+		if commonIndent < len(line) {
+			normalizedLines[i] = line[commonIndent:]
+		}
+	}
+
+	var parsedValue string
+	if scalarStyle == '|' {
+		parsedValue = strings.Join(normalizedLines, "\n")
+	} else {
+		foldedLines := normalizedLines[:0]
+		for _, line := range normalizedLines {
+			if line != "" {
+				foldedLines = append(foldedLines, line)
+			}
+		}
+		parsedValue = strings.Join(foldedLines, " ")
+	}
+
+	if keepTrailingNewline {
+		return parsedValue + "\n"
+	}
+	return parsedValue
+}
+
+func leadingWhitespaceCount(line string) int {
+	count := 0
+	for count < len(line) && (line[count] == ' ' || line[count] == '\t') {
+		count++
+	}
+	return count
 }
 
 func (s *Source) discoverResourceFiles(skillFS fs.FS, skillName string) []skills.Resource {

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -303,12 +303,12 @@ func parseYamlScalarValue(yamlContent string, kv []int) string {
 	}
 
 	remaining := yamlContent[kv[1]+lineBreak+1:]
-	if strings.HasSuffix(remaining, "\n") {
-		remaining = strings.TrimSuffix(remaining, "\n")
+	if before, ok := strings.CutSuffix(remaining, "\n"); ok {
+		remaining = before
 	}
 
 	var blockLines []string
-	for _, line := range strings.Split(remaining, "\n") {
+	for line := range strings.SplitSeq(remaining, "\n") {
 		line = strings.TrimSuffix(line, "\r")
 		if strings.TrimSpace(line) == "" {
 			blockLines = append(blockLines, "")

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -181,6 +181,33 @@ func TestFileSource_FoldedScalarDescription_ParsesMultilineValue(t *testing.T) {
 	}
 }
 
+func TestFileSource_FoldedScalarDescription_PreservesParagraphBreaks(t *testing.T) {
+	root := t.TempDir()
+	createSkillDirRaw(t, root, "folded-paragraph-skill", strings.Join([]string{
+		"---",
+		"name: folded-paragraph-skill",
+		"description: >",
+		"  First paragraph line one",
+		"  line two",
+		"",
+		"  Second paragraph.",
+		"---",
+		"Body text.",
+	}, "\n"))
+	source := fsskills.NewSource(os.DirFS(root))
+
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(loaded))
+	}
+	if loaded[0].Frontmatter.Description != "First paragraph line one line two\nSecond paragraph." {
+		t.Fatalf("unexpected description: %q", loaded[0].Frontmatter.Description)
+	}
+}
+
 func TestFileSource_ScalarDescriptionWithChompingIndicator_ParsesValue(t *testing.T) {
 	tests := []struct {
 		indicator string

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -131,6 +131,106 @@ func TestFileSource_MetadataWithQuotedValues_ParsedCorrectly(t *testing.T) {
 	}
 }
 
+func TestFileSource_BlockScalarDescription_ParsesMultilineValue(t *testing.T) {
+	root := t.TempDir()
+	createSkillDirRaw(t, root, "block-scalar-skill", strings.Join([]string{
+		"---",
+		"name: block-scalar-skill",
+		"description: |",
+		"  This is a multiline",
+		"  description for the skill.",
+		"---",
+		"Body text.",
+	}, "\n"))
+	source := fsskills.NewSource(os.DirFS(root))
+
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(loaded))
+	}
+	if loaded[0].Frontmatter.Description != "This is a multiline\ndescription for the skill." {
+		t.Fatalf("unexpected description: %q", loaded[0].Frontmatter.Description)
+	}
+}
+
+func TestFileSource_FoldedScalarDescription_ParsesMultilineValue(t *testing.T) {
+	root := t.TempDir()
+	createSkillDirRaw(t, root, "folded-scalar-skill", strings.Join([]string{
+		"---",
+		"name: folded-scalar-skill",
+		"description: >",
+		"  This is a multiline",
+		"  description for the skill.",
+		"---",
+		"Body text.",
+	}, "\n"))
+	source := fsskills.NewSource(os.DirFS(root))
+
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(loaded))
+	}
+	if loaded[0].Frontmatter.Description != "This is a multiline description for the skill." {
+		t.Fatalf("unexpected description: %q", loaded[0].Frontmatter.Description)
+	}
+}
+
+func TestFileSource_ScalarDescriptionWithChompingIndicator_ParsesValue(t *testing.T) {
+	tests := []struct {
+		indicator string
+		expected  string
+	}{
+		{indicator: "|-", expected: "This is a multiline\ndescription for the skill."},
+		{indicator: "|+", expected: "This is a multiline\ndescription for the skill.\n"},
+		{indicator: ">-", expected: "This is a multiline description for the skill."},
+		{indicator: ">+", expected: "This is a multiline description for the skill.\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.indicator, func(t *testing.T) {
+			root := t.TempDir()
+			chomping := "strip"
+			if tt.indicator[1] == '+' {
+				chomping = "keep"
+			}
+			skillName := "chomping-scalar-skill-"
+			if tt.indicator[0] == '|' {
+				skillName += "literal-"
+			} else {
+				skillName += "folded-"
+			}
+			skillName += chomping
+			createSkillDirRaw(t, root, skillName, strings.Join([]string{
+				"---",
+				"name: " + skillName,
+				"description: " + tt.indicator,
+				"  This is a multiline",
+				"  description for the skill.",
+				"---",
+				"Body text.",
+			}, "\n"))
+			source := fsskills.NewSource(os.DirFS(root))
+
+			loaded, err := source.Skills(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(loaded) != 1 {
+				t.Fatalf("expected 1 skill, got %d", len(loaded))
+			}
+			if loaded[0].Frontmatter.Description != tt.expected {
+				t.Fatalf("unexpected description: %q", loaded[0].Frontmatter.Description)
+			}
+		})
+	}
+}
+
 func TestFileSource_ParsesOptionalFrontmatterFields(t *testing.T) {
 	root := t.TempDir()
 	createSkillDirRaw(t, root, "meta-skill", strings.Join([]string{


### PR DESCRIPTION
## Summary
- Port microsoft/agent-framework#5610: parse YAML block scalar values in file skill frontmatter.
- Port microsoft/agent-framework#5410: filter hosted-agent response messages before forwarding them through workflows.
- Strip message-level raw provider representations while preserving portable content and content-level raw data.

## Validation
- go test ./agent/skills/fsskills
- go test ./agent/skills
- go test ./agent/hosting/workflowhosting -run 'TestHostedAgent_(FiltersNonPortableContentFromForwardedResponseMessages|StripsRawRepresentationFromForwardedResponseMessages|PreservesForwardableContentInMixedForwardedResponseMessages|DropsResponseMessagesWithOnlyNonPortableContent)$' -count=1 -timeout=30s -v
- go test ./agent/hosting/workflowhosting -count=1 -timeout=60s