### PR TITLE
Stabilize hosted agent streaming update test

### DIFF
--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -223,7 +223,8 @@ func collectForwardedResponseMessages(t *testing.T, a *agent.Agent, cfg workflow
 
 // runHostedAgent builds a single-node workflow hosting the agent under cfg,
 // drives it with the given input messages and a TurnToken, and returns the
-// collected workflow events.
+// collected workflow events. Lockstep execution keeps these host-behavior
+// assertions independent of off-thread scheduling.
 func runHostedAgent(t *testing.T, a *agent.Agent, cfg workflowhosting.Config, token workflow.TurnToken, msgs []*message.Message) []workflow.Event {
 	t.Helper()
 	binding := workflowhosting.New(a, cfg)
@@ -233,7 +234,7 @@ func runHostedAgent(t *testing.T, a *agent.Agent, cfg workflowhosting.Config, to
 	}
 
 	ctx := context.Background()
-	stream, err := inproc.Default.RunStreaming(ctx, wf, nil)
+	stream, err := inproc.Lockstep.RunStreaming(ctx, wf, nil)
 	if err != nil {
 		t.Fatalf("Stream: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Run the hosted-agent behavior helper with the lockstep in-process environment
- Keep the streaming update emission matrix independent of off-thread scheduling

## Validation
- go test ./agent/hosting/workflowhosting -run TestHostedAgent_EmitsStreamingUpdatesIfConfigured -count=200
- go test ./agent/hosting/workflowhosting -count=50
- git diff --check -- agent/hosting/workflowhosting/workflow_test.go