### PR TITLE
[dotnet-port] Port string[] arguments for file-based skill scripts

### DIFF
--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -531,15 +531,12 @@ func validateExtensions(extensions []string) {
 func newScript(name string, fsys fs.FS, runner skills.ScriptRunner) skills.Script {
 	return skills.Script{
 		Name: name,
-		Run: func(ctx context.Context, owner *skills.Skill, arguments map[string]any) (any, error) {
+		Run: func(ctx context.Context, owner *skills.Skill, arguments []string) (any, error) {
 			if _, err := FSFromSkill(owner); err != nil {
 				return nil, fmt.Errorf("file-based script %q requires a skill with a backing fs.FS: %w", name, err)
 			}
 			if runner == nil {
 				return nil, fmt.Errorf("script %q cannot be executed because no file script runner was provided", name)
-			}
-			if arguments == nil {
-				arguments = map[string]any{}
 			}
 			script := &skills.Script{Name: name}
 			return runner(ctx, owner, script, arguments)

--- a/agent/skills/fsskills/source_script_test.go
+++ b/agent/skills/fsskills/source_script_test.go
@@ -17,7 +17,7 @@ func TestFileSource_WithScriptFiles_DiscoversScripts(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "my-skill", "A test skill", "Body.")
 	createRelativeFile(t, filepath.Join(root, "my-skill"), "scripts/convert.py", "print('hello')")
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 		return nil, nil
 	}}, os.DirFS(root))
 
@@ -41,7 +41,7 @@ func TestFileSource_WithMultipleScriptExtensions_DiscoversAll(t *testing.T) {
 	for _, fileName := range []string{"scripts/run.py", "scripts/run.sh", "scripts/run.js", "scripts/run.ps1", "scripts/run.cs", "scripts/run.csx"} {
 		createRelativeFile(t, skillDir, fileName, "echo")
 	}
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 		return nil, nil
 	}}, os.DirFS(root))
 
@@ -81,7 +81,7 @@ func TestFileSource_NonScriptExtensionsAreNotDiscovered(t *testing.T) {
 	createRelativeFile(t, skillDir, "scripts/data.txt", "text data")
 	createRelativeFile(t, skillDir, "scripts/config.json", "{}")
 	createRelativeFile(t, skillDir, "scripts/notes.md", "# Notes")
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 		return nil, nil
 	}}, os.DirFS(root))
 
@@ -114,7 +114,7 @@ func TestFileSource_ScriptsOutsideScriptsDir_AreNotDiscovered(t *testing.T) {
 	skillDir := filepath.Join(root, "root-scripts")
 	createRelativeFile(t, skillDir, "convert.py", "print('root')")
 	createRelativeFile(t, skillDir, "tools/helper.sh", "echo 'helper'")
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 		return nil, nil
 	}}, os.DirFS(root))
 
@@ -132,7 +132,7 @@ func TestFileSource_WithRunner_ScriptsCanRun(t *testing.T) {
 	createSkillDir(t, root, "exec-skill", "Executor test", "Body.")
 	createRelativeFile(t, filepath.Join(root, "exec-skill"), "scripts/test.py", "print('ok')")
 	executorCalled := false
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(_ context.Context, skill *skills.Skill, script *skills.Script, arguments map[string]any) (any, error) {
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(_ context.Context, skill *skills.Skill, script *skills.Script, arguments []string) (any, error) {
 		executorCalled = true
 		if skill.Frontmatter.Name != "exec-skill" {
 			t.Fatalf("expected exec-skill, got %q", skill.Frontmatter.Name)
@@ -147,7 +147,7 @@ func TestFileSource_WithRunner_ScriptsCanRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := loaded[0].Scripts[0].Run(t.Context(), loaded[0], map[string]any{})
+	result, err := loaded[0].Scripts[0].Run(t.Context(), loaded[0], nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestFileSource_ScriptsWithNoRunner_ReturnsErrorOnRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = loaded[0].Scripts[0].Run(t.Context(), loaded[0], map[string]any{})
+	_, err = loaded[0].Scripts[0].Run(t.Context(), loaded[0], nil)
 	if err == nil {
 		t.Fatal("expected script run to fail without a runner")
 	}
@@ -187,7 +187,7 @@ func TestFileSource_CustomScriptExtensions_OnlyDiscoversMatching(t *testing.T) {
 	createRelativeFile(t, skillDir, "scripts/run.rb", "puts 'rb'")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
 		AllowedScriptExtensions: []string{".rb"},
-		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
 	}, os.DirFS(root))
@@ -209,8 +209,8 @@ func TestFileSource_ExecutorReceivesArguments(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "args-skill", "Args test", "Body.")
 	createRelativeFile(t, filepath.Join(root, "args-skill"), "scripts/test.py", "print('ok')")
-	var captured map[string]any
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(_ context.Context, _ *skills.Skill, _ *skills.Script, arguments map[string]any) (any, error) {
+	var captured []string
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(_ context.Context, _ *skills.Skill, _ *skills.Script, arguments []string) (any, error) {
 		captured = arguments
 		return "done", nil
 	}}, os.DirFS(root))
@@ -219,11 +219,11 @@ func TestFileSource_ExecutorReceivesArguments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	arguments := map[string]any{"value": 26.2, "factor": 1.60934}
+	arguments := []string{"--value", "26.2", "--factor", "1.60934"}
 	if _, err := loaded[0].Scripts[0].Run(t.Context(), loaded[0], arguments); err != nil {
 		t.Fatal(err)
 	}
-	if captured == nil || captured["value"] != 26.2 || captured["factor"] != 1.60934 {
+	if len(captured) != 4 || captured[0] != "--value" || captured[1] != "26.2" || captured[2] != "--factor" || captured[3] != "1.60934" {
 		t.Fatalf("unexpected captured arguments: %#v", captured)
 	}
 }
@@ -234,7 +234,7 @@ func TestFileSource_ScriptDirectoriesWithNestedPath_DiscoversScripts(t *testing.
 	createRelativeFile(t, filepath.Join(root, "nested-script-skill"), "f1/f2/f3/run.py", "print('nested')")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
 		ScriptDirectories: []string{"f1/f2/f3"},
-		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
 	}, os.DirFS(root))
@@ -262,7 +262,7 @@ func TestFileSource_ScriptDirectoryWithDotSlashPrefix_DiscoversScripts(t *testin
 	}
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
 		ScriptDirectories: directories,
-		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
 	}, os.DirFS(root))
@@ -305,7 +305,7 @@ func TestFileSource_ScriptInSkillRoot_DiscoveredWhenRootDirectoryConfigured(t *t
 	createRelativeFile(t, filepath.Join(root, "root-script-skill"), "run.py", "print('hello')")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
 		ScriptDirectories: []string{"."},
-		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
 	}, os.DirFS(root))
@@ -329,7 +329,7 @@ func TestFileSource_BackslashDirectoryNormalized_NoDuplicateScripts(t *testing.T
 	createRelativeFile(t, filepath.Join(root, "backslash-skill"), "scripts/run.py", "print('hello')")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
 		ScriptDirectories: []string{"scripts", ".\\scripts"},
-		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
 	}, os.DirFS(root))
@@ -350,7 +350,7 @@ func TestFileScript_RunWithNonFileSkill_ReturnsError(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "script-owner", "Script owner", "Body.")
 	createRelativeFile(t, filepath.Join(root, "script-owner"), "scripts/run.py", "print('ok')")
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 		return "result", nil
 	}}, os.DirFS(root))
 
@@ -362,7 +362,7 @@ func TestFileScript_RunWithNonFileSkill_ReturnsError(t *testing.T) {
 		Frontmatter: skills.Frontmatter{Name: "my-skill", Description: "A skill"},
 		Content:     "Instructions.",
 	}
-	_, err = loaded[0].Scripts[0].Run(t.Context(), nonFileSkill, map[string]any{})
+	_, err = loaded[0].Scripts[0].Run(t.Context(), nonFileSkill, nil)
 	if err == nil {
 		t.Fatal("expected file script to reject non-file skill owner")
 	}

--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -400,9 +400,9 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 			Description: "Runs a script associated with a skill.",
 		},
 		func(callCtx tool.Context, in struct {
-			SkillName  string         `json:"skillName" jsonschema:"The name of the skill"`
-			ScriptName string         `json:"scriptName" jsonschema:"The exact script name to run"`
-			Arguments  map[string]any `json:"arguments,omitempty" jsonschema:"Optional arguments for the script"`
+			SkillName  string   `json:"skillName" jsonschema:"The name of the skill"`
+			ScriptName string   `json:"scriptName" jsonschema:"The exact script name to run"`
+			Arguments  []string `json:"arguments,omitempty" jsonschema:"Positional CLI-style string arguments for the script, e.g. [\"--value\",\"26.2\",\"--factor\",\"1.60934\"]"`
 		},
 		) (any, error) {
 			return p.runSkillScript(callCtx.Context, skills, in.SkillName, in.ScriptName, in.Arguments), nil
@@ -454,7 +454,7 @@ func (p *providerState) readSkillResource(ctx context.Context, skills providedSk
 	return content
 }
 
-func (p *providerState) runSkillScript(ctx context.Context, skills providedSkillSet, skillName, scriptName string, arguments map[string]any) any {
+func (p *providerState) runSkillScript(ctx context.Context, skills providedSkillSet, skillName, scriptName string, arguments []string) any {
 	if strings.TrimSpace(skillName) == "" {
 		return "Error: Skill name cannot be empty."
 	}

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -103,7 +103,7 @@ func TestProvider_FromFileSourceWithOptions_DiscoversSkills(t *testing.T) {
 	createSkillDir(t, root, "opts-skill", "Options skill", "Options body.")
 	provider := providerFromFileSource(
 		fsskills.NewSourceOptions(fsskills.SourceOptions{
-			ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+			ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 				return nil, nil
 			},
 		}, os.DirFS(root)),
@@ -122,7 +122,7 @@ func TestProvider_FromFileSourceWithMultipleFileSystems_DiscoversMultipleSkills(
 	createSkillDir(t, filepath.Join(root, "multi-opts-2"), "skill-y", "Skill Y", "Body Y.")
 	provider := providerFromFileSource(
 		fsskills.NewSourceOptions(fsskills.SourceOptions{
-			ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+			ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 				return nil, nil
 			},
 		}, os.DirFS(filepath.Join(root, "multi-opts-1")), os.DirFS(filepath.Join(root, "multi-opts-2"))),
@@ -139,7 +139,7 @@ func TestProvider_WithScriptsNoScriptApproval_DoesNotWrapRunScriptTool(t *testin
 	root := t.TempDir()
 	createSkillDir(t, root, "no-approval-skill", "No approval test", "Body.")
 	createRelativeFile(t, filepath.Join(root, "no-approval-skill"), "scripts/run.py", "print('hello')")
-	provider := newProviderWithConfig(t, &fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+	provider := newProviderWithConfig(t, &fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 		return "ok", nil
 	}}, nil, root)
 
@@ -355,7 +355,7 @@ func TestProvider_WithScripts_ExposesRunSkillScriptTool(t *testing.T) {
 
 	runnerCalled := false
 	provider := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ScriptRunner: func(_ context.Context, skill *skills.Skill, script *skills.Script, arguments map[string]any) (any, error) {
+		ScriptRunner: func(_ context.Context, skill *skills.Skill, script *skills.Script, arguments []string) (any, error) {
 			runnerCalled = true
 			if skill.Frontmatter.Name != "script-skill" {
 				t.Fatalf("expected script-skill, got %q", skill.Frontmatter.Name)
@@ -363,13 +363,13 @@ func TestProvider_WithScripts_ExposesRunSkillScriptTool(t *testing.T) {
 			if script.Name != "scripts/run.py" {
 				t.Fatalf("expected scripts/run.py, got %q", script.Name)
 			}
-			return map[string]any{"status": "ok", "value": arguments["value"]}, nil
+			return map[string]any{"status": "ok", "args": arguments}, nil
 		},
 	}, nil, root)
 
 	_, tools := captureProviderContext(t, provider)
 	runTool := findTool(t, tools, "run_skill_script")
-	result, err := runTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"script-skill","scriptName":"scripts/run.py","arguments":{"value":42}}`)
+	result, err := runTool.Call(tool.Context{Context: t.Context()}, `{"skillName":"script-skill","scriptName":"scripts/run.py","arguments":["--value","42"]}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,8 +380,9 @@ func TestProvider_WithScripts_ExposesRunSkillScriptTool(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected structured script result, got %T", result)
 	}
-	if resultMap["status"] != "ok" || resultMap["value"] != float64(42) {
-		t.Fatalf("expected structured script result, got %#v", resultMap)
+	args, ok := resultMap["args"].([]string)
+	if !ok || resultMap["status"] != "ok" || len(args) != 2 || args[0] != "--value" || args[1] != "42" {
+		t.Fatalf("expected structured script result with args, got %#v", resultMap)
 	}
 }
 
@@ -391,7 +392,7 @@ func TestProvider_RunSkillScript_RequiresExactName(t *testing.T) {
 	createRelativeFile(t, filepath.Join(root, "script-skill"), "scripts/run.py", "print('ok')")
 
 	provider := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ScriptRunner: func(_ context.Context, _ *skills.Skill, _ *skills.Script, _ map[string]any) (any, error) {
+		ScriptRunner: func(_ context.Context, _ *skills.Skill, _ *skills.Script, _ []string) (any, error) {
 			t.Fatal("did not expect script runner to be called")
 			return nil, nil
 		},
@@ -418,7 +419,7 @@ func TestProvider_ScriptApproval_MarksToolAsApprovalRequired(t *testing.T) {
 	createRelativeFile(t, filepath.Join(root, "approval-skill"), "scripts/run.py", "print('ok')")
 
 	provider := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return "ok", nil
 		},
 	}, &skills.ContextProviderOptions{ScriptApproval: true}, root)
@@ -438,7 +439,7 @@ func TestProvider_FromFileSourceWithRunner_UsesScriptRunner(t *testing.T) {
 	runnerCalled := false
 	provider := providerFromFileSource(
 		fsskills.NewSourceOptions(fsskills.SourceOptions{
-			ScriptRunner: func(_ context.Context, _ *skills.Skill, _ *skills.Script, _ map[string]any) (any, error) {
+			ScriptRunner: func(_ context.Context, _ *skills.Skill, _ *skills.Script, _ []string) (any, error) {
 				runnerCalled = true
 				return "executed", nil
 			},
@@ -533,7 +534,7 @@ func TestProvider_AggregatesMultipleSources(t *testing.T) {
 		Sources: []skills.Source{
 			fsskills.NewSourceOptions(fsskills.SourceOptions{
 				ScriptDirectories: []string{"unused-scripts"},
-				ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, map[string]any) (any, error) {
+				ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 					return "ok", nil
 				},
 			}, os.DirFS(fileRoot)),

--- a/agent/skills/skills.go
+++ b/agent/skills/skills.go
@@ -71,15 +71,24 @@ type Resource struct {
 }
 
 // Script is executable skill functionality that can be run on demand.
+//
+// Arguments passed to [Script.Run] are positional CLI-style string tokens, for
+// example ["--value", "26.2", "--factor", "1.60934"]. The LLM is instructed to
+// pass a JSON array of strings, and the run_skill_script tool forwards those
+// strings verbatim. Code-defined scripts may parse the strings however they
+// choose; file-based scripts pass them directly to the subprocess.
 type Script struct {
 	Name                 string
 	Description          string
-	Run                  func(context.Context, *Skill, map[string]any) (any, error)
+	Run                  func(context.Context, *Skill, []string) (any, error)
 	AdditionalProperties map[string]any
 }
 
 // ScriptRunner defines the function signature for running a script.
-type ScriptRunner func(context.Context, *Skill, *Script, map[string]any) (any, error)
+//
+// The args slice contains positional CLI-style string tokens as sent by the LLM
+// (for example ["--value", "26.2", "--factor", "1.60934"]).
+type ScriptRunner func(context.Context, *Skill, *Script, []string) (any, error)
 
 // validateName validates a skill name.
 func validateName(name string) error {

--- a/examples/02-agents/skills/internal/skillhelpers/inline.go
+++ b/examples/02-agents/skills/internal/skillhelpers/inline.go
@@ -3,58 +3,31 @@
 package skillhelpers
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
 )
 
-// NumberArg reads a numeric argument from a tool call argument map.
-func NumberArg(arguments map[string]any, name string) (float64, error) {
-	value, ok := arguments[name]
-	if !ok {
-		return 0, fmt.Errorf("missing argument %q", name)
+// NumberArg reads a numeric argument from a positional CLI-style string slice.
+// index is the position in the args slice.
+func NumberArg(args []string, index int) (float64, error) {
+	if index < 0 || index >= len(args) {
+		return 0, fmt.Errorf("missing positional argument at index %d (got %d args)", index, len(args))
 	}
-
-	switch typed := value.(type) {
-	case float64:
-		return typed, nil
-	case float32:
-		return float64(typed), nil
-	case int:
-		return float64(typed), nil
-	case int32:
-		return float64(typed), nil
-	case int64:
-		return float64(typed), nil
-	case json.Number:
-		return typed.Float64()
-	case string:
-		parsed, err := strconv.ParseFloat(typed, 64)
-		if err != nil {
-			return 0, fmt.Errorf("argument %q must be numeric: %w", name, err)
-		}
-		return parsed, nil
-	default:
-		return 0, fmt.Errorf("argument %q must be numeric, got %T", name, value)
+	parsed, err := strconv.ParseFloat(args[index], 64)
+	if err != nil {
+		return 0, fmt.Errorf("argument at index %d must be numeric: %w", index, err)
 	}
+	return parsed, nil
 }
 
-// StringArg reads a string argument from a tool call argument map.
-func StringArg(arguments map[string]any, name string) (string, error) {
-	value, ok := arguments[name]
-	if !ok {
-		return "", fmt.Errorf("missing argument %q", name)
+// StringArg reads a string argument from a positional CLI-style string slice.
+// index is the position in the args slice.
+func StringArg(args []string, index int) (string, error) {
+	if index < 0 || index >= len(args) {
+		return "", fmt.Errorf("missing positional argument at index %d (got %d args)", index, len(args))
 	}
-
-	switch typed := value.(type) {
-	case string:
-		return typed, nil
-	case fmt.Stringer:
-		return typed.String(), nil
-	default:
-		return "", fmt.Errorf("argument %q must be a string, got %T", name, value)
-	}
+	return args[index], nil
 }
 
 // Round rounds a float to the given number of decimal places.

--- a/examples/02-agents/skills/internal/skillhelpers/subprocess_script_runner.go
+++ b/examples/02-agents/skills/internal/skillhelpers/subprocess_script_runner.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/microsoft/agent-framework-go/agent/skills"
@@ -18,7 +17,11 @@ import (
 const rootFSPropertyKey = "fsskills.rootFS"
 
 // RunSubprocessScript materializes a file-backed skill to a temp directory and executes a script from it.
-func RunSubprocessScript(ctx context.Context, skill *skills.Skill, script *skills.Script, arguments map[string]any) (any, error) {
+//
+// The args slice contains positional CLI-style string tokens exactly as sent by the LLM
+// (for example ["--value", "26.2", "--factor", "1.60934"]). They are passed verbatim
+// as subprocess arguments.
+func RunSubprocessScript(ctx context.Context, skill *skills.Skill, script *skills.Script, args []string) (any, error) {
 	tempDir, err := os.MkdirTemp("", "agent-framework-go-skill-")
 	if err != nil {
 		return nil, err
@@ -30,12 +33,12 @@ func RunSubprocessScript(ctx context.Context, skill *skills.Skill, script *skill
 	}
 
 	scriptPath := filepath.Join(tempDir, filepath.FromSlash(script.Name))
-	command, args, err := scriptCommand(scriptPath, arguments)
+	command, scriptArgs, err := scriptCommand(scriptPath, args)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := exec.CommandContext(ctx, command, scriptArgs...)
 	cmd.Dir = tempDir
 	output, err := cmd.CombinedOutput()
 	text := strings.TrimSpace(string(output))
@@ -87,45 +90,18 @@ func materializeSkill(skill *skills.Skill, destination string) error {
 	})
 }
 
-func scriptCommand(scriptPath string, arguments map[string]any) (string, []string, error) {
+func scriptCommand(scriptPath string, args []string) (string, []string, error) {
 	ext := strings.ToLower(filepath.Ext(scriptPath))
-	flags := buildCLIFlags(arguments)
 	switch ext {
 	case ".py":
-		return "python", append([]string{scriptPath}, flags...), nil
+		return "python", append([]string{scriptPath}, args...), nil
 	case ".js":
-		return "node", append([]string{scriptPath}, flags...), nil
+		return "node", append([]string{scriptPath}, args...), nil
 	case ".sh":
-		return "bash", append([]string{scriptPath}, flags...), nil
+		return "bash", append([]string{scriptPath}, args...), nil
 	case ".ps1":
-		return "pwsh", append([]string{scriptPath}, flags...), nil
+		return "pwsh", append([]string{scriptPath}, args...), nil
 	default:
 		return "", nil, fmt.Errorf("unsupported script type %q", ext)
 	}
-}
-
-func buildCLIFlags(arguments map[string]any) []string {
-	if len(arguments) == 0 {
-		return nil
-	}
-
-	keys := make([]string, 0, len(arguments))
-	for key := range arguments {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	flags := make([]string, 0, len(arguments)*2)
-	for _, key := range keys {
-		flag := "--" + strings.TrimLeft(key, "-")
-		value := arguments[key]
-		if boolean, ok := value.(bool); ok {
-			if boolean {
-				flags = append(flags, flag)
-			}
-			continue
-		}
-		flags = append(flags, flag, fmt.Sprint(value))
-	}
-	return flags
 }

--- a/examples/02-agents/skills/step02_code_defined_skills/main.go
+++ b/examples/02-agents/skills/step02_code_defined_skills/main.go
@@ -25,7 +25,7 @@ const unitConverterInstructions = `Use this skill when the user asks to convert 
 
 1. Review the conversion-table resource to find the factor for the requested conversion.
 2. Check the conversion-policy resource for rounding and formatting rules.
-3. Use the convert script, passing the value and factor from the table.`
+3. Use the convert script, passing the value and factor as two positional arguments: ["<value>", "<factor>"].`
 
 const conversionTable = `# Conversion Tables
 
@@ -67,13 +67,13 @@ var unitConverterSkill = &skills.Skill{
 	Scripts: []skills.Script{
 		{
 			Name:        "convert",
-			Description: "Multiplies a value by a conversion factor and returns the result as JSON.",
-			Run: func(_ context.Context, _ *skills.Skill, arguments map[string]any) (any, error) {
-				value, err := skillhelpers.NumberArg(arguments, "value")
+			Description: "Multiplies a value by a conversion factor and returns the result as JSON. Pass value and factor as two positional string arguments: [\"<value>\", \"<factor>\"].",
+			Run: func(_ context.Context, _ *skills.Skill, args []string) (any, error) {
+				value, err := skillhelpers.NumberArg(args, 0)
 				if err != nil {
 					return nil, err
 				}
-				factor, err := skillhelpers.NumberArg(arguments, "factor")
+				factor, err := skillhelpers.NumberArg(args, 1)
 				if err != nil {
 					return nil, err
 				}

--- a/examples/02-agents/skills/step03_mixed_skills/main.go
+++ b/examples/02-agents/skills/step03_mixed_skills/main.go
@@ -25,7 +25,7 @@ import (
 const volumeConverterInstructions = `Use this skill when the user asks to convert between gallons and liters.
 
 1. Review the volume-conversion-table resource to find the correct factor.
-2. Use the convert-volume script, passing the value and factor.
+2. Use the convert-volume script, passing the value and factor as positional arguments: ["<value>", "<factor>"].
 3. Present the result clearly with both units.`
 
 const volumeConversionTable = `# Volume Conversion Table
@@ -40,7 +40,7 @@ Formula: **result = value * factor**
 const temperatureConverterInstructions = `Use this skill when the user asks to convert temperatures.
 
 1. Review the temperature-conversion-formulas resource for the correct formula.
-2. Use the convert-temperature script, passing the value, source scale, and target scale.
+2. Use the convert-temperature script, passing value, source scale, and target scale as positional arguments: ["<value>", "<from>", "<to>"].
 3. Present the result clearly with both temperature scales.`
 
 const temperatureConversionFormulas = `# Temperature Conversion Formulas
@@ -70,13 +70,13 @@ var volumeConverterSkill = &skills.Skill{
 	Scripts: []skills.Script{
 		{
 			Name:        "convert-volume",
-			Description: "Multiplies a value by a conversion factor and returns the result as JSON.",
-			Run: func(_ context.Context, _ *skills.Skill, arguments map[string]any) (any, error) {
-				value, err := skillhelpers.NumberArg(arguments, "value")
+			Description: "Multiplies a value by a conversion factor and returns the result as JSON. Pass value and factor as two positional string arguments: [\"<value>\", \"<factor>\"].",
+			Run: func(_ context.Context, _ *skills.Skill, args []string) (any, error) {
+				value, err := skillhelpers.NumberArg(args, 0)
 				if err != nil {
 					return nil, err
 				}
-				factor, err := skillhelpers.NumberArg(arguments, "factor")
+				factor, err := skillhelpers.NumberArg(args, 1)
 				if err != nil {
 					return nil, err
 				}
@@ -104,17 +104,17 @@ var temperatureConverterSkill = skills.Skill{
 	Scripts: []skills.Script{
 		{
 			Name:        "convert-temperature",
-			Description: "Converts a temperature value from one scale to another.",
-			Run: func(_ context.Context, _ *skills.Skill, arguments map[string]any) (any, error) {
-				value, err := skillhelpers.NumberArg(arguments, "value")
+			Description: "Converts a temperature value from one scale to another. Pass value, source scale, and target scale as three positional string arguments: [\"<value>\", \"<from>\", \"<to>\"].",
+			Run: func(_ context.Context, _ *skills.Skill, args []string) (any, error) {
+				value, err := skillhelpers.NumberArg(args, 0)
 				if err != nil {
 					return nil, err
 				}
-				from, err := skillhelpers.StringArg(arguments, "from")
+				from, err := skillhelpers.StringArg(args, 1)
 				if err != nil {
 					return nil, err
 				}
-				to, err := skillhelpers.StringArg(arguments, "to")
+				to, err := skillhelpers.StringArg(args, 2)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Aligns the Go SDK with the .NET breaking change in microsoft/agent-framework#5475.

Previously, skill scripts received arguments as map[string]any (a key-value dictionary). Now they receive arguments as []string (positional CLI-style string tokens), matching the .NET change that shifted the run_skill_script tool schema to {"type":"array","items":{"type":"string"}}.

Changes:
- skills.Script.Run: map[string]any -> []string
- skills.ScriptRunner: map[string]any -> []string
- provider.go: run_skill_script tool Arguments field []string; jsonschema updated
- fsskills/source.go: newScript closure updated; nil-map fallback removed
- Tests updated: source_script_test.go, provider_test.go
- Examples updated: skillhelpers/inline.go, subprocess_script_runner.go, step02_code_defined_skills/main.go, step03_mixed_skills/main.go