### PR TITLE
Add tool approval middleware for HITL parity

### DIFF
--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -288,6 +288,8 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 	return false
 }
 
+// canonicalizeArguments normalizes JSON argument strings for stable equality
+// matching by unmarshaling and remarshaling them into canonical JSON.
 func canonicalizeArguments(arguments string) string {
 	var v any
 	if err := json.Unmarshal([]byte(arguments), &v); err != nil {

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -24,8 +24,10 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-const stateKey = "toolApprovalState"
-const rawArgumentsKey = "$raw"
+const (
+	stateKey        = "toolApprovalState"
+	rawArgumentsKey = "$raw"
+)
 
 // Rule is a standing approval rule. If Arguments is empty, all invocations
 // of the named tool are auto-approved. Otherwise only invocations with an

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -1,0 +1,310 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// Package toolapproval provides middleware that manages human-in-the-loop
+// tool approval with support for "don't ask again" standing rules.
+//
+// When an inner agent returns tool calls that require approval, this
+// middleware surfaces approval requests one at a time to the caller. The
+// caller may approve or deny individual calls, and optionally indicate that
+// a tool (or a tool with specific arguments) should always be approved in
+// the future for the lifetime of the session.
+//
+// Standing approval rules and queued requests are persisted across turns
+// using the [agent.Session].
+package toolapproval
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"slices"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+const stateKey = "toolApprovalState"
+
+// Rule is a standing approval rule. If Arguments is empty, all invocations
+// of the named tool are auto-approved. Otherwise only invocations with an
+// exact argument match are auto-approved.
+type Rule struct {
+	ToolName  string `json:"toolName"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+// matches reports whether r auto-approves a call to toolName with the given
+// serialized arguments.
+func (r Rule) matches(toolName, arguments string) bool {
+	if r.ToolName != toolName {
+		return false
+	}
+	if r.Arguments == "" {
+		return true
+	}
+	return r.Arguments == arguments
+}
+
+// state is persisted in the session across turns.
+type state struct {
+	Rules              []Rule                                 `json:"rules,omitempty"`
+	CollectedResponses []*message.ToolApprovalResponseContent `json:"collectedResponses,omitempty"`
+	QueuedRequests     []*message.ToolApprovalRequestContent  `json:"queuedRequests,omitempty"`
+}
+
+func loadState(opts []agent.Option) state {
+	session, ok := agent.GetOption(opts, agent.WithSession)
+	if !ok {
+		return state{}
+	}
+	var s state
+	if found, _ := session.Get(stateKey, &s); found {
+		return s
+	}
+	return state{}
+}
+
+func saveState(opts []agent.Option, s state) {
+	session, ok := agent.GetOption(opts, agent.WithSession)
+	if !ok {
+		return
+	}
+	session.Set(stateKey, s)
+}
+
+// New creates a tool-approval middleware that wraps agent runs with
+// human-in-the-loop approval management.
+func New() agent.Middleware {
+	return agent.MiddlewareFunc(run)
+}
+
+func run(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+	return func(yield func(*agent.ResponseUpdate, error) bool) {
+		st := loadState(opts)
+
+		// Step 1: Process inbound approval responses from the caller.
+		messages, st = prepareInbound(messages, st)
+
+		// Step 2: If we have queued requests from a previous turn, drain any
+		// that are now auto-approvable and surface the next one.
+		drainAutoApprovable(&st)
+		if len(st.QueuedRequests) > 0 {
+			next := st.QueuedRequests[0]
+			st.QueuedRequests = st.QueuedRequests[1:]
+			saveState(opts, st)
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{next},
+			}, nil)
+			return
+		}
+
+		// Step 3: Main loop — call inner agent, classify approval requests.
+		for {
+			// Inject collected approval responses as user messages.
+			callMessages := messages
+			if len(st.CollectedResponses) > 0 {
+				injected := responseMessage(st.CollectedResponses)
+				callMessages = append(slices.Clone(messages), injected)
+				st.CollectedResponses = nil
+			}
+
+			var updates []*agent.ResponseUpdate
+			for update, err := range next(ctx, callMessages, opts...) {
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				updates = append(updates, update)
+			}
+
+			// Collect all approval request contents from the response.
+			var approvalRequests []*message.ToolApprovalRequestContent
+			for _, u := range updates {
+				for _, c := range u.Contents {
+					if req, ok := c.(*message.ToolApprovalRequestContent); ok {
+						approvalRequests = append(approvalRequests, req)
+					}
+				}
+			}
+
+			if len(approvalRequests) == 0 {
+				// No approval requests — yield all updates and return.
+				for _, u := range updates {
+					if !yield(u, nil) {
+						return
+					}
+				}
+				saveState(opts, st)
+				return
+			}
+
+			// Classify each approval request.
+			var autoApproved []*message.ToolApprovalResponseContent
+			var needsApproval []*message.ToolApprovalRequestContent
+			for _, req := range approvalRequests {
+				if matchesRule(st.Rules, req) {
+					autoApproved = append(autoApproved, req.CreateResponse(true, ""))
+				} else {
+					needsApproval = append(needsApproval, req)
+				}
+			}
+
+			if len(needsApproval) > 0 {
+				// Surface the first unapproved request, queue the rest.
+				first := needsApproval[0]
+				st.QueuedRequests = append(st.QueuedRequests, needsApproval[1:]...)
+				st.CollectedResponses = append(st.CollectedResponses, autoApproved...)
+
+				// Yield non-approval updates, then the first approval request.
+				for _, u := range updates {
+					stripped := stripApprovalContents(u)
+					if stripped != nil {
+						if !yield(stripped, nil) {
+							saveState(opts, st)
+							return
+						}
+					}
+				}
+				if !yield(&agent.ResponseUpdate{
+					Role:     message.RoleAssistant,
+					Contents: []message.Content{first},
+				}, nil) {
+					saveState(opts, st)
+					return
+				}
+				saveState(opts, st)
+				return
+			}
+
+			// All were auto-approved — collect responses and loop to call
+			// inner agent again with the approvals injected.
+			st.CollectedResponses = append(st.CollectedResponses, autoApproved...)
+			// Yield non-approval updates before looping.
+			for _, u := range updates {
+				stripped := stripApprovalContents(u)
+				if stripped != nil {
+					if !yield(stripped, nil) {
+						saveState(opts, st)
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+// prepareInbound processes caller messages, extracting approval responses
+// and any "always approve" flags into standing rules.
+func prepareInbound(messages []*message.Message, st state) ([]*message.Message, state) {
+	var cleaned []*message.Message
+	for i, msg := range messages {
+		var hasApproval bool
+		for _, c := range msg.Contents {
+			if resp, ok := c.(*message.ToolApprovalResponseContent); ok {
+				hasApproval = true
+				if fc, ok := resp.ToolCall.(*message.FunctionCallContent); ok && fc != nil {
+					if resp.AlwaysApproveTool {
+						st.Rules = append(st.Rules, Rule{ToolName: fc.Name})
+					} else if resp.AlwaysApproveToolWithArgs {
+						args, _ := json.Marshal(fc.Arguments)
+						st.Rules = append(st.Rules, Rule{
+							ToolName:  fc.Name,
+							Arguments: string(args),
+						})
+					}
+				}
+				st.CollectedResponses = append(st.CollectedResponses, resp)
+			}
+		}
+		if hasApproval {
+			if cleaned == nil {
+				cleaned = make([]*message.Message, 0, len(messages))
+				cleaned = append(cleaned, messages[:i]...)
+			}
+			// Strip approval contents from the message, keep the rest.
+			var remaining []message.Content
+			for _, c := range msg.Contents {
+				if _, ok := c.(*message.ToolApprovalResponseContent); !ok {
+					remaining = append(remaining, c)
+				}
+			}
+			if len(remaining) > 0 {
+				clone := msg.Clone()
+				clone.Contents = remaining
+				cleaned = append(cleaned, clone)
+			}
+		} else if cleaned != nil {
+			cleaned = append(cleaned, msg)
+		}
+	}
+	if cleaned != nil {
+		return cleaned, st
+	}
+	return messages, st
+}
+
+// drainAutoApprovable removes queued requests that now match a standing rule,
+// adding auto-approve responses to collected.
+func drainAutoApprovable(st *state) {
+	if len(st.QueuedRequests) == 0 || len(st.Rules) == 0 {
+		return
+	}
+	var remaining []*message.ToolApprovalRequestContent
+	for _, req := range st.QueuedRequests {
+		if matchesRule(st.Rules, req) {
+			st.CollectedResponses = append(st.CollectedResponses, req.CreateResponse(true, ""))
+		} else {
+			remaining = append(remaining, req)
+		}
+	}
+	st.QueuedRequests = remaining
+}
+
+func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
+	fc, ok := req.ToolCall.(*message.FunctionCallContent)
+	if !ok || fc == nil {
+		return false
+	}
+	args, _ := json.Marshal(fc.Arguments)
+	for _, r := range rules {
+		if r.matches(fc.Name, string(args)) {
+			return true
+		}
+	}
+	return false
+}
+
+func responseMessage(responses []*message.ToolApprovalResponseContent) *message.Message {
+	contents := make([]message.Content, len(responses))
+	for i, r := range responses {
+		contents[i] = r
+	}
+	return &message.Message{
+		Role:     message.RoleUser,
+		Contents: contents,
+	}
+}
+
+func stripApprovalContents(u *agent.ResponseUpdate) *agent.ResponseUpdate {
+	var stripped []message.Content
+	for i, c := range u.Contents {
+		if _, ok := c.(*message.ToolApprovalRequestContent); ok {
+			if stripped == nil {
+				stripped = make([]message.Content, 0, len(u.Contents))
+				stripped = append(stripped, u.Contents[:i]...)
+			}
+		} else if stripped != nil {
+			stripped = append(stripped, c)
+		}
+	}
+	if stripped != nil {
+		if len(stripped) == 0 {
+			return nil
+		}
+		clone := *u
+		clone.Contents = stripped
+		return &clone
+	}
+	return u
+}

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -75,7 +75,8 @@ func saveState(opts []agent.Option, s state) {
 
 // New creates a tool-approval middleware that wraps agent runs with
 // human-in-the-loop approval management.
-func New(_ Config) agent.Middleware {
+func New(cfg Config) agent.Middleware {
+	_ = cfg
 	return agent.MiddlewareFunc(run)
 }
 
@@ -268,7 +269,7 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 
 func serializeArguments(arguments string) map[string]string {
 	if strings.TrimSpace(arguments) == "" {
-		return nil
+		return map[string]string{"$raw": arguments}
 	}
 	var values map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(arguments), &values); err != nil {

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -27,7 +27,7 @@ const stateKey = "toolApprovalState"
 
 // Rule is a standing approval rule. If Arguments is empty, all invocations
 // of the named tool are auto-approved. Otherwise only invocations with an
-// exact argument match are auto-approved.
+// exact canonical argument match are auto-approved.
 type Rule struct {
 	ToolName  string `json:"toolName"`
 	Arguments string `json:"arguments,omitempty"`
@@ -201,19 +201,26 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 	for i, msg := range messages {
 		var hasApproval bool
 		for _, c := range msg.Contents {
-			if resp, ok := c.(*message.ToolApprovalResponseContent); ok {
+			switch resp := c.(type) {
+			case *message.AlwaysApproveToolApprovalResponseContent:
 				hasApproval = true
-				if fc, ok := resp.ToolCall.(*message.FunctionCallContent); ok && fc != nil {
-					if resp.AlwaysApproveTool {
-						st.Rules = append(st.Rules, Rule{ToolName: fc.Name})
-					} else if resp.AlwaysApproveToolWithArgs {
-						args, _ := json.Marshal(fc.Arguments)
-						st.Rules = append(st.Rules, Rule{
-							ToolName:  fc.Name,
-							Arguments: string(args),
-						})
+				if resp.InnerResponse != nil {
+					if fc, ok := resp.InnerResponse.ToolCall.(*message.FunctionCallContent); ok && fc != nil {
+						if resp.AlwaysApproveTool {
+							addRuleIfNotExists(&st, Rule{ToolName: fc.Name})
+						} else if resp.AlwaysApproveToolWithArguments {
+							addRuleIfNotExists(&st, Rule{
+								ToolName:  fc.Name,
+								Arguments: canonicalizeArguments(fc.Arguments),
+							})
+						}
 					}
 				}
+				if resp.InnerResponse != nil {
+					st.CollectedResponses = append(st.CollectedResponses, resp.InnerResponse)
+				}
+			case *message.ToolApprovalResponseContent:
+				hasApproval = true
 				st.CollectedResponses = append(st.CollectedResponses, resp)
 			}
 		}
@@ -225,7 +232,13 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 			// Strip approval contents from the message, keep the rest.
 			var remaining []message.Content
 			for _, c := range msg.Contents {
-				if _, ok := c.(*message.ToolApprovalResponseContent); !ok {
+				if _, ok := c.(*message.ToolApprovalResponseContent); ok {
+					continue
+				}
+				if _, ok := c.(*message.AlwaysApproveToolApprovalResponseContent); ok {
+					continue
+				}
+				if c != nil {
 					remaining = append(remaining, c)
 				}
 			}
@@ -266,13 +279,34 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 	if !ok || fc == nil {
 		return false
 	}
-	args, _ := json.Marshal(fc.Arguments)
+	args := canonicalizeArguments(fc.Arguments)
 	for _, r := range rules {
-		if r.matches(fc.Name, string(args)) {
+		if r.matches(fc.Name, args) {
 			return true
 		}
 	}
 	return false
+}
+
+func canonicalizeArguments(arguments string) string {
+	var v any
+	if err := json.Unmarshal([]byte(arguments), &v); err != nil {
+		return arguments
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return arguments
+	}
+	return string(b)
+}
+
+func addRuleIfNotExists(st *state, rule Rule) {
+	for _, existing := range st.Rules {
+		if existing.ToolName == rule.ToolName && existing.Arguments == rule.Arguments {
+			return
+		}
+	}
+	st.Rules = append(st.Rules, rule)
 }
 
 func responseMessage(responses []*message.ToolApprovalResponseContent) *message.Message {

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -27,7 +27,8 @@ const stateKey = "toolApprovalState"
 
 // Rule is a standing approval rule. If Arguments is empty, all invocations
 // of the named tool are auto-approved. Otherwise only invocations with an
-// exact canonical argument match are auto-approved.
+// exact canonical argument match are auto-approved, where canonical means JSON
+// normalized to a stable representation independent of object key ordering.
 type Rule struct {
 	ToolName  string `json:"toolName"`
 	Arguments string `json:"arguments,omitempty"`

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -16,6 +16,7 @@ package toolapproval
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"iter"
 	"slices"
 	"strings"
@@ -24,10 +25,7 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
-const (
-	stateKey        = "toolApprovalState"
-	rawArgumentsKey = "$raw"
-)
+const stateKey = "toolApprovalState"
 
 // Rule is a standing approval rule. If Arguments is empty, all invocations
 // of the named tool are auto-approved. Otherwise only invocations with an
@@ -192,9 +190,14 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 						if resp.AlwaysApproveTool {
 							addRuleIfNotExists(&st, Rule{ToolName: fc.Name})
 						} else if resp.AlwaysApproveToolWithArguments {
+							args, err := serializeArguments(fc.Arguments)
+							if err != nil {
+								// If we can't parse the arguments, skip adding a rule.
+								break
+							}
 							addRuleIfNotExists(&st, Rule{
 								ToolName:  fc.Name,
-								Arguments: serializeArguments(fc.Arguments),
+								Arguments: args,
 							})
 						}
 					}
@@ -262,7 +265,10 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 	if !ok || fc == nil {
 		return false
 	}
-	args := serializeArguments(fc.Arguments)
+	args, err := serializeArguments(fc.Arguments)
+	if err != nil {
+		return false
+	}
 	for _, r := range rules {
 		if r.matches(fc.Name, args) {
 			return true
@@ -271,34 +277,22 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 	return false
 }
 
-func serializeArguments(arguments string) map[string]string {
+func serializeArguments(arguments string) (map[string]string, error) {
 	if strings.TrimSpace(arguments) == "" {
-		return map[string]string{rawArgumentsKey: arguments}
+		return nil, nil
 	}
 	var values map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(arguments), &values); err != nil {
-		return map[string]string{rawArgumentsKey: arguments}
+		return nil, fmt.Errorf("failed to parse tool arguments: %w", err)
 	}
 	if len(values) == 0 {
-		return map[string]string{}
+		return map[string]string{}, nil
 	}
 	serialized := make(map[string]string, len(values))
-	for k, raw := range values {
-		serialized[k] = serializeArgumentValue(raw)
+	for k, v := range values {
+		serialized[k] = string(v)
 	}
-	return serialized
-}
-
-func serializeArgumentValue(raw json.RawMessage) string {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return string(raw)
-	}
-	b, err := json.Marshal(v)
-	if err != nil {
-		return string(raw)
-	}
-	return string(b)
+	return serialized, nil
 }
 
 func argumentMapsEqual(a, b map[string]string) bool {

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -25,6 +25,7 @@ import (
 )
 
 const stateKey = "toolApprovalState"
+const rawArgumentsKey = "$raw"
 
 // Rule is a standing approval rule. If Arguments is empty, all invocations
 // of the named tool are auto-approved. Otherwise only invocations with an
@@ -76,6 +77,7 @@ func saveState(opts []agent.Option, s state) {
 // New creates a tool-approval middleware that wraps agent runs with
 // human-in-the-loop approval management.
 func New(cfg Config) agent.Middleware {
+	// Config is currently empty and reserved for future extensibility.
 	_ = cfg
 	return agent.MiddlewareFunc(run)
 }
@@ -269,14 +271,14 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 
 func serializeArguments(arguments string) map[string]string {
 	if strings.TrimSpace(arguments) == "" {
-		return map[string]string{"$raw": arguments}
+		return map[string]string{rawArgumentsKey: arguments}
 	}
 	var values map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(arguments), &values); err != nil {
-		return map[string]string{"$raw": arguments}
+		return map[string]string{rawArgumentsKey: arguments}
 	}
 	if len(values) == 0 {
-		return nil
+		return map[string]string{}
 	}
 	serialized := make(map[string]string, len(values))
 	for k, raw := range values {

--- a/agent/middleware/toolapproval/toolapproval.go
+++ b/agent/middleware/toolapproval/toolapproval.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"iter"
 	"slices"
+	"strings"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/message"
@@ -27,23 +28,22 @@ const stateKey = "toolApprovalState"
 
 // Rule is a standing approval rule. If Arguments is empty, all invocations
 // of the named tool are auto-approved. Otherwise only invocations with an
-// exact canonical argument match are auto-approved, where canonical means JSON
-// normalized to a stable representation independent of object key ordering.
+// exact argument map match are auto-approved.
 type Rule struct {
-	ToolName  string `json:"toolName"`
-	Arguments string `json:"arguments,omitempty"`
+	ToolName  string            `json:"toolName"`
+	Arguments map[string]string `json:"arguments,omitempty"`
 }
 
 // matches reports whether r auto-approves a call to toolName with the given
 // serialized arguments.
-func (r Rule) matches(toolName, arguments string) bool {
+func (r Rule) matches(toolName string, arguments map[string]string) bool {
 	if r.ToolName != toolName {
 		return false
 	}
-	if r.Arguments == "" {
+	if len(r.Arguments) == 0 {
 		return true
 	}
-	return r.Arguments == arguments
+	return argumentMapsEqual(r.Arguments, arguments)
 }
 
 // state is persisted in the session across turns.
@@ -75,9 +75,12 @@ func saveState(opts []agent.Option, s state) {
 
 // New creates a tool-approval middleware that wraps agent runs with
 // human-in-the-loop approval management.
-func New() agent.Middleware {
+func New(_ Config) agent.Middleware {
 	return agent.MiddlewareFunc(run)
 }
+
+// Config configures tool-approval middleware behavior.
+type Config struct{}
 
 func run(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -110,32 +113,24 @@ func run(next agent.RunFunc, ctx context.Context, messages []*message.Message, o
 				st.CollectedResponses = nil
 			}
 
-			var updates []*agent.ResponseUpdate
+			var approvalRequests []*message.ToolApprovalRequestContent
 			for update, err := range next(ctx, callMessages, opts...) {
 				if err != nil {
 					yield(nil, err)
 					return
 				}
-				updates = append(updates, update)
-			}
-
-			// Collect all approval request contents from the response.
-			var approvalRequests []*message.ToolApprovalRequestContent
-			for _, u := range updates {
-				for _, c := range u.Contents {
-					if req, ok := c.(*message.ToolApprovalRequestContent); ok {
-						approvalRequests = append(approvalRequests, req)
+				stripped, requests := splitApprovalRequestContents(update)
+				approvalRequests = append(approvalRequests, requests...)
+				if stripped != nil {
+					if !yield(stripped, nil) {
+						saveState(opts, st)
+						return
 					}
 				}
 			}
 
 			if len(approvalRequests) == 0 {
-				// No approval requests — yield all updates and return.
-				for _, u := range updates {
-					if !yield(u, nil) {
-						return
-					}
-				}
+				// No approval requests — all streaming updates were already yielded.
 				saveState(opts, st)
 				return
 			}
@@ -157,16 +152,7 @@ func run(next agent.RunFunc, ctx context.Context, messages []*message.Message, o
 				st.QueuedRequests = append(st.QueuedRequests, needsApproval[1:]...)
 				st.CollectedResponses = append(st.CollectedResponses, autoApproved...)
 
-				// Yield non-approval updates, then the first approval request.
-				for _, u := range updates {
-					stripped := stripApprovalContents(u)
-					if stripped != nil {
-						if !yield(stripped, nil) {
-							saveState(opts, st)
-							return
-						}
-					}
-				}
+				// Non-approval updates were already yielded during streaming.
 				if !yield(&agent.ResponseUpdate{
 					Role:     message.RoleAssistant,
 					Contents: []message.Content{first},
@@ -181,16 +167,7 @@ func run(next agent.RunFunc, ctx context.Context, messages []*message.Message, o
 			// All were auto-approved — collect responses and loop to call
 			// inner agent again with the approvals injected.
 			st.CollectedResponses = append(st.CollectedResponses, autoApproved...)
-			// Yield non-approval updates before looping.
-			for _, u := range updates {
-				stripped := stripApprovalContents(u)
-				if stripped != nil {
-					if !yield(stripped, nil) {
-						saveState(opts, st)
-						return
-					}
-				}
-			}
+			// Non-approval updates were already yielded during streaming.
 		}
 	}
 }
@@ -212,7 +189,7 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 						} else if resp.AlwaysApproveToolWithArguments {
 							addRuleIfNotExists(&st, Rule{
 								ToolName:  fc.Name,
-								Arguments: canonicalizeArguments(fc.Arguments),
+								Arguments: serializeArguments(fc.Arguments),
 							})
 						}
 					}
@@ -280,7 +257,7 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 	if !ok || fc == nil {
 		return false
 	}
-	args := canonicalizeArguments(fc.Arguments)
+	args := serializeArguments(fc.Arguments)
 	for _, r := range rules {
 		if r.matches(fc.Name, args) {
 			return true
@@ -289,23 +266,51 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 	return false
 }
 
-// canonicalizeArguments normalizes JSON argument strings for stable equality
-// matching by unmarshaling and remarshaling them into canonical JSON.
-func canonicalizeArguments(arguments string) string {
+func serializeArguments(arguments string) map[string]string {
+	if strings.TrimSpace(arguments) == "" {
+		return nil
+	}
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(arguments), &values); err != nil {
+		return map[string]string{"$raw": arguments}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	serialized := make(map[string]string, len(values))
+	for k, raw := range values {
+		serialized[k] = serializeArgumentValue(raw)
+	}
+	return serialized
+}
+
+func serializeArgumentValue(raw json.RawMessage) string {
 	var v any
-	if err := json.Unmarshal([]byte(arguments), &v); err != nil {
-		return arguments
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
 	}
 	b, err := json.Marshal(v)
 	if err != nil {
-		return arguments
+		return string(raw)
 	}
 	return string(b)
 }
 
+func argumentMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		if bv, ok := b[k]; !ok || av != bv {
+			return false
+		}
+	}
+	return true
+}
+
 func addRuleIfNotExists(st *state, rule Rule) {
 	for _, existing := range st.Rules {
-		if existing.ToolName == rule.ToolName && existing.Arguments == rule.Arguments {
+		if existing.ToolName == rule.ToolName && argumentMapsEqual(existing.Arguments, rule.Arguments) {
 			return
 		}
 	}
@@ -323,25 +328,27 @@ func responseMessage(responses []*message.ToolApprovalResponseContent) *message.
 	}
 }
 
-func stripApprovalContents(u *agent.ResponseUpdate) *agent.ResponseUpdate {
+func splitApprovalRequestContents(u *agent.ResponseUpdate) (*agent.ResponseUpdate, []*message.ToolApprovalRequestContent) {
 	var stripped []message.Content
+	var requests []*message.ToolApprovalRequestContent
 	for i, c := range u.Contents {
-		if _, ok := c.(*message.ToolApprovalRequestContent); ok {
+		if req, ok := c.(*message.ToolApprovalRequestContent); ok {
 			if stripped == nil {
 				stripped = make([]message.Content, 0, len(u.Contents))
 				stripped = append(stripped, u.Contents[:i]...)
 			}
+			requests = append(requests, req)
 		} else if stripped != nil {
 			stripped = append(stripped, c)
 		}
 	}
 	if stripped != nil {
 		if len(stripped) == 0 {
-			return nil
+			return nil, requests
 		}
 		clone := *u
 		clone.Contents = stripped
-		return &clone
+		return &clone, requests
 	}
-	return u
+	return u, nil
 }

--- a/agent/middleware/toolapproval/toolapproval_test.go
+++ b/agent/middleware/toolapproval/toolapproval_test.go
@@ -95,7 +95,22 @@ func TestToolApproval_AlwaysApproveToolCreatesRule(t *testing.T) {
 					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc},
 				},
 			}).
-			NewTurn().
+			NewTurn(func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+				var sawResponse bool
+				for _, msg := range messages {
+					for _, c := range msg.Contents {
+						if _, ok := c.(*message.AlwaysApproveToolApprovalResponseContent); ok {
+							t.Fatal("always-approve wrapper should be unwrapped before forwarding to inner agent")
+						}
+						if _, ok := c.(*message.ToolApprovalResponseContent); ok {
+							sawResponse = true
+						}
+					}
+				}
+				if !sawResponse {
+					t.Fatal("expected approval response to be forwarded to inner agent")
+				}
+			}).
 			AddText("done").
 			Build(),
 	}
@@ -202,17 +217,94 @@ func TestToolApproval_QueuedRequestsSurfacedOneAtATime(t *testing.T) {
 	}
 }
 
-func TestToolApproval_AlwaysApproveToolWithArgsResponse(t *testing.T) {
+func TestToolApproval_AlwaysApproveToolWithArgumentsResponse(t *testing.T) {
 	req := &message.ToolApprovalRequestContent{
 		RequestID: "r1",
 		ToolCall:  &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`},
 	}
 
-	resp := req.AlwaysApproveToolWithArgsResponse()
-	if !resp.AlwaysApproveToolWithArgs {
-		t.Error("expected AlwaysApproveToolWithArgs to be true")
+	resp := req.AlwaysApproveToolWithArgumentsResponse()
+	if !resp.AlwaysApproveToolWithArguments {
+		t.Error("expected AlwaysApproveToolWithArguments to be true")
 	}
-	if !resp.Approved {
+	if resp.InnerResponse == nil || !resp.InnerResponse.Approved {
 		t.Error("expected Approved to be true")
+	}
+}
+
+func TestToolApproval_AlwaysApproveToolWithArgumentsMatchesByValue(t *testing.T) {
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{
+						RequestID: "r1",
+						ToolCall: &message.FunctionCallContent{
+							CallID:    "c1",
+							Name:      "deploy",
+							Arguments: `{"a":1,"b":2}`,
+						},
+					},
+				},
+			}).
+			NewTurn().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{
+						RequestID: "r2",
+						ToolCall: &message.FunctionCallContent{
+							CallID:    "c2",
+							Name:      "deploy",
+							Arguments: `{"b":2,"a":1}`,
+						},
+					},
+				},
+			}).
+			NewTurn().
+			AddText("done").
+			Build(),
+	}
+
+	mw := toolapproval.New()
+	session := agenttest.CreateSession()
+	opts := []agent.Option{agent.WithSession(session)}
+
+	updates := collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
+		opts...,
+	)
+
+	var req *message.ToolApprovalRequestContent
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if r, ok := c.(*message.ToolApprovalRequestContent); ok {
+				req = r
+			}
+		}
+	}
+	if req == nil {
+		t.Fatal("expected approval request in turn 1")
+	}
+
+	updates = collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolWithArgumentsResponse()}}},
+		opts...,
+	)
+
+	var sawDone bool
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if tc, ok := c.(*message.TextContent); ok && tc.Text == "done" {
+				sawDone = true
+			}
+			if _, ok := c.(*message.ToolApprovalRequestContent); ok {
+				t.Fatal("expected second request to be auto-approved after argument-value match")
+			}
+		}
+	}
+	if !sawDone {
+		t.Fatal("expected done after auto-approval with argument-value match")
 	}
 }

--- a/agent/middleware/toolapproval/toolapproval_test.go
+++ b/agent/middleware/toolapproval/toolapproval_test.go
@@ -4,6 +4,7 @@ package toolapproval_test
 
 import (
 	"context"
+	"iter"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -29,7 +30,7 @@ func TestToolApproval_PassthroughWithoutApprovalRequests(t *testing.T) {
 		Responses: agenttest.NewResponseBuilder().AddText("hello").Build(),
 	}
 
-	mw := toolapproval.New()
+	mw := toolapproval.New(toolapproval.Config{})
 	updates := collectUpdates(t, mw, runner.Run, []*message.Message{
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "hi"}}},
 	})
@@ -39,6 +40,64 @@ func TestToolApproval_PassthroughWithoutApprovalRequests(t *testing.T) {
 	}
 	if tc, ok := updates[0].Contents[0].(*message.TextContent); !ok || tc.Text != "hello" {
 		t.Errorf("expected text 'hello', got %v", updates[0].Contents)
+	}
+}
+
+func TestToolApproval_StreamsNonApprovalBeforeInnerCompletes(t *testing.T) {
+	innerCompleted := false
+	next := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			if !yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.TextContent{Text: "progress"}},
+			}, nil) {
+				return
+			}
+			if !yield(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.TextContent{Text: "needs approval"},
+					&message.ToolApprovalRequestContent{
+						RequestID: "r1",
+						ToolCall: &message.FunctionCallContent{
+							CallID:    "c1",
+							Name:      "deploy",
+							Arguments: `{"env":"prod"}`,
+						},
+					},
+				},
+			}, nil) {
+				return
+			}
+			innerCompleted = true
+		}
+	}
+
+	mw := toolapproval.New(toolapproval.Config{})
+	var updates []*agent.ResponseUpdate
+	for u, err := range mw.Run(next, context.Background(), []*message.Message{
+		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}},
+	}) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		updates = append(updates, u)
+		if len(updates) == 1 && innerCompleted {
+			t.Fatal("expected first streamed non-approval update before inner stream completes")
+		}
+	}
+
+	if len(updates) != 3 {
+		t.Fatalf("expected 3 updates, got %d", len(updates))
+	}
+	if tc, ok := updates[0].Contents[0].(*message.TextContent); !ok || tc.Text != "progress" {
+		t.Fatalf("expected first update to be progress text, got %#v", updates[0].Contents)
+	}
+	if tc, ok := updates[1].Contents[0].(*message.TextContent); !ok || tc.Text != "needs approval" {
+		t.Fatalf("expected second update to be stripped text, got %#v", updates[1].Contents)
+	}
+	if _, ok := updates[2].Contents[0].(*message.ToolApprovalRequestContent); !ok {
+		t.Fatalf("expected final update to surface approval request, got %#v", updates[2].Contents)
 	}
 }
 
@@ -58,7 +117,7 @@ func TestToolApproval_SurfacesFirstApprovalRequest(t *testing.T) {
 			Build(),
 	}
 
-	mw := toolapproval.New()
+	mw := toolapproval.New(toolapproval.Config{})
 	session := agenttest.CreateSession()
 	updates := collectUpdates(t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
@@ -115,7 +174,7 @@ func TestToolApproval_AlwaysApproveToolCreatesRule(t *testing.T) {
 			Build(),
 	}
 
-	mw := toolapproval.New()
+	mw := toolapproval.New(toolapproval.Config{})
 	session := agenttest.CreateSession()
 	opts := []agent.Option{agent.WithSession(session)}
 
@@ -176,7 +235,7 @@ func TestToolApproval_QueuedRequestsSurfacedOneAtATime(t *testing.T) {
 			Build(),
 	}
 
-	mw := toolapproval.New()
+	mw := toolapproval.New(toolapproval.Config{})
 	session := agenttest.CreateSession()
 	opts := []agent.Option{agent.WithSession(session)}
 
@@ -267,7 +326,7 @@ func TestToolApproval_AlwaysApproveToolWithArgumentsMatchesByValue(t *testing.T)
 			Build(),
 	}
 
-	mw := toolapproval.New()
+	mw := toolapproval.New(toolapproval.Config{})
 	session := agenttest.CreateSession()
 	opts := []agent.Option{agent.WithSession(session)}
 

--- a/agent/middleware/toolapproval/toolapproval_test.go
+++ b/agent/middleware/toolapproval/toolapproval_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package toolapproval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/middleware/toolapproval"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+func collectUpdates(t *testing.T, mw agent.Middleware, next agent.RunFunc, messages []*message.Message, opts ...agent.Option) []*agent.ResponseUpdate {
+	t.Helper()
+	var updates []*agent.ResponseUpdate
+	for u, err := range mw.Run(next, context.Background(), messages, opts...) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		updates = append(updates, u)
+	}
+	return updates
+}
+
+func TestToolApproval_PassthroughWithoutApprovalRequests(t *testing.T) {
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().AddText("hello").Build(),
+	}
+
+	mw := toolapproval.New()
+	updates := collectUpdates(t, mw, runner.Run, []*message.Message{
+		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "hi"}}},
+	})
+
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updates))
+	}
+	if tc, ok := updates[0].Contents[0].(*message.TextContent); !ok || tc.Text != "hello" {
+		t.Errorf("expected text 'hello', got %v", updates[0].Contents)
+	}
+}
+
+func TestToolApproval_SurfacesFirstApprovalRequest(t *testing.T) {
+	fcc1 := &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`}
+	fcc2 := &message.FunctionCallContent{CallID: "c2", Name: "restart", Arguments: `{}`}
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc1},
+					&message.ToolApprovalRequestContent{RequestID: "r2", ToolCall: fcc2},
+				},
+			}).
+			Build(),
+	}
+
+	mw := toolapproval.New()
+	session := agenttest.CreateSession()
+	updates := collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
+		agent.WithSession(session),
+	)
+
+	// Should receive exactly one approval request (the first one).
+	var approvalReqs []*message.ToolApprovalRequestContent
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if req, ok := c.(*message.ToolApprovalRequestContent); ok {
+				approvalReqs = append(approvalReqs, req)
+			}
+		}
+	}
+	if len(approvalReqs) != 1 {
+		t.Fatalf("expected 1 approval request, got %d", len(approvalReqs))
+	}
+	if approvalReqs[0].RequestID != "r1" {
+		t.Errorf("expected request ID 'r1', got %q", approvalReqs[0].RequestID)
+	}
+}
+
+func TestToolApproval_AlwaysApproveToolCreatesRule(t *testing.T) {
+	fcc := &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`}
+
+	// Turn 1: inner agent returns an approval request.
+	// Turn 2: inner agent returns the same tool approval request again — should be auto-approved.
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc},
+				},
+			}).
+			NewTurn().
+			AddText("done").
+			Build(),
+	}
+
+	mw := toolapproval.New()
+	session := agenttest.CreateSession()
+	opts := []agent.Option{agent.WithSession(session)}
+
+	// Turn 1: Get the approval request.
+	updates := collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
+		opts...,
+	)
+	var req *message.ToolApprovalRequestContent
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if r, ok := c.(*message.ToolApprovalRequestContent); ok {
+				req = r
+			}
+		}
+	}
+	if req == nil {
+		t.Fatal("expected approval request in turn 1")
+	}
+
+	// Respond with "always approve this tool".
+	alwaysApproveResp := req.AlwaysApproveToolResponse()
+
+	// Turn 2: Send the always-approve response. The queued requests from the
+	// inner agent should now be auto-approved and the inner agent called again.
+	updates = collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{alwaysApproveResp}}},
+		opts...,
+	)
+
+	// Should get the "done" text from the inner agent (approval was auto-applied).
+	var gotDone bool
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if tc, ok := c.(*message.TextContent); ok && tc.Text == "done" {
+				gotDone = true
+			}
+		}
+	}
+	if !gotDone {
+		t.Error("expected 'done' text after auto-approval, but did not get it")
+	}
+}
+
+func TestToolApproval_QueuedRequestsSurfacedOneAtATime(t *testing.T) {
+	fcc1 := &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`}
+	fcc2 := &message.FunctionCallContent{CallID: "c2", Name: "restart", Arguments: `{}`}
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc1},
+					&message.ToolApprovalRequestContent{RequestID: "r2", ToolCall: fcc2},
+				},
+			}).
+			Build(),
+	}
+
+	mw := toolapproval.New()
+	session := agenttest.CreateSession()
+	opts := []agent.Option{agent.WithSession(session)}
+
+	// Turn 1: Get first approval request.
+	updates := collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
+		opts...,
+	)
+	var firstReq *message.ToolApprovalRequestContent
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if r, ok := c.(*message.ToolApprovalRequestContent); ok {
+				firstReq = r
+			}
+		}
+	}
+	if firstReq == nil || firstReq.RequestID != "r1" {
+		t.Fatal("expected first approval request to be r1")
+	}
+
+	// Turn 2: Approve r1, should get r2 next.
+	resp := firstReq.CreateResponse(true, "")
+	updates = collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{resp}}},
+		opts...,
+	)
+
+	var secondReq *message.ToolApprovalRequestContent
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if r, ok := c.(*message.ToolApprovalRequestContent); ok {
+				secondReq = r
+			}
+		}
+	}
+	if secondReq == nil || secondReq.RequestID != "r2" {
+		t.Fatalf("expected second approval request to be r2, got %v", secondReq)
+	}
+}
+
+func TestToolApproval_AlwaysApproveToolWithArgsResponse(t *testing.T) {
+	req := &message.ToolApprovalRequestContent{
+		RequestID: "r1",
+		ToolCall:  &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`},
+	}
+
+	resp := req.AlwaysApproveToolWithArgsResponse()
+	if !resp.AlwaysApproveToolWithArgs {
+		t.Error("expected AlwaysApproveToolWithArgs to be true")
+	}
+	if !resp.Approved {
+		t.Error("expected Approved to be true")
+	}
+}

--- a/message/content.go
+++ b/message/content.go
@@ -749,12 +749,12 @@ type AlwaysApproveToolApprovalResponseContent struct {
 
 	// AlwaysApproveTool, when true, indicates a standing rule to auto-approve
 	// all future calls to the same tool regardless of arguments.
-	AlwaysApproveTool bool `json:"alwaysApproveTool,omitempty"`
+	AlwaysApproveTool bool `json:",omitempty"`
 
 	// AlwaysApproveToolWithArguments, when true, indicates a standing rule to
 	// auto-approve future calls to the same tool only when the arguments
 	// match exactly.
-	AlwaysApproveToolWithArguments bool `json:"alwaysApproveToolWithArguments,omitempty"`
+	AlwaysApproveToolWithArguments bool `json:",omitempty"`
 }
 
 func (t *AlwaysApproveToolApprovalResponseContent) MarshalJSON() ([]byte, error) {

--- a/message/content.go
+++ b/message/content.go
@@ -34,6 +34,7 @@ func init() {
 		&UsageContent{},
 		&ToolApprovalRequestContent{},
 		&ToolApprovalResponseContent{},
+		&AlwaysApproveToolApprovalResponseContent{},
 		&MCPServerToolCallContent{},
 	} {
 		supportedContents[c.kind()] = reflect.TypeOf(c).Elem()
@@ -625,19 +626,28 @@ func (t *ToolApprovalRequestContent) CreateResponse(approved bool, reason string
 // AlwaysApproveToolResponse creates a response that approves this tool call and
 // records a standing rule to automatically approve all future calls to the same
 // tool, regardless of arguments.
-func (t *ToolApprovalRequestContent) AlwaysApproveToolResponse() *ToolApprovalResponseContent {
-	resp := t.CreateResponse(true, "")
-	resp.AlwaysApproveTool = true
-	return resp
+func (t *ToolApprovalRequestContent) AlwaysApproveToolResponse() *AlwaysApproveToolApprovalResponseContent {
+	return &AlwaysApproveToolApprovalResponseContent{
+		InnerResponse:     t.CreateResponse(true, ""),
+		AlwaysApproveTool: true,
+		ContentHeader:     ContentHeader{AdditionalProperties: t.AdditionalProperties},
+	}
 }
 
-// AlwaysApproveToolWithArgsResponse creates a response that approves this tool
+// AlwaysApproveToolWithArgumentsResponse creates a response that approves this tool
 // call and records a standing rule to automatically approve future calls to the
 // same tool only when the arguments match exactly.
-func (t *ToolApprovalRequestContent) AlwaysApproveToolWithArgsResponse() *ToolApprovalResponseContent {
-	resp := t.CreateResponse(true, "")
-	resp.AlwaysApproveToolWithArgs = true
-	return resp
+func (t *ToolApprovalRequestContent) AlwaysApproveToolWithArgumentsResponse() *AlwaysApproveToolApprovalResponseContent {
+	return &AlwaysApproveToolApprovalResponseContent{
+		InnerResponse:                  t.CreateResponse(true, ""),
+		AlwaysApproveToolWithArguments: true,
+		ContentHeader:                  ContentHeader{AdditionalProperties: t.AdditionalProperties},
+	}
+}
+
+// AlwaysApproveToolWithArgsResponse is an alias for AlwaysApproveToolWithArgumentsResponse.
+func (t *ToolApprovalRequestContent) AlwaysApproveToolWithArgsResponse() *AlwaysApproveToolApprovalResponseContent {
+	return t.AlwaysApproveToolWithArgumentsResponse()
 }
 
 type serializedToolApprovalResponseContent struct {
@@ -647,9 +657,6 @@ type serializedToolApprovalResponseContent struct {
 	Reason    string `json:",omitempty"`
 	Approved  bool
 	ToolCall  ToolCallContent
-
-	AlwaysApproveTool         bool `json:"alwaysApproveTool,omitempty"`
-	AlwaysApproveToolWithArgs bool `json:"alwaysApproveToolWithArgs,omitempty"`
 
 	Type contentKind
 }
@@ -661,9 +668,6 @@ type serializedToolApprovalResponseContentForUnmarshal struct {
 	Reason    string `json:",omitempty"`
 	Approved  bool
 	ToolCall  json.RawMessage
-
-	AlwaysApproveTool         bool `json:"alwaysApproveTool,omitempty"`
-	AlwaysApproveToolWithArgs bool `json:"alwaysApproveToolWithArgs,omitempty"`
 }
 
 // ToolApprovalResponseContent represents a response to a [ToolApprovalRequestContent].
@@ -674,27 +678,16 @@ type ToolApprovalResponseContent struct {
 	Reason    string `json:",omitempty"`
 	Approved  bool
 	ToolCall  ToolCallContent
-
-	// AlwaysApproveTool, when true, indicates a standing rule to auto-approve
-	// all future calls to the same tool regardless of arguments.
-	AlwaysApproveTool bool `json:"alwaysApproveTool,omitempty"`
-
-	// AlwaysApproveToolWithArgs, when true, indicates a standing rule to
-	// auto-approve future calls to the same tool only when the arguments
-	// match exactly.
-	AlwaysApproveToolWithArgs bool `json:"alwaysApproveToolWithArgs,omitempty"`
 }
 
 func (t *ToolApprovalResponseContent) MarshalJSON() ([]byte, error) {
 	tmp := serializedToolApprovalResponseContent{
-		ContentHeader:             t.ContentHeader,
-		RequestID:                 t.RequestID,
-		Reason:                    t.Reason,
-		Approved:                  t.Approved,
-		ToolCall:                  t.ToolCall,
-		AlwaysApproveTool:         t.AlwaysApproveTool,
-		AlwaysApproveToolWithArgs: t.AlwaysApproveToolWithArgs,
-		Type:                      t.kind(),
+		ContentHeader: t.ContentHeader,
+		RequestID:     t.RequestID,
+		Reason:        t.Reason,
+		Approved:      t.Approved,
+		ToolCall:      t.ToolCall,
+		Type:          t.kind(),
 	}
 	return json.Marshal(tmp)
 }
@@ -713,8 +706,6 @@ func (t *ToolApprovalResponseContent) UnmarshalJSON(data []byte) error {
 	t.Reason = tmp.Reason
 	t.Approved = tmp.Approved
 	t.ToolCall = toolCall
-	t.AlwaysApproveTool = tmp.AlwaysApproveTool
-	t.AlwaysApproveToolWithArgs = tmp.AlwaysApproveToolWithArgs
 	return nil
 }
 
@@ -746,6 +737,39 @@ func unmarshalToolApprovalToolCall(data json.RawMessage) (ToolCallContent, error
 	default:
 		return nil, fmt.Errorf("unsupported tool call content type: %v", header.Type)
 	}
+}
+
+// AlwaysApproveToolApprovalResponseContent wraps a tool approval response and
+// adds standing rule hints for tool-approval middleware.
+type AlwaysApproveToolApprovalResponseContent struct {
+	ContentHeader
+
+	InnerResponse *ToolApprovalResponseContent `json:"innerResponse"`
+
+	// AlwaysApproveTool, when true, indicates a standing rule to auto-approve
+	// all future calls to the same tool regardless of arguments.
+	AlwaysApproveTool bool `json:"alwaysApproveTool,omitempty"`
+
+	// AlwaysApproveToolWithArguments, when true, indicates a standing rule to
+	// auto-approve future calls to the same tool only when the arguments
+	// match exactly.
+	AlwaysApproveToolWithArguments bool `json:"alwaysApproveToolWithArguments,omitempty"`
+}
+
+func (t *AlwaysApproveToolApprovalResponseContent) MarshalJSON() ([]byte, error) {
+	type alias AlwaysApproveToolApprovalResponseContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t AlwaysApproveToolApprovalResponseContent) kind() contentKind {
+	return "alwaysApproveToolApprovalResponse"
 }
 
 type CodeInterpreterToolCallContent struct {

--- a/message/content.go
+++ b/message/content.go
@@ -645,6 +645,7 @@ func (t *ToolApprovalRequestContent) AlwaysApproveToolWithArgumentsResponse() *A
 	}
 }
 
+// Deprecated: Use AlwaysApproveToolWithArgumentsResponse instead.
 // AlwaysApproveToolWithArgsResponse is an alias for AlwaysApproveToolWithArgumentsResponse.
 func (t *ToolApprovalRequestContent) AlwaysApproveToolWithArgsResponse() *AlwaysApproveToolApprovalResponseContent {
 	return t.AlwaysApproveToolWithArgumentsResponse()

--- a/message/content.go
+++ b/message/content.go
@@ -622,6 +622,24 @@ func (t *ToolApprovalRequestContent) CreateResponse(approved bool, reason string
 	}
 }
 
+// AlwaysApproveToolResponse creates a response that approves this tool call and
+// records a standing rule to automatically approve all future calls to the same
+// tool, regardless of arguments.
+func (t *ToolApprovalRequestContent) AlwaysApproveToolResponse() *ToolApprovalResponseContent {
+	resp := t.CreateResponse(true, "")
+	resp.AlwaysApproveTool = true
+	return resp
+}
+
+// AlwaysApproveToolWithArgsResponse creates a response that approves this tool
+// call and records a standing rule to automatically approve future calls to the
+// same tool only when the arguments match exactly.
+func (t *ToolApprovalRequestContent) AlwaysApproveToolWithArgsResponse() *ToolApprovalResponseContent {
+	resp := t.CreateResponse(true, "")
+	resp.AlwaysApproveToolWithArgs = true
+	return resp
+}
+
 type serializedToolApprovalResponseContent struct {
 	ContentHeader
 
@@ -629,6 +647,9 @@ type serializedToolApprovalResponseContent struct {
 	Reason    string `json:",omitempty"`
 	Approved  bool
 	ToolCall  ToolCallContent
+
+	AlwaysApproveTool         bool `json:"alwaysApproveTool,omitempty"`
+	AlwaysApproveToolWithArgs bool `json:"alwaysApproveToolWithArgs,omitempty"`
 
 	Type contentKind
 }
@@ -640,6 +661,9 @@ type serializedToolApprovalResponseContentForUnmarshal struct {
 	Reason    string `json:",omitempty"`
 	Approved  bool
 	ToolCall  json.RawMessage
+
+	AlwaysApproveTool         bool `json:"alwaysApproveTool,omitempty"`
+	AlwaysApproveToolWithArgs bool `json:"alwaysApproveToolWithArgs,omitempty"`
 }
 
 // ToolApprovalResponseContent represents a response to a [ToolApprovalRequestContent].
@@ -650,16 +674,27 @@ type ToolApprovalResponseContent struct {
 	Reason    string `json:",omitempty"`
 	Approved  bool
 	ToolCall  ToolCallContent
+
+	// AlwaysApproveTool, when true, indicates a standing rule to auto-approve
+	// all future calls to the same tool regardless of arguments.
+	AlwaysApproveTool bool `json:"alwaysApproveTool,omitempty"`
+
+	// AlwaysApproveToolWithArgs, when true, indicates a standing rule to
+	// auto-approve future calls to the same tool only when the arguments
+	// match exactly.
+	AlwaysApproveToolWithArgs bool `json:"alwaysApproveToolWithArgs,omitempty"`
 }
 
 func (t *ToolApprovalResponseContent) MarshalJSON() ([]byte, error) {
 	tmp := serializedToolApprovalResponseContent{
-		ContentHeader: t.ContentHeader,
-		RequestID:     t.RequestID,
-		Reason:        t.Reason,
-		Approved:      t.Approved,
-		ToolCall:      t.ToolCall,
-		Type:          t.kind(),
+		ContentHeader:             t.ContentHeader,
+		RequestID:                 t.RequestID,
+		Reason:                    t.Reason,
+		Approved:                  t.Approved,
+		ToolCall:                  t.ToolCall,
+		AlwaysApproveTool:         t.AlwaysApproveTool,
+		AlwaysApproveToolWithArgs: t.AlwaysApproveToolWithArgs,
+		Type:                      t.kind(),
 	}
 	return json.Marshal(tmp)
 }
@@ -678,6 +713,8 @@ func (t *ToolApprovalResponseContent) UnmarshalJSON(data []byte) error {
 	t.Reason = tmp.Reason
 	t.Approved = tmp.Approved
 	t.ToolCall = toolCall
+	t.AlwaysApproveTool = tmp.AlwaysApproveTool
+	t.AlwaysApproveToolWithArgs = tmp.AlwaysApproveToolWithArgs
 	return nil
 }
 

--- a/message/content.go
+++ b/message/content.go
@@ -749,12 +749,12 @@ type AlwaysApproveToolApprovalResponseContent struct {
 
 	// AlwaysApproveTool, when true, indicates a standing rule to auto-approve
 	// all future calls to the same tool regardless of arguments.
-	AlwaysApproveTool bool `json:",omitempty"`
+	AlwaysApproveTool bool `json:"AlwaysApproveTool,omitempty"`
 
 	// AlwaysApproveToolWithArguments, when true, indicates a standing rule to
 	// auto-approve future calls to the same tool only when the arguments
 	// match exactly.
-	AlwaysApproveToolWithArguments bool `json:",omitempty"`
+	AlwaysApproveToolWithArguments bool `json:"AlwaysApproveToolWithArguments,omitempty"`
 }
 
 func (t *AlwaysApproveToolApprovalResponseContent) MarshalJSON() ([]byte, error) {

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -147,6 +147,17 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 				ServerName: "mcpServer",
 			},
 		},
+		&message.AlwaysApproveToolApprovalResponseContent{
+			InnerResponse: &message.ToolApprovalResponseContent{
+				RequestID: "approval-124",
+				Approved:  true,
+				ToolCall: &message.FunctionCallContent{
+					CallID: "2",
+					Name:   "deploy",
+				},
+			},
+			AlwaysApproveToolWithArguments: true,
+		},
 		&message.MCPServerToolCallContent{
 			CallID:     "mcp-call-123",
 			Arguments:  "{\"arg1\":\"value1\"}",


### PR DESCRIPTION
## Summary

Adds a `toolapproval` middleware package for .NET `ToolApprovalAgent` parity, closing the primary Human-in-the-Loop gap identified in the feature comparison.

### New: `agent/middleware/toolapproval`
- Implements the .NET `ToolApprovalAgent` pattern as idiomatic Go middleware
- **One-at-a-time surfacing**: When the inner agent returns multiple approval requests, only the first is surfaced to the caller; the rest are queued in session state
- **Standing rules ("don't ask again")**: Callers can respond with `AlwaysApproveToolResponse()` or `AlwaysApproveToolWithArgsResponse()` to create rules that auto-approve matching future tool calls for the session lifetime
- **Auto-approve loop**: When all approval requests match standing rules, the middleware automatically approves them and re-calls the inner agent without surfacing anything to the caller
- **Session persistence**: Rules, queued requests, and collected responses are persisted across turns via `agent.Session`

### Changes to `message` package
- Added `AlwaysApproveTool` and `AlwaysApproveToolWithArgs` fields to `FunctionApprovalResponseContent`
- Added `AlwaysApproveToolResponse()` and `AlwaysApproveToolWithArgsResponse()` convenience methods on `FunctionApprovalRequestContent`

### Tests
- Passthrough (no approval requests)
- First request surfacing with queuing
- Always-approve tool rule creation and auto-approval
- Queued requests surfaced one at a time
- AlwaysApproveToolWithArgs response creation