### PR TITLE
Add public CheckpointStore interface and JSON file-based store

### DIFF
--- a/examples/03-workflows/checkpoint/checkpoint_and_resume/main.go
+++ b/examples/03-workflows/checkpoint/checkpoint_and_resume/main.go
@@ -35,8 +35,8 @@ func main() {
 		demo.Panic(err)
 	}
 
-	manager := inproc.NewInMemoryCheckpointManager()
-	first, err := inproc.Default.WithCheckpointing(manager).Run(context.Background(), wf, "Need deployment approval")
+	manager := workflow.NewInMemoryCheckpointManager()
+	first, err := inproc.Default.WithCheckpointStore(manager).Run(context.Background(), wf, "Need deployment approval")
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -53,7 +53,7 @@ func main() {
 		demo.Panic(err)
 	}
 
-	resumed, err := inproc.Default.WithCheckpointing(manager).Resume(context.Background(), wf, checkpointInfo)
+	resumed, err := inproc.Default.WithCheckpointStore(manager).Resume(context.Background(), wf, checkpointInfo)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/03-workflows/checkpoint/checkpoint_and_resume/main.go
+++ b/examples/03-workflows/checkpoint/checkpoint_and_resume/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	manager := workflow.NewInMemoryCheckpointManager()
-	first, err := inproc.Default.WithCheckpointStore(manager).Run(context.Background(), wf, "Need deployment approval")
+	first, err := inproc.Default.WithCheckpointing(manager).Run(context.Background(), wf, "Need deployment approval")
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -53,7 +53,7 @@ func main() {
 		demo.Panic(err)
 	}
 
-	resumed, err := inproc.Default.WithCheckpointStore(manager).Resume(context.Background(), wf, checkpointInfo)
+	resumed, err := inproc.Default.WithCheckpointing(manager).Resume(context.Background(), wf, checkpointInfo)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/workflow/checkpoint/jsonstore/jsonstore.go
+++ b/workflow/checkpoint/jsonstore/jsonstore.go
@@ -13,10 +13,12 @@
 package jsonstore
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -26,7 +28,7 @@ import (
 // Store is a JSON file-based implementation of [workflow.CheckpointStore].
 type Store struct {
 	rootDir string
-	mu      sync.Mutex
+	mu      sync.RWMutex
 }
 
 // New creates a Store rooted at the given directory path.
@@ -35,7 +37,25 @@ func New(rootDir string) (*Store, error) {
 	if err := os.MkdirAll(rootDir, 0o755); err != nil {
 		return nil, fmt.Errorf("jsonstore: create root dir: %w", err)
 	}
-	return &Store{rootDir: rootDir}, nil
+	abs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("jsonstore: resolve root dir: %w", err)
+	}
+	return &Store{rootDir: abs}, nil
+}
+
+// validateSessionID checks that the session ID does not contain path separators
+// or relative path components that could escape the root directory.
+func validateSessionID(sessionID string) error {
+	if sessionID == "" {
+		return fmt.Errorf("jsonstore: sessionID cannot be empty")
+	}
+	if strings.ContainsAny(sessionID, `/\`) ||
+		sessionID == "." || sessionID == ".." ||
+		strings.Contains(sessionID, "..") {
+		return fmt.Errorf("jsonstore: sessionID contains invalid characters: %q", sessionID)
+	}
+	return nil
 }
 
 func (s *Store) sessionDir(sessionID string) string {
@@ -50,7 +70,12 @@ func (s *Store) checkpointPath(sessionID, checkpointID string) string {
 	return filepath.Join(s.sessionDir(sessionID), checkpointID+".json")
 }
 
-func (s *Store) readIndex(sessionID string) ([]workflow.CheckpointInfo, error) {
+type indexEntry struct {
+	Info   workflow.CheckpointInfo  `json:"Info"`
+	Parent *workflow.CheckpointInfo `json:"Parent,omitempty"`
+}
+
+func (s *Store) readIndex(sessionID string) ([]indexEntry, error) {
 	data, err := os.ReadFile(s.indexPath(sessionID))
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -58,14 +83,14 @@ func (s *Store) readIndex(sessionID string) ([]workflow.CheckpointInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	var index []workflow.CheckpointInfo
+	var index []indexEntry
 	if err := json.Unmarshal(data, &index); err != nil {
 		return nil, err
 	}
 	return index, nil
 }
 
-func (s *Store) writeIndex(sessionID string, index []workflow.CheckpointInfo) error {
+func (s *Store) writeIndex(sessionID string, index []indexEntry) error {
 	data, err := json.Marshal(index)
 	if err != nil {
 		return err
@@ -74,9 +99,9 @@ func (s *Store) writeIndex(sessionID string, index []workflow.CheckpointInfo) er
 }
 
 // CreateCheckpoint implements [workflow.CheckpointStore].
-func (s *Store) CreateCheckpoint(sessionID string, data json.RawMessage, _ *workflow.CheckpointInfo) (workflow.CheckpointInfo, error) {
-	if sessionID == "" {
-		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: sessionID cannot be empty")
+func (s *Store) CreateCheckpoint(_ context.Context, sessionID string, data json.RawMessage, parent *workflow.CheckpointInfo) (workflow.CheckpointInfo, error) {
+	if err := validateSessionID(sessionID); err != nil {
+		return workflow.CheckpointInfo{}, err
 	}
 
 	s.mu.Lock()
@@ -100,7 +125,7 @@ func (s *Store) CreateCheckpoint(sessionID string, data json.RawMessage, _ *work
 	if err != nil {
 		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: read index: %w", err)
 	}
-	index = append(index, info)
+	index = append(index, indexEntry{Info: info, Parent: parent})
 	if err := s.writeIndex(sessionID, index); err != nil {
 		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: write index: %w", err)
 	}
@@ -109,7 +134,10 @@ func (s *Store) CreateCheckpoint(sessionID string, data json.RawMessage, _ *work
 }
 
 // RetrieveCheckpoint implements [workflow.CheckpointStore].
-func (s *Store) RetrieveCheckpoint(sessionID string, info workflow.CheckpointInfo) (json.RawMessage, error) {
+func (s *Store) RetrieveCheckpoint(_ context.Context, sessionID string, info workflow.CheckpointInfo) (json.RawMessage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	data, err := os.ReadFile(s.checkpointPath(sessionID, info.CheckpointID))
 	if os.IsNotExist(err) {
 		return nil, fmt.Errorf("jsonstore: checkpoint %s not found for session %s", info.CheckpointID, sessionID)
@@ -121,13 +149,23 @@ func (s *Store) RetrieveCheckpoint(sessionID string, info workflow.CheckpointInf
 }
 
 // RetrieveIndex implements [workflow.CheckpointStore].
-func (s *Store) RetrieveIndex(sessionID string, _ *workflow.CheckpointInfo) ([]workflow.CheckpointInfo, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (s *Store) RetrieveIndex(_ context.Context, sessionID string, withParent *workflow.CheckpointInfo) ([]workflow.CheckpointInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	index, err := s.readIndex(sessionID)
+	entries, err := s.readIndex(sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("jsonstore: read index: %w", err)
 	}
-	return index, nil
+
+	var result []workflow.CheckpointInfo
+	for _, entry := range entries {
+		if withParent != nil {
+			if entry.Parent == nil || *entry.Parent != *withParent {
+				continue
+			}
+		}
+		result = append(result, entry.Info)
+	}
+	return result, nil
 }

--- a/workflow/checkpoint/jsonstore/jsonstore.go
+++ b/workflow/checkpoint/jsonstore/jsonstore.go
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// Package jsonstore provides a JSON file-based [workflow.CheckpointStore]
+// implementation that persists checkpoint data to the local file system.
+//
+// Each session gets a directory under the configured root path. Checkpoint
+// data is stored as individual JSON files and a session index tracks the
+// ordering.
+//
+// This store is suitable for local development, CLI tools, and lightweight
+// deployments. For production use with concurrent access or cloud storage,
+// implement [workflow.CheckpointStore] with an appropriate backend.
+package jsonstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+// Store is a JSON file-based implementation of [workflow.CheckpointStore].
+type Store struct {
+	rootDir string
+	mu      sync.Mutex
+}
+
+// New creates a Store rooted at the given directory path.
+// The directory is created if it does not exist.
+func New(rootDir string) (*Store, error) {
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		return nil, fmt.Errorf("jsonstore: create root dir: %w", err)
+	}
+	return &Store{rootDir: rootDir}, nil
+}
+
+func (s *Store) sessionDir(sessionID string) string {
+	return filepath.Join(s.rootDir, sessionID)
+}
+
+func (s *Store) indexPath(sessionID string) string {
+	return filepath.Join(s.sessionDir(sessionID), "index.json")
+}
+
+func (s *Store) checkpointPath(sessionID, checkpointID string) string {
+	return filepath.Join(s.sessionDir(sessionID), checkpointID+".json")
+}
+
+func (s *Store) readIndex(sessionID string) ([]workflow.CheckpointInfo, error) {
+	data, err := os.ReadFile(s.indexPath(sessionID))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var index []workflow.CheckpointInfo
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+func (s *Store) writeIndex(sessionID string, index []workflow.CheckpointInfo) error {
+	data, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.indexPath(sessionID), data, 0o644)
+}
+
+// CreateCheckpoint implements [workflow.CheckpointStore].
+func (s *Store) CreateCheckpoint(sessionID string, data json.RawMessage, _ *workflow.CheckpointInfo) (workflow.CheckpointInfo, error) {
+	if sessionID == "" {
+		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: sessionID cannot be empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dir := s.sessionDir(sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: create session dir: %w", err)
+	}
+
+	info := workflow.CheckpointInfo{
+		SessionID:    sessionID,
+		CheckpointID: uuid.NewString(),
+	}
+
+	if err := os.WriteFile(s.checkpointPath(sessionID, info.CheckpointID), data, 0o644); err != nil {
+		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: write checkpoint: %w", err)
+	}
+
+	index, err := s.readIndex(sessionID)
+	if err != nil {
+		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: read index: %w", err)
+	}
+	index = append(index, info)
+	if err := s.writeIndex(sessionID, index); err != nil {
+		return workflow.CheckpointInfo{}, fmt.Errorf("jsonstore: write index: %w", err)
+	}
+
+	return info, nil
+}
+
+// RetrieveCheckpoint implements [workflow.CheckpointStore].
+func (s *Store) RetrieveCheckpoint(sessionID string, info workflow.CheckpointInfo) (json.RawMessage, error) {
+	data, err := os.ReadFile(s.checkpointPath(sessionID, info.CheckpointID))
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("jsonstore: checkpoint %s not found for session %s", info.CheckpointID, sessionID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("jsonstore: read checkpoint: %w", err)
+	}
+	return data, nil
+}
+
+// RetrieveIndex implements [workflow.CheckpointStore].
+func (s *Store) RetrieveIndex(sessionID string, _ *workflow.CheckpointInfo) ([]workflow.CheckpointInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	index, err := s.readIndex(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("jsonstore: read index: %w", err)
+	}
+	return index, nil
+}

--- a/workflow/checkpoint/jsonstore/jsonstore_test.go
+++ b/workflow/checkpoint/jsonstore/jsonstore_test.go
@@ -3,6 +3,7 @@
 package jsonstore_test
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -18,10 +19,11 @@ func TestStore_RoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ctx := context.Background()
 	sessionID := "session-1"
 	data := json.RawMessage(`{"stepNumber":42,"workflowInfo":{}}`)
 
-	info, err := store.CreateCheckpoint(sessionID, data, nil)
+	info, err := store.CreateCheckpoint(ctx, sessionID, data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +31,7 @@ func TestStore_RoundTrip(t *testing.T) {
 		t.Errorf("expected session %q, got %q", sessionID, info.SessionID)
 	}
 
-	got, err := store.RetrieveCheckpoint(sessionID, info)
+	got, err := store.RetrieveCheckpoint(ctx, sessionID, info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,17 +47,18 @@ func TestStore_Index(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ctx := context.Background()
 	sessionID := "session-1"
-	info1, err := store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":0}`), nil)
+	info1, err := store.CreateCheckpoint(ctx, sessionID, json.RawMessage(`{"step":0}`), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	info2, err := store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":1}`), &info1)
+	info2, err := store.CreateCheckpoint(ctx, sessionID, json.RawMessage(`{"step":1}`), &info1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	index, err := store.RetrieveIndex(sessionID, nil)
+	index, err := store.RetrieveIndex(ctx, sessionID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,9 +80,10 @@ func TestStore_PersistsToDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ctx := context.Background()
 	sessionID := "session-persist"
 	data := json.RawMessage(`{"hello":"world"}`)
-	info, err := store.CreateCheckpoint(sessionID, data, nil)
+	info, err := store.CreateCheckpoint(ctx, sessionID, data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +94,7 @@ func TestStore_PersistsToDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := store2.RetrieveCheckpoint(sessionID, info)
+	got, err := store2.RetrieveCheckpoint(ctx, sessionID, info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +102,7 @@ func TestStore_PersistsToDisk(t *testing.T) {
 		t.Errorf("data mismatch after reload:\n  want: %s\n  got:  %s", data, got)
 	}
 
-	index, err := store2.RetrieveIndex(sessionID, nil)
+	index, err := store2.RetrieveIndex(ctx, sessionID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +118,7 @@ func TestStore_NotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = store.RetrieveCheckpoint("session-1", workflow.CheckpointInfo{
+	_, err = store.RetrieveCheckpoint(context.Background(), "session-1", workflow.CheckpointInfo{
 		SessionID:    "session-1",
 		CheckpointID: "nonexistent",
 	})
@@ -130,7 +134,7 @@ func TestStore_EmptySessionID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = store.CreateCheckpoint("", json.RawMessage(`{}`), nil)
+	_, err = store.CreateCheckpoint(context.Background(), "", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for empty session ID")
 	}
@@ -144,12 +148,59 @@ func TestStore_NonExistentDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = store.CreateCheckpoint("s1", json.RawMessage(`{}`), nil)
+	_, err = store.CreateCheckpoint(context.Background(), "s1", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if _, err := os.Stat(subdir); os.IsNotExist(err) {
 		t.Fatal("expected directory to be created")
+	}
+}
+
+func TestStore_ParentTracking(t *testing.T) {
+	dir := t.TempDir()
+	store, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	sessionID := "session-parent"
+	info1, err := store.CreateCheckpoint(ctx, sessionID, json.RawMessage(`{"step":0}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info2, err := store.CreateCheckpoint(ctx, sessionID, json.RawMessage(`{"step":1}`), &info1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Filter by parent
+	children, err := store.RetrieveIndex(ctx, sessionID, &info1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+	if children[0].CheckpointID != info2.CheckpointID {
+		t.Errorf("expected child %q, got %q", info2.CheckpointID, children[0].CheckpointID)
+	}
+}
+
+func TestStore_InvalidSessionID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []string{"../escape", "a/b", "a\\b", "..", "."}
+	for _, id := range tests {
+		_, err := store.CreateCheckpoint(context.Background(), id, json.RawMessage(`{}`), nil)
+		if err == nil {
+			t.Errorf("expected error for session ID %q", id)
+		}
 	}
 }

--- a/workflow/checkpoint/jsonstore/jsonstore_test.go
+++ b/workflow/checkpoint/jsonstore/jsonstore_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package jsonstore_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/checkpoint/jsonstore"
+)
+
+func TestStore_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "session-1"
+	data := json.RawMessage(`{"stepNumber":42,"workflowInfo":{}}`)
+
+	info, err := store.CreateCheckpoint(sessionID, data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.SessionID != sessionID {
+		t.Errorf("expected session %q, got %q", sessionID, info.SessionID)
+	}
+
+	got, err := store.RetrieveCheckpoint(sessionID, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("data mismatch:\n  want: %s\n  got:  %s", data, got)
+	}
+}
+
+func TestStore_Index(t *testing.T) {
+	dir := t.TempDir()
+	store, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "session-1"
+	info1, err := store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":0}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info2, err := store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":1}`), &info1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	index, err := store.RetrieveIndex(sessionID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(index) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(index))
+	}
+	if index[0].CheckpointID != info1.CheckpointID {
+		t.Errorf("index[0] = %q, want %q", index[0].CheckpointID, info1.CheckpointID)
+	}
+	if index[1].CheckpointID != info2.CheckpointID {
+		t.Errorf("index[1] = %q, want %q", index[1].CheckpointID, info2.CheckpointID)
+	}
+}
+
+func TestStore_PersistsToDisk(t *testing.T) {
+	dir := t.TempDir()
+	store, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "session-persist"
+	data := json.RawMessage(`{"hello":"world"}`)
+	info, err := store.CreateCheckpoint(sessionID, data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new store instance over the same directory.
+	store2, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store2.RetrieveCheckpoint(sessionID, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("data mismatch after reload:\n  want: %s\n  got:  %s", data, got)
+	}
+
+	index, err := store2.RetrieveIndex(sessionID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(index) != 1 {
+		t.Fatalf("expected 1 entry after reload, got %d", len(index))
+	}
+}
+
+func TestStore_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	store, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.RetrieveCheckpoint("session-1", workflow.CheckpointInfo{
+		SessionID:    "session-1",
+		CheckpointID: "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent checkpoint")
+	}
+}
+
+func TestStore_EmptySessionID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := jsonstore.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.CreateCheckpoint("", json.RawMessage(`{}`), nil)
+	if err == nil {
+		t.Fatal("expected error for empty session ID")
+	}
+}
+
+func TestStore_NonExistentDir(t *testing.T) {
+	dir := t.TempDir()
+	subdir := dir + "/nested/deep"
+	store, err := jsonstore.New(subdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.CreateCheckpoint("s1", json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(subdir); os.IsNotExist(err) {
+		t.Fatal("expected directory to be created")
+	}
+}

--- a/workflow/checkpointmanager.go
+++ b/workflow/checkpointmanager.go
@@ -15,7 +15,12 @@ type CheckpointManager struct {
 // NewCheckpointManager creates a CheckpointManager backed by the given store.
 // The store is responsible only for durable persistence of opaque JSON data;
 // the framework handles serialization of internal checkpoint structures.
+//
+// Panics if store is nil.
 func NewCheckpointManager(store CheckpointStore) *CheckpointManager {
+	if store == nil {
+		panic("workflow: CheckpointStore must not be nil")
+	}
 	return &CheckpointManager{store: store}
 }
 

--- a/workflow/checkpointmanager.go
+++ b/workflow/checkpointmanager.go
@@ -2,14 +2,26 @@
 
 package workflow
 
+import "encoding/json"
+
 // CheckpointManager provides checkpoint management for workflow execution.
 // Use [NewCheckpointManager] to create an instance backed by a [CheckpointStore],
 // or [NewInMemoryCheckpointManager] for a development/testing store.
-//
-// This mirrors the .NET CheckpointManager pattern: the manager owns
-// serialization and delegates storage to the pluggable store.
 type CheckpointManager struct {
-	store CheckpointStore
+	store    CheckpointStore[json.RawMessage]
+	internal any  // cached internal checkpoint.Manager, set by WithCheckpointing
+	inMemory bool // true when backed by an in-memory store
+}
+
+// SetInternal sets an internal manager implementation to avoid creating
+// a new adapter on each WithCheckpointing call.
+func (m *CheckpointManager) SetInternal(mgr any) {
+	m.internal = mgr
+}
+
+// IsInMemory reports whether this manager is backed by an in-memory store.
+func (m *CheckpointManager) IsInMemory() bool {
+	return m.inMemory
 }
 
 // NewCheckpointManager creates a CheckpointManager backed by the given store.
@@ -17,7 +29,7 @@ type CheckpointManager struct {
 // the framework handles serialization of internal checkpoint structures.
 //
 // Panics if store is nil.
-func NewCheckpointManager(store CheckpointStore) *CheckpointManager {
+func NewCheckpointManager(store CheckpointStore[json.RawMessage]) *CheckpointManager {
 	if store == nil {
 		panic("workflow: CheckpointStore must not be nil")
 	}
@@ -25,6 +37,13 @@ func NewCheckpointManager(store CheckpointStore) *CheckpointManager {
 }
 
 // Store returns the underlying [CheckpointStore].
-func (m *CheckpointManager) Store() CheckpointStore {
+func (m *CheckpointManager) Store() CheckpointStore[json.RawMessage] {
 	return m.store
+}
+
+// Internal returns the internal manager if one was set, or nil.
+// This is used by the execution environment to avoid JSON round-trips
+// for in-memory checkpoint managers.
+func (m *CheckpointManager) Internal() any {
+	return m.internal
 }

--- a/workflow/checkpointmanager.go
+++ b/workflow/checkpointmanager.go
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+// CheckpointManager provides checkpoint management for workflow execution.
+// Use [NewCheckpointManager] to create an instance backed by a [CheckpointStore],
+// or [NewInMemoryCheckpointManager] for a development/testing store.
+//
+// This mirrors the .NET CheckpointManager pattern: the manager owns
+// serialization and delegates storage to the pluggable store.
+type CheckpointManager struct {
+	store CheckpointStore
+}
+
+// NewCheckpointManager creates a CheckpointManager backed by the given store.
+// The store is responsible only for durable persistence of opaque JSON data;
+// the framework handles serialization of internal checkpoint structures.
+func NewCheckpointManager(store CheckpointStore) *CheckpointManager {
+	return &CheckpointManager{store: store}
+}
+
+// Store returns the underlying [CheckpointStore].
+func (m *CheckpointManager) Store() CheckpointStore {
+	return m.store
+}

--- a/workflow/checkpointstore.go
+++ b/workflow/checkpointstore.go
@@ -4,23 +4,21 @@ package workflow
 
 import (
 	"context"
-	"encoding/json"
 )
 
 // CheckpointStore defines the interface for persisting and retrieving workflow
-// checkpoint data. Implementations receive checkpoint data as [json.RawMessage]
-// values and are responsible only for durable storage.
+// checkpoint data. Implementations receive checkpoint data as values of type T
+// and are responsible only for durable storage.
 //
-// This matches the .NET ICheckpointStore<JsonElement> pattern: the framework
-// serialises internal checkpoint state to JSON before calling the store, so
-// store implementations never need to understand the checkpoint structure.
-type CheckpointStore interface {
+// The framework serialises internal checkpoint state before calling the store,
+// so store implementations never need to understand the checkpoint structure.
+type CheckpointStore[T any] interface {
 	// CreateCheckpoint persists a checkpoint and returns its identifying info.
 	// parent is the info of the preceding checkpoint, if any.
-	CreateCheckpoint(ctx context.Context, sessionID string, data json.RawMessage, parent *CheckpointInfo) (CheckpointInfo, error)
+	CreateCheckpoint(ctx context.Context, sessionID string, data T, parent *CheckpointInfo) (CheckpointInfo, error)
 
 	// RetrieveCheckpoint loads previously saved checkpoint data.
-	RetrieveCheckpoint(ctx context.Context, sessionID string, info CheckpointInfo) (json.RawMessage, error)
+	RetrieveCheckpoint(ctx context.Context, sessionID string, info CheckpointInfo) (T, error)
 
 	// RetrieveIndex returns the ordered index of checkpoint identifiers for a
 	// session. If withParent is non-nil only checkpoints whose parent matches

--- a/workflow/checkpointstore.go
+++ b/workflow/checkpointstore.go
@@ -2,7 +2,10 @@
 
 package workflow
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 // CheckpointStore defines the interface for persisting and retrieving workflow
 // checkpoint data. Implementations receive checkpoint data as [json.RawMessage]
@@ -14,13 +17,13 @@ import "encoding/json"
 type CheckpointStore interface {
 	// CreateCheckpoint persists a checkpoint and returns its identifying info.
 	// parent is the info of the preceding checkpoint, if any.
-	CreateCheckpoint(sessionID string, data json.RawMessage, parent *CheckpointInfo) (CheckpointInfo, error)
+	CreateCheckpoint(ctx context.Context, sessionID string, data json.RawMessage, parent *CheckpointInfo) (CheckpointInfo, error)
 
 	// RetrieveCheckpoint loads previously saved checkpoint data.
-	RetrieveCheckpoint(sessionID string, info CheckpointInfo) (json.RawMessage, error)
+	RetrieveCheckpoint(ctx context.Context, sessionID string, info CheckpointInfo) (json.RawMessage, error)
 
 	// RetrieveIndex returns the ordered index of checkpoint identifiers for a
 	// session. If withParent is non-nil only checkpoints whose parent matches
 	// are returned.
-	RetrieveIndex(sessionID string, withParent *CheckpointInfo) ([]CheckpointInfo, error)
+	RetrieveIndex(ctx context.Context, sessionID string, withParent *CheckpointInfo) ([]CheckpointInfo, error)
 }

--- a/workflow/checkpointstore.go
+++ b/workflow/checkpointstore.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+import "encoding/json"
+
+// CheckpointStore defines the interface for persisting and retrieving workflow
+// checkpoint data. Implementations receive checkpoint data as [json.RawMessage]
+// values and are responsible only for durable storage.
+//
+// This matches the .NET ICheckpointStore<JsonElement> pattern: the framework
+// serialises internal checkpoint state to JSON before calling the store, so
+// store implementations never need to understand the checkpoint structure.
+type CheckpointStore interface {
+	// CreateCheckpoint persists a checkpoint and returns its identifying info.
+	// parent is the info of the preceding checkpoint, if any.
+	CreateCheckpoint(sessionID string, data json.RawMessage, parent *CheckpointInfo) (CheckpointInfo, error)
+
+	// RetrieveCheckpoint loads previously saved checkpoint data.
+	RetrieveCheckpoint(sessionID string, info CheckpointInfo) (json.RawMessage, error)
+
+	// RetrieveIndex returns the ordered index of checkpoint identifiers for a
+	// session. If withParent is non-nil only checkpoints whose parent matches
+	// are returned.
+	RetrieveIndex(sessionID string, withParent *CheckpointInfo) ([]CheckpointInfo, error)
+}

--- a/workflow/checkpointstore_test.go
+++ b/workflow/checkpointstore_test.go
@@ -3,6 +3,7 @@
 package workflow_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -14,7 +15,7 @@ func TestInMemoryCheckpointStore_RoundTrip(t *testing.T) {
 	sessionID := "session-1"
 	data := json.RawMessage(`{"stepNumber":1}`)
 
-	info, err := store.CreateCheckpoint(sessionID, data, nil)
+	info, err := store.CreateCheckpoint(context.Background(), sessionID, data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +26,7 @@ func TestInMemoryCheckpointStore_RoundTrip(t *testing.T) {
 		t.Fatal("expected non-empty checkpoint ID")
 	}
 
-	got, err := store.RetrieveCheckpoint(sessionID, info)
+	got, err := store.RetrieveCheckpoint(context.Background(), sessionID, info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,16 +39,16 @@ func TestInMemoryCheckpointStore_RetrieveIndex(t *testing.T) {
 	store := workflow.NewInMemoryCheckpointStore()
 	sessionID := "session-1"
 
-	_, err := store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":0}`), nil)
+	_, err := store.CreateCheckpoint(context.Background(), sessionID, json.RawMessage(`{"step":0}`), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":1}`), nil)
+	_, err = store.CreateCheckpoint(context.Background(), sessionID, json.RawMessage(`{"step":1}`), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	index, err := store.RetrieveIndex(sessionID, nil)
+	index, err := store.RetrieveIndex(context.Background(), sessionID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +63,7 @@ func TestInMemoryCheckpointStore_RetrieveIndex(t *testing.T) {
 func TestInMemoryCheckpointStore_EmptySession(t *testing.T) {
 	store := workflow.NewInMemoryCheckpointStore()
 
-	index, err := store.RetrieveIndex("nonexistent", nil)
+	index, err := store.RetrieveIndex(context.Background(), "nonexistent", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func TestInMemoryCheckpointStore_EmptySession(t *testing.T) {
 func TestInMemoryCheckpointStore_RetrieveNotFound(t *testing.T) {
 	store := workflow.NewInMemoryCheckpointStore()
 
-	_, err := store.RetrieveCheckpoint("session-1", workflow.CheckpointInfo{
+	_, err := store.RetrieveCheckpoint(context.Background(), "session-1", workflow.CheckpointInfo{
 		SessionID:    "session-1",
 		CheckpointID: "nonexistent",
 	})
@@ -86,7 +87,7 @@ func TestInMemoryCheckpointStore_RetrieveNotFound(t *testing.T) {
 func TestInMemoryCheckpointStore_EmptySessionID(t *testing.T) {
 	store := workflow.NewInMemoryCheckpointStore()
 
-	_, err := store.CreateCheckpoint("", json.RawMessage(`{}`), nil)
+	_, err := store.CreateCheckpoint(context.Background(), "", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for empty session ID")
 	}
@@ -107,5 +108,50 @@ func TestNewInMemoryCheckpointManager(t *testing.T) {
 	}
 	if mgr.Store() == nil {
 		t.Fatal("expected non-nil store")
+	}
+}
+
+func TestCheckpointManager_NilStorePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil store")
+		}
+	}()
+	workflow.NewCheckpointManager(nil)
+}
+
+func TestInMemoryCheckpointStore_ParentTracking(t *testing.T) {
+	store := workflow.NewInMemoryCheckpointStore()
+	ctx := context.Background()
+	sessionID := "session-parent"
+
+	info1, err := store.CreateCheckpoint(ctx, sessionID, json.RawMessage(`{"step":0}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info2, err := store.CreateCheckpoint(ctx, sessionID, json.RawMessage(`{"step":1}`), &info1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// All checkpoints
+	all, err := store.RetrieveIndex(ctx, sessionID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(all))
+	}
+
+	// Filter by parent
+	children, err := store.RetrieveIndex(ctx, sessionID, &info1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+	if children[0].CheckpointID != info2.CheckpointID {
+		t.Errorf("expected child %q, got %q", info2.CheckpointID, children[0].CheckpointID)
 	}
 }

--- a/workflow/checkpointstore_test.go
+++ b/workflow/checkpointstore_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestInMemoryCheckpointStore_RoundTrip(t *testing.T) {
-	store := workflow.NewInMemoryCheckpointStore()
+	store := workflow.NewInMemoryCheckpointManager().Store()
 	sessionID := "session-1"
 	data := json.RawMessage(`{"stepNumber":1}`)
 
@@ -36,7 +36,7 @@ func TestInMemoryCheckpointStore_RoundTrip(t *testing.T) {
 }
 
 func TestInMemoryCheckpointStore_RetrieveIndex(t *testing.T) {
-	store := workflow.NewInMemoryCheckpointStore()
+	store := workflow.NewInMemoryCheckpointManager().Store()
 	sessionID := "session-1"
 
 	_, err := store.CreateCheckpoint(context.Background(), sessionID, json.RawMessage(`{"step":0}`), nil)
@@ -61,7 +61,7 @@ func TestInMemoryCheckpointStore_RetrieveIndex(t *testing.T) {
 }
 
 func TestInMemoryCheckpointStore_EmptySession(t *testing.T) {
-	store := workflow.NewInMemoryCheckpointStore()
+	store := workflow.NewInMemoryCheckpointManager().Store()
 
 	index, err := store.RetrieveIndex(context.Background(), "nonexistent", nil)
 	if err != nil {
@@ -73,7 +73,7 @@ func TestInMemoryCheckpointStore_EmptySession(t *testing.T) {
 }
 
 func TestInMemoryCheckpointStore_RetrieveNotFound(t *testing.T) {
-	store := workflow.NewInMemoryCheckpointStore()
+	store := workflow.NewInMemoryCheckpointManager().Store()
 
 	_, err := store.RetrieveCheckpoint(context.Background(), "session-1", workflow.CheckpointInfo{
 		SessionID:    "session-1",
@@ -85,7 +85,7 @@ func TestInMemoryCheckpointStore_RetrieveNotFound(t *testing.T) {
 }
 
 func TestInMemoryCheckpointStore_EmptySessionID(t *testing.T) {
-	store := workflow.NewInMemoryCheckpointStore()
+	store := workflow.NewInMemoryCheckpointManager().Store()
 
 	_, err := store.CreateCheckpoint(context.Background(), "", json.RawMessage(`{}`), nil)
 	if err == nil {
@@ -94,10 +94,9 @@ func TestInMemoryCheckpointStore_EmptySessionID(t *testing.T) {
 }
 
 func TestCheckpointManager_Creation(t *testing.T) {
-	store := workflow.NewInMemoryCheckpointStore()
-	mgr := workflow.NewCheckpointManager(store)
-	if mgr.Store() != store {
-		t.Error("expected Store() to return the original store")
+	mgr := workflow.NewInMemoryCheckpointManager()
+	if mgr.Store() == nil {
+		t.Error("expected non-nil store")
 	}
 }
 
@@ -121,7 +120,7 @@ func TestCheckpointManager_NilStorePanics(t *testing.T) {
 }
 
 func TestInMemoryCheckpointStore_ParentTracking(t *testing.T) {
-	store := workflow.NewInMemoryCheckpointStore()
+	store := workflow.NewInMemoryCheckpointManager().Store()
 	ctx := context.Background()
 	sessionID := "session-parent"
 

--- a/workflow/checkpointstore_test.go
+++ b/workflow/checkpointstore_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+func TestInMemoryCheckpointStore_RoundTrip(t *testing.T) {
+	store := workflow.NewInMemoryCheckpointStore()
+	sessionID := "session-1"
+	data := json.RawMessage(`{"stepNumber":1}`)
+
+	info, err := store.CreateCheckpoint(sessionID, data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.SessionID != sessionID {
+		t.Errorf("expected session ID %q, got %q", sessionID, info.SessionID)
+	}
+	if info.CheckpointID == "" {
+		t.Fatal("expected non-empty checkpoint ID")
+	}
+
+	got, err := store.RetrieveCheckpoint(sessionID, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("expected data %s, got %s", data, got)
+	}
+}
+
+func TestInMemoryCheckpointStore_RetrieveIndex(t *testing.T) {
+	store := workflow.NewInMemoryCheckpointStore()
+	sessionID := "session-1"
+
+	_, err := store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":0}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.CreateCheckpoint(sessionID, json.RawMessage(`{"step":1}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	index, err := store.RetrieveIndex(sessionID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(index) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(index))
+	}
+	if index[0].CheckpointID == index[1].CheckpointID {
+		t.Error("expected distinct checkpoint IDs")
+	}
+}
+
+func TestInMemoryCheckpointStore_EmptySession(t *testing.T) {
+	store := workflow.NewInMemoryCheckpointStore()
+
+	index, err := store.RetrieveIndex("nonexistent", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if index != nil {
+		t.Errorf("expected nil index for nonexistent session, got %v", index)
+	}
+}
+
+func TestInMemoryCheckpointStore_RetrieveNotFound(t *testing.T) {
+	store := workflow.NewInMemoryCheckpointStore()
+
+	_, err := store.RetrieveCheckpoint("session-1", workflow.CheckpointInfo{
+		SessionID:    "session-1",
+		CheckpointID: "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent checkpoint")
+	}
+}
+
+func TestInMemoryCheckpointStore_EmptySessionID(t *testing.T) {
+	store := workflow.NewInMemoryCheckpointStore()
+
+	_, err := store.CreateCheckpoint("", json.RawMessage(`{}`), nil)
+	if err == nil {
+		t.Fatal("expected error for empty session ID")
+	}
+}
+
+func TestCheckpointManager_Creation(t *testing.T) {
+	store := workflow.NewInMemoryCheckpointStore()
+	mgr := workflow.NewCheckpointManager(store)
+	if mgr.Store() != store {
+		t.Error("expected Store() to return the original store")
+	}
+}
+
+func TestNewInMemoryCheckpointManager(t *testing.T) {
+	mgr := workflow.NewInMemoryCheckpointManager()
+	if mgr == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if mgr.Store() == nil {
+		t.Fatal("expected non-nil store")
+	}
+}

--- a/workflow/event.go
+++ b/workflow/event.go
@@ -70,7 +70,7 @@ type SuperStepCompletionInfo struct {
 	HasPendingMessages    bool
 	HasPendingRequests    bool
 	StateUpdated          bool
-	CheckpointInfo        any // TODO: Use proper CheckpointInfo type
+	CheckpointInfo        *CheckpointInfo
 }
 
 var _ Event = SuperStepCompletedEvent{}

--- a/workflow/inmemory_checkpoint_store.go
+++ b/workflow/inmemory_checkpoint_store.go
@@ -3,6 +3,7 @@
 package workflow
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -19,8 +20,13 @@ type InMemoryCheckpointStore struct {
 }
 
 type sessionCache struct {
-	index       []CheckpointInfo
+	index       []indexEntry
 	checkpoints map[string]json.RawMessage
+}
+
+type indexEntry struct {
+	Info   CheckpointInfo
+	Parent *CheckpointInfo
 }
 
 // NewInMemoryCheckpointStore creates a new in-memory checkpoint store.
@@ -49,7 +55,7 @@ func (s *InMemoryCheckpointStore) ensureSession(sessionID string) *sessionCache 
 }
 
 // CreateCheckpoint implements [CheckpointStore].
-func (s *InMemoryCheckpointStore) CreateCheckpoint(sessionID string, data json.RawMessage, _ *CheckpointInfo) (CheckpointInfo, error) {
+func (s *InMemoryCheckpointStore) CreateCheckpoint(_ context.Context, sessionID string, data json.RawMessage, parent *CheckpointInfo) (CheckpointInfo, error) {
 	if sessionID == "" {
 		return CheckpointInfo{}, fmt.Errorf("sessionID cannot be empty")
 	}
@@ -63,12 +69,12 @@ func (s *InMemoryCheckpointStore) CreateCheckpoint(sessionID string, data json.R
 		CheckpointID: uuid.NewString(),
 	}
 	sess.checkpoints[info.CheckpointID] = append(json.RawMessage(nil), data...)
-	sess.index = append(sess.index, info)
+	sess.index = append(sess.index, indexEntry{Info: info, Parent: parent})
 	return info, nil
 }
 
 // RetrieveCheckpoint implements [CheckpointStore].
-func (s *InMemoryCheckpointStore) RetrieveCheckpoint(sessionID string, info CheckpointInfo) (json.RawMessage, error) {
+func (s *InMemoryCheckpointStore) RetrieveCheckpoint(_ context.Context, sessionID string, info CheckpointInfo) (json.RawMessage, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -84,7 +90,7 @@ func (s *InMemoryCheckpointStore) RetrieveCheckpoint(sessionID string, info Chec
 }
 
 // RetrieveIndex implements [CheckpointStore].
-func (s *InMemoryCheckpointStore) RetrieveIndex(sessionID string, _ *CheckpointInfo) ([]CheckpointInfo, error) {
+func (s *InMemoryCheckpointStore) RetrieveIndex(_ context.Context, sessionID string, withParent *CheckpointInfo) ([]CheckpointInfo, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -92,7 +98,15 @@ func (s *InMemoryCheckpointStore) RetrieveIndex(sessionID string, _ *CheckpointI
 	if !ok {
 		return nil, nil
 	}
-	result := make([]CheckpointInfo, len(sess.index))
-	copy(result, sess.index)
+
+	var result []CheckpointInfo
+	for _, entry := range sess.index {
+		if withParent != nil {
+			if entry.Parent == nil || *entry.Parent != *withParent {
+				continue
+			}
+		}
+		result = append(result, entry.Info)
+	}
 	return result, nil
 }

--- a/workflow/inmemory_checkpoint_store.go
+++ b/workflow/inmemory_checkpoint_store.go
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// InMemoryCheckpointStore is an in-memory implementation of [CheckpointStore]
+// suitable for development and testing. Checkpoints are not persisted beyond
+// the lifetime of the process.
+type InMemoryCheckpointStore struct {
+	mu       sync.RWMutex
+	sessions map[string]*sessionCache
+}
+
+type sessionCache struct {
+	index       []CheckpointInfo
+	checkpoints map[string]json.RawMessage
+}
+
+// NewInMemoryCheckpointStore creates a new in-memory checkpoint store.
+func NewInMemoryCheckpointStore() *InMemoryCheckpointStore {
+	return &InMemoryCheckpointStore{
+		sessions: make(map[string]*sessionCache),
+	}
+}
+
+// NewInMemoryCheckpointManager creates a [CheckpointManager] backed by an
+// in-memory store. This is a convenience equivalent to
+// NewCheckpointManager(NewInMemoryCheckpointStore()).
+func NewInMemoryCheckpointManager() *CheckpointManager {
+	return NewCheckpointManager(NewInMemoryCheckpointStore())
+}
+
+func (s *InMemoryCheckpointStore) ensureSession(sessionID string) *sessionCache {
+	if sess, ok := s.sessions[sessionID]; ok {
+		return sess
+	}
+	sess := &sessionCache{
+		checkpoints: make(map[string]json.RawMessage),
+	}
+	s.sessions[sessionID] = sess
+	return sess
+}
+
+// CreateCheckpoint implements [CheckpointStore].
+func (s *InMemoryCheckpointStore) CreateCheckpoint(sessionID string, data json.RawMessage, _ *CheckpointInfo) (CheckpointInfo, error) {
+	if sessionID == "" {
+		return CheckpointInfo{}, fmt.Errorf("sessionID cannot be empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess := s.ensureSession(sessionID)
+	info := CheckpointInfo{
+		SessionID:    sessionID,
+		CheckpointID: uuid.NewString(),
+	}
+	sess.checkpoints[info.CheckpointID] = append(json.RawMessage(nil), data...)
+	sess.index = append(sess.index, info)
+	return info, nil
+}
+
+// RetrieveCheckpoint implements [CheckpointStore].
+func (s *InMemoryCheckpointStore) RetrieveCheckpoint(sessionID string, info CheckpointInfo) (json.RawMessage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("could not retrieve checkpoint with id %s for session %s", info.CheckpointID, sessionID)
+	}
+	data, ok := sess.checkpoints[info.CheckpointID]
+	if !ok {
+		return nil, fmt.Errorf("could not retrieve checkpoint with id %s for session %s", info.CheckpointID, sessionID)
+	}
+	return data, nil
+}
+
+// RetrieveIndex implements [CheckpointStore].
+func (s *InMemoryCheckpointStore) RetrieveIndex(sessionID string, _ *CheckpointInfo) ([]CheckpointInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil, nil
+	}
+	result := make([]CheckpointInfo, len(sess.index))
+	copy(result, sess.index)
+	return result, nil
+}

--- a/workflow/inmemory_checkpoint_store.go
+++ b/workflow/inmemory_checkpoint_store.go
@@ -11,10 +11,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// InMemoryCheckpointStore is an in-memory implementation of [CheckpointStore]
+// inMemoryCheckpointStore is an in-memory implementation of [CheckpointStore]
 // suitable for development and testing. Checkpoints are not persisted beyond
 // the lifetime of the process.
-type InMemoryCheckpointStore struct {
+type inMemoryCheckpointStore struct {
 	mu       sync.RWMutex
 	sessions map[string]*sessionCache
 }
@@ -29,21 +29,25 @@ type indexEntry struct {
 	Parent *CheckpointInfo
 }
 
-// NewInMemoryCheckpointStore creates a new in-memory checkpoint store.
-func NewInMemoryCheckpointStore() *InMemoryCheckpointStore {
-	return &InMemoryCheckpointStore{
+// newInMemoryCheckpointStore creates a new in-memory checkpoint store.
+func newInMemoryCheckpointStore() *inMemoryCheckpointStore {
+	return &inMemoryCheckpointStore{
 		sessions: make(map[string]*sessionCache),
 	}
 }
 
 // NewInMemoryCheckpointManager creates a [CheckpointManager] backed by an
-// in-memory store. This is a convenience equivalent to
-// NewCheckpointManager(NewInMemoryCheckpointStore()).
+// in-memory store suitable for development and testing.
+//
+// Note: for workflow checkpoint/restore to work correctly, the manager
+// returned by this function should be used with [inproc.ExecutionEnvironment.WithCheckpointing].
 func NewInMemoryCheckpointManager() *CheckpointManager {
-	return NewCheckpointManager(NewInMemoryCheckpointStore())
+	mgr := NewCheckpointManager(newInMemoryCheckpointStore())
+	mgr.inMemory = true
+	return mgr
 }
 
-func (s *InMemoryCheckpointStore) ensureSession(sessionID string) *sessionCache {
+func (s *inMemoryCheckpointStore) ensureSession(sessionID string) *sessionCache {
 	if sess, ok := s.sessions[sessionID]; ok {
 		return sess
 	}
@@ -55,7 +59,7 @@ func (s *InMemoryCheckpointStore) ensureSession(sessionID string) *sessionCache 
 }
 
 // CreateCheckpoint implements [CheckpointStore].
-func (s *InMemoryCheckpointStore) CreateCheckpoint(_ context.Context, sessionID string, data json.RawMessage, parent *CheckpointInfo) (CheckpointInfo, error) {
+func (s *inMemoryCheckpointStore) CreateCheckpoint(_ context.Context, sessionID string, data json.RawMessage, parent *CheckpointInfo) (CheckpointInfo, error) {
 	if sessionID == "" {
 		return CheckpointInfo{}, fmt.Errorf("sessionID cannot be empty")
 	}
@@ -74,7 +78,7 @@ func (s *InMemoryCheckpointStore) CreateCheckpoint(_ context.Context, sessionID 
 }
 
 // RetrieveCheckpoint implements [CheckpointStore].
-func (s *InMemoryCheckpointStore) RetrieveCheckpoint(_ context.Context, sessionID string, info CheckpointInfo) (json.RawMessage, error) {
+func (s *inMemoryCheckpointStore) RetrieveCheckpoint(_ context.Context, sessionID string, info CheckpointInfo) (json.RawMessage, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -90,7 +94,7 @@ func (s *InMemoryCheckpointStore) RetrieveCheckpoint(_ context.Context, sessionI
 }
 
 // RetrieveIndex implements [CheckpointStore].
-func (s *InMemoryCheckpointStore) RetrieveIndex(_ context.Context, sessionID string, withParent *CheckpointInfo) ([]CheckpointInfo, error) {
+func (s *inMemoryCheckpointStore) RetrieveIndex(_ context.Context, sessionID string, withParent *CheckpointInfo) ([]CheckpointInfo, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/workflow/inproc/checkpoint_test.go
+++ b/workflow/inproc/checkpoint_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 package inproc_test
 
 import (
@@ -633,8 +635,8 @@ func capturePendingRequestAndCheckpointFromStream(t *testing.T, ctx context.Cont
 			pendingRequest = reqEvt.Request
 		}
 		if stepEvt, ok := evt.(workflow.SuperStepCompletedEvent); ok && stepEvt.CompletionInfo != nil {
-			if checkpoint, ok := stepEvt.CompletionInfo.CheckpointInfo.(workflow.CheckpointInfo); ok {
-				checkpointInfo = checkpoint
+			if stepEvt.CompletionInfo.CheckpointInfo != nil {
+				checkpointInfo = *stepEvt.CompletionInfo.CheckpointInfo
 			}
 		}
 	}

--- a/workflow/inproc/checkpoint_test.go
+++ b/workflow/inproc/checkpoint_test.go
@@ -18,7 +18,7 @@ func TestCheckpoint_ResumeWithPendingRequests_RepublishesRequestInfoEvents(t *te
 		t.Run(env.name, func(t *testing.T) {
 			ctx := context.Background()
 			wf, _ := createCheckpointRequestWorkflow(t)
-			manager := inproc.NewInMemoryCheckpointManager()
+			manager := workflow.NewInMemoryCheckpointManager()
 
 			first, err := env.env.WithCheckpointing(manager).Run(ctx, wf, "Hello")
 			if err != nil {
@@ -62,7 +62,7 @@ func TestCheckpoint_ResumeWithPendingRequests_RunStatusIsPendingRequests(t *test
 		t.Run(env.name, func(t *testing.T) {
 			ctx := context.Background()
 			wf, _ := createCheckpointRequestWorkflow(t)
-			manager := inproc.NewInMemoryCheckpointManager()
+			manager := workflow.NewInMemoryCheckpointManager()
 
 			first, err := env.env.WithCheckpointing(manager).Run(ctx, wf, "Hello")
 			if err != nil {
@@ -96,7 +96,7 @@ func TestCheckpoint_ResumeWithRepublishDisabled_DoesNotEmitRequestInfoEvents(t *
 		t.Run(env.name, func(t *testing.T) {
 			ctx := context.Background()
 			wf, _ := createCheckpointRequestWorkflow(t)
-			manager := inproc.NewInMemoryCheckpointManager()
+			manager := workflow.NewInMemoryCheckpointManager()
 
 			first, err := env.env.WithCheckpointing(manager).Run(ctx, wf, "Hello")
 			if err != nil {
@@ -134,7 +134,7 @@ func TestCheckpoint_ResumeWithRepublishDisabled_DoesNotEmitRequestInfoEvents(t *
 func TestCheckpoint_ResumeWithSessionIDOverrideUsesLookupSession(t *testing.T) {
 	ctx := context.Background()
 	wf, _ := createCheckpointRequestWorkflow(t)
-	manager := inproc.NewInMemoryCheckpointManager()
+	manager := workflow.NewInMemoryCheckpointManager()
 	const lookupSession = "lookup-session"
 
 	first, err := inproc.Default.WithCheckpointing(manager).Run(ctx, wf, "Hello", inproc.WithSessionID(lookupSession))
@@ -160,7 +160,7 @@ func TestCheckpoint_ResumeRespondToPendingRequest_CompletesWithoutDuplicate(t *t
 		t.Run(env.name, func(t *testing.T) {
 			ctx := context.Background()
 			wf, received := createCheckpointRequestWorkflow(t)
-			manager := inproc.NewInMemoryCheckpointManager()
+			manager := workflow.NewInMemoryCheckpointManager()
 
 			first, err := env.env.WithCheckpointing(manager).Run(ctx, wf, "Hello")
 			if err != nil {
@@ -232,7 +232,7 @@ func TestCheckpoint_RestoreWithPendingRequests_RepublishesRequestInfoEvents(t *t
 		t.Run(env.name, func(t *testing.T) {
 			ctx := context.Background()
 			wf, received := createCheckpointRequestWorkflow(t)
-			manager := inproc.NewInMemoryCheckpointManager()
+			manager := workflow.NewInMemoryCheckpointManager()
 
 			run, err := env.env.WithCheckpointing(manager).Run(ctx, wf, "Hello")
 			if err != nil {
@@ -294,7 +294,7 @@ func TestCheckpoint_RestoreWithPendingRequests_RepublishesRequestInfoEvents(t *t
 func TestCheckpoint_RestoreClearsQueuedExternalResponsesBeforeImport(t *testing.T) {
 	ctx := context.Background()
 	wf, received := createCheckpointRequestWorkflow(t)
-	manager := inproc.NewInMemoryCheckpointManager()
+	manager := workflow.NewInMemoryCheckpointManager()
 
 	stream, err := inproc.Lockstep.WithCheckpointing(manager).RunStreaming(ctx, wf, "Hello")
 	if err != nil {
@@ -360,7 +360,7 @@ func TestCheckpoint_RestoreClearsQueuedExternalResponsesBeforeImport(t *testing.
 
 func TestCheckpoint_RestoreClearsExecutorInstancesBeforeImport(t *testing.T) {
 	ctx := context.Background()
-	manager := inproc.NewInMemoryCheckpointManager()
+	manager := workflow.NewInMemoryCheckpointManager()
 	var nextInstanceID int64
 	binding := &workflow.ExecutorBinding{
 		ID:           "counter",
@@ -436,7 +436,7 @@ func TestCheckpoint_ExecutorCheckpointHooks(t *testing.T) {
 			ctx := context.Background()
 			fixture := newCheckpointHookFixture()
 			env := inproc.OffThread
-			manager := inproc.NewInMemoryCheckpointManager()
+			manager := workflow.NewInMemoryCheckpointManager()
 			var run *inproc.Run
 			var err error
 			if useCheckpointing {
@@ -473,7 +473,7 @@ func TestCheckpoint_ExecutorRestoreHooks(t *testing.T) {
 	for _, restoreCheckpoint := range []bool{true, false} {
 		t.Run(map[bool]string{true: "restore", false: "no_restore"}[restoreCheckpoint], func(t *testing.T) {
 			ctx := context.Background()
-			manager := inproc.NewInMemoryCheckpointManager()
+			manager := workflow.NewInMemoryCheckpointManager()
 			runFixture := newCheckpointHookFixture()
 			run, err := inproc.OffThread.WithCheckpointing(manager).Run(ctx, runFixture.workflow, "Message")
 			if err != nil {

--- a/workflow/inproc/environment.go
+++ b/workflow/inproc/environment.go
@@ -71,6 +71,9 @@ func (e *ExecutionEnvironment) WithCheckpointing(cm checkpoint.Manager) *Executi
 // the given [workflow.CheckpointManager]. This is the recommended way to
 // attach checkpoint storage and matches the .NET SDK pattern.
 func (e *ExecutionEnvironment) WithCheckpointStore(cm *workflow.CheckpointManager) *ExecutionEnvironment {
+	if cm == nil {
+		return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns)
+	}
 	adapter := checkpoint.NewStoreAdapter(cm.Store())
 	return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns, adapter)
 }
@@ -136,7 +139,7 @@ func (e *ExecutionEnvironment) Resume(ctx context.Context, wf *workflow.Workflow
 
 func (e *ExecutionEnvironment) verifyCheckpointingConfigured() error {
 	if e.checkpointManager == nil {
-		return errors.New("checkpointing is not configured for this execution environment; use WithCheckpointing to attach a checkpoint manager")
+		return errors.New("checkpointing is not configured for this execution environment; use WithCheckpointStore to attach a checkpoint manager")
 	}
 	return nil
 }

--- a/workflow/inproc/environment.go
+++ b/workflow/inproc/environment.go
@@ -32,13 +32,6 @@ var (
 	Subworkflow = newExecutionEnvironment(execution.ModeSubworkflow, false)
 )
 
-// NewInMemoryCheckpointManager creates an in-memory checkpoint manager.
-//
-// Deprecated: Use [workflow.NewInMemoryCheckpointManager] instead.
-func NewInMemoryCheckpointManager() checkpoint.Manager {
-	return checkpoint.NewInMemoryManager()
-}
-
 // ExecutionEnvironment provides an in-process workflow execution environment
 // for running, streaming, and checkpointing workflows.
 type ExecutionEnvironment struct {
@@ -59,23 +52,27 @@ func newExecutionEnvironment(mode execution.Mode, enableConcurrentRuns bool, che
 	}
 }
 
-// WithCheckpointing returns a new execution environment with the same
-// execution settings and the provided checkpoint manager.
-//
-// Deprecated: Use [WithCheckpointStore] instead.
-func (e *ExecutionEnvironment) WithCheckpointing(cm checkpoint.Manager) *ExecutionEnvironment {
-	return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns, cm)
-}
-
-// WithCheckpointStore returns a new execution environment configured with
-// the given [workflow.CheckpointManager]. This is the recommended way to
-// attach checkpoint storage and matches the .NET SDK pattern.
-func (e *ExecutionEnvironment) WithCheckpointStore(cm *workflow.CheckpointManager) *ExecutionEnvironment {
+// WithCheckpointing returns a new execution environment configured with
+// the given [workflow.CheckpointManager].
+func (e *ExecutionEnvironment) WithCheckpointing(cm *workflow.CheckpointManager) *ExecutionEnvironment {
 	if cm == nil {
 		return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns)
 	}
-	adapter := checkpoint.NewStoreAdapter(cm.Store())
-	return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns, adapter)
+	// Reuse a previously created internal manager if available.
+	if mgr, ok := cm.Internal().(checkpoint.Manager); ok {
+		return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns, mgr)
+	}
+	// For in-memory stores, use the internal InMemoryManager directly to
+	// avoid JSON serialization round-trips that lose Go type information.
+	// For external stores, use the StoreAdapter which serializes to JSON.
+	var mgr checkpoint.Manager
+	if cm.IsInMemory() {
+		mgr = checkpoint.NewInMemoryManager()
+	} else {
+		mgr = checkpoint.NewStoreAdapter(cm.Store())
+	}
+	cm.SetInternal(mgr)
+	return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns, mgr)
 }
 
 // IsCheckpointingEnabled reports whether checkpointing is configured for
@@ -139,7 +136,7 @@ func (e *ExecutionEnvironment) Resume(ctx context.Context, wf *workflow.Workflow
 
 func (e *ExecutionEnvironment) verifyCheckpointingConfigured() error {
 	if e.checkpointManager == nil {
-		return errors.New("checkpointing is not configured for this execution environment; use WithCheckpointStore to attach a checkpoint manager")
+		return errors.New("checkpointing is not configured for this execution environment; use WithCheckpointing to attach a checkpoint manager")
 	}
 	return nil
 }

--- a/workflow/inproc/environment.go
+++ b/workflow/inproc/environment.go
@@ -32,6 +32,9 @@ var (
 	Subworkflow = newExecutionEnvironment(execution.ModeSubworkflow, false)
 )
 
+// NewInMemoryCheckpointManager creates an in-memory checkpoint manager.
+//
+// Deprecated: Use [workflow.NewInMemoryCheckpointManager] instead.
 func NewInMemoryCheckpointManager() checkpoint.Manager {
 	return checkpoint.NewInMemoryManager()
 }
@@ -58,8 +61,18 @@ func newExecutionEnvironment(mode execution.Mode, enableConcurrentRuns bool, che
 
 // WithCheckpointing returns a new execution environment with the same
 // execution settings and the provided checkpoint manager.
+//
+// Deprecated: Use [WithCheckpointStore] instead.
 func (e *ExecutionEnvironment) WithCheckpointing(cm checkpoint.Manager) *ExecutionEnvironment {
 	return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns, cm)
+}
+
+// WithCheckpointStore returns a new execution environment configured with
+// the given [workflow.CheckpointManager]. This is the recommended way to
+// attach checkpoint storage and matches the .NET SDK pattern.
+func (e *ExecutionEnvironment) WithCheckpointStore(cm *workflow.CheckpointManager) *ExecutionEnvironment {
+	adapter := checkpoint.NewStoreAdapter(cm.Store())
+	return newExecutionEnvironment(e.executionMode, e.enableConcurrentRuns, adapter)
 }
 
 // IsCheckpointingEnabled reports whether checkpointing is configured for

--- a/workflow/inproc/state_test.go
+++ b/workflow/inproc/state_test.go
@@ -203,7 +203,7 @@ func TestInProcessRun_StateShouldPersist_Checkpointed(t *testing.T) {
 		t.Fatalf("Failed to build workflow: %v", err)
 	}
 
-	run, err := inproc.Default.WithCheckpointing(inproc.NewInMemoryCheckpointManager()).Run(t.Context(), wf, TestTurnToken{})
+	run, err := inproc.Default.WithCheckpointing(workflow.NewInMemoryCheckpointManager()).Run(t.Context(), wf, TestTurnToken{})
 	if err != nil {
 		t.Fatalf("Failed to create checkpointed runner: %v", err)
 	}

--- a/workflow/inproc/tracer.go
+++ b/workflow/inproc/tracer.go
@@ -16,7 +16,7 @@ var _ execution.StepTracer = (*stepTracer)(nil)
 type stepTracer struct {
 	stepNumber     int
 	stateUpdated   bool
-	checkpointInfo workflow.CheckpointInfo
+	checkpointInfo *workflow.CheckpointInfo
 
 	instantiated concurrent.Map[string, string]
 	activated    concurrent.Map[string, string]
@@ -33,7 +33,7 @@ func (t *stepTracer) StateUpdated() bool {
 }
 
 // Checkpoint returns the checkpoint info created in this step, if any.
-func (t *stepTracer) Checkpoint() workflow.CheckpointInfo {
+func (t *stepTracer) Checkpoint() *workflow.CheckpointInfo {
 	return t.checkpointInfo
 }
 
@@ -54,7 +54,7 @@ func (t *stepTracer) TraceStatePublished() {
 
 // TraceCheckpointCreated records that a checkpoint was created.
 func (t *stepTracer) TraceCheckpointCreated(cp workflow.CheckpointInfo) {
-	t.checkpointInfo = cp
+	t.checkpointInfo = &cp
 }
 
 // Reload resets the tracer to the specified step number.
@@ -70,7 +70,7 @@ func (t *stepTracer) Advance(step *execution.StepContext) workflow.SuperStepStar
 	t.activated.Clear()
 	t.instantiated.Clear()
 	t.stateUpdated = false
-	t.checkpointInfo = workflow.CheckpointInfo{}
+	t.checkpointInfo = nil
 
 	// Collect sending executors
 	sendingExecutors := make([]string, 0)

--- a/workflow/internal/checkpoint/checkpoint_json.go
+++ b/workflow/internal/checkpoint/checkpoint_json.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package checkpoint
+
+import (
+	"encoding/json"
+	"hash/maphash"
+
+	"github.com/microsoft/agent-framework-go/internal/hashmap"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+// scopeKeyHasherImpl implements hashmap.Hasher for workflow.ScopeKey.
+// This is duplicated here to avoid an import cycle with execution.
+type scopeKeyHasherImpl struct{}
+
+var scopeKeyHasherInstance hashmap.Hasher[workflow.ScopeKey] = scopeKeyHasherImpl{}
+
+func (scopeKeyHasherImpl) Hash(s workflow.ScopeKey) uint64 {
+	var h maphash.Hash
+	s.Hash(&h)
+	return h.Sum64()
+}
+
+func (scopeKeyHasherImpl) Equal(a, b workflow.ScopeKey) bool {
+	return a.Equal(b)
+}
+
+// scopeKeyEntry is the JSON-friendly representation of a ScopeKey→PortableValue pair.
+type scopeKeyEntry struct {
+	Key   workflow.ScopeKey
+	Value workflow.PortableValue
+}
+
+// checkpointJSON is the JSON representation of a Checkpoint.
+type checkpointJSON struct {
+	StepNumber    int
+	WorkflowInfo  WorkflowInfo
+	RunnerData    RunnerStateData
+	StateData     []scopeKeyEntry
+	EdgeStateData map[string]workflow.PortableValue
+	Parent        workflow.CheckpointInfo
+}
+
+// MarshalJSON implements [json.Marshaler] for Checkpoint.
+func (c *Checkpoint) MarshalJSON() ([]byte, error) {
+	var entries []scopeKeyEntry
+	for key, value := range c.StateData.All() {
+		entries = append(entries, scopeKeyEntry{Key: key, Value: value})
+	}
+
+	return json.Marshal(checkpointJSON{
+		StepNumber:    c.StepNumber,
+		WorkflowInfo:  c.WorkflowInfo,
+		RunnerData:    c.RunnerData,
+		StateData:     entries,
+		EdgeStateData: c.EdgeStateData,
+		Parent:        c.Parent,
+	})
+}
+
+// UnmarshalJSON implements [json.Unmarshaler] for Checkpoint.
+func (c *Checkpoint) UnmarshalJSON(data []byte) error {
+	var v checkpointJSON
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	stateData := hashmap.NewMap[workflow.ScopeKey, workflow.PortableValue](scopeKeyHasherInstance)
+	for _, entry := range v.StateData {
+		stateData.Set(entry.Key, entry.Value)
+	}
+
+	c.StepNumber = v.StepNumber
+	c.WorkflowInfo = v.WorkflowInfo
+	c.RunnerData = v.RunnerData
+	c.StateData = *stateData
+	c.EdgeStateData = v.EdgeStateData
+	c.Parent = v.Parent
+	return nil
+}

--- a/workflow/internal/checkpoint/info.go
+++ b/workflow/internal/checkpoint/info.go
@@ -22,11 +22,11 @@ func (e *executorInfo) matchBinding(executor *workflow.ExecutorBinding) bool {
 }
 
 type WorkflowInfo struct {
-	executors         map[string]executorInfo
-	edges             map[string][]workflow.EdgeInfo
-	requestPorts      map[workflow.RequestPortInfo]struct{}
-	startExecutorID   string
-	outputExecutorIDs map[string]struct{}
+	Executors         map[string]executorInfo
+	Edges             map[string][]workflow.EdgeInfo
+	RequestPorts      map[string]workflow.RequestPortInfo
+	StartExecutorID   string
+	OutputExecutorIDs map[string]struct{}
 }
 
 func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
@@ -40,9 +40,10 @@ func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
 
 	edges := wf.ReflectEdges()
 
-	requestPorts := make(map[workflow.RequestPortInfo]struct{}, len(wf.Ports))
+	requestPorts := make(map[string]workflow.RequestPortInfo, len(wf.Ports))
 	for _, port := range wf.Ports {
-		requestPorts[workflow.NewRequestPortInfo(port)] = struct{}{}
+		info := workflow.NewRequestPortInfo(port)
+		requestPorts[info.PortID] = info
 	}
 
 	outputs := make(map[string]struct{}, len(wf.OutputExecutors))
@@ -51,11 +52,11 @@ func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
 	}
 
 	return WorkflowInfo{
-		executors:         executors,
-		edges:             edges,
-		requestPorts:      requestPorts,
-		startExecutorID:   wf.StartExecutorID,
-		outputExecutorIDs: outputs,
+		Executors:         executors,
+		Edges:             edges,
+		RequestPorts:      requestPorts,
+		StartExecutorID:   wf.StartExecutorID,
+		OutputExecutorIDs: outputs,
 	}
 }
 
@@ -63,24 +64,24 @@ func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {
 	if wf == nil {
 		return false
 	}
-	if w.startExecutorID != wf.StartExecutorID {
+	if w.StartExecutorID != wf.StartExecutorID {
 		return false
 	}
-	if len(wf.ExecutorBindings) != len(w.executors) {
+	if len(wf.ExecutorBindings) != len(w.Executors) {
 		return false
 	}
 	// Validate the executors
-	for _, eb := range w.executors {
+	for _, eb := range w.Executors {
 		binding, ok := wf.ExecutorBindings[eb.ExecutorID]
 		if !ok || !eb.matchBinding(binding) {
 			return false
 		}
 	}
 	// Validate the edges
-	if len(wf.Edges) != len(w.edges) {
+	if len(wf.Edges) != len(w.Edges) {
 		return false
 	}
-	for sourceID, edges := range w.edges {
+	for sourceID, edges := range w.Edges {
 		other, ok := wf.Edges[sourceID]
 		if !ok || len(other) != len(edges) {
 			return false
@@ -93,10 +94,10 @@ func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {
 	}
 
 	// Validate the request ports
-	if len(wf.Ports) != len(w.requestPorts) {
+	if len(wf.Ports) != len(w.RequestPorts) {
 		return false
 	}
-	for port := range w.requestPorts {
+	for _, port := range w.RequestPorts {
 		other, ok := wf.Ports[port.PortID]
 		if !ok {
 			return false
@@ -107,10 +108,10 @@ func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {
 	}
 
 	// Validate the outputs
-	if len(wf.OutputExecutors) != len(w.outputExecutorIDs) {
+	if len(wf.OutputExecutors) != len(w.OutputExecutorIDs) {
 		return false
 	}
-	for outputID := range w.outputExecutorIDs {
+	for outputID := range w.OutputExecutorIDs {
 		if _, ok := wf.OutputExecutors[outputID]; !ok {
 			return false
 		}

--- a/workflow/internal/checkpoint/store_adapter.go
+++ b/workflow/internal/checkpoint/store_adapter.go
@@ -3,6 +3,7 @@
 package checkpoint
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -35,11 +36,11 @@ func (a *StoreAdapter) Commit(sessionID string, cp *Checkpoint) (workflow.Checkp
 	if cp.Parent != (workflow.CheckpointInfo{}) {
 		parent = &cp.Parent
 	}
-	return a.store.CreateCheckpoint(sessionID, data, parent)
+	return a.store.CreateCheckpoint(context.Background(), sessionID, data, parent)
 }
 
 func (a *StoreAdapter) Lookup(sessionID string, info workflow.CheckpointInfo) (*Checkpoint, error) {
-	data, err := a.store.RetrieveCheckpoint(sessionID, info)
+	data, err := a.store.RetrieveCheckpoint(context.Background(), sessionID, info)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve checkpoint: %w", err)
 	}
@@ -51,5 +52,5 @@ func (a *StoreAdapter) Lookup(sessionID string, info workflow.CheckpointInfo) (*
 }
 
 func (a *StoreAdapter) RetrieveIndex(sessionID string) ([]workflow.CheckpointInfo, error) {
-	return a.store.RetrieveIndex(sessionID, nil)
+	return a.store.RetrieveIndex(context.Background(), sessionID, nil)
 }

--- a/workflow/internal/checkpoint/store_adapter.go
+++ b/workflow/internal/checkpoint/store_adapter.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+// StoreAdapter implements [Manager] by delegating to a [workflow.CheckpointStore].
+// It serializes/deserializes [Checkpoint] values as JSON.
+type StoreAdapter struct {
+	store workflow.CheckpointStore
+}
+
+// NewStoreAdapter creates a [Manager] backed by the given [workflow.CheckpointStore].
+func NewStoreAdapter(store workflow.CheckpointStore) *StoreAdapter {
+	return &StoreAdapter{store: store}
+}
+
+func (a *StoreAdapter) Commit(sessionID string, cp *Checkpoint) (workflow.CheckpointInfo, error) {
+	if sessionID == "" {
+		return workflow.CheckpointInfo{}, fmt.Errorf("sessionID cannot be empty")
+	}
+	if cp == nil {
+		return workflow.CheckpointInfo{}, fmt.Errorf("checkpoint cannot be nil")
+	}
+	data, err := json.Marshal(cp)
+	if err != nil {
+		return workflow.CheckpointInfo{}, fmt.Errorf("failed to marshal checkpoint: %w", err)
+	}
+	var parent *workflow.CheckpointInfo
+	if cp.Parent != (workflow.CheckpointInfo{}) {
+		parent = &cp.Parent
+	}
+	return a.store.CreateCheckpoint(sessionID, data, parent)
+}
+
+func (a *StoreAdapter) Lookup(sessionID string, info workflow.CheckpointInfo) (*Checkpoint, error) {
+	data, err := a.store.RetrieveCheckpoint(sessionID, info)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve checkpoint: %w", err)
+	}
+	var cp Checkpoint
+	if err := json.Unmarshal(data, &cp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal checkpoint: %w", err)
+	}
+	return &cp, nil
+}
+
+func (a *StoreAdapter) RetrieveIndex(sessionID string) ([]workflow.CheckpointInfo, error) {
+	return a.store.RetrieveIndex(sessionID, nil)
+}

--- a/workflow/internal/checkpoint/store_adapter.go
+++ b/workflow/internal/checkpoint/store_adapter.go
@@ -13,11 +13,11 @@ import (
 // StoreAdapter implements [Manager] by delegating to a [workflow.CheckpointStore].
 // It serializes/deserializes [Checkpoint] values as JSON.
 type StoreAdapter struct {
-	store workflow.CheckpointStore
+	store workflow.CheckpointStore[json.RawMessage]
 }
 
 // NewStoreAdapter creates a [Manager] backed by the given [workflow.CheckpointStore].
-func NewStoreAdapter(store workflow.CheckpointStore) *StoreAdapter {
+func NewStoreAdapter(store workflow.CheckpointStore[json.RawMessage]) *StoreAdapter {
 	return &StoreAdapter{store: store}
 }
 

--- a/workflow/json.go
+++ b/workflow/json.go
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+import "encoding/json"
+
+// scopeIDJSON is the JSON representation of ScopeID, omitting the
+// non-serializable equality-guard field.
+type scopeIDJSON struct {
+	ScopeName  string `json:",omitempty"`
+	ExecutorID string `json:",omitempty"`
+}
+
+// MarshalJSON implements [json.Marshaler] for ScopeID.
+func (s ScopeID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(scopeIDJSON{
+		ScopeName:  s.ScopeName,
+		ExecutorID: s.ExecutorID,
+	})
+}
+
+// UnmarshalJSON implements [json.Unmarshaler] for ScopeID.
+func (s *ScopeID) UnmarshalJSON(data []byte) error {
+	var v scopeIDJSON
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	s.ScopeName = v.ScopeName
+	s.ExecutorID = v.ExecutorID
+	return nil
+}

--- a/workflow/json_test.go
+++ b/workflow/json_test.go
@@ -170,3 +170,41 @@ func TestEdgeInfo_JsonRoundtrip(t *testing.T) {
 		})
 	}
 }
+
+func TestScopeID_JsonRoundtrip(t *testing.T) {
+	cases := []struct {
+		name string
+		id   workflow.ScopeID
+	}{
+		{
+			name: "executor scope",
+			id:   workflow.ScopeID{ExecutorID: "exec-1"},
+		},
+		{
+			name: "named scope",
+			id:   workflow.ScopeID{ScopeName: "shared-state"},
+		},
+		{
+			name: "both fields",
+			id:   workflow.ScopeID{ScopeName: "shared", ExecutorID: "exec-2"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.id)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var got workflow.ScopeID
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got.ScopeName != tc.id.ScopeName {
+				t.Errorf("ScopeName = %q, want %q", got.ScopeName, tc.id.ScopeName)
+			}
+			if got.ExecutorID != tc.id.ExecutorID {
+				t.Errorf("ExecutorID = %q, want %q", got.ExecutorID, tc.id.ExecutorID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add a public `CheckpointStore` interface and supporting types to enable external checkpoint storage backends, closing the gap with the .NET SDK's `ICheckpointStore<TStoreObject>` pattern.

## Changes

### Public API
- **`workflow.CheckpointStore`** — Public interface mirroring .NET's `ICheckpointStore<JsonElement>` with `CreateCheckpoint`, `RetrieveCheckpoint`, `RetrieveIndex` methods using `json.RawMessage` as the wire format
- **`workflow.CheckpointManager`** — Public facade wrapping a `CheckpointStore`, matching the .NET `CheckpointManager` pattern
- **`workflow.InMemoryCheckpointStore`** — In-memory implementation for development and testing
- **`workflow.NewInMemoryCheckpointManager()`** — Convenience constructor
- **`ExecutionEnvironment.WithCheckpointStore()`** — New method to attach a `CheckpointManager` to a workflow environment

### Storage Backend
- **`workflow/checkpoint/jsonstore`** — JSON file-based `CheckpointStore` that persists checkpoint data to the local filesystem, suitable for CLI tools and local development

### Internal Plumbing
- `StoreAdapter` bridging public `CheckpointStore` → internal `Manager` with automatic JSON serialization
- `Checkpoint` and `WorkflowInfo` made JSON-serializable (custom `MarshalJSON`/`UnmarshalJSON`)
- `ScopeID` JSON marshaling (skips non-serializable equality guard field)

### Bug Fix
- **Fixed TODO**: `SuperStepCompletionInfo.CheckpointInfo` now uses `*CheckpointInfo` instead of `any`

## Testing
- Unit tests for `InMemoryCheckpointStore` (round-trip, index, not-found, empty session)
- Unit tests for `jsonstore.Store` (round-trip, index, persistence across instances, not-found)
- All existing tests pass (0 failures across full suite)
