### PR TITLE
Align hosted agent workflow behavior

### DIFF
--- a/agent/hosting/workflowhosting/workflow.go
+++ b/agent/hosting/workflowhosting/workflow.go
@@ -7,24 +7,38 @@ package workflowhosting
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"maps"
 	"reflect"
-	"slices"
-	"sync"
+	"regexp"
+	"strings"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/internal/contentexthandler"
 	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/message/messageworkflow"
 	"github.com/microsoft/agent-framework-go/workflow"
 )
 
 const (
-	agentSessionStateKey     = "agent_session"
-	agentTurnEmitStateKey    = "agent_turn_emit"
-	agentBufferedStateKey    = "agent_buffered"
-	pendingApprovalsStateKey = "agent_pending_approvals"
-	pendingCallsStateKey     = "agent_pending_calls"
+	agentHostStateKey        = "AIAgentHostState"
+	agentBufferedStateKey    = "AIAgentHostExecutor.State"
+	pendingApprovalsStateKey = "_userInputHandler_PendingRequests"
+	pendingCallsStateKey     = "_functionCallHandler_PendingRequests"
 )
+
+var invalidDescriptiveIDChars = regexp.MustCompile(`[^0-9A-Za-z]+`)
+
+type agentHostState struct {
+	ThreadState           []byte
+	CurrentTurnEmitEvents *bool
+}
+
+// ResetSignal notifies an agent-hosting executor to reset its agent
+// conversation state and start a new session when appropriate.
+type ResetSignal struct{}
 
 // Config configures how an [agent.Agent] is hosted as a workflow
 // [workflow.Executor].
@@ -117,9 +131,7 @@ func New(a *agent.Agent, cfg Config) *workflow.ExecutorBinding {
 		NewExecutor: func(_ string) (*workflow.Executor, error) {
 			return newHostExecutor(a, cfg).executor(), nil
 		},
-		// Each run gets its own executor instance via NewExecutor so
-		// per-instance turn state is not shared across runs.
-		SupportsConcurrentSharedExecution: true,
+		SupportsConcurrentSharedExecution: false,
 	}
 }
 
@@ -141,50 +153,54 @@ func hostPorts(id string) (userInput, functionCall workflow.RequestPort) {
 // All per-run state (buffered turn messages, pending request bookkeeping,
 // agent session) is kept on this struct.
 type hostExecutor struct {
-	id       string
-	selfName string
-	agent    *agent.Agent
-	cfg      Config
+	id    string
+	agent *agent.Agent
+	cfg   Config
 
-	// Ports used to raise external requests when the corresponding
-	// Intercept* flag is false (the default).
-	userInputPort    workflow.RequestPort
-	functionCallPort workflow.RequestPort
+	session agent.Session
 
-	mu       sync.Mutex
-	session  agent.Session
-	buffered []*message.Message
-	// pendingApprovals tracks ToolApprovalRequestContent IDs that have
-	// been dispatched and are awaiting a matching response.
-	pendingApprovals map[string]struct{}
-	// pendingCalls tracks FunctionCallContent CallIDs that have been
-	// dispatched and are awaiting a matching FunctionResultContent.
-	pendingCalls map[string]struct{}
-	// pendingTurn, when non-nil, is the TurnToken whose downstream
-	// propagation is being held until all outstanding requests resolve.
-	pendingTurn *workflow.TurnToken
-	// currentTurnEmitUpdates is the effective EmitUpdates setting for the
-	// in-flight turn. It applies to subsequent agent re-invocations
-	// triggered by intercepted-request responses.
-	currentTurnEmitUpdates bool
+	messageState    *messageworkflow.MessageState
+	approvalHandler *contentexthandler.Handler[*message.ToolApprovalRequestContent, *message.ToolApprovalResponseContent]
+	callHandler     *contentexthandler.Handler[*message.FunctionCallContent, *message.FunctionResultContent]
+	turnEmitEvents  *bool
 }
 
 func newHostExecutor(a *agent.Agent, cfg Config) *hostExecutor {
 	id := descriptiveID(a)
 	userInputPort, functionCallPort := hostPorts(id)
-	return &hostExecutor{
-		id:               id,
-		selfName:         a.Name(),
-		agent:            a,
-		cfg:              cfg,
-		userInputPort:    userInputPort,
-		functionCallPort: functionCallPort,
-		pendingApprovals: make(map[string]struct{}),
-		pendingCalls:     make(map[string]struct{}),
+	h := &hostExecutor{
+		id:           id,
+		agent:        a,
+		cfg:          cfg,
+		messageState: messageworkflow.NewMessageState(agentBufferedStateKey, ""),
 	}
+	h.approvalHandler = contentexthandler.New(contentexthandler.Options[*message.ToolApprovalRequestContent, *message.ToolApprovalResponseContent]{
+		Port:            userInputPort,
+		StateKey:        pendingApprovalsStateKey,
+		Intercepted:     cfg.InterceptUserInputRequests,
+		RequestID:       func(req *message.ToolApprovalRequestContent) string { return req.RequestID },
+		ResponseID:      func(resp *message.ToolApprovalResponseContent) string { return resp.RequestID },
+		ResponseHandler: h.handleApprovalResponse,
+	})
+	h.callHandler = contentexthandler.New(contentexthandler.Options[*message.FunctionCallContent, *message.FunctionResultContent]{
+		Port:            functionCallPort,
+		StateKey:        pendingCallsStateKey,
+		Intercepted:     cfg.InterceptUnterminatedFunctionCalls,
+		RequestID:       func(req *message.FunctionCallContent) string { return req.CallID },
+		ResponseID:      func(resp *message.FunctionResultContent) string { return resp.CallID },
+		ResponseHandler: h.handleFunctionResult,
+	})
+	return h
 }
 
 func (h *hostExecutor) executor() *workflow.Executor {
+	messageConfig := messageworkflow.NewExecutorConfig(&messageworkflow.Options{
+		StateKey:                 agentBufferedStateKey,
+		TakeTurnHandler:          h.handleTurnToken,
+		StringMessageRole:        string(message.RoleUser),
+		DisableAutoSendTurnToken: true,
+		MessageState:             h.messageState,
+	})
 	return &workflow.Executor{
 		ID: h.id,
 		Options: workflow.ExecutorOptions{
@@ -192,81 +208,53 @@ func (h *hostExecutor) executor() *workflow.Executor {
 			DisableAutoYieldOutputHandlerResultObject: true,
 		},
 		Config: []*workflow.ExecutorConfig{
+			messageConfig,
 			{
 				OnCheckpoint: func(wctx *workflow.Context) error {
-					h.mu.Lock()
-					session := h.session
-					emit := h.currentTurnEmitUpdates
-					approvals := slices.Collect(maps.Keys(h.pendingApprovals))
-					calls := slices.Collect(maps.Keys(h.pendingCalls))
-					buffered := slices.Clone(h.buffered)
-					h.mu.Unlock()
-					if session != nil {
-						data, err := h.agent.MarshalSession(wctx, session)
+					state := agentHostState{CurrentTurnEmitEvents: h.turnEmitEvents}
+					if h.session != nil {
+						data, err := h.agent.MarshalSession(wctx, h.session)
 						if err != nil {
 							return err
 						}
-						if err := wctx.QueueStateUpdate(agentSessionStateKey, "", data); err != nil {
-							return err
-						}
+						state.ThreadState = data
 					}
-					if err := wctx.QueueStateUpdate(agentTurnEmitStateKey, "", emit); err != nil {
+					if err := wctx.QueueStateUpdate(agentHostStateKey, "", state); err != nil {
 						return err
 					}
-					if err := wctx.QueueStateUpdate(agentBufferedStateKey, "", buffered); err != nil {
+					if err := h.approvalHandler.Checkpoint(wctx); err != nil {
 						return err
 					}
-					if err := wctx.QueueStateUpdate(pendingApprovalsStateKey, "", approvals); err != nil {
+					if err := h.callHandler.Checkpoint(wctx); err != nil {
 						return err
 					}
-					return wctx.QueueStateUpdate(pendingCallsStateKey, "", calls)
+					return nil
 				},
 				OnCheckpointRestored: func(wctx *workflow.Context) error {
-					if data, err := wctx.ReadState(agentSessionStateKey, ""); err != nil {
+					h.session = nil
+					h.turnEmitEvents = nil
+					if err := h.approvalHandler.Restore(wctx); err != nil {
 						return err
-					} else if data != nil {
-						session, err := h.agent.UnmarshalSession(wctx, data.([]byte))
-						if err != nil {
-							return err
-						}
-						h.mu.Lock()
-						h.session = session
-						h.mu.Unlock()
 					}
-					if v, err := wctx.ReadState(agentTurnEmitStateKey, ""); err != nil {
+					if err := h.callHandler.Restore(wctx); err != nil {
 						return err
-					} else if v != nil {
-						if b, ok := v.(bool); ok {
-							h.mu.Lock()
-							h.currentTurnEmitUpdates = b
-							h.mu.Unlock()
-						}
 					}
-					if v, err := wctx.ReadState(agentBufferedStateKey, ""); err != nil {
+					data, err := wctx.ReadState(agentHostStateKey, "")
+					if err != nil {
 						return err
-					} else if v != nil {
-						if msgs, ok := v.([]*message.Message); ok {
-							h.mu.Lock()
-							h.buffered = msgs
-							h.mu.Unlock()
-						}
 					}
-					if v, err := wctx.ReadState(pendingApprovalsStateKey, ""); err != nil {
+					state, err := agentHostStateFromAny(data)
+					if err != nil {
 						return err
-					} else if v != nil {
-						if ks, ok := v.([]string); ok {
-							h.mu.Lock()
-							h.pendingApprovals = setFromKeys(ks)
-							h.mu.Unlock()
-						}
 					}
-					if v, err := wctx.ReadState(pendingCallsStateKey, ""); err != nil {
-						return err
-					} else if v != nil {
-						if ks, ok := v.([]string); ok {
-							h.mu.Lock()
-							h.pendingCalls = setFromKeys(ks)
-							h.mu.Unlock()
+					if state != nil {
+						h.turnEmitEvents = state.CurrentTurnEmitEvents
+						if state.ThreadState != nil {
+							session, err := h.agent.UnmarshalSession(wctx, state.ThreadState)
+							if err != nil {
+								return err
+							}
+							h.session = session
 						}
 					}
 					return nil
@@ -278,18 +266,13 @@ func (h *hostExecutor) executor() *workflow.Executor {
 }
 
 func (h *hostExecutor) configureRoutes(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-	rb = rb.
-		AddHandler(reflect.TypeFor[*message.Message](), nil, false, func(_ *workflow.Context, msg any) (any, error) {
-			h.appendMessages(msg.(*message.Message))
-			return nil, nil
-		}).
-		AddHandler(reflect.TypeFor[[]*message.Message](), nil, false, func(_ *workflow.Context, msgs any) (any, error) {
-			h.appendMessages(msgs.([]*message.Message)...)
-			return nil, nil
-		}).
-		AddHandler(reflect.TypeFor[workflow.TurnToken](), nil, false, func(wctx *workflow.Context, msg any) (any, error) {
-			return nil, h.handleTurnToken(wctx, msg.(workflow.TurnToken))
-		})
+	rb = h.approvalHandler.ConfigureRoutes(rb)
+	rb = h.callHandler.ConfigureRoutes(rb)
+	rb = rb.AddHandler(reflect.TypeFor[ResetSignal](), nil, false, func(wctx *workflow.Context, msg any) (any, error) {
+		h.session = nil
+		h.turnEmitEvents = nil
+		return nil, nil
+	})
 
 	// External-response handler is always installed; it dispatches by port
 	// ID so it serves as the back-channel for both kinds of port-mode
@@ -299,107 +282,86 @@ func (h *hostExecutor) configureRoutes(rb *workflow.RouteBuilder) (*workflow.Rou
 		return nil, h.handleExternalResponse(wctx, msg.(*workflow.ExternalResponse))
 	})
 
-	// Workflow-message response handlers are only installed when the
-	// matching flag is true.
-	if h.cfg.InterceptUserInputRequests {
-		rb = rb.AddHandler(reflect.TypeFor[*message.ToolApprovalResponseContent](), nil, false, func(wctx *workflow.Context, msg any) (any, error) {
-			return nil, h.handleApprovalResponse(wctx, msg.(*message.ToolApprovalResponseContent))
-		})
-	}
-	if h.cfg.InterceptUnterminatedFunctionCalls {
-		rb = rb.AddHandler(reflect.TypeFor[*message.FunctionResultContent](), nil, false, func(wctx *workflow.Context, msg any) (any, error) {
-			return nil, h.handleFunctionResult(wctx, msg.(*message.FunctionResultContent))
-		})
-	}
-
 	return rb, nil
 }
 
-func (h *hostExecutor) appendMessages(msgs ...*message.Message) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	for _, m := range msgs {
-		if m != nil {
-			h.buffered = append(h.buffered, m)
-		}
-	}
-}
-
 // drainBuffered returns the currently buffered messages and resets the buffer.
-func (h *hostExecutor) drainBuffered() []*message.Message {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	msgs := h.buffered
-	h.buffered = nil
-	return msgs
+func (h *hostExecutor) drainBuffered(wctx *workflow.Context) ([]*message.Message, error) {
+	var messages []*message.Message
+	err := h.messageState.ProcessTurnMessages(wctx, func(_ *workflow.Context, buffered []*message.Message) ([]*message.Message, error) {
+		messages = buffered
+		return nil, nil
+	})
+	return messages, err
 }
 
-// hasOutstandingRequests reports whether any dispatched requests are awaiting
-// a response.
-func (h *hostExecutor) hasOutstandingRequests() bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return len(h.pendingApprovals)+len(h.pendingCalls) > 0
-}
-
-func (h *hostExecutor) handleTurnToken(wctx *workflow.Context, token workflow.TurnToken) error {
+func (h *hostExecutor) handleTurnToken(wctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
 	emitUpdates := token.EmitEventsOr(h.cfg.EmitUpdateEvents)
-	h.mu.Lock()
-	h.currentTurnEmitUpdates = emitUpdates
-	h.pendingTurn = &token
-	h.mu.Unlock()
-	return h.runAgentAndDispatch(wctx)
+	h.turnEmitEvents = &emitUpdates
+	return h.runAgentAndDispatch(wctx, messages)
 }
 
 func (h *hostExecutor) handleApprovalResponse(wctx *workflow.Context, resp *message.ToolApprovalResponseContent) error {
-	h.mu.Lock()
-	if _, ok := h.pendingApprovals[resp.RequestID]; !ok {
-		h.mu.Unlock()
-		return fmt.Errorf("workflowhosting: no pending FunctionApprovalRequest with ID %q", resp.RequestID)
-	}
-	delete(h.pendingApprovals, resp.RequestID)
-	h.mu.Unlock()
 	wrapped := &message.Message{
-		Role:     message.RoleUser,
-		Contents: []message.Content{resp},
+		ID:        newMessageID(),
+		Role:      message.RoleUser,
+		Contents:  []message.Content{resp},
+		CreatedAt: time.Now().UTC(),
 	}
-	h.appendMessages(wrapped)
-	return h.runAgentAndDispatch(wctx)
+	found, err := h.approvalHandler.MarkRequestAsHandled(wctx, resp)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("workflowhosting: no pending tool approval request with id %q", resp.RequestID)
+	}
+	if err := h.messageState.ProcessTurnMessages(wctx, func(_ *workflow.Context, buffered []*message.Message) ([]*message.Message, error) {
+		return append(buffered, wrapped), nil
+	}); err != nil {
+		return err
+	}
+	messages, err := h.drainBuffered(wctx)
+	if err != nil {
+		return err
+	}
+	return h.runAgentAndDispatch(wctx, messages)
 }
 
 func (h *hostExecutor) handleFunctionResult(wctx *workflow.Context, result *message.FunctionResultContent) error {
-	h.mu.Lock()
-	if _, ok := h.pendingCalls[result.CallID]; !ok {
-		h.mu.Unlock()
-		return fmt.Errorf("workflowhosting: no pending FunctionCall with CallID %q", result.CallID)
-	}
-	delete(h.pendingCalls, result.CallID)
-	h.mu.Unlock()
 	wrapped := &message.Message{
+		ID:         newMessageID(),
 		Role:       message.RoleTool,
-		AuthorName: h.selfName,
+		AuthorName: agentNameOrID(h.agent),
 		Contents:   []message.Content{result},
+		CreatedAt:  time.Now().UTC(),
 	}
-	h.appendMessages(wrapped)
-	return h.runAgentAndDispatch(wctx)
+	found, err := h.callHandler.MarkRequestAsHandled(wctx, result)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("workflowhosting: no pending function call with id %q", result.CallID)
+	}
+	if err := h.messageState.ProcessTurnMessages(wctx, func(_ *workflow.Context, buffered []*message.Message) ([]*message.Message, error) {
+		return append(buffered, wrapped), nil
+	}); err != nil {
+		return err
+	}
+	messages, err := h.drainBuffered(wctx)
+	if err != nil {
+		return err
+	}
+	return h.runAgentAndDispatch(wctx, messages)
 }
 
 // handleExternalResponse routes a port-mode response back to the appropriate
 // content-typed handler.
 func (h *hostExecutor) handleExternalResponse(wctx *workflow.Context, resp *workflow.ExternalResponse) error {
-	switch resp.PortInfo.PortID {
-	case h.userInputPort.ID:
-		v, ok := resp.Data.As(h.userInputPort.Response)
-		if !ok {
-			return fmt.Errorf("workflowhosting: expected %v for user input port, got %T", h.userInputPort.Response, resp.Data.Any())
-		}
-		return h.handleApprovalResponse(wctx, v.(*message.ToolApprovalResponseContent))
-	case h.functionCallPort.ID:
-		v, ok := resp.Data.As(h.functionCallPort.Response)
-		if !ok {
-			return fmt.Errorf("workflowhosting: expected %v for function call port, got %T", h.functionCallPort.Response, resp.Data.Any())
-		}
-		return h.handleFunctionResult(wctx, v.(*message.FunctionResultContent))
+	if handled, err := h.approvalHandler.HandleExternalResponse(wctx, resp); handled || err != nil {
+		return err
+	}
+	if handled, err := h.callHandler.HandleExternalResponse(wctx, resp); handled || err != nil {
+		return err
 	}
 	return nil
 }
@@ -407,9 +369,7 @@ func (h *hostExecutor) handleExternalResponse(wctx *workflow.Context, resp *work
 // runAgentAndDispatch invokes the hosted agent with the buffered turn
 // messages, dispatches outputs and any requests, and propagates the held
 // TurnToken downstream when no outstanding requests remain.
-func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
-	messages := h.drainBuffered()
-
+func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context, messages []*message.Message) error {
 	if !h.cfg.DisableMessageForwarding && len(messages) > 0 {
 		if err := wctx.SendMessage("", messages); err != nil {
 			return err
@@ -418,7 +378,7 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 
 	agentInput := messages
 	if !h.cfg.DisableRoleReassignment {
-		agentInput = reassignOtherAgentsAsUsers(messages, h.selfName)
+		agentInput = reassignOtherAgentsAsUsers(messages, agentNameOrID(h.agent))
 	}
 
 	session, err := h.ensureSession(wctx)
@@ -426,9 +386,11 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 		return err
 	}
 
-	h.mu.Lock()
-	emitUpdates := h.currentTurnEmitUpdates
-	h.mu.Unlock()
+	emitEvents := h.turnEmitEvents
+	emitUpdates := false
+	if emitEvents != nil {
+		emitUpdates = *emitEvents
+	}
 
 	runOpts := []agent.Option{
 		agent.WithSession(session),
@@ -454,13 +416,19 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 	// so the role-reassignment logic in receiving hosts works correctly.
 	resp.AgentID = h.agent.ID()
 	for _, m := range resp.Messages {
-		m.AuthorName = h.selfName
+		if m.AuthorName == "" {
+			m.AuthorName = h.agent.Name()
+		}
 	}
 
 	if h.cfg.EmitResponseEvents {
 		if err := wctx.AddEvent(workflow.OutputEvent{ExecutorID: h.id, Output: &resp}); err != nil {
 			return err
 		}
+	}
+
+	if err := h.dispatchRequests(wctx, resp.Messages); err != nil {
+		return err
 	}
 
 	// Filter out server-side artifacts (reasoning tokens, web search calls, etc.)
@@ -473,28 +441,55 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context) error {
 		}
 	}
 
-	if err := h.dispatchRequests(wctx, resp.Messages); err != nil {
+	if err := h.releasePendingTurnIfReady(wctx); err != nil {
 		return err
 	}
-
-	// Only release the held TurnToken downstream once all outstanding
-	// requests have been resolved.
-	if !h.hasOutstandingRequests() {
-		h.mu.Lock()
-		held := h.pendingTurn
-		had := held != nil
-		emit := h.currentTurnEmitUpdates
-		h.pendingTurn = nil
-		h.currentTurnEmitUpdates = false
-		h.mu.Unlock()
-		if had {
-			// Forward a fresh TurnToken stamped with the resolved
-			// EmitEvents value so downstream executors observe the
-			// effective per-turn setting (not the possibly-nil input).
-			return wctx.SendMessage("", workflow.TurnToken{EmitEvents: &emit})
-		}
-	}
 	return nil
+}
+
+// releasePendingTurnIfReady propagates the held TurnToken downstream once all
+// outstanding requests have been resolved.
+func (h *hostExecutor) releasePendingTurnIfReady(wctx *workflow.Context) error {
+	var emit *bool
+	hasApprovals, err := h.approvalHandler.HasPending(wctx)
+	if err != nil {
+		return err
+	}
+	hasCalls, err := h.callHandler.HasPending(wctx)
+	if err != nil {
+		return err
+	}
+	if !hasApprovals && !hasCalls {
+		emit = h.turnEmitEvents
+		h.turnEmitEvents = nil
+	}
+	if emit == nil {
+		return nil
+	}
+	// Forward a fresh TurnToken stamped with the resolved EmitEvents value so
+	// downstream executors observe the effective per-turn setting.
+	return wctx.SendMessage("", workflow.TurnToken{EmitEvents: emit})
+}
+
+func agentHostStateFromAny(value any) (*agentHostState, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch state := value.(type) {
+	case agentHostState:
+		return &state, nil
+	case *agentHostState:
+		return state, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var state agentHostState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
 }
 
 // filterForwardableMessages filters response messages to only include portable
@@ -551,106 +546,87 @@ func filterForwardableContents(contents message.Contents) message.Contents {
 // already pending from a previous response (e.g. a re-emission) is silently
 // skipped (idempotent) so the executor doesn't double-dispatch.
 func (h *hostExecutor) dispatchRequests(wctx *workflow.Context, msgs []*message.Message) error {
-	// Pre-compute the set of FunctionCallContent CallIDs that already have a
-	// matching FunctionResultContent in the same response, so they are not
-	// considered unresolved.
-	resolved := make(map[string]struct{})
-	for _, m := range msgs {
-		for _, c := range m.Contents {
-			if r, ok := c.(*message.FunctionResultContent); ok {
-				resolved[r.CallID] = struct{}{}
-			}
-		}
-	}
-
-	// Track IDs seen so far in this single dispatch to detect within-response
-	// duplicates as errors.
-	seenApprovals := make(map[string]struct{})
-	seenCalls := make(map[string]struct{})
+	approvalRequests := make(map[string]*message.ToolApprovalRequestContent)
+	functionCalls := make(map[string]*message.FunctionCallContent)
+	var approvalOrder []string
+	var callOrder []string
 
 	for _, m := range msgs {
 		for _, c := range m.Contents {
 			switch v := c.(type) {
 			case *message.ToolApprovalRequestContent:
-				if _, dup := seenApprovals[v.RequestID]; dup {
-					return fmt.Errorf("workflowhosting: duplicate ToolApprovalRequest  ID %q in same response", v.RequestID)
+				if _, exists := approvalRequests[v.RequestID]; exists {
+					return fmt.Errorf("workflowhosting: duplicate tool approval request id %q", v.RequestID)
 				}
-				seenApprovals[v.RequestID] = struct{}{}
-				h.mu.Lock()
-				if _, alreadyPending := h.pendingApprovals[v.RequestID]; alreadyPending {
-					h.mu.Unlock()
-					// Already-pending request: idempotent re-emission, no-op.
-					continue
-				}
-				h.pendingApprovals[v.RequestID] = struct{}{}
-				h.mu.Unlock()
-				if h.cfg.InterceptUserInputRequests {
-					if err := wctx.SendMessage("", v); err != nil {
-						return err
-					}
-				} else {
-					req, err := workflow.NewExternalRequest(h.userInputPort.ID+":"+v.RequestID, h.userInputPort, v)
-					if err != nil {
-						return err
-					}
-					if err := wctx.PostRequest(req); err != nil {
-						return err
-					}
-				}
+				approvalRequests[v.RequestID] = v
+				approvalOrder = append(approvalOrder, v.RequestID)
+			case *message.ToolApprovalResponseContent:
+				delete(approvalRequests, v.RequestID)
 			case *message.FunctionCallContent:
-				if _, done := resolved[v.CallID]; done {
-					continue
+				if _, exists := functionCalls[v.CallID]; exists {
+					return fmt.Errorf("workflowhosting: duplicate function call id %q", v.CallID)
 				}
-				if _, dup := seenCalls[v.CallID]; dup {
-					return fmt.Errorf("workflowhosting: duplicate FunctionCall CallID %q in same response", v.CallID)
-				}
-				seenCalls[v.CallID] = struct{}{}
-				h.mu.Lock()
-				if _, alreadyPending := h.pendingCalls[v.CallID]; alreadyPending {
-					h.mu.Unlock()
-					// Already-pending call: idempotent re-emission, no-op.
-					continue
-				}
-				h.pendingCalls[v.CallID] = struct{}{}
-				h.mu.Unlock()
-				if h.cfg.InterceptUnterminatedFunctionCalls {
-					if err := wctx.SendMessage("", v); err != nil {
-						return err
-					}
-				} else {
-					req, err := workflow.NewExternalRequest(h.functionCallPort.ID+":"+v.CallID, h.functionCallPort, v)
-					if err != nil {
-						return err
-					}
-					if err := wctx.PostRequest(req); err != nil {
-						return err
-					}
-				}
+				functionCalls[v.CallID] = v
+				callOrder = append(callOrder, v.CallID)
+			case *message.FunctionResultContent:
+				delete(functionCalls, v.CallID)
 			}
+		}
+	}
+
+	var approvalDispatches []*message.ToolApprovalRequestContent
+	var callDispatches []*message.FunctionCallContent
+	for _, id := range approvalOrder {
+		approval, ok := approvalRequests[id]
+		if !ok {
+			continue
+		}
+		delete(approvalRequests, id)
+		added, err := h.approvalHandler.TrackRequest(wctx, approval)
+		if err != nil {
+			return err
+		}
+		if added {
+			approvalDispatches = append(approvalDispatches, approval)
+		}
+	}
+	for _, id := range callOrder {
+		call, ok := functionCalls[id]
+		if !ok {
+			continue
+		}
+		delete(functionCalls, id)
+		added, err := h.callHandler.TrackRequest(wctx, call)
+		if err != nil {
+			return err
+		}
+		if added {
+			callDispatches = append(callDispatches, call)
+		}
+	}
+
+	for _, approval := range approvalDispatches {
+		if err := h.approvalHandler.DispatchRequest(wctx, approval); err != nil {
+			return err
+		}
+	}
+	for _, call := range callDispatches {
+		if err := h.callHandler.DispatchRequest(wctx, call); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
 func (h *hostExecutor) ensureSession(ctx context.Context) (agent.Session, error) {
-	h.mu.Lock()
 	if h.session != nil {
-		s := h.session
-		h.mu.Unlock()
-		return s, nil
+		return h.session, nil
 	}
-	h.mu.Unlock()
 	s, err := h.agent.CreateSession(ctx)
 	if err != nil {
 		return nil, err
 	}
-	h.mu.Lock()
-	if h.session == nil {
-		h.session = s
-	} else {
-		s = h.session
-	}
-	h.mu.Unlock()
+	h.session = s
 	return s, nil
 }
 
@@ -660,7 +636,7 @@ func (h *hostExecutor) ensureSession(ctx context.Context) (agent.Session, error)
 func reassignOtherAgentsAsUsers(msgs []*message.Message, selfName string) []*message.Message {
 	var out []*message.Message
 	for i, m := range msgs {
-		if m == nil || m.Role != message.RoleAssistant || m.AuthorName == selfName {
+		if !shouldReassignAssistantMessage(m, selfName) {
 			if out != nil {
 				out = append(out, m)
 			}
@@ -680,17 +656,35 @@ func reassignOtherAgentsAsUsers(msgs []*message.Message, selfName string) []*mes
 	return out
 }
 
-func descriptiveID(a *agent.Agent) string {
-	if a.Name() != "" {
-		return a.Name() + "_" + a.ID()
+func shouldReassignAssistantMessage(m *message.Message, selfName string) bool {
+	if m == nil || m.Role != message.RoleAssistant || m.AuthorName == selfName {
+		return false
+	}
+	for _, content := range m.Contents {
+		switch content.(type) {
+		case *message.TextContent, *message.DataContent, *message.URIContent, *message.UsageContent:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func agentNameOrID(a *agent.Agent) string {
+	if name := a.Name(); name != "" {
+		return name
 	}
 	return a.ID()
 }
 
-func setFromKeys(ks []string) map[string]struct{} {
-	out := make(map[string]struct{}, len(ks))
-	for _, k := range ks {
-		out[k] = struct{}{}
+func newMessageID() string {
+	return strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
+func descriptiveID(a *agent.Agent) string {
+	id := a.ID()
+	if a.Name() != "" {
+		id = a.Name() + "_" + id
 	}
-	return out
+	return invalidDescriptiveIDChars.ReplaceAllString(id, "_")
 }

--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -208,8 +208,8 @@ func TestHostedAgent_BindingIDUsesAgentNameWhenProvided(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	assertHostedAgentBindingID(t, wf, agentA, "AgentA_agent-a-id")
-	assertHostedAgentBindingID(t, wf, agentB, "AgentB_agent-b-id")
+	assertHostedAgentBindingID(t, wf, agentA, "AgentA_agent_a_id")
+	assertHostedAgentBindingID(t, wf, agentB, "AgentB_agent_b_id")
 }
 
 func TestHostedAgent_BindingIDUsesAgentIDWhenNameMissing(t *testing.T) {
@@ -220,8 +220,17 @@ func TestHostedAgent_BindingIDUsesAgentIDWhenNameMissing(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	assertHostedAgentBindingID(t, wf, agentA, "agent-a-id")
-	assertHostedAgentBindingID(t, wf, agentB, "agent-b-id")
+	assertHostedAgentBindingID(t, wf, agentA, "agent_a_id")
+	assertHostedAgentBindingID(t, wf, agentB, "agent_b_id")
+}
+
+func TestHostedAgent_BindingIDSanitizesNameAndID(t *testing.T) {
+	binding := workflowhosting.New(newNamedNoopAgent("agent id", "Agent A!"), workflowhosting.Config{})
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	assertHostedAgentBindingID(t, wf, binding, "Agent_A_agent_id")
 }
 
 func assertHostedAgentBindingID(t *testing.T, wf *workflow.Workflow, binding *workflow.ExecutorBinding, want string) {
@@ -544,6 +553,35 @@ func TestHostedAgent_ReassignsRolesIfConfigured(t *testing.T) {
 	}
 }
 
+func TestHostedAgent_RoleReassignmentSkipsNonConversationalAssistantMessages(t *testing.T) {
+	var calls [][]*message.Message
+	textMsg := &message.Message{
+		Role:       message.RoleAssistant,
+		AuthorName: "OtherAgent",
+		Contents:   []message.Content{&message.TextContent{Text: "hello"}},
+	}
+	callMsg := &message.Message{
+		Role:       message.RoleAssistant,
+		AuthorName: "OtherAgent",
+		Contents:   []message.Content{&message.FunctionCallContent{CallID: "call-1", Name: "do"}},
+	}
+
+	runHostedAgent(t, newRecordingAgent(&calls), workflowhosting.Config{}, workflow.TurnToken{}, []*message.Message{textMsg, callMsg})
+
+	if len(calls) != 1 {
+		t.Fatalf("agent invocation count = %d, want 1", len(calls))
+	}
+	if len(calls[0]) != 2 {
+		t.Fatalf("received message count = %d, want 2", len(calls[0]))
+	}
+	if calls[0][0].Role != message.RoleUser {
+		t.Fatalf("text assistant message role = %s, want %s", calls[0][0].Role, message.RoleUser)
+	}
+	if calls[0][1].Role != message.RoleAssistant {
+		t.Fatalf("function-call assistant message role = %s, want %s", calls[0][1].Role, message.RoleAssistant)
+	}
+}
+
 // TestHostedAgent_ForwardsIncomingMessages verifies that incoming messages
 // are forwarded downstream by default and not when the option is disabled.
 func TestHostedAgent_ForwardsIncomingMessages(t *testing.T) {
@@ -659,6 +697,93 @@ func TestHostedAgent_HandlesSingleMessage(t *testing.T) {
 	}
 	if calls[0][0] != input {
 		t.Fatalf("agent received %p, want original message %p", calls[0][0], input)
+	}
+}
+
+func TestHostedAgent_QueuesDotNetStateKeys(t *testing.T) {
+	var calls [][]*message.Message
+	binding := workflowhosting.New(newRecordingAgent(&calls), workflowhosting.Config{})
+	executor, err := binding.CreateInstance("")
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	queued := make(map[string]any)
+	ctx := &workflow.Context{
+		Context: context.Background(),
+		AddEvent: func(workflow.Event) error {
+			return nil
+		},
+		SendMessage: func(string, any) error {
+			return nil
+		},
+		QueueStateUpdate: func(key string, _ string, value any) error {
+			queued[key] = value
+			return nil
+		},
+	}
+
+	_, err = executor.Execute(ctx, &message.Message{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: "buffered"}},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if err := executor.OnCheckpoint(ctx); err != nil {
+		t.Fatalf("OnCheckpoint: %v", err)
+	}
+
+	for _, key := range []string{
+		"AIAgentHostExecutor.State",
+		"AIAgentHostState",
+		"_userInputHandler_PendingRequests",
+		"_functionCallHandler_PendingRequests",
+	} {
+		if _, ok := queued[key]; !ok {
+			t.Fatalf("missing queued state key %q; got %v", key, queued)
+		}
+	}
+	if _, ok := queued["agent_buffered"]; ok {
+		t.Fatalf("queued old buffered state key agent_buffered; got %v", queued)
+	}
+}
+
+func TestHostedAgent_HandlesStringMessageAsUser(t *testing.T) {
+	var calls [][]*message.Message
+	binding := workflowhosting.New(newRecordingAgent(&calls), workflowhosting.Config{})
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("build workflow: %v", err)
+	}
+
+	ctx := context.Background()
+	stream, err := inproc.Lockstep.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.CancelRun() }()
+
+	sendStreamMessage(t, stream, ctx, "hello")
+	sendStreamMessage(t, stream, ctx, workflow.TurnToken{})
+	for _, err := range stream.WatchUntilHalt(ctx) {
+		if err != nil {
+			t.Fatalf("watch: %v", err)
+		}
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("agent invocation count = %d, want 1", len(calls))
+	}
+	if len(calls[0]) != 1 {
+		t.Fatalf("received message count = %d, want 1", len(calls[0]))
+	}
+	got := calls[0][0]
+	if got.Role != message.RoleUser {
+		t.Fatalf("message role = %s, want %s", got.Role, message.RoleUser)
+	}
+	if got.Contents.Text() != "hello" {
+		t.Fatalf("message text = %q, want hello", got.Contents.Text())
 	}
 }
 
@@ -788,6 +913,23 @@ func TestHostedAgent_StripsRawRepresentationFromForwardedResponseMessages(t *tes
 	forwardedText := forwarded[0].Contents[0].(*message.TextContent)
 	if forwardedText.RawRepresentation != "content-raw" {
 		t.Fatalf("expected content RawRepresentation to be preserved, got %#v", forwardedText.RawRepresentation)
+	}
+}
+
+func TestHostedAgent_PreservesProviderAuthorNameOnForwardedResponseMessages(t *testing.T) {
+	agent := newContentAgent(&agent.ResponseUpdate{
+		Role:       message.RoleAssistant,
+		AuthorName: "provider-author",
+		MessageID:  "provider-author-message",
+		Contents:   message.Contents{&message.TextContent{Text: "Response"}},
+	})
+
+	forwarded := collectForwardedResponseMessages(t, agent, workflowhosting.Config{})
+	if len(forwarded) != 1 {
+		t.Fatalf("expected 1 forwarded message, got %d", len(forwarded))
+	}
+	if forwarded[0].AuthorName != "provider-author" {
+		t.Fatalf("AuthorName = %q, want provider-author", forwarded[0].AuthorName)
 	}
 }
 
@@ -1120,6 +1262,85 @@ func TestHostedAgent_InterceptUnterminatedFunctionCalls(t *testing.T) {
 	}
 }
 
+func TestHostedAgent_FunctionResultMessageMetadataMatchesHostedAgent(t *testing.T) {
+	const agentID = "agent-without-name"
+	var calls [][]*message.Message
+	step := 0
+	run := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			snapshot := make([]*message.Message, len(msgs))
+			copy(snapshot, msgs)
+			calls = append(calls, snapshot)
+			defer func() { step++ }()
+			if step == 0 {
+				yield(&agent.ResponseUpdate{
+					Role:     message.RoleAssistant,
+					Contents: []message.Content{&message.FunctionCallContent{CallID: "call-1", Name: "do"}},
+				}, nil)
+				return
+			}
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.TextContent{Text: "done"}},
+			}, nil)
+		}
+	}
+	a := agent.New(
+		agent.ProviderConfig{ProviderName: "metadata", Run: run},
+		agent.Config{ID: agentID, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop"}},
+	)
+	host := workflowhosting.New(a, workflowhosting.Config{InterceptUnterminatedFunctionCalls: true})
+	exec := resultExecutor(host, "42")
+	wf, err := workflow.NewBuilder(host).
+		AddEdge(host, exec).
+		AddEdge(exec, host).
+		Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	ctx := context.Background()
+	stream, err := inproc.Default.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.CancelRun() }()
+
+	sendStreamMessage(t, stream, ctx, workflow.TurnToken{})
+	for _, err := range stream.WatchUntilHalt(ctx) {
+		if err != nil {
+			t.Fatalf("watch: %v", err)
+		}
+	}
+
+	if len(calls) < 2 {
+		t.Fatalf("agent invocation count = %d, want at least 2", len(calls))
+	}
+	var resultMsg *message.Message
+	for _, msg := range calls[1] {
+		for _, content := range msg.Contents {
+			if _, ok := content.(*message.FunctionResultContent); ok {
+				resultMsg = msg
+			}
+		}
+	}
+	if resultMsg == nil {
+		t.Fatal("second invocation did not include a function result message")
+	}
+	if resultMsg.Role != message.RoleTool {
+		t.Fatalf("result message role = %s, want %s", resultMsg.Role, message.RoleTool)
+	}
+	if resultMsg.AuthorName != agentID {
+		t.Fatalf("result message AuthorName = %q, want %q", resultMsg.AuthorName, agentID)
+	}
+	if resultMsg.ID == "" {
+		t.Fatal("result message ID is empty")
+	}
+	if resultMsg.CreatedAt.IsZero() {
+		t.Fatal("result message CreatedAt is zero")
+	}
+}
+
 // TestHostedAgent_InterceptDisabled_PostsExternalRequest verifies that when
 // the Intercept flags are not set (the default), the agent's request content
 // is raised as a workflow ExternalRequest via PostRequest rather than being
@@ -1162,10 +1383,12 @@ func TestHostedAgent_InterceptDisabled_PostsExternalRequest(t *testing.T) {
 	}
 
 	var sawExternalRequest bool
+	var externalRequestID string
 	for evt := range run.OutgoingEvents() {
 		if r, ok := evt.(workflow.RequestInfoEvent); ok {
 			if r.Request != nil && r.Request.PortInfo.PortID == host.ID+"_UserInput" {
 				sawExternalRequest = true
+				externalRequestID = r.Request.ID
 			}
 		}
 	}
@@ -1176,6 +1399,11 @@ func TestHostedAgent_InterceptDisabled_PostsExternalRequest(t *testing.T) {
 	if !sawExternalRequest {
 		t.Errorf("expected a RequestInfoEvent for the user-input port when InterceptUserInputRequests is false")
 	}
+	portID := host.ID + "_UserInput"
+	wantRequestID := fmt.Sprintf("%d:%s:%s", len(portID), portID, "call-1")
+	if externalRequestID != wantRequestID {
+		t.Errorf("external request ID = %q, want %q", externalRequestID, wantRequestID)
+	}
 
 	status, err := run.GetStatus(ctx)
 	if err != nil {
@@ -1183,6 +1411,86 @@ func TestHostedAgent_InterceptDisabled_PostsExternalRequest(t *testing.T) {
 	}
 	if status != inproc.RunStatusPendingRequests {
 		t.Errorf("status = %v, want PendingRequests", status)
+	}
+}
+
+func TestHostedAgent_BindingIsNotConcurrentShareable(t *testing.T) {
+	host := workflowhosting.New(newApprovalAgent(), workflowhosting.Config{})
+	if host.SupportsConcurrentSharedExecution {
+		t.Fatal("hosted agent binding is concurrent-shareable; want false to match AIAgentHostExecutor")
+	}
+}
+
+func TestHostedAgent_ResetSignal_StartsNewSession(t *testing.T) {
+	var sessions []agent.Session
+	createSessions := 0
+	run := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			session, ok := agent.GetOption(options, agent.WithSession)
+			if !ok {
+				yield(nil, errors.New("missing session"))
+				return
+			}
+			sessions = append(sessions, session)
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.TextContent{Text: "ok"}},
+			}, nil)
+		}
+	}
+	a := agent.New(
+		agent.ProviderConfig{
+			ProviderName: "reset-session",
+			Run:          run,
+			CreateSession: func(_ context.Context, _ agent.Session, _ ...agent.Option) error {
+				createSessions++
+				return nil
+			},
+		},
+		agent.Config{ID: testAgentID, Name: testAgentName, DisableFuncAutoCall: true},
+	)
+	host := workflowhosting.New(a, workflowhosting.Config{})
+	wf, err := workflow.NewBuilder(host).Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	ctx := context.Background()
+	stream, err := inproc.Lockstep.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.CancelRun() }()
+
+	sendStreamMessage(t, stream, ctx, "first")
+	sendStreamMessage(t, stream, ctx, workflow.TurnToken{})
+	for _, err := range stream.WatchUntilHalt(ctx) {
+		if err != nil {
+			t.Fatalf("watch first turn: %v", err)
+		}
+	}
+	sendStreamMessage(t, stream, ctx, workflowhosting.ResetSignal{})
+	for _, err := range stream.WatchUntilHalt(ctx) {
+		if err != nil {
+			t.Fatalf("watch reset: %v", err)
+		}
+	}
+	sendStreamMessage(t, stream, ctx, "second")
+	sendStreamMessage(t, stream, ctx, workflow.TurnToken{})
+	for _, err := range stream.WatchUntilHalt(ctx) {
+		if err != nil {
+			t.Fatalf("watch second turn: %v", err)
+		}
+	}
+
+	if createSessions != 2 {
+		t.Fatalf("CreateSession calls = %d, want 2", createSessions)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("agent session count = %d, want 2", len(sessions))
+	}
+	if sessions[0] == sessions[1] {
+		t.Fatalf("expected ResetSignal to create a new session")
 	}
 }
 
@@ -1391,6 +1699,52 @@ func TestHostedAgent_InterceptsOnlyUnpairedFunctionCalls_PortMode(t *testing.T) 
 	}
 }
 
+func TestHostedAgent_ResultBeforeFunctionCall_StillInterceptsCall(t *testing.T) {
+	const callID = "call-after-result"
+	run := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.FunctionResultContent{CallID: callID, Result: "early"},
+					&message.FunctionCallContent{CallID: callID, Name: "do"},
+				},
+			}, nil)
+		}
+	}
+	a := agent.New(
+		agent.ProviderConfig{ProviderName: "ordered", Run: run},
+		agent.Config{ID: testAgentID, Name: testAgentName, DisableFuncAutoCall: true},
+	)
+	host := workflowhosting.New(a, workflowhosting.Config{})
+	wf, err := workflow.NewBuilder(host).Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	runResult, err := inproc.Default.Run(context.Background(), wf, workflow.TurnToken{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var requests []*workflow.ExternalRequest
+	for evt := range runResult.OutgoingEvents() {
+		if r, ok := evt.(workflow.RequestInfoEvent); ok {
+			requests = append(requests, r.Request)
+		}
+	}
+	if len(requests) != 1 {
+		t.Fatalf("external request count = %d, want 1", len(requests))
+	}
+	payload, ok := requests[0].Data.As(reflect.TypeFor[*message.FunctionCallContent]())
+	if !ok {
+		t.Fatalf("request payload type = %T, want *message.FunctionCallContent", requests[0].Data.Any())
+	}
+	if got := payload.(*message.FunctionCallContent).CallID; got != callID {
+		t.Fatalf("request CallID = %q, want %q", got, callID)
+	}
+}
+
 // lastResponseText drains all currently-available events from the run and
 // returns the text of the last response output observed (or "" if none).
 func lastResponseText(t *testing.T, run *inproc.Run) string {
@@ -1441,7 +1795,7 @@ func TestHostedAgent_DuplicateRequestID_RaisesError(t *testing.T) {
 	var sawErr bool
 	for evt := range run.OutgoingEvents() {
 		if e, ok := evt.(workflow.ErrorEvent); ok && e.Error != nil &&
-			strings.Contains(e.Error.Error(), "duplicate FunctionCall") {
+			strings.Contains(e.Error.Error(), "duplicate function call id") {
 			sawErr = true
 		}
 	}
@@ -1514,7 +1868,7 @@ func TestHostedAgent_UnknownResponseID_RaisesError(t *testing.T) {
 	var sawErr bool
 	for evt := range run.OutgoingEvents() {
 		if e, ok := evt.(workflow.ErrorEvent); ok && e.Error != nil &&
-			strings.Contains(e.Error.Error(), "no pending FunctionCall") {
+			strings.Contains(e.Error.Error(), "no pending function call") {
 			sawErr = true
 		}
 	}

--- a/internal/contentexthandler/contentexthandler.go
+++ b/internal/contentexthandler/contentexthandler.go
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package contentexthandler
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"reflect"
+
+	"github.com/microsoft/agent-framework-go/internal/concurrent"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+type Handler[TRequest any, TResponse any] struct {
+	port        workflow.RequestPort
+	intercepted bool
+	stateKey    string
+	pending     concurrent.Map[string, TRequest]
+
+	requestID       func(TRequest) string
+	responseID      func(TResponse) string
+	responseHandler func(*workflow.Context, TResponse) error
+}
+
+type Options[TRequest any, TResponse any] struct {
+	Port            workflow.RequestPort
+	StateKey        string
+	Intercepted     bool
+	RequestID       func(TRequest) string
+	ResponseID      func(TResponse) string
+	ResponseHandler func(*workflow.Context, TResponse) error
+}
+
+func New[TRequest any, TResponse any](options Options[TRequest, TResponse]) *Handler[TRequest, TResponse] {
+	return &Handler[TRequest, TResponse]{
+		port:            options.Port,
+		intercepted:     options.Intercepted,
+		stateKey:        options.StateKey,
+		requestID:       options.RequestID,
+		responseID:      options.ResponseID,
+		responseHandler: options.ResponseHandler,
+	}
+}
+
+func (h *Handler[TRequest, TResponse]) ConfigureRoutes(rb *workflow.RouteBuilder) *workflow.RouteBuilder {
+	if !h.intercepted {
+		return rb
+	}
+	return rb.AddHandler(reflect.TypeFor[TResponse](), nil, false, func(ctx *workflow.Context, msg any) (any, error) {
+		return nil, h.responseHandler(ctx, msg.(TResponse))
+	})
+}
+
+func (h *Handler[TRequest, TResponse]) HandleExternalResponse(ctx *workflow.Context, resp *workflow.ExternalResponse) (bool, error) {
+	if h.intercepted {
+		return false, nil
+	}
+	if resp.PortInfo.PortID != h.port.ID {
+		return false, nil
+	}
+	value, ok := resp.Data.As(h.port.Response)
+	if !ok {
+		return true, fmt.Errorf("contentexthandler: response for port %q has type %T, want %v", h.port.ID, resp.Data.Any(), h.port.Response)
+	}
+	return true, h.responseHandler(ctx, value.(TResponse))
+}
+
+func (h *Handler[TRequest, TResponse]) HasPending(ctx *workflow.Context) (bool, error) {
+	for range h.pending.Keys() {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (h *Handler[TRequest, TResponse]) MarkRequestAsHandled(ctx *workflow.Context, response TResponse) (bool, error) {
+	id := h.responseID(response)
+	request, found := h.pending.LoadAndDelete(id)
+	if !found {
+		return false, nil
+	}
+	if err := h.queuePendingState(ctx); err != nil {
+		h.pending.Store(id, request)
+		return true, err
+	}
+	return true, nil
+}
+
+func (h *Handler[TRequest, TResponse]) TrackRequest(ctx *workflow.Context, request TRequest) (bool, error) {
+	id := h.requestID(request)
+	if _, loaded := h.pending.LoadOrStore(id, request); loaded {
+		return false, nil
+	}
+	if err := h.queuePendingState(ctx); err != nil {
+		h.pending.Delete(id)
+		return false, err
+	}
+	return true, nil
+}
+
+func (h *Handler[TRequest, TResponse]) DispatchRequest(ctx *workflow.Context, request TRequest) error {
+	if h.intercepted {
+		return ctx.SendMessage("", request)
+	}
+	id := h.requestID(request)
+	req, err := workflow.NewExternalRequest(h.createExternalRequestID(id), h.port, request)
+	if err != nil {
+		return err
+	}
+	return ctx.PostRequest(req)
+}
+
+func (h *Handler[TRequest, TResponse]) createExternalRequestID(requestID string) string {
+	return fmt.Sprintf("%d:%s:%s", len(h.port.ID), h.port.ID, requestID)
+}
+
+func (h *Handler[TRequest, TResponse]) Reset() error {
+	h.pending.Clear()
+	return nil
+}
+
+func (h *Handler[TRequest, TResponse]) Checkpoint(ctx *workflow.Context) error {
+	return h.queuePendingState(ctx)
+}
+
+func (h *Handler[TRequest, TResponse]) Restore(ctx *workflow.Context) error {
+	h.pending.Clear()
+	if ctx.ReadState == nil {
+		return nil
+	}
+	state, err := ctx.ReadState(h.stateKey, "")
+	if err != nil {
+		return err
+	}
+	pending, err := pendingRequestsFromState[TRequest](h.stateKey, state)
+	if err != nil {
+		return err
+	}
+	for id, request := range pending {
+		h.pending.Store(id, request)
+	}
+	return nil
+}
+
+func (h *Handler[TRequest, TResponse]) queuePendingState(ctx *workflow.Context) error {
+	if ctx.QueueStateUpdate == nil {
+		return nil
+	}
+	return ctx.QueueStateUpdate(h.stateKey, "", maps.Collect(h.pending.All()))
+}
+
+func pendingRequestsFromState[TRequest any](stateKey string, state any) (map[string]TRequest, error) {
+	if state == nil {
+		return nil, nil
+	}
+	if pending, ok := state.(map[string]TRequest); ok {
+		return pending, nil
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return nil, fmt.Errorf("contentexthandler: state %q has type %T, want %v", stateKey, state, reflect.TypeFor[map[string]TRequest]())
+	}
+	var pending map[string]TRequest
+	if err := json.Unmarshal(data, &pending); err != nil {
+		return nil, fmt.Errorf("contentexthandler: state %q has type %T, want %v", stateKey, state, reflect.TypeFor[map[string]TRequest]())
+	}
+	return pending, nil
+}

--- a/message/messageworkflow/messageworkflow.go
+++ b/message/messageworkflow/messageworkflow.go
@@ -16,8 +16,34 @@ type Options struct {
 	TakeTurnHandler func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error
 
 	// Optional fields
-	StringMessageRole string
-	ScopeName         string
+	StringMessageRole        string
+	ScopeName                string
+	DisableAutoSendTurnToken bool
+	MessageState             *MessageState
+}
+
+type MessageState struct {
+	cache workflow.StatefulExecutorCache[[]*message.Message]
+}
+
+func NewMessageState(stateKey string, scopeName string) *MessageState {
+	return &MessageState{
+		cache: workflow.StatefulExecutorCache[[]*message.Message]{
+			StateKey:  stateKey,
+			ScopeName: scopeName,
+		},
+	}
+}
+
+func (s *MessageState) ProcessTurnMessages(ctx *workflow.Context, fn func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error)) error {
+	if fn == nil {
+		panic("messageworkflow: process function is required")
+	}
+	return s.cache.InvokeWithState(ctx, false, fn)
+}
+
+func (s *MessageState) Reset() error {
+	return s.cache.Reset()
 }
 
 func NewExecutorConfig(options *Options) *workflow.ExecutorConfig {
@@ -27,59 +53,58 @@ func NewExecutorConfig(options *Options) *workflow.ExecutorConfig {
 	if options.TakeTurnHandler == nil {
 		panic("TakeTurnHandler is required")
 	}
-	cache := &workflow.StatefulExecutorCache[[]*message.Message]{
-		StateKey: options.StateKey,
-		InitialStateFactory: func() []*message.Message {
-			return nil
-		},
-		ScopeName: options.ScopeName,
+	autoSendTurnToken := !options.DisableAutoSendTurnToken
+	state := options.MessageState
+	if state == nil {
+		state = NewMessageState(options.StateKey, options.ScopeName)
 	}
 	return &workflow.ExecutorConfig{
-		Reset: cache.Reset,
+		Reset: state.Reset,
+		OnCheckpointRestored: func(ctx *workflow.Context) error {
+			return state.Reset()
+		},
 		ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
 			if options.StringMessageRole != "" {
 				rb.AddHandler(reflect.TypeFor[string](), nil, false, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, cache.InvokeWithState(ctx, false, func(ctx *workflow.Context, state []*message.Message) ([]*message.Message, error) {
-						return append(state, &message.Message{
+					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
+						return append(messages, &message.Message{
 							Role:     message.Role(options.StringMessageRole),
 							Contents: []message.Content{&message.TextContent{Text: msg.(string)}},
-						},
-						), nil
-					})
-				})
-			}
-			if options.TakeTurnHandler != nil {
-				rb.AddHandler(reflect.TypeFor[workflow.TurnToken](), nil, false, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, cache.InvokeWithState(ctx, false, func(ctx *workflow.Context, state []*message.Message) ([]*message.Message, error) {
-						token := msg.(workflow.TurnToken)
-						if err := options.TakeTurnHandler(ctx, token, state); err != nil {
-							return nil, err
-						}
-						if err := ctx.SendMessage("", token); err != nil {
-							return nil, err
-						}
-						// Reset the state to empty list.
-						return nil, nil
+						}), nil
 					})
 				})
 			}
 			return rb.
 				AddHandler(reflect.TypeFor[*message.Message](), nil, false, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, cache.InvokeWithState(ctx, false, func(ctx *workflow.Context, state []*message.Message) ([]*message.Message, error) {
-						return append(state, msg.(*message.Message)), nil
+					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
+						return append(messages, msg.(*message.Message)), nil
 					})
 				}).
 				AddHandler(reflect.TypeFor[[]*message.Message](), nil, false, func(ctx *workflow.Context, msgs any) (any, error) {
-					return struct{}{}, cache.InvokeWithState(ctx, false, func(ctx *workflow.Context, state []*message.Message) ([]*message.Message, error) {
-						return append(state, msgs.([]*message.Message)...), nil
+					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
+						return append(messages, msgs.([]*message.Message)...), nil
 					})
 				}).
 				AddHandler(reflect.TypeFor[iter.Seq[*message.Message]](), nil, false, func(ctx *workflow.Context, msgs any) (any, error) {
-					return struct{}{}, cache.InvokeWithState(ctx, false, func(ctx *workflow.Context, state []*message.Message) ([]*message.Message, error) {
+					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
 						for msg := range msgs.(iter.Seq[*message.Message]) {
-							state = append(state, msg)
+							messages = append(messages, msg)
 						}
-						return state, nil
+						return messages, nil
+					})
+				}).
+				AddHandler(reflect.TypeFor[workflow.TurnToken](), nil, false, func(ctx *workflow.Context, msg any) (any, error) {
+					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
+						token := msg.(workflow.TurnToken)
+						if err := options.TakeTurnHandler(ctx, token, messages); err != nil {
+							return nil, err
+						}
+						if autoSendTurnToken {
+							if err := ctx.SendMessage("", token); err != nil {
+								return nil, err
+							}
+						}
+						return nil, nil
 					})
 				}), nil
 		},

--- a/message/messageworkflow/messageworkflow_test.go
+++ b/message/messageworkflow/messageworkflow_test.go
@@ -24,6 +24,11 @@ func (e *TestExecutor) takeTurn(ctx *workflow.Context, token workflow.TurnToken,
 }
 
 func createExecutor(options *messageworkflow.Options) (*workflow.Executor, *workflow.Context) {
+	executor, ctx, _ := createExecutorWithSent(options)
+	return executor, ctx
+}
+
+func createExecutorWithSent(options *messageworkflow.Options) (*workflow.Executor, *workflow.Context, *[]any) {
 	config := messageworkflow.NewExecutorConfig(options)
 	executor := &workflow.Executor{
 		ID: "test-executor",
@@ -31,15 +36,17 @@ func createExecutor(options *messageworkflow.Options) (*workflow.Executor, *work
 			config,
 		},
 	}
+	var sent []any
 
 	ctx := &workflow.Context{
 		SendMessage: func(targetID string, message any) error {
+			sent = append(sent, message)
 			return nil
 		},
 		AddEvent: func(event workflow.Event) error { return nil },
 	}
 
-	return executor, ctx
+	return executor, ctx, &sent
 }
 
 func TestExecutor_DescribedProtocol(t *testing.T) {
@@ -223,6 +230,37 @@ func TestExecutor_WithStringRole_ConvertsStringToMessage(t *testing.T) {
 	}
 }
 
+func TestExecutor_UsesSharedMessageState(t *testing.T) {
+	te := &TestExecutor{}
+	state := messageworkflow.NewMessageState("test-state", "")
+	executor, ctx := createExecutor(&messageworkflow.Options{
+		StateKey:        "test-state",
+		TakeTurnHandler: te.takeTurn,
+		MessageState:    state,
+	})
+
+	first := &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "buffered"}}}
+	second := &message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "injected"}}}
+	if _, err := executor.Execute(ctx, first); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if err := state.ProcessTurnMessages(ctx, func(_ *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
+		return append(messages, second), nil
+	}); err != nil {
+		t.Fatalf("ProcessTurnMessages: %v", err)
+	}
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute turn token failed: %v", err)
+	}
+
+	if len(te.receivedMessages) != 2 {
+		t.Fatalf("received message count = %d, want 2", len(te.receivedMessages))
+	}
+	if te.receivedMessages[0] != first || te.receivedMessages[1] != second {
+		t.Fatalf("received messages = %#v, want first then second", te.receivedMessages)
+	}
+}
+
 func TestExecutor_EmptyCollection_HandledCorrectly(t *testing.T) {
 	te := &TestExecutor{}
 	executor, ctx := createExecutor(&messageworkflow.Options{
@@ -233,6 +271,10 @@ func TestExecutor_EmptyCollection_HandledCorrectly(t *testing.T) {
 	if _, err := executor.Execute(ctx, []*message.Message{}); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
+	emptySeq := func(yield func(*message.Message) bool) {}
+	if _, err := executor.Execute(ctx, iter.Seq[*message.Message](emptySeq)); err != nil {
+		t.Fatalf("Execute seq failed: %v", err)
+	}
 	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -242,6 +284,50 @@ func TestExecutor_EmptyCollection_HandledCorrectly(t *testing.T) {
 	}
 	if te.turnCount != 1 {
 		t.Errorf("Expected 1 turn, got %d", te.turnCount)
+	}
+}
+
+func TestExecutor_RoutesCollectionTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{
+			name: "slice",
+			input: []*message.Message{
+				{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test message"}}},
+			},
+		},
+		{
+			name: "sequence",
+			input: iter.Seq[*message.Message](func(yield func(*message.Message) bool) {
+				yield(&message.Message{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Test message"}}})
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := &TestExecutor{}
+			executor, ctx := createExecutor(&messageworkflow.Options{
+				StateKey:        "test-state",
+				TakeTurnHandler: te.takeTurn,
+			})
+
+			if _, err := executor.Execute(ctx, tt.input); err != nil {
+				t.Fatalf("Execute failed: %v", err)
+			}
+			if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+				t.Fatalf("Execute failed: %v", err)
+			}
+
+			if len(te.receivedMessages) != 1 {
+				t.Fatalf("Expected 1 message, got %d", len(te.receivedMessages))
+			}
+			if te.receivedMessages[0].Contents.Text() != "Test message" {
+				t.Fatalf("message text = %q, want %q", te.receivedMessages[0].Contents.Text(), "Test message")
+			}
+		})
 	}
 }
 
@@ -281,5 +367,72 @@ func TestExecutor_MultipleTurns_EachTurnProcessesSeparately(t *testing.T) {
 	}
 	if te.turnCount != 2 {
 		t.Errorf("Expected 2 turns, got %d", te.turnCount)
+	}
+}
+
+func TestExecutor_InitialWorkflowMessages_RoutedCorrectly(t *testing.T) {
+	te := &TestExecutor{}
+	executor, ctx := createExecutor(&messageworkflow.Options{
+		StateKey:        "test-state",
+		TakeTurnHandler: te.takeTurn,
+	})
+
+	initialMessages := []*message.Message{
+		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Kick off the workflow"}}},
+	}
+	if _, err := executor.Execute(ctx, initialMessages); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(te.receivedMessages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(te.receivedMessages))
+	}
+	if te.receivedMessages[0].Contents.Text() != "Kick off the workflow" {
+		t.Fatalf("message text = %q, want %q", te.receivedMessages[0].Contents.Text(), "Kick off the workflow")
+	}
+}
+
+func TestExecutor_DefaultAutoSendsTurnToken(t *testing.T) {
+	te := &TestExecutor{}
+	executor, ctx, sent := createExecutorWithSent(&messageworkflow.Options{
+		StateKey:        "test-state",
+		TakeTurnHandler: te.takeTurn,
+	})
+
+	emit := true
+	token := workflow.TurnToken{EmitEvents: &emit}
+	if _, err := executor.Execute(ctx, token); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent message count = %d, want 1", len(*sent))
+	}
+	got, ok := (*sent)[0].(workflow.TurnToken)
+	if !ok {
+		t.Fatalf("sent message type = %T, want workflow.TurnToken", (*sent)[0])
+	}
+	if got.EmitEvents == nil || !*got.EmitEvents {
+		t.Fatalf("sent token EmitEvents = %v, want true", got.EmitEvents)
+	}
+}
+
+func TestExecutor_DisableAutoSendTurnToken(t *testing.T) {
+	te := &TestExecutor{}
+	executor, ctx, sent := createExecutorWithSent(&messageworkflow.Options{
+		StateKey:                 "test-state",
+		TakeTurnHandler:          te.takeTurn,
+		DisableAutoSendTurnToken: true,
+	})
+
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(*sent) != 0 {
+		t.Fatalf("sent message count = %d, want 0", len(*sent))
 	}
 }

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -296,36 +296,107 @@ func (s *StatefulExecutorCache[T]) cache(v T) {
 	s.stateCache = v
 }
 
-func (s *StatefulExecutorCache[T]) InvokeWithState(ctx *Context, skipCache bool, fn func(ctx *Context, state T) (T, error)) error {
-	if !skipCache && !ctx.ConcurrentRunsEnabled {
-		state := s.stateCache
-		if !s.cached {
-			state = s.InitialStateFactory()
-		}
-		newState, err := fn(ctx, state)
+func (s *StatefulExecutorCache[T]) initialState() T {
+	if s.InitialStateFactory == nil {
+		var zero T
+		return zero
+	}
+	return s.InitialStateFactory()
+}
+
+func (s *StatefulExecutorCache[T]) normalizeState(state T) T {
+	if isNilState(state) {
+		return s.initialState()
+	}
+	return state
+}
+
+func (s *StatefulExecutorCache[T]) stateFromAny(v any) (T, error) {
+	if v == nil {
+		return s.initialState(), nil
+	}
+	state, ok := v.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("workflow: state %q has type %T, want %v", s.StateKey, v, reflect.TypeFor[T]())
+	}
+	return s.normalizeState(state), nil
+}
+
+func isNilState(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+func (s *StatefulExecutorCache[T]) readOrInitState(ctx *Context) (T, error) {
+	if ctx.ReadOrInitState != nil {
+		state, err := ctx.ReadOrInitState(s.StateKey, s.ScopeName, func(context.Context, string, string) (any, error) {
+			return s.initialState(), nil
+		})
 		if err != nil {
+			var zero T
+			return zero, err
+		}
+		return s.stateFromAny(state)
+	}
+	if ctx.ReadState != nil {
+		state, err := ctx.ReadState(s.StateKey, s.ScopeName)
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+		return s.stateFromAny(state)
+	}
+	return s.initialState(), nil
+}
+
+func (s *StatefulExecutorCache[T]) ReadState(ctx *Context, skipCache bool) (T, error) {
+	if !skipCache && !ctx.ConcurrentRunsEnabled {
+		if s.cached {
+			return s.stateCache, nil
+		}
+		state, err := s.readOrInitState(ctx)
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+		s.cache(state)
+		return state, nil
+	}
+	return s.readOrInitState(ctx)
+}
+
+func (s *StatefulExecutorCache[T]) QueueStateUpdate(ctx *Context, state T) error {
+	state = s.normalizeState(state)
+	if ctx.QueueStateUpdate != nil {
+		if err := ctx.QueueStateUpdate(s.StateKey, s.ScopeName, state); err != nil {
 			return err
 		}
-		if ctx.QueueStateUpdate != nil {
-			if err := ctx.QueueStateUpdate(s.StateKey, s.ScopeName, newState); err != nil {
-				return err
-			}
-		}
-		s.cache(newState)
-		return nil
 	}
-	state, err := ctx.ReadState(s.StateKey, s.ScopeName)
+	if !ctx.ConcurrentRunsEnabled {
+		s.cache(state)
+	}
+	return nil
+}
+
+func (s *StatefulExecutorCache[T]) InvokeWithState(ctx *Context, skipCache bool, fn func(ctx *Context, state T) (T, error)) error {
+	state, err := s.ReadState(ctx, skipCache)
 	if err != nil {
 		return err
 	}
-	newState, err := fn(ctx, state.(T))
+	newState, err := fn(ctx, state)
 	if err != nil {
 		return err
 	}
-	if ctx.QueueStateUpdate == nil {
-		return nil
-	}
-	return ctx.QueueStateUpdate(s.StateKey, s.ScopeName, newState)
+	return s.QueueStateUpdate(ctx, newState)
 }
 
 func (s *StatefulExecutorCache[T]) Reset() error {


### PR DESCRIPTION
## Summary
- align hosted agent workflow behavior with .NET AIAgentHostExecutor semantics
- move reusable external content request handling into internal/contentexthandler
- expand message workflow state sharing and hosted-agent parity coverage

## Testing
- go test ./internal/contentexthandler ./agent/hosting/workflowhosting ./message/messageworkflow ./workflow ./agent/provider/workflowprovider