### PR TITLE
Make sessions directly JSON serializable

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -31,11 +31,7 @@ type ProviderConfig struct {
 	Unmarshal func(format ResponseFormat, data []byte, v any) error
 
 	// CreateSession configures a provider-specific session.
-	CreateSession func(ctx context.Context, session Session, options ...Option) error
-	// BeforeMarshalSession configures a provider-specific session before serialization.
-	BeforeMarshalSession func(ctx context.Context, session Session, options ...Option) error
-	// AfterUnmarshalSession configures a deserialized provider-specific session.
-	AfterUnmarshalSession func(ctx context.Context, session Session, options ...Option) error
+	CreateSession func(ctx context.Context, session *Session, options ...Option) error
 }
 
 // Config configures an Agent instance.
@@ -195,40 +191,12 @@ func (a *Agent) ProviderName() string {
 }
 
 // CreateSession creates a session for this agent.
-func (a *Agent) CreateSession(ctx context.Context, options ...Option) (Session, error) {
-	session := &session{}
+func (a *Agent) CreateSession(ctx context.Context, options ...Option) (*Session, error) {
+	session := &Session{}
 	serviceID, _ := GetOption(options, WithServiceID)
 	session.SetServiceID(serviceID)
 	if a.provider.CreateSession != nil {
 		if err := a.provider.CreateSession(ctx, session, options...); err != nil {
-			return nil, err
-		}
-	}
-	return session, nil
-}
-
-// MarshalSession serializes a session created for this agent.
-//
-// Any provided options are forwarded to the provider's BeforeMarshalSession hook.
-func (a *Agent) MarshalSession(ctx context.Context, session Session, options ...Option) ([]byte, error) {
-	if a.provider.BeforeMarshalSession != nil {
-		if err := a.provider.BeforeMarshalSession(ctx, session, options...); err != nil {
-			return nil, err
-		}
-	}
-	return marshalSession(session)
-}
-
-// UnmarshalSession deserializes a session for this agent.
-//
-// Any provided options are forwarded to the provider's AfterUnmarshalSession hook.
-func (a *Agent) UnmarshalSession(ctx context.Context, data []byte, options ...Option) (Session, error) {
-	session, err := unmarshalSession(data)
-	if err != nil {
-		return nil, err
-	}
-	if a.provider.AfterUnmarshalSession != nil {
-		if err := a.provider.AfterUnmarshalSession(ctx, session, options...); err != nil {
 			return nil, err
 		}
 	}
@@ -405,7 +373,7 @@ func withoutContinuationToken(options []Option) []Option {
 	})
 }
 
-func (a *Agent) historyProviderForRun(session Session, continuationToken string, noSession bool) *HistoryProvider {
+func (a *Agent) historyProviderForRun(session *Session, continuationToken string, noSession bool) *HistoryProvider {
 	if a.historyProvider == nil || continuationToken != "" || session == nil {
 		return nil
 	}
@@ -425,7 +393,7 @@ func (a *Agent) historyProviderForRun(session Session, continuationToken string,
 	return a.historyProvider
 }
 
-func (a *Agent) historyProviderForContinuationStore(session Session, noSession bool) *HistoryProvider {
+func (a *Agent) historyProviderForContinuationStore(session *Session, noSession bool) *HistoryProvider {
 	if a.historyProvider == nil || session == nil {
 		return nil
 	}
@@ -441,7 +409,7 @@ func (a *Agent) historyProviderForContinuationStore(session Session, noSession b
 	return a.historyProvider
 }
 
-func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session Session) bool {
+func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session *Session) bool {
 	if provider == nil {
 		return false
 	}
@@ -454,7 +422,7 @@ func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session Se
 	return session != nil && session.ServiceID() == ""
 }
 
-func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider *HistoryProvider, session Session) (bool, error) {
+func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider *HistoryProvider, session *Session) (bool, error) {
 	if provider == nil || !a.hasConfiguredHistory || session == nil || session.ServiceID() == "" {
 		return true, nil
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -32,7 +32,7 @@ type prependMiddleware struct {
 	prependMessages []*message.Message
 	instructions    string
 	runCalls        int
-	lastSession     agent.Session
+	lastSession     *agent.Session
 }
 
 func (m *prependMiddleware) Run(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
@@ -115,89 +115,6 @@ func newGenericTestAgent(runFn func(context.Context, []*message.Message, ...agen
 		Middlewares: middlewares,
 		RunOptions:  runOptions,
 	})
-}
-
-func TestAgent_UnmarshalSession_CallsAfterUnmarshalSession(t *testing.T) {
-	called := false
-	a := agent.New(agent.ProviderConfig{
-		Run: func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
-			return func(yield func(*agent.ResponseUpdate, error) bool) {}
-		},
-		AfterUnmarshalSession: func(_ context.Context, session agent.Session, opts ...agent.Option) error {
-			called = true
-			serviceID, ok := agent.GetOption(opts, agent.WithServiceID)
-			if !ok || serviceID != "hook-option" {
-				t.Fatalf("expected hook option service id hook-option, got %q (present=%v)", serviceID, ok)
-			}
-			if got := session.ServiceID(); got != "service-123" {
-				t.Fatalf("session.ServiceID() = %q, want %q", got, "service-123")
-			}
-
-			var value string
-			ok, err := session.Get("key", &value)
-			if err != nil || !ok || value != "value" {
-				t.Fatalf("session.Get() = ok %v, value %q, err %v", ok, value, err)
-			}
-
-			session.Set("provider", "configured")
-			return nil
-		},
-	}, agent.Config{})
-
-	session, err := a.UnmarshalSession(t.Context(), []byte(`{"ServiceID":"service-123","State":{"key":"value"}}`), agent.WithServiceID("hook-option"))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !called {
-		t.Fatal("expected provider AfterUnmarshalSession to be called")
-	}
-
-	var providerValue string
-	if ok, err := session.Get("provider", &providerValue); err != nil || !ok || providerValue != "configured" {
-		t.Fatalf("session.Get(provider) = ok %v, value %q, err %v", ok, providerValue, err)
-	}
-}
-
-func TestAgent_MarshalSession_CallsBeforeMarshalSession(t *testing.T) {
-	called := false
-	a := agent.New(agent.ProviderConfig{
-		Run: func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
-			return func(yield func(*agent.ResponseUpdate, error) bool) {}
-		},
-		BeforeMarshalSession: func(_ context.Context, session agent.Session, opts ...agent.Option) error {
-			called = true
-			serviceID, ok := agent.GetOption(opts, agent.WithServiceID)
-			if !ok || serviceID != "hook-option" {
-				t.Fatalf("expected hook option service id hook-option, got %q (present=%v)", serviceID, ok)
-			}
-			session.Set("provider", "configured")
-			return nil
-		},
-	}, agent.Config{})
-
-	session, err := a.CreateSession(t.Context(), agent.WithServiceID("service-123"))
-	if err != nil {
-		t.Fatalf("unexpected create session error: %v", err)
-	}
-	data, err := a.MarshalSession(t.Context(), session, agent.WithServiceID("hook-option"))
-	if err != nil {
-		t.Fatalf("unexpected marshal error: %v", err)
-	}
-	if !called {
-		t.Fatal("expected provider BeforeMarshalSession to be called")
-	}
-
-	restored, err := a.UnmarshalSession(t.Context(), data)
-	if err != nil {
-		t.Fatalf("unexpected unmarshal error: %v", err)
-	}
-	if got := restored.ServiceID(); got != "service-123" {
-		t.Fatalf("restored.ServiceID() = %q, want %q", got, "service-123")
-	}
-	var providerValue string
-	if ok, err := restored.Get("provider", &providerValue); err != nil || !ok || providerValue != "configured" {
-		t.Fatalf("restored.Get(provider) = ok %v, value %q, err %v", ok, providerValue, err)
-	}
 }
 
 func TestAgent_RunText(t *testing.T) {

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -4,6 +4,7 @@ package compaction_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"slices"
 	"testing"
@@ -390,13 +391,12 @@ func TestNewProvider_CompactsAndPersistsIndex(t *testing.T) {
 	var state struct {
 		MessageGroups []*compaction.MessageGroup `json:"messagegroups,omitempty"`
 	}
-	a := agenttest.New(nil)
-	data, err := a.MarshalSession(t.Context(), session)
+	data, err := json.Marshal(session)
 	if err != nil {
 		t.Fatalf("unexpected marshal error: %v", err)
 	}
-	restored, err := a.UnmarshalSession(t.Context(), data)
-	if err != nil {
+	restored := agenttest.CreateSession()
+	if err := json.Unmarshal(data, restored); err != nil {
 		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 	if ok, err := restored.Get("compaction-test", &state); err != nil || !ok {

--- a/agent/hosting/workflowhosting/workflow.go
+++ b/agent/hosting/workflowhosting/workflow.go
@@ -157,7 +157,7 @@ type hostExecutor struct {
 	agent *agent.Agent
 	cfg   Config
 
-	session agent.Session
+	session *agent.Session
 
 	messageState    *messageworkflow.MessageState
 	approvalHandler *contentexthandler.Handler[*message.ToolApprovalRequestContent, *message.ToolApprovalResponseContent]
@@ -223,7 +223,7 @@ func (h *hostExecutor) executor() *workflow.Executor {
 func (h *hostExecutor) onCheckpoint(wctx *workflow.Context) error {
 	state := agentHostState{CurrentTurnEmitEvents: h.turnEmitEvents}
 	if h.session != nil {
-		data, err := h.agent.MarshalSession(wctx, h.session)
+		data, err := json.Marshal(h.session)
 		if err != nil {
 			return err
 		}
@@ -261,8 +261,11 @@ func (h *hostExecutor) onCheckpointRestored(wctx *workflow.Context) error {
 	if state != nil {
 		h.turnEmitEvents = state.CurrentTurnEmitEvents
 		if state.ThreadState != nil {
-			session, err := h.agent.UnmarshalSession(wctx, state.ThreadState)
+			session, err := h.agent.CreateSession(wctx)
 			if err != nil {
+				return err
+			}
+			if err := json.Unmarshal(state.ThreadState, session); err != nil {
 				return err
 			}
 			h.session = session
@@ -624,7 +627,7 @@ func (h *hostExecutor) dispatchRequests(wctx *workflow.Context, msgs []*message.
 	return nil
 }
 
-func (h *hostExecutor) ensureSession(ctx context.Context) (agent.Session, error) {
+func (h *hostExecutor) ensureSession(ctx context.Context) (*agent.Session, error) {
 	if h.session != nil {
 		return h.session, nil
 	}

--- a/agent/hosting/workflowhosting/workflow.go
+++ b/agent/hosting/workflowhosting/workflow.go
@@ -261,10 +261,7 @@ func (h *hostExecutor) onCheckpointRestored(wctx *workflow.Context) error {
 	if state != nil {
 		h.turnEmitEvents = state.CurrentTurnEmitEvents
 		if state.ThreadState != nil {
-			session, err := h.agent.CreateSession(wctx)
-			if err != nil {
-				return err
-			}
+			session := &agent.Session{}
 			if err := json.Unmarshal(state.ThreadState, session); err != nil {
 				return err
 			}

--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -1414,7 +1414,7 @@ func TestHostedAgent_BindingSupportsConcurrentSharedExecution(t *testing.T) {
 }
 
 func TestHostedAgent_ResetSignal_StartsNewSession(t *testing.T) {
-	var sessions []agent.Session
+	var sessions []*agent.Session
 	createSessions := 0
 	run := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -1434,7 +1434,7 @@ func TestHostedAgent_ResetSignal_StartsNewSession(t *testing.T) {
 		agent.ProviderConfig{
 			ProviderName: "reset-session",
 			Run:          run,
-			CreateSession: func(_ context.Context, _ agent.Session, _ ...agent.Option) error {
+			CreateSession: func(_ context.Context, _ *agent.Session, _ ...agent.Option) error {
 				createSessions++
 				return nil
 			},

--- a/agent/options.go
+++ b/agent/options.go
@@ -45,7 +45,7 @@ func (o toolOpt) Value() any                     { return o.Tool }
 func (o structuredOutputOpt) Value() any         { return o.any }
 func (o serviceIDOpt) Value() any                { return string(o) }
 
-type sessionOpt struct{ Session }
+type sessionOpt struct{ *Session }
 
 func (o sessionOpt) Value() any { return o.Session }
 
@@ -123,7 +123,7 @@ func WithResponseFormat(format ResponseFormat) Option {
 }
 
 // WithSession sets the session to use during the agent run.
-func WithSession(session Session) Option {
+func WithSession(session *Session) Option {
 	return sessionOpt{session}
 }
 

--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -52,7 +52,7 @@ func New(aclient *a2aclient.Client, config Config) *agent.Agent {
 	}, config.Config)
 }
 
-func (a *a2aagent) createSession(ctx context.Context, session agent.Session, options ...agent.Option) error {
+func (a *a2aagent) createSession(ctx context.Context, session *agent.Session, options ...agent.Option) error {
 	setTaskIDs(session, slices.Collect(agent.AllOptions(options, TaskID)))
 	return nil
 }
@@ -147,7 +147,7 @@ func (a *a2aagent) subscribeToTaskWithFallback(ctx context.Context, taskID a2a.T
 	}
 }
 
-func sendMsg(session agent.Session, seq iter.Seq2[a2a.Event, error], yield func(*agent.ResponseUpdate, error) bool) {
+func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func(*agent.ResponseUpdate, error) bool) {
 	for e, err := range seq {
 		if err != nil {
 			yield(nil, err)
@@ -251,7 +251,7 @@ func yieldTask(yield func(*agent.ResponseUpdate, error) bool, task *a2a.Task) bo
 	}, nil)
 }
 
-func updateSessionContextID(session agent.Session, contextID, taskID string) error {
+func updateSessionContextID(session *agent.Session, contextID, taskID string) error {
 	if session == nil {
 		return nil
 	}

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -195,7 +195,7 @@ func newTestAgent(transport a2aclient.Transport, config agent.Config) *agent.Age
 	return a2a1.New(client, a2a1.Config{Config: config})
 }
 
-func latestTaskID(session agent.Session) string {
+func latestTaskID(session *agent.Session) string {
 	taskIDs := a2a1.TaskIDsFromSession(session)
 	if len(taskIDs) == 0 {
 		return ""

--- a/agent/provider/a2aagent/session.go
+++ b/agent/provider/a2aagent/session.go
@@ -8,29 +8,29 @@ const (
 	taskIDsStateKey = "a2aagent.taskIDs"
 )
 
-func setContextID(session agent.Session, contextID string) {
+func setContextID(session *agent.Session, contextID string) {
 	session.SetServiceID(contextID)
 }
 
-func getContextID(session agent.Session) string {
+func getContextID(session *agent.Session) string {
 	return session.ServiceID()
 }
 
-func setTaskID(session agent.Session, taskID string) {
+func setTaskID(session *agent.Session, taskID string) {
 	if taskID == "" {
 		return
 	}
 	setTaskIDs(session, append(getTaskIDs(session), taskID))
 }
 
-func setTaskIDs(session agent.Session, taskIDs []string) {
+func setTaskIDs(session *agent.Session, taskIDs []string) {
 	if len(taskIDs) == 0 {
 		return
 	}
 	session.Set(taskIDsStateKey, taskIDs)
 }
 
-func getTaskIDs(session agent.Session) []string {
+func getTaskIDs(session *agent.Session) []string {
 	var taskIDs []string
 	if ok, err := session.Get(taskIDsStateKey, &taskIDs); err != nil || !ok {
 		return nil
@@ -39,6 +39,6 @@ func getTaskIDs(session agent.Session) []string {
 }
 
 // TaskIDsFromSession returns all known A2A task IDs stored in session state.
-func TaskIDsFromSession(session agent.Session) []string {
+func TaskIDsFromSession(session *agent.Session) []string {
 	return getTaskIDs(session)
 }

--- a/agent/provider/aguiagent/agui.go
+++ b/agent/provider/aguiagent/agui.go
@@ -156,7 +156,7 @@ func decodeFrame(decoder *aguiEvents.EventDecoder, data []byte) (aguiEvents.Even
 	return decoder.DecodeEvent(envelope.Type, data)
 }
 
-func getOrCreateThreadID(session agent.Session) string {
+func getOrCreateThreadID(session *agent.Session) string {
 	if session != nil && session.ServiceID() != "" {
 		return session.ServiceID()
 	}

--- a/agent/provider/openaiagent/responses.go
+++ b/agent/provider/openaiagent/responses.go
@@ -87,7 +87,7 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 		stream, _ := agent.GetOption(options, agent.Stream)
 
 		// Get session for conversation ID management
-		var session agent.Session
+		var session *agent.Session
 		var keepConversationID bool // true if we should keep the conversation ID unchanged (it's a "conv_" ID)
 		if t, ok := agent.GetOption(options, agent.WithSession); ok && t != nil {
 			session = t

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -75,9 +75,8 @@ type pendingReq struct {
 // [agent.Session] under [sessionStateKey].
 //
 // The streaming run is an in-memory object and is not portable across
-// process boundaries; sessions that are persisted via
-// [agent.Agent.MarshalSession] retain the request-tracking metadata but
-// drop the live run.
+// process boundaries; sessions that are persisted via encoding/json retain the
+// request-tracking metadata but drop the live run.
 type providerState struct {
 	stream  *inproc.StreamingRun
 	pending map[string]pendingReq // keyed by request content ID (e.g. CallID/RequestID)
@@ -244,7 +243,7 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 // streaming workflow run on first use.
 func loadOrInitState(
 	ctx context.Context,
-	sess agent.Session,
+	sess *agent.Session,
 	env *inproc.ExecutionEnvironment,
 	wf *workflow.Workflow,
 ) (*providerState, error) {
@@ -264,7 +263,7 @@ func loadOrInitState(
 	return &providerState{stream: stream, pending: make(map[string]pendingReq)}, nil
 }
 
-func saveState(sess agent.Session, state *providerState) {
+func saveState(sess *agent.Session, state *providerState) {
 	if sess == nil || state == nil {
 		return
 	}

--- a/agent/session.go
+++ b/agent/session.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // Session contains the state of a specific conversation with an agent which may include:
@@ -13,59 +12,30 @@ import (
 //   - Memories or a reference to externally stored memories.
 //   - Any other state that the agent needs to persist across runs for a conversation.
 //
-// A Session may also have behaviors attached to it that may include:
+// Agent behaviors such as history and context providers live on the agent and store their state in the Session.
+// The zero value is ready to use. [Agent.CreateSession] can be used when a provider needs to configure
+// provider-specific session state before the first run.
 //
-//   - Customized storage of state.
-//   - Data extraction from and injection into a conversation.
-//   - Chat history reduction, e.g. where messages needs to be summarized or truncated to reduce the size.
-//
-// A Session is always constructed by an [Agent] so that the [Agent] can attach any necessary behaviors to the Session.
-// See the [Agent.CreateSession], [Agent.MarshalSession], and [Agent.UnmarshalSession] methods for more information.
-//
-// Because of these behaviors, a Session may not be reusable across different agents, since each agent may add different
-// behaviors to the Session it creates.
+// Because provider-specific state can be associated with the agent that created it, a Session may not be reusable across
+// different agents.
 //
 // To support conversations that may need to survive application restarts or separate service requests,
-// a Session can be serialized and deserialized through [Agent.MarshalSession] and
-// [Agent.UnmarshalSession], so that it can be saved in a persistent store.
-type Session interface {
-	// Get attempts to read the value associated with key into value.
-	//
-	// It returns ok=true only when the value exists and can be read into the destination type.
-	// It returns ok=false with a nil error when the key is missing or the stored value cannot be read as the
-	// requested type.
-	//
-	// value must be a non-nil pointer to the desired destination type.
-	Get(key string, value any) (ok bool, err error)
-
-	// Set stores a value in the session state under the given key.
-	// If the key already exists, its value is overwritten.
-	Set(key string, value any)
-
-	// Delete removes the value with the given key.
-	Delete(key string)
-
-	// ServiceID returns the provider-specific identifier associated with the session.
-	ServiceID() string
-
-	// SetServiceID sets the provider-specific identifier associated with the session.
-	SetServiceID(id string)
-
-	// sealedSession prevents implementations outside this package so sessions can only
-	// be created by an Agent. This also allows Session to grow with new methods without
-	// breaking existing implementations.
-	sealedSession()
-}
-
-type session struct {
+// a Session can be serialized and deserialized directly with encoding/json, so that it can be saved in a
+// persistent store.
+type Session struct {
 	serviceID string
 
 	state map[string]*stateValue
 }
 
-func (s *session) sealedSession() {}
-
-func (s *session) Get(key string, value any) (bool, error) {
+// Get attempts to read the value associated with key into value.
+//
+// It returns ok=true only when the value exists and can be read into the destination type.
+// It returns ok=false with a nil error when the key is missing or the stored value cannot be read as the
+// requested type.
+//
+// value must be a non-nil pointer to the desired destination type.
+func (s *Session) Get(key string, value any) (bool, error) {
 	if s == nil {
 		return false, nil
 	}
@@ -76,7 +46,9 @@ func (s *session) Get(key string, value any) (bool, error) {
 	return wrapped.readInto(value)
 }
 
-func (s *session) Set(key string, value any) {
+// Set stores a value in the session state under the given key.
+// If the key already exists, its value is overwritten.
+func (s *Session) Set(key string, value any) {
 	if s == nil {
 		return
 	}
@@ -91,51 +63,32 @@ func (s *session) Set(key string, value any) {
 	s.state[key] = wrapped
 }
 
-func (s *session) Delete(key string) {
+// Delete removes the value with the given key.
+func (s *Session) Delete(key string) {
 	if s == nil {
 		return
 	}
 	delete(s.state, key)
 }
 
-func (s *session) ServiceID() string {
+// ServiceID returns the provider-specific identifier associated with the session.
+func (s *Session) ServiceID() string {
 	if s == nil {
 		return ""
 	}
 	return s.serviceID
 }
 
-func (s *session) SetServiceID(id string) {
+// SetServiceID sets the provider-specific identifier associated with the session.
+func (s *Session) SetServiceID(id string) {
 	if s == nil {
 		return
 	}
 	s.serviceID = id
 }
 
-func (s *session) MarshalJSON() ([]byte, error) {
-	return nil, errors.New("sessions must be marshaled with Agent.MarshalSession")
-}
-
-func (s *session) UnmarshalJSON([]byte) error {
-	return errors.New("sessions must be unmarshaled with Agent.UnmarshalSession")
-}
-
-type sessionData struct {
-	State map[string]*stateValue
-
-	ServiceID string
-}
-
-func marshalSession(sess Session) ([]byte, error) {
-	s, ok := sess.(*session)
-	if !ok || s == nil {
-		return nil, errors.New("the provided session is nil")
-	}
-	tmp := struct {
-		State map[string]*stateValue
-
-		ServiceID string
-	}{
+func (s Session) MarshalJSON() ([]byte, error) {
+	tmp := sessionData{
 		ServiceID: s.serviceID,
 	}
 	if s.state == nil {
@@ -146,16 +99,21 @@ func marshalSession(sess Session) ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
-func unmarshalSession(data []byte) (Session, error) {
+func (s *Session) UnmarshalJSON(data []byte) error {
 	var tmp sessionData
 	if err := json.Unmarshal(data, &tmp); err != nil {
-		return nil, err
+		return err
 	}
 	if tmp.State == nil {
 		tmp.State = make(map[string]*stateValue)
 	}
-	return &session{
-		serviceID: tmp.ServiceID,
-		state:     tmp.State,
-	}, nil
+	s.serviceID = tmp.ServiceID
+	s.state = tmp.State
+	return nil
+}
+
+type sessionData struct {
+	State map[string]*stateValue
+
+	ServiceID string
 }

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -171,8 +171,19 @@ func TestSession_MarshalJSON_DirectMarshalIncludesState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got, want := string(data), `{"State":{"key1":"value1"},"ServiceID":""}`; got != want {
-		t.Fatalf("json.Marshal(session) = %s, want %s", got, want)
+
+	var payload struct {
+		ServiceID string
+		State     map[string]string
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if payload.ServiceID != "" {
+		t.Fatalf("ServiceID = %q, want empty string", payload.ServiceID)
+	}
+	if len(payload.State) != 1 || payload.State["key1"] != "value1" {
+		t.Fatalf("State = %#v, want map[string]string{\"key1\": \"value1\"}", payload.State)
 	}
 }
 

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -4,7 +4,6 @@ package agent_test
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -149,45 +148,77 @@ func TestSessionState_Get_InvalidDestinationReturnsError(t *testing.T) {
 
 func TestSession_MarshalJSON_EmptyState(t *testing.T) {
 	session := agenttest.CreateSession()
-	data, err := agenttest.New(nil).MarshalSession(t.Context(), session)
+	data, err := json.Marshal(session)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(string(data), `"State":{}`) {
+	var payload struct {
+		State map[string]json.RawMessage
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if len(payload.State) != 0 {
 		t.Errorf("expected marshaled session to contain empty State, got %q", string(data))
 	}
 }
 
-func TestSession_MarshalJSON_DirectMarshalReturnsError(t *testing.T) {
+func TestSession_MarshalJSON_DirectMarshalIncludesState(t *testing.T) {
 	session := agenttest.CreateSession()
-	if _, err := json.Marshal(session); err == nil {
-		t.Fatal("expected direct JSON marshaling to fail")
-	}
-}
+	session.Set("key1", "value1")
 
-func TestSession_UnmarshalJSON_DirectUnmarshalReturnsError(t *testing.T) {
-	var session agent.Session
-	if err := json.Unmarshal([]byte(`{"State":{"key1":"value1"}}`), &session); err == nil {
-		t.Fatal("expected direct JSON unmarshaling to fail")
-	}
-}
-
-func TestSession_UnmarshalJSON_IntoCreatedSessionReturnsGuardError(t *testing.T) {
-	session := agenttest.CreateSession()
-	err := json.Unmarshal([]byte(`{"State":{"key1":"value1"}}`), session)
-	if err == nil {
-		t.Fatal("expected direct JSON unmarshaling to fail")
-	}
-	if !strings.Contains(err.Error(), "sessions must be unmarshaled with Agent.UnmarshalSession") {
-		t.Fatalf("expected guard error, got %v", err)
-	}
-}
-
-func TestSession_UnmarshalSession_WithStateValues(t *testing.T) {
-	session, err := agenttest.New(nil).UnmarshalSession(t.Context(), []byte(`{"State":{"key1":"value1","key2":42}}`))
+	data, err := json.Marshal(session)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if got, want := string(data), `{"State":{"key1":"value1"},"ServiceID":""}`; got != want {
+		t.Fatalf("json.Marshal(session) = %s, want %s", got, want)
+	}
+}
+
+func TestSession_UnmarshalJSON_IntoCreatedSession(t *testing.T) {
+	session := agenttest.CreateSession()
+	err := json.Unmarshal([]byte(`{"State":{"key1":"value1"}}`), session)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var value string
+	if ok, err := session.Get("key1", &value); err != nil || !ok || value != "value1" {
+		t.Fatalf("session.Get(key1) = ok %v, value %q, err %v", ok, value, err)
+	}
+}
+
+func TestSession_UnmarshalJSON_IntoZeroValueSession(t *testing.T) {
+	var session agent.Session
+	err := json.Unmarshal([]byte(`{"ServiceID":"service-123","State":{"key1":"value1"}}`), &session)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := session.ServiceID(); got != "service-123" {
+		t.Fatalf("session.ServiceID() = %q, want %q", got, "service-123")
+	}
+
+	var value string
+	if ok, err := session.Get("key1", &value); err != nil || !ok || value != "value1" {
+		t.Fatalf("session.Get(key1) = ok %v, value %q, err %v", ok, value, err)
+	}
+}
+
+func TestSession_MarshalJSON_ZeroValueSession(t *testing.T) {
+	var session agent.Session
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := string(data), `{"State":{},"ServiceID":""}`; got != want {
+		t.Fatalf("json.Marshal(session) = %s, want %s", got, want)
+	}
+}
+
+func TestSession_UnmarshalJSON_WithStateValues(t *testing.T) {
+	session := agenttest.CreateSession()
+	mustUnmarshalJSON(t, []byte(`{"State":{"key1":"value1","key2":42}}`), session)
 
 	var s string
 	if ok, err := session.Get("key1", &s); err != nil || !ok || s != "value1" {
@@ -200,10 +231,8 @@ func TestSession_UnmarshalSession_WithStateValues(t *testing.T) {
 }
 
 func TestSessionState_Get_LazyDecodesAndCaches(t *testing.T) {
-	session, err := agenttest.New(nil).UnmarshalSession(t.Context(), []byte(`{"State":{"person":{"Name":"Ada"}}}`))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	session := agenttest.CreateSession()
+	mustUnmarshalJSON(t, []byte(`{"State":{"person":{"Name":"Ada"}}}`), session)
 
 	var person person
 	ok, err := session.Get("person", &person)
@@ -216,10 +245,8 @@ func TestSessionState_Get_LazyDecodesAndCaches(t *testing.T) {
 }
 
 func TestSessionState_Get_LazyDecodedValueTypeMismatchReturnsError(t *testing.T) {
-	session, err := agenttest.New(nil).UnmarshalSession(t.Context(), []byte(`{"State":{"person":{"Name":"Ada"}}}`))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	session := agenttest.CreateSession()
+	mustUnmarshalJSON(t, []byte(`{"State":{"person":{"Name":"Ada"}}}`), session)
 
 	var p person
 	if ok, err := session.Get("person", &p); err != nil || !ok {
@@ -236,5 +263,12 @@ func TestSessionState_Get_LazyDecodedValueTypeMismatchReturnsError(t *testing.T)
 	}
 	if err != nil {
 		t.Fatalf("expected no error on type mismatch, got %v", err)
+	}
+}
+
+func mustUnmarshalJSON(t *testing.T, data []byte, session *agent.Session) {
+	t.Helper()
+	if err := json.Unmarshal(data, session); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 }

--- a/examples/01-get-started/04_memory/main.go
+++ b/examples/01-get-started/04_memory/main.go
@@ -86,7 +86,7 @@ type providerState struct {
 	UserName string `json:"user_name,omitempty"`
 }
 
-func getProviderState(session agent.Session) providerState {
+func getProviderState(session *agent.Session) providerState {
 	if session == nil {
 		return providerState{}
 	}

--- a/examples/02-agents/agents/step06_persisted_conversation/main.go
+++ b/examples/02-agents/agents/step06_persisted_conversation/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 
@@ -60,7 +61,7 @@ func main() {
 	demo.Response(resp, err)
 
 	// Serialize the session state so it can be stored for later use.
-	serializedSession, err := a.MarshalSession(ctx, session)
+	serializedSession, err := json.Marshal(session)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -82,12 +83,12 @@ func main() {
 	}
 
 	// Deserialize the session state after loading from storage.
-	resumedSession, err := a.UnmarshalSession(ctx, loadedData)
-	if err != nil {
+	var resumedSession agent.Session
+	if err := json.Unmarshal(loadedData, &resumedSession); err != nil {
 		demo.Panic(err)
 	}
 
 	// Run the agent again with the resumed session.
-	resp, err = a.RunText(ctx, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agent.WithSession(resumedSession)).Collect()
+	resp, err = a.RunText(ctx, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agent.WithSession(&resumedSession)).Collect()
 	demo.Response(resp, err)
 }

--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -74,7 +74,7 @@ func main() {
 	// Serialize the session state, so it can be stored for later use.
 	// The disk store holds the chat history.
 	// The serialized session only contains the message-store ID.
-	serializedSession, err := a.MarshalSession(ctx, session)
+	serializedSession, err := json.Marshal(session)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -84,13 +84,13 @@ func main() {
 	// The serialized session can now be saved and loaded again later.
 
 	// Deserialize the session state after loading from storage.
-	resumedSession, err := a.UnmarshalSession(ctx, serializedSession)
-	if err != nil {
+	var resumedSession agent.Session
+	if err := json.Unmarshal(serializedSession, &resumedSession); err != nil {
 		demo.Panic(err)
 	}
 
 	// Run the agent with the session that stores conversation history in the disk store a second time.
-	resp, err = a.RunText(ctx, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agent.WithSession(resumedSession)).Collect()
+	resp, err = a.RunText(ctx, "Now tell the same joke in the voice of a pirate, and add some emojis to the joke.", agent.WithSession(&resumedSession)).Collect()
 	demo.Response(resp, err)
 }
 
@@ -107,7 +107,7 @@ func newFSHistoryProvider(dir string) *agent.HistoryProvider {
 	}
 }
 
-func (d *fsMessageStore) getFiles(session agent.Session) []string {
+func (d *fsMessageStore) getFiles(session *agent.Session) []string {
 	if session == nil {
 		return nil
 	}
@@ -119,7 +119,7 @@ func (d *fsMessageStore) getFiles(session agent.Session) []string {
 	return files
 }
 
-func (d *fsMessageStore) loadMessages(session agent.Session) ([]*message.Message, error) {
+func (d *fsMessageStore) loadMessages(session *agent.Session) ([]*message.Message, error) {
 	var msgs []*message.Message
 	for _, file := range d.getFiles(session) {
 		data, err := os.ReadFile(filepath.Join(d.Dir, file))

--- a/examples/02-agents/agents/step17_additional_ai_context/main.go
+++ b/examples/02-agents/agents/step17_additional_ai_context/main.go
@@ -86,7 +86,7 @@ You remind users of upcoming calendar events when the user interacts with you.`,
 	}
 
 	// Serialize the session. It contains the chat history plus state serialized by the context providers.
-	serializedSession, err := a.MarshalSession(ctx, session)
+	serializedSession, err := json.Marshal(session)
 	if err != nil {
 		demo.Panic(err)
 	}
@@ -97,10 +97,11 @@ You remind users of upcoming calendar events when the user interacts with you.`,
 	fmt.Println(prettySession.String())
 
 	// The serialized session can be stored long term in a persistent store. Here we deserialize it and continue.
-	session, err = a.UnmarshalSession(ctx, serializedSession)
-	if err != nil {
+	var resumedSession agent.Session
+	if err := json.Unmarshal(serializedSession, &resumedSession); err != nil {
 		demo.Panic(err)
 	}
+	session = &resumedSession
 
 	resp, err := a.RunText(ctx, "Considering my appointments, can you create a plan for my day that plans out when I should complete the items on my todo list?", agent.WithSession(session)).Collect()
 	demo.Response(resp, err)
@@ -154,7 +155,7 @@ func newTodoListContextProvider() *agent.ContextProvider {
 	}
 }
 
-func getTodoListState(session agent.Session) todoListState {
+func getTodoListState(session *agent.Session) todoListState {
 	if session == nil {
 		return todoListState{}
 	}
@@ -163,7 +164,7 @@ func getTodoListState(session agent.Session) todoListState {
 	return state
 }
 
-func setTodoListState(session agent.Session, state todoListState) {
+func setTodoListState(session *agent.Session, state todoListState) {
 	if session != nil {
 		session.Set(todoListSourceID, state)
 	}

--- a/examples/02-agents/agui/step04_human_in_loop/client/main.go
+++ b/examples/02-agents/agui/step04_human_in_loop/client/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 }
 
-func runWithApprovals(ctx context.Context, a *agent.Agent, session agent.Session, input *message.Message) error {
+func runWithApprovals(ctx context.Context, a *agent.Agent, session *agent.Session, input *message.Message) error {
 	current := input
 	for {
 		resp, err := a.RunMessage(ctx, current, agent.WithSession(session)).Collect()

--- a/internal/agenttest/agenttest.go
+++ b/internal/agenttest/agenttest.go
@@ -122,20 +122,16 @@ func (a *testagent) run(ctx context.Context, messages []*message.Message, opts .
 	}
 }
 
-func (a *testagent) createSession(_ context.Context, _ agent.Session, opts ...agent.Option) error {
+func (a *testagent) createSession(_ context.Context, _ *agent.Session, opts ...agent.Option) error {
 	return nil
 }
 
-func CreateSession(options ...agent.Option) agent.Session {
+func CreateSession(options ...agent.Option) *agent.Session {
 	session, err := New(nil).CreateSession(context.Background(), options...)
 	if err != nil {
 		panic(err)
 	}
 	return session
-}
-
-func MarshalSession(session agent.Session) ([]byte, error) {
-	return New(nil).MarshalSession(context.Background(), session)
 }
 
 // Middleware is a test implementation of the Middleware interface


### PR DESCRIPTION
## Summary
- follow the agent session serialization decision in https://github.com/microsoft/agent-framework/blob/main/docs/decisions/0018-agentthread-serialization.md.
- make agent.Session an exported zero-value struct with direct encoding/json support
- remove agent-level session marshal/unmarshal APIs and provider serialization hooks
- update session option/provider APIs, workflow checkpointing, examples, and tests

## Tests
- go test ./...