### PR TITLE
[dotnet-port] Port A2A input-required task routing fix from .NET

### DIFF
--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -75,7 +75,7 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 				yield(nil, err)
 				return
 			}
-			if err := updateSessionContextID(session, task.ContextID, string(task.ID)); err != nil {
+			if err := updateSessionContextID(session, task.ContextID, string(task.ID), task.Status.State); err != nil {
 				yield(nil, err)
 				return
 			}
@@ -99,7 +99,15 @@ func (a *a2aagent) run(ctx context.Context, messages []*message.Message, options
 				userMsg.ID = msg.ID
 			}
 			userMsg.ContextID = getContextID(session)
-			userMsg.ReferenceTasks = taskIDs
+			// When the task is waiting for user input (InputRequired), link the message
+			// directly to the task via TaskId so it is treated as input for that task.
+			// Otherwise, use ReferenceTasks to link as a follow-up.
+			// See: https://github.com/a2aproject/A2A/blob/main/docs/topics/life-of-a-task.md#task-refinements
+			if getLastTaskState(session) == a2a.TaskStateInputRequired && len(taskIDs) > 0 {
+				userMsg.TaskID = taskIDs[len(taskIDs)-1]
+			} else {
+				userMsg.ReferenceTasks = taskIDs
+			}
 			userMsg.Metadata = maps.Clone(msg.AdditionalProperties)
 
 			params := &a2a.SendMessageRequest{Message: userMsg}
@@ -154,7 +162,14 @@ func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func
 			return
 		}
 		taskInfo := e.TaskInfo()
-		if err := updateSessionContextID(session, taskInfo.ContextID, string(taskInfo.TaskID)); err != nil {
+		var taskState a2a.TaskState
+		switch evt := e.(type) {
+		case *a2a.Task:
+			taskState = evt.Status.State
+		case *a2a.TaskStatusUpdateEvent:
+			taskState = evt.Status.State
+		}
+		if err := updateSessionContextID(session, taskInfo.ContextID, string(taskInfo.TaskID), taskState); err != nil {
 			yield(nil, err)
 			return
 		}
@@ -251,7 +266,7 @@ func yieldTask(yield func(*agent.ResponseUpdate, error) bool, task *a2a.Task) bo
 	}, nil)
 }
 
-func updateSessionContextID(session *agent.Session, contextID, taskID string) error {
+func updateSessionContextID(session *agent.Session, contextID, taskID string, taskState a2a.TaskState) error {
 	if session == nil {
 		return nil
 	}
@@ -263,6 +278,7 @@ func updateSessionContextID(session *agent.Session, contextID, taskID string) er
 	}
 	setContextID(session, contextID)
 	setTaskID(session, taskID)
+	setLastTaskState(session, taskState)
 	return nil
 }
 

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -707,6 +707,110 @@ func TestRunWithMultipleTaskIDsInSessionAndMessage(t *testing.T) {
 	}
 }
 
+// TestRunWithInputRequiredTask_UsesTaskId tests that when the last task state is InputRequired,
+// the follow-up message uses TaskId (not ReferenceTasks) to link to the waiting task.
+func TestRunWithInputRequiredTask_UsesTaskId(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-waiting"),
+			ContextID: "ctx-123",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateInputRequired,
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First run: agent returns InputRequired task.
+	_, err = a.RunText(t.Context(), "Do something", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first run error = %v, want nil", err)
+	}
+
+	// Now simulate a second message (the user providing input).
+	transport.responseToReturn = &a2a.Message{
+		ID:        "response-final",
+		ContextID: "ctx-123",
+		Role:      a2a.MessageRoleAgent,
+		Parts:     a2a.ContentParts{a2a.NewTextPart("Done")},
+	}
+	transport.capturedMessageSendParams = nil
+
+	_, err = a.RunText(t.Context(), "Here is your input", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second run error = %v, want nil", err)
+	}
+
+	capturedMsg := transport.capturedMessageSendParams.Message
+	if capturedMsg == nil {
+		t.Fatal("capturedMessageSendParams.Message is nil")
+	}
+	if len(capturedMsg.ReferenceTasks) != 0 {
+		t.Errorf("message.ReferenceTasks = %v, want empty (should use TaskId instead)", capturedMsg.ReferenceTasks)
+	}
+	if string(capturedMsg.TaskID) != "task-waiting" {
+		t.Errorf("message.TaskID = %q, want %q", capturedMsg.TaskID, "task-waiting")
+	}
+}
+
+// TestRunWithCompletedTask_UsesReferenceTasks tests that a follow-up after a completed task
+// uses ReferenceTasks (not TaskId).
+func TestRunWithCompletedTask_UsesReferenceTasks(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-done"),
+			ContextID: "ctx-456",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First run: agent completes the task.
+	_, err = a.RunText(t.Context(), "Do something", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first run error = %v, want nil", err)
+	}
+
+	// Follow-up run after completed task should use ReferenceTasks.
+	transport.responseToReturn = &a2a.Message{
+		ID:        "response-followup",
+		ContextID: "ctx-456",
+		Role:      a2a.MessageRoleAgent,
+		Parts:     a2a.ContentParts{a2a.NewTextPart("Follow-up done")},
+	}
+	transport.capturedMessageSendParams = nil
+
+	_, err = a.RunText(t.Context(), "Do a follow-up", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second run error = %v, want nil", err)
+	}
+
+	capturedMsg := transport.capturedMessageSendParams.Message
+	if capturedMsg == nil {
+		t.Fatal("capturedMessageSendParams.Message is nil")
+	}
+	if string(capturedMsg.TaskID) != "" {
+		t.Errorf("message.TaskID = %q, want empty (should use ReferenceTasks)", capturedMsg.TaskID)
+	}
+	if len(capturedMsg.ReferenceTasks) == 0 {
+		t.Error("message.ReferenceTasks is empty, want task-done")
+	} else if string(capturedMsg.ReferenceTasks[0]) != "task-done" {
+		t.Errorf("message.ReferenceTasks[0] = %q, want %q", capturedMsg.ReferenceTasks[0], "task-done")
+	}
+}
+
 // TestRunWithAgentTask tests that session task ID is updated
 func TestRunWithAgentTask(t *testing.T) {
 	transport := &mockA2ATransport{

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -707,15 +707,13 @@ func TestRunWithMultipleTaskIDsInSessionAndMessage(t *testing.T) {
 	}
 }
 
-// TestRunWithInputRequiredTask_UsesTaskId tests that when the last task state is InputRequired,
-// the follow-up message uses TaskId (not ReferenceTasks) to link to the waiting task.
-func TestRunWithInputRequiredTask_UsesTaskId(t *testing.T) {
+func assertTaskRoutingAfterFollowUp(t *testing.T, initialTaskID string, initialTaskState a2a.TaskState, wantTaskID string, wantReferenceTask string) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Task{
-			ID:        a2a.TaskID("task-waiting"),
+			ID:        a2a.TaskID(initialTaskID),
 			ContextID: "ctx-123",
 			Status: a2a.TaskStatus{
-				State: a2a.TaskStateInputRequired,
+				State: initialTaskState,
 			},
 		},
 	}
@@ -726,13 +724,11 @@ func TestRunWithInputRequiredTask_UsesTaskId(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// First run: agent returns InputRequired task.
 	_, err = a.RunText(t.Context(), "Do something", agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("first run error = %v, want nil", err)
 	}
 
-	// Now simulate a second message (the user providing input).
 	transport.responseToReturn = &a2a.Message{
 		ID:        "response-final",
 		ContextID: "ctx-123",
@@ -750,65 +746,33 @@ func TestRunWithInputRequiredTask_UsesTaskId(t *testing.T) {
 	if capturedMsg == nil {
 		t.Fatal("capturedMessageSendParams.Message is nil")
 	}
-	if len(capturedMsg.ReferenceTasks) != 0 {
-		t.Errorf("message.ReferenceTasks = %v, want empty (should use TaskId instead)", capturedMsg.ReferenceTasks)
+	if got := string(capturedMsg.TaskID); got != wantTaskID {
+		t.Errorf("message.TaskID = %q, want %q", capturedMsg.TaskID, wantTaskID)
 	}
-	if string(capturedMsg.TaskID) != "task-waiting" {
-		t.Errorf("message.TaskID = %q, want %q", capturedMsg.TaskID, "task-waiting")
+	switch {
+	case wantReferenceTask == "":
+		if len(capturedMsg.ReferenceTasks) != 0 {
+			t.Errorf("message.ReferenceTasks = %v, want empty", capturedMsg.ReferenceTasks)
+		}
+	case len(capturedMsg.ReferenceTasks) == 0:
+		t.Fatalf("message.ReferenceTasks is empty, want %q", wantReferenceTask)
+	default:
+		if got := string(capturedMsg.ReferenceTasks[0]); got != wantReferenceTask {
+			t.Errorf("message.ReferenceTasks[0] = %q, want %q", got, wantReferenceTask)
+		}
 	}
+}
+
+// TestRunWithInputRequiredTask_UsesTaskId tests that when the last task state is InputRequired,
+// the follow-up message uses TaskId (not ReferenceTasks) to link to the waiting task.
+func TestRunWithInputRequiredTask_UsesTaskId(t *testing.T) {
+	assertTaskRoutingAfterFollowUp(t, "task-waiting", a2a.TaskStateInputRequired, "task-waiting", "")
 }
 
 // TestRunWithCompletedTask_UsesReferenceTasks tests that a follow-up after a completed task
 // uses ReferenceTasks (not TaskId).
 func TestRunWithCompletedTask_UsesReferenceTasks(t *testing.T) {
-	transport := &mockA2ATransport{
-		responseToReturn: &a2a.Task{
-			ID:        a2a.TaskID("task-done"),
-			ContextID: "ctx-456",
-			Status: a2a.TaskStatus{
-				State: a2a.TaskStateCompleted,
-			},
-		},
-	}
-	a := newTestAgent(transport, agent.Config{})
-
-	session, err := a.CreateSession(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// First run: agent completes the task.
-	_, err = a.RunText(t.Context(), "Do something", agent.WithSession(session)).Collect()
-	if err != nil {
-		t.Fatalf("first run error = %v, want nil", err)
-	}
-
-	// Follow-up run after completed task should use ReferenceTasks.
-	transport.responseToReturn = &a2a.Message{
-		ID:        "response-followup",
-		ContextID: "ctx-456",
-		Role:      a2a.MessageRoleAgent,
-		Parts:     a2a.ContentParts{a2a.NewTextPart("Follow-up done")},
-	}
-	transport.capturedMessageSendParams = nil
-
-	_, err = a.RunText(t.Context(), "Do a follow-up", agent.WithSession(session)).Collect()
-	if err != nil {
-		t.Fatalf("second run error = %v, want nil", err)
-	}
-
-	capturedMsg := transport.capturedMessageSendParams.Message
-	if capturedMsg == nil {
-		t.Fatal("capturedMessageSendParams.Message is nil")
-	}
-	if string(capturedMsg.TaskID) != "" {
-		t.Errorf("message.TaskID = %q, want empty (should use ReferenceTasks)", capturedMsg.TaskID)
-	}
-	if len(capturedMsg.ReferenceTasks) == 0 {
-		t.Error("message.ReferenceTasks is empty, want task-done")
-	} else if string(capturedMsg.ReferenceTasks[0]) != "task-done" {
-		t.Errorf("message.ReferenceTasks[0] = %q, want %q", capturedMsg.ReferenceTasks[0], "task-done")
-	}
+	assertTaskRoutingAfterFollowUp(t, "task-done", a2a.TaskStateCompleted, "", "task-done")
 }
 
 // TestRunWithAgentTask tests that session task ID is updated

--- a/agent/provider/a2aagent/session.go
+++ b/agent/provider/a2aagent/session.go
@@ -48,7 +48,11 @@ func TaskIDsFromSession(session *agent.Session) []string {
 }
 
 func setLastTaskState(session *agent.Session, state a2a.TaskState) {
-	if session == nil || state == a2a.TaskStateUnspecified {
+	if session == nil {
+		return
+	}
+	if state == a2a.TaskStateUnspecified {
+		session.Delete(taskStateKey)
 		return
 	}
 	session.Set(taskStateKey, string(state))

--- a/agent/provider/a2aagent/session.go
+++ b/agent/provider/a2aagent/session.go
@@ -2,10 +2,14 @@
 
 package a2aagent
 
-import "github.com/microsoft/agent-framework-go/agent"
+import (
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/microsoft/agent-framework-go/agent"
+)
 
 const (
 	taskIDsStateKey = "a2aagent.taskIDs"
+	taskStateKey    = "a2aagent.taskState"
 )
 
 func setContextID(session *agent.Session, contextID string) {
@@ -41,4 +45,22 @@ func getTaskIDs(session *agent.Session) []string {
 // TaskIDsFromSession returns all known A2A task IDs stored in session state.
 func TaskIDsFromSession(session *agent.Session) []string {
 	return getTaskIDs(session)
+}
+
+func setLastTaskState(session *agent.Session, state a2a.TaskState) {
+	if session == nil || state == a2a.TaskStateUnspecified {
+		return
+	}
+	session.Set(taskStateKey, string(state))
+}
+
+func getLastTaskState(session *agent.Session) a2a.TaskState {
+	if session == nil {
+		return a2a.TaskStateUnspecified
+	}
+	var state string
+	if ok, err := session.Get(taskStateKey, &state); err != nil || !ok {
+		return a2a.TaskStateUnspecified
+	}
+	return a2a.TaskState(state)
 }


### PR DESCRIPTION
When an A2A task returns TaskStateInputRequired, follow-up messages should link to the waiting task via TaskId (direct link for input) rather than ReferenceTasks (context-only reference). This aligns with .NET PR microsoft/agent-framework#5743 which introduced the same fix.

- Track last task state in session state (a2aagent.taskState key)
- Pass task state to updateSessionContextID from all call sites, including yieldTask, sendMsg (Task/TaskStatusUpdateEvent events), and the GetTask continuation path
- Use userMsg.TaskId when last task state is InputRequired (with a known task ID); fall back to ReferenceTasks otherwise
- Add TestRunWithInputRequiredTask_UsesTaskId and TestRunWithCompletedTask_UsesReferenceTasks to cover both paths