### PR TITLE
Align workflow APIs with .NET parity

### DIFF
--- a/agent/hosting/workflowhosting/builders.go
+++ b/agent/hosting/workflowhosting/builders.go
@@ -142,7 +142,9 @@ func newAggregateTurnMessagesBinding(id string) workflow.ExecutorBinding {
 		SupportsConcurrentSharedExecution: true,
 		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
 			spec := workflow.ExecutorSpec{
-				SendTypes: []reflect.Type{reflect.TypeFor[[]*message.Message]()},
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					return pb.SendsMessageType(reflect.TypeFor[[]*message.Message]()), nil
+				},
 			}
 			messageworkflow.Configure(&spec, &messageworkflow.Options{
 				StateKey:                 aggregateTurnMessagesStateKey,
@@ -167,7 +169,9 @@ func newOutputMessagesBinding() workflow.ExecutorBinding {
 		SupportsConcurrentSharedExecution: true,
 		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
 			spec := workflow.ExecutorSpec{
-				YieldTypes: []reflect.Type{reflect.TypeFor[[]*message.Message]()},
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					return pb.YieldsOutputType(reflect.TypeFor[[]*message.Message]()), nil
+				},
 			}
 			messageworkflow.Configure(&spec, &messageworkflow.Options{
 				StateKey:                 outputMessagesStateKey,
@@ -208,13 +212,13 @@ func newConcurrentEndBinding(expectedInputs int, aggregator MessageAggregator) w
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: true,
 					DisableAutoYieldOutputHandlerResultObject: true,
-					YieldTypes: []reflect.Type{reflect.TypeFor[[]*message.Message]()},
 					Reset: func() error {
 						reset()
 						return nil
 					},
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.YieldsOutputType(reflect.TypeFor[[]*message.Message]())
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 							allResults = append(allResults, msg.([]*message.Message))
 							remaining--
 							if remaining == 0 {
@@ -225,7 +229,8 @@ func newConcurrentEndBinding(expectedInputs int, aggregator MessageAggregator) w
 								}
 							}
 							return struct{}{}, nil
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil

--- a/agent/hosting/workflowhosting/builders_test.go
+++ b/agent/hosting/workflowhosting/builders_test.go
@@ -303,8 +303,8 @@ func TestBuildSequential_SingleAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSequential: %v", err)
 	}
-	if wf.Name != "single-agent" {
-		t.Fatalf("workflow name = %q, want %q", wf.Name, "single-agent")
+	if wf.Name() != "single-agent" {
+		t.Fatalf("workflow name = %q, want %q", wf.Name(), "single-agent")
 	}
 
 	texts := collectOutputTexts(runBuiltWorkflow(t, wf))
@@ -323,8 +323,8 @@ func TestBuildSequential_MultiAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSequential: %v", err)
 	}
-	if wf.Name != "" {
-		t.Fatalf("workflow name = %q, want empty", wf.Name)
+	if wf.Name() != "" {
+		t.Fatalf("workflow name = %q, want empty", wf.Name())
 	}
 
 	texts := collectOutputTexts(runBuiltWorkflow(t, wf))
@@ -407,8 +407,8 @@ func TestBuildConcurrent_SingleAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildConcurrent: %v", err)
 	}
-	if wf.Name != "single-concurrent" {
-		t.Fatalf("workflow name = %q, want %q", wf.Name, "single-concurrent")
+	if wf.Name() != "single-concurrent" {
+		t.Fatalf("workflow name = %q, want %q", wf.Name(), "single-concurrent")
 	}
 
 	events := runBuiltWorkflow(t, wf)

--- a/agent/hosting/workflowhosting/workflow.go
+++ b/agent/hosting/workflowhosting/workflow.go
@@ -205,13 +205,7 @@ func (h *hostExecutor) executor() *workflow.Executor {
 	spec.Extend(workflow.ExecutorSpec{
 		OnCheckpoint:         h.onCheckpoint,
 		OnCheckpointRestored: h.onCheckpointRestored,
-		SendTypes: []reflect.Type{
-			reflect.TypeFor[[]*message.Message](),
-			reflect.TypeFor[workflow.TurnToken](),
-			reflect.TypeFor[*message.ToolApprovalRequestContent](),
-			reflect.TypeFor[*message.FunctionCallContent](),
-		},
-		ConfigureRoutes: h.configureRoutes,
+		ConfigureProtocol:    h.configureRoutes,
 	})
 
 	return &workflow.Executor{
@@ -271,9 +265,17 @@ func (h *hostExecutor) onCheckpointRestored(wctx *workflow.Context) error {
 	return nil
 }
 
-func (h *hostExecutor) configureRoutes(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
+func (h *hostExecutor) configureRoutes(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+	pb.SendsMessageType(
+		reflect.TypeFor[[]*message.Message](),
+		reflect.TypeFor[workflow.TurnToken](),
+		reflect.TypeFor[*message.ToolApprovalRequestContent](),
+		reflect.TypeFor[*message.FunctionCallContent](),
+	)
+	rb := &pb.RouteBuilder
 	rb = h.approvalHandler.ConfigureRoutes(rb)
 	rb = h.callHandler.ConfigureRoutes(rb)
+	pb.RouteBuilder = *rb
 	rb = rb.AddHandlerRaw(reflect.TypeFor[ResetSignal](), nil, func(wctx *workflow.Context, msg any) (any, error) {
 		h.session = nil
 		h.turnEmitEvents = nil
@@ -288,7 +290,8 @@ func (h *hostExecutor) configureRoutes(rb *workflow.RouteBuilder) (*workflow.Rou
 		return nil, h.handleExternalResponse(wctx, msg.(*workflow.ExternalResponse))
 	})
 
-	return rb, nil
+	pb.RouteBuilder = *rb
+	return pb, nil
 }
 
 // drainBuffered returns the currently buffered messages and resets the buffer.

--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -265,11 +265,12 @@ func collectForwardedResponseMessages(t *testing.T, a *agent.Agent, cfg workflow
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(_ *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(_ *workflow.Context, msg any) (any, error) {
 						observed = append(observed, msg.([]*message.Message)...)
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -598,11 +599,12 @@ func TestHostedAgent_ForwardsIncomingMessages(t *testing.T) {
 					Spec: workflow.ExecutorSpec{
 						DisableAutoSendMessageHandlerResultObject: true,
 						DisableAutoYieldOutputHandlerResultObject: true,
-						ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-							return rb.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(_ *workflow.Context, msg any) (any, error) {
+						ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+							rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(_ *workflow.Context, msg any) (any, error) {
 								observed = append(observed, msg)
 								return nil, nil
-							}), nil
+							})
+							return rb, nil
 						},
 					},
 				}, nil
@@ -1087,12 +1089,13 @@ func approverExecutor(target workflow.ExecutorBinding, approve bool) workflow.Ex
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[*message.ToolApprovalResponseContent]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[*message.ToolApprovalRequestContent](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[*message.ToolApprovalResponseContent]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*message.ToolApprovalRequestContent](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						req := msg.(*message.ToolApprovalRequestContent)
 						return nil, ctx.SendMessage(target.ID, req.CreateResponse(approve, ""))
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -1113,15 +1116,16 @@ func resultExecutor(target workflow.ExecutorBinding, result any) workflow.Execut
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[*message.FunctionResultContent]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[*message.FunctionCallContent](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[*message.FunctionResultContent]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*message.FunctionCallContent](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						call := msg.(*message.FunctionCallContent)
 						return nil, ctx.SendMessage(target.ID, &message.FunctionResultContent{
 							CallID: call.CallID,
 							Result: result,
 						})
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -1353,11 +1357,12 @@ func TestHostedAgent_InterceptDisabled_PostsExternalRequest(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[*message.ToolApprovalRequestContent](), nil, func(_ *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*message.ToolApprovalRequestContent](), nil, func(_ *workflow.Context, _ any) (any, error) {
 						sawApprovalRequestMessage = true
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -1830,14 +1835,15 @@ func TestHostedAgent_UnknownResponseID_RaisesError(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[*message.FunctionResultContent]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[*message.FunctionResultContent]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
 						return nil, ctx.SendMessage(host.ID, &message.FunctionResultContent{
 							CallID: "no-such-call",
 							Result: "x",
 						})
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -1893,11 +1899,12 @@ func TestHostedAgent_HeldTurnToken_StampsResolvedEmitEvents(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, func(_ *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, func(_ *workflow.Context, msg any) (any, error) {
 						observed = append(observed, msg.(workflow.TurnToken))
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -1946,7 +1953,7 @@ func TestHostedAgent_HeldTurnToken_StampsResolvedEmitEvents(t *testing.T) {
 
 // TestHostedAgent_RegistersDynamicPorts verifies that the hosting binding
 // declares its UserInput / FunctionCall ports so they appear in
-// Workflow.Ports (and hence in workflow metadata via ReflectPorts).
+// Workflow request ports (and hence workflow metadata via ReflectPorts).
 func TestHostedAgent_RegistersDynamicPorts(t *testing.T) {
 	a := newReplayAgent()
 	host := workflowhosting.New(a, workflowhosting.Config{})
@@ -1959,11 +1966,11 @@ func TestHostedAgent_RegistersDynamicPorts(t *testing.T) {
 	wantUserInput := host.ID + "_UserInput"
 	wantFunctionCall := host.ID + "_FunctionCall"
 
-	if _, ok := wf.Ports[wantUserInput]; !ok {
-		t.Errorf("expected Workflow.Ports to contain %q, got %v", wantUserInput, wf.Ports)
+	if _, ok := wf.RequestPort(wantUserInput); !ok {
+		t.Errorf("expected workflow request ports to contain %q, got %v", wantUserInput, wf.RequestPorts())
 	}
-	if _, ok := wf.Ports[wantFunctionCall]; !ok {
-		t.Errorf("expected Workflow.Ports to contain %q, got %v", wantFunctionCall, wf.Ports)
+	if _, ok := wf.RequestPort(wantFunctionCall); !ok {
+		t.Errorf("expected workflow request ports to contain %q, got %v", wantFunctionCall, wf.RequestPorts())
 	}
 }
 
@@ -2062,11 +2069,12 @@ func TestHostedAgent_AlreadyPendingRequest_IsIdempotent_InterceptMode(t *testing
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[*message.ToolApprovalRequestContent](), nil, func(_ *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*message.ToolApprovalRequestContent](), nil, func(_ *workflow.Context, msg any) (any, error) {
 						seen = append(seen, msg.(*message.ToolApprovalRequestContent))
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -129,7 +129,7 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 
 			// Split incoming messages into ExternalResponses for pending
 			// requests and the remaining workflow messages.
-			remaining, responses, hasMatchedStartResponse := splitResponses(messages, state.pending, wf.StartExecutorID, state.stream.ResponsePortExecutorID)
+			remaining, responses, hasMatchedStartResponse := splitResponses(messages, state.pending, wf.StartExecutorID(), state.stream.ResponsePortExecutorID)
 
 			for _, resp := range responses {
 				if err := state.stream.SendResponse(ctx, resp); err != nil {

--- a/agent/provider/workflowprovider/workflow_test.go
+++ b/agent/provider/workflowprovider/workflow_test.go
@@ -22,11 +22,14 @@ import (
 func newMessageSpec(options *messageworkflow.Options) workflow.ExecutorSpec {
 	spec := workflow.ExecutorSpec{}
 	messageworkflow.Configure(&spec, options)
-	spec.YieldTypes = append(
-		spec.YieldTypes,
-		reflect.TypeFor[*message.Message](),
-		reflect.TypeFor[*agent.Response](),
-	)
+	spec.Extend(workflow.ExecutorSpec{
+		ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+			return pb.YieldsOutputType(
+				reflect.TypeFor[*message.Message](),
+				reflect.TypeFor[*agent.Response](),
+			), nil
+		},
+	})
 	return spec
 }
 
@@ -307,9 +310,10 @@ func TestNew_RejectsIncompatibleWorkflow(t *testing.T) {
 		ex := &workflow.Executor{
 			ID: id,
 			Spec: workflow.ExecutorSpec{
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil,
-						func(ctx *workflow.Context, msg any) (any, error) { return nil, nil }), nil
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil,
+						func(ctx *workflow.Context, msg any) (any, error) { return nil, nil })
+					return rb, nil
 				},
 			},
 		}
@@ -497,8 +501,8 @@ func callRequestExecutorBinding(t *testing.T, id string) workflow.ExecutorBindin
 			},
 		})
 		spec.Extend(workflow.ExecutorSpec{
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					resp := msg.(*workflow.ExternalResponse)
 					v, ok := resp.Data.As(port.Response)
 					if !ok {
@@ -513,7 +517,8 @@ func callRequestExecutorBinding(t *testing.T, id string) workflow.ExecutorBindin
 						Contents: []message.Content{&message.TextContent{Text: "got:" + r.Result.(string)}},
 					}
 					return nil, ctx.YieldOutput(out)
-				}), nil
+				})
+				return rb, nil
 			},
 		})
 		return &workflow.Executor{
@@ -630,8 +635,8 @@ func approvalRequestExecutorBinding(t *testing.T, id string) workflow.ExecutorBi
 			},
 		})
 		spec.Extend(workflow.ExecutorSpec{
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					resp := msg.(*workflow.ExternalResponse)
 					v, ok := resp.Data.As(port.Response)
 					if !ok {
@@ -650,7 +655,8 @@ func approvalRequestExecutorBinding(t *testing.T, id string) workflow.ExecutorBi
 						Contents: []message.Content{&message.TextContent{Text: text}},
 					}
 					return nil, ctx.YieldOutput(out)
-				}), nil
+				})
+				return rb, nil
 			},
 		})
 		return &workflow.Executor{
@@ -845,8 +851,8 @@ func TestNew_MixedResponseAndRegularMessage_BothProcessed(t *testing.T) {
 			},
 		})
 		spec.Extend(workflow.ExecutorSpec{
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					resp := msg.(*workflow.ExternalResponse)
 					v, ok := resp.Data.As(port.Response)
 					if !ok {
@@ -858,7 +864,8 @@ func TestNew_MixedResponseAndRegularMessage_BothProcessed(t *testing.T) {
 						Contents: []message.Content{&message.TextContent{Text: "result:" + r.Result.(string)}},
 					}
 					return nil, ctx.YieldOutput(out)
-				}), nil
+				})
+				return rb, nil
 			},
 		})
 		return &workflow.Executor{

--- a/examples/03-workflows/concurrent/concurrent/main.go
+++ b/examples/03-workflows/concurrent/concurrent/main.go
@@ -65,10 +65,11 @@ func bindStep[In any](id string, fn func(*workflow.Context, In) error) workflow.
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: true,
 					DisableAutoYieldOutputHandlerResultObject: true,
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[In](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[In](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 							return struct{}{}, fn(ctx, msg.(In))
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil
@@ -88,11 +89,12 @@ func aggregateStrings(id string) workflow.ExecutorBinding {
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: true,
 					DisableAutoYieldOutputHandlerResultObject: true,
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, msg any) (any, error) {
 							messages = append(messages, msg.(string))
 							return struct{}{}, nil
-						}), nil
+						})
+						return rb, nil
 					},
 					OnMessageDeliveryFinished: func(ctx *workflow.Context) error {
 						if len(messages) == 0 {

--- a/examples/03-workflows/loop/main.go
+++ b/examples/03-workflows/loop/main.go
@@ -67,8 +67,8 @@ func newGuessNumberExecutor(id string, low int, high int) workflow.ExecutorBindi
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: true,
 					DisableAutoYieldOutputHandlerResultObject: true,
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[NumberSignal](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[NumberSignal](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 							switch msg.(NumberSignal) {
 							case Above:
 								upper = nextGuess() - 1
@@ -76,7 +76,8 @@ func newGuessNumberExecutor(id string, low int, high int) workflow.ExecutorBindi
 								lower = nextGuess() + 1
 							}
 							return struct{}{}, ctx.SendMessage("", nextGuess())
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil
@@ -95,8 +96,8 @@ func newJudgeExecutor(id string, target int) workflow.ExecutorBinding {
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: true,
 					DisableAutoYieldOutputHandlerResultObject: true,
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[int](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[int](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 							guess := msg.(int)
 							tries++
 							switch {
@@ -107,7 +108,8 @@ func newJudgeExecutor(id string, target int) workflow.ExecutorBinding {
 							default:
 								return struct{}{}, ctx.SendMessage("", Above)
 							}
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil

--- a/examples/03-workflows/shared-states/main.go
+++ b/examples/03-workflows/shared-states/main.go
@@ -72,10 +72,11 @@ func bindContextFunc[In, Out any](id string, fn func(*workflow.Context, In) (Out
 		ExecutorType: reflect.TypeOf(fn),
 		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
 			return &workflow.Executor{ID: id, Spec: workflow.ExecutorSpec{
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[In](), reflect.TypeFor[Out](), func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[In](), reflect.TypeFor[Out](), func(ctx *workflow.Context, msg any) (any, error) {
 						return fn(ctx, msg.(In))
-					}), nil
+					})
+					return rb, nil
 				},
 			}}, nil
 		},

--- a/message/messageworkflow/messageforwarding.go
+++ b/message/messageworkflow/messageforwarding.go
@@ -35,22 +35,22 @@ func ConfigureForwarding(spec *workflow.ExecutorSpec, options *ForwardingOptions
 	forwardingSpec := workflow.ExecutorSpec{
 		DisableAutoSendMessageHandlerResultObject: true,
 		DisableAutoYieldOutputHandlerResultObject: true,
-		SendTypes: []reflect.Type{
-			reflect.TypeFor[*message.Message](),
-			reflect.TypeFor[[]*message.Message](),
-			reflect.TypeFor[workflow.TurnToken](),
-		},
 		Reset: func() error { return nil },
-		ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
+		ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+			rb.SendsMessageType(
+				reflect.TypeFor[*message.Message](),
+				reflect.TypeFor[[]*message.Message](),
+				reflect.TypeFor[workflow.TurnToken](),
+			)
 			if stringMessageRole != "" {
-				rb = rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					return struct{}{}, ctx.SendMessage("", &message.Message{
 						Role:     stringMessageRole,
 						Contents: []message.Content{&message.TextContent{Text: msg.(string)}},
 					})
 				})
 			}
-			return rb.
+			rb.RouteBuilder.
 				AddHandlerRaw(reflect.TypeFor[*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					return struct{}{}, ctx.SendMessage("", msg.(*message.Message))
 				}).
@@ -66,7 +66,8 @@ func ConfigureForwarding(spec *workflow.ExecutorSpec, options *ForwardingOptions
 				}).
 				AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					return struct{}{}, ctx.SendMessage("", msg.(workflow.TurnToken))
-				}), nil
+				})
+			return rb, nil
 		},
 	}
 	spec.Extend(forwardingSpec)

--- a/message/messageworkflow/messageworkflow.go
+++ b/message/messageworkflow/messageworkflow.go
@@ -68,9 +68,12 @@ func Configure(spec *workflow.ExecutorSpec, options *Options) {
 		OnCheckpointRestored: func(ctx *workflow.Context) error {
 			return state.Reset()
 		},
-		ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
+		ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+			if !options.DisableAutoSendTurnToken {
+				rb.SendsMessageType(reflect.TypeFor[workflow.TurnToken]())
+			}
 			if options.StringMessageRole != "" {
-				rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
 						return append(messages, &message.Message{
 							Role:     message.Role(options.StringMessageRole),
@@ -79,7 +82,7 @@ func Configure(spec *workflow.ExecutorSpec, options *Options) {
 					})
 				})
 			}
-			return rb.
+			rb.RouteBuilder.
 				AddHandlerRaw(reflect.TypeFor[*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
 						return append(messages, msg.(*message.Message)), nil
@@ -111,11 +114,9 @@ func Configure(spec *workflow.ExecutorSpec, options *Options) {
 						}
 						return nil, nil
 					})
-				}), nil
+				})
+			return rb, nil
 		},
-	}
-	if !options.DisableAutoSendTurnToken {
-		messageSpec.SendTypes = []reflect.Type{reflect.TypeFor[workflow.TurnToken]()}
 	}
 	spec.Extend(messageSpec)
 }

--- a/workflow/binding.go
+++ b/workflow/binding.go
@@ -43,7 +43,7 @@ type ExecutorBinding struct {
 	// Ports lists [RequestPort]s that this binding exposes, either as the
 	// workflow boundary port created by [BindRequestPort] or as additional ports
 	// an executor uses to raise [ExternalRequest]s via [Context.PostRequest]. The
-	// builder registers them in [Workflow.Ports] so they appear in workflow
+	// builder registers them so they appear in [Workflow.ReflectPorts]
 	// metadata.
 	Ports []RequestPort
 
@@ -175,13 +175,13 @@ func newRequestPortExecutor(port RequestPort) *Executor {
 	return &Executor{
 		ID: port.ID,
 		Spec: ExecutorSpec{
-			SendTypes: []reflect.Type{port.Response, reflect.TypeFor[*ExternalResponse]()},
 			// The executor's handler return values are exposed via PostRequest /
 			// SendMessage explicitly; suppress the default auto-forwarding.
 			DisableAutoSendMessageHandlerResultObject: true,
 			DisableAutoYieldOutputHandlerResultObject: true,
-			ConfigureRoutes: func(rb *RouteBuilder) (*RouteBuilder, error) {
-				return rb.
+			ConfigureProtocol: func(rb *ProtocolBuilder) (*ProtocolBuilder, error) {
+				rb.SendsMessageType(port.Response, reflect.TypeFor[*ExternalResponse]())
+				rb.RouteBuilder.
 					AddHandlerRaw(port.Request, nil, func(ctx *Context, msg any) (any, error) {
 						req, err := NewExternalRequest("", port, msg)
 						if err != nil {
@@ -237,7 +237,8 @@ func newRequestPortExecutor(port RequestPort) *Executor {
 							return nil, err
 						}
 						return nil, ctx.SendMessage("", data)
-					}), nil
+					})
+				return rb, nil
 			},
 		},
 	}
@@ -256,10 +257,11 @@ func BindFunc[In, Out any](id string, fn func(In) Out) ExecutorBinding {
 			return &Executor{
 				ID: id,
 				Spec: ExecutorSpec{
-					ConfigureRoutes: func(rb *RouteBuilder) (*RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[In](), reflect.TypeFor[Out](), func(_ *Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *ProtocolBuilder) (*ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[In](), reflect.TypeFor[Out](), func(_ *Context, msg any) (any, error) {
 							return fn(msg.(In)), nil
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil

--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -218,18 +218,26 @@ func (wb *Builder) build(validateOrphans bool) (*Workflow, error) {
 	}
 	activity.AddEvent(internalobservability.EventBuildValidationCompleted)
 	wf := &Workflow{
-		StartExecutorID:  wb.startExecutorId,
-		Name:             wb.name,
-		Description:      wb.description,
-		Edges:            wb.edges,
-		Ports:            wb.inputPorts,
-		ExecutorBindings: wb.executorsBindings,
-		OutputExecutors:  wb.outputExecutors,
+		startExecutorID:  wb.startExecutorId,
+		name:             wb.name,
+		description:      wb.description,
+		edges:            cloneEdges(wb.edges),
+		ports:            maps.Clone(wb.inputPorts),
+		executorBindings: maps.Clone(wb.executorsBindings),
+		outputExecutors:  maps.Clone(wb.outputExecutors),
 		telemetry:        telemetry,
 	}
 	internalobservability.SetBuildWorkflowAttributes(activity, observabilityMetadata(wf, ""), workflowTelemetryDefinitionFrom(wf))
 	activity.AddEvent(internalobservability.EventBuildCompleted)
 	return wf, nil
+}
+
+func cloneEdges(edges map[string][]Edge) map[string][]Edge {
+	out := make(map[string][]Edge, len(edges))
+	for sourceID, sourceEdges := range edges {
+		out[sourceID] = slices.Clone(sourceEdges)
+	}
+	return out
 }
 
 func (wb *Builder) validate(validateOrphans bool) bool {

--- a/workflow/builder_test.go
+++ b/workflow/builder_test.go
@@ -22,10 +22,11 @@ func (n *noOpExecutor) NewExecutor(sessionID string) (*workflow.Executor, error)
 	return &workflow.Executor{
 		ID: n.id,
 		Spec: workflow.ExecutorSpec{
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddCatchAll(func(ctx *workflow.Context, msg workflow.PortableValue) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddCatchAll(func(ctx *workflow.Context, msg workflow.PortableValue) (any, error) {
 					return nil, ctx.SendMessage("", msg.Any())
-				}), nil
+				})
+				return rb, nil
 			},
 		},
 	}, nil
@@ -48,10 +49,11 @@ func (n *someOtherNoOpExecutor) NewExecutor(sessionID string) (*workflow.Executo
 	return &workflow.Executor{
 		ID: n.id,
 		Spec: workflow.ExecutorSpec{
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddCatchAll(func(ctx *workflow.Context, msg workflow.PortableValue) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddCatchAll(func(ctx *workflow.Context, msg workflow.PortableValue) (any, error) {
 					return nil, ctx.SendMessage("", msg.Any())
-				}), nil
+				})
+				return rb, nil
 			},
 		},
 	}, nil
@@ -77,10 +79,11 @@ func TestBuilder_AllowsNilExecutorType(t *testing.T) {
 			return &workflow.Executor{
 				ID: "start",
 				Spec: workflow.ExecutorSpec{
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddCatchAll(func(*workflow.Context, workflow.PortableValue) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddCatchAll(func(*workflow.Context, workflow.PortableValue) (any, error) {
 							return nil, nil
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil
@@ -91,13 +94,14 @@ func TestBuilder_AllowsNilExecutorType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if got := wf.ExecutorBindings["start"].ExecutorType; got != nil {
+	bindings := wf.ReflectExecutors()
+	if got := bindings["start"].ExecutorType; got != nil {
 		t.Fatalf("ExecutorType = %v, want nil", got)
 	}
-	if got := wf.ExecutorBindings["start"].String(); got != "start:<unknown>" {
+	if got := bindings["start"].String(); got != "start:<unknown>" {
 		t.Fatalf("String() = %q, want start:<unknown>", got)
 	}
-	executor, err := wf.ExecutorBindings["start"].CreateInstance("session")
+	executor, err := bindings["start"].CreateInstance("session")
 	if err != nil {
 		t.Fatalf("CreateInstance: %v", err)
 	}
@@ -141,19 +145,20 @@ func TestBuilder_Validation_AddEdgesOutOfOrderDoesNotImpactReachability(t *testi
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if wf.StartExecutorID != "start" {
-		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID)
+	if wf.StartExecutorID() != "start" {
+		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID())
 	}
 
-	if len(wf.ExecutorBindings) != 3 {
-		t.Errorf("expected 3 executor bindings, got %d", len(wf.ExecutorBindings))
+	bindings := wf.ReflectExecutors()
+	if len(bindings) != 3 {
+		t.Errorf("expected 3 executor bindings, got %d", len(bindings))
 	}
 
 	for _, id := range []string{"start", "not-unreachable", "also-not-unreachable"} {
-		if _, ok := wf.ExecutorBindings[id]; !ok {
+		if _, ok := bindings[id]; !ok {
 			t.Errorf("expected binding for %s", id)
 		} else {
-			if wf.ExecutorBindings[id].ExecutorType != reflect.TypeFor[*noOpExecutor]() {
+			if bindings[id].ExecutorType != reflect.TypeFor[*noOpExecutor]() {
 				t.Errorf("expected executor type *noOpExecutor for %s", id)
 			}
 		}
@@ -168,15 +173,16 @@ func TestBuilder_LateBinding_Executor(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if wf.StartExecutorID != "start" {
-		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID)
+	if wf.StartExecutorID() != "start" {
+		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID())
 	}
 
-	if len(wf.ExecutorBindings) != 1 {
-		t.Errorf("expected 1 executor binding, got %d", len(wf.ExecutorBindings))
+	bindings := wf.ReflectExecutors()
+	if len(bindings) != 1 {
+		t.Errorf("expected 1 executor binding, got %d", len(bindings))
 	}
 
-	if binding, ok := wf.ExecutorBindings["start"]; !ok {
+	if binding, ok := bindings["start"]; !ok {
 		t.Error("expected binding for start")
 	} else {
 		if binding.ExecutorType != reflect.TypeFor[*noOpExecutor]() {
@@ -194,15 +200,16 @@ func TestBuilder_LateImplicitBinding_Executor(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if wf.StartExecutorID != "start" {
-		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID)
+	if wf.StartExecutorID() != "start" {
+		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID())
 	}
 
-	if len(wf.ExecutorBindings) != 1 {
-		t.Errorf("expected 1 executor binding, got %d", len(wf.ExecutorBindings))
+	bindings := wf.ReflectExecutors()
+	if len(bindings) != 1 {
+		t.Errorf("expected 1 executor binding, got %d", len(bindings))
 	}
 
-	if binding, ok := wf.ExecutorBindings["start"]; !ok {
+	if binding, ok := bindings["start"]; !ok {
 		t.Error("expected binding for start")
 	} else {
 		if binding.ExecutorType != reflect.TypeFor[*noOpExecutor]() {
@@ -249,15 +256,16 @@ func TestBuilder_RebindToSameish_Allowed(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if wf.StartExecutorID != "start" {
-		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID)
+	if wf.StartExecutorID() != "start" {
+		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID())
 	}
 
-	if len(wf.ExecutorBindings) != 1 {
-		t.Errorf("expected 1 executor binding, got %d", len(wf.ExecutorBindings))
+	bindings := wf.ReflectExecutors()
+	if len(bindings) != 1 {
+		t.Errorf("expected 1 executor binding, got %d", len(bindings))
 	}
 
-	if binding, ok := wf.ExecutorBindings["start"]; !ok {
+	if binding, ok := bindings["start"]; !ok {
 		t.Error("expected binding for start")
 	} else {
 		if binding.ExecutorType != reflect.TypeFor[*noOpExecutor]() {
@@ -277,11 +285,11 @@ func TestBuilder_Workflow_NameAndDescription(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if wf1.Name != "Test Pipeline" {
-		t.Errorf("expected name 'Test Pipeline', got %s", wf1.Name)
+	if wf1.Name() != "Test Pipeline" {
+		t.Errorf("expected name 'Test Pipeline', got %s", wf1.Name())
 	}
-	if wf1.Description != "Test workflow description" {
-		t.Errorf("expected description 'Test workflow description', got %s", wf1.Description)
+	if wf1.Description() != "Test workflow description" {
+		t.Errorf("expected description 'Test workflow description', got %s", wf1.Description())
 	}
 
 	// Test without (defaults to empty string in Go)
@@ -292,11 +300,11 @@ func TestBuilder_Workflow_NameAndDescription(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if wf2.Name != "" {
-		t.Errorf("expected empty name, got %s", wf2.Name)
+	if wf2.Name() != "" {
+		t.Errorf("expected empty name, got %s", wf2.Name())
 	}
-	if wf2.Description != "" {
-		t.Errorf("expected empty description, got %s", wf2.Description)
+	if wf2.Description() != "" {
+		t.Errorf("expected empty description, got %s", wf2.Description())
 	}
 
 	// Test with only name (no description)
@@ -308,11 +316,11 @@ func TestBuilder_Workflow_NameAndDescription(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if wf3.Name != "Named Only" {
-		t.Errorf("expected name 'Named Only', got %s", wf3.Name)
+	if wf3.Name() != "Named Only" {
+		t.Errorf("expected name 'Named Only', got %s", wf3.Name())
 	}
-	if wf3.Description != "" {
-		t.Errorf("expected empty description, got %s", wf3.Description)
+	if wf3.Description() != "" {
+		t.Errorf("expected empty description, got %s", wf3.Description())
 	}
 }
 
@@ -329,12 +337,13 @@ func recordingBinding(id string, sink *[]string) workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						*sink = append(*sink, id+":"+msg.(string))
 						return nil, ctx.SendMessage("", msg)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -503,8 +512,8 @@ func TestBuilder_Validation_SelfLoopWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error for self-loop, got %v", err)
 	}
-	if wf.StartExecutorID != "start" {
-		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID)
+	if wf.StartExecutorID() != "start" {
+		t.Errorf("expected start executor ID 'start', got %s", wf.StartExecutorID())
 	}
 }
 
@@ -523,7 +532,7 @@ func TestBuilder_Validation_DeadEndLogging(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error for dead-end, got %v", err)
 	}
-	if _, ok := wf.ExecutorBindings["leaf"]; !ok {
+	if _, ok := wf.ExecutorBinding("leaf"); !ok {
 		t.Error("expected leaf executor in bindings")
 	}
 	if !strings.Contains(logs, "dead-end executors detected") || !strings.Contains(logs, "leaf") {
@@ -570,10 +579,11 @@ func newTypedExecutor[T any, U any](id string) workflow.ExecutorBinding {
 		return &workflow.Executor{
 			ID: id,
 			Spec: workflow.ExecutorSpec{
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[T](), reflect.TypeFor[U](), func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[T](), reflect.TypeFor[U](), func(ctx *workflow.Context, msg any) (any, error) {
 						return *new(U), nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -592,11 +602,12 @@ func newDeclaredSendExecutor[T any](id string, sendTypes ...reflect.Type) workfl
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: sendTypes,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[T](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(sendTypes...)
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[T](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -671,10 +682,11 @@ func TestBuilder_Validation_TypeCompatibility_RespectsAutoSendDisabled(t *testin
 			ID: source.ID,
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[int](), func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[int](), func(ctx *workflow.Context, msg any) (any, error) {
 						return 1, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -27,19 +27,10 @@ type ExecutorSpec struct {
 	// yielded as workflow output from the executor.
 	DisableAutoYieldOutputHandlerResultObject bool
 
-	// SendTypes declares message types this executor may send with
-	// [Context.SendMessage], in addition to handler result types automatically
-	// sent when DisableAutoSendMessageHandlerResultObject is false.
-	SendTypes []reflect.Type
-
-	// YieldTypes declares output types this executor may yield with
-	// [Context.YieldOutput], in addition to handler result types automatically
-	// yielded when DisableAutoYieldOutputHandlerResultObject is false.
-	YieldTypes []reflect.Type
-
-	// ConfigureRoutes adds message handlers to the supplied builder.
+	// ConfigureProtocol configures message handlers and declared send/yield
+	// message types on the supplied builder.
 	// It may return the same builder or a replacement builder.
-	ConfigureRoutes func(builder *RouteBuilder) (*RouteBuilder, error)
+	ConfigureProtocol func(builder *ProtocolBuilder) (*ProtocolBuilder, error)
 
 	// Initialize is called when the executor instance is created for a run.
 	Initialize func(ctx *Context) error
@@ -67,7 +58,7 @@ type ExecutorSpec struct {
 
 // Extend adds spec to s.
 //
-// Existing route configuration and lifecycle hooks run before hooks from spec.
+// Existing protocol configuration and lifecycle hooks run before hooks from spec.
 // Most hooks stop on the first error. OnMessageDeliveryFinished runs every hook
 // and returns the first error encountered.
 //
@@ -80,10 +71,7 @@ func (s *ExecutorSpec) Extend(spec ExecutorSpec) {
 
 	s.DisableAutoSendMessageHandlerResultObject = s.DisableAutoSendMessageHandlerResultObject || spec.DisableAutoSendMessageHandlerResultObject
 	s.DisableAutoYieldOutputHandlerResultObject = s.DisableAutoYieldOutputHandlerResultObject || spec.DisableAutoYieldOutputHandlerResultObject
-	s.SendTypes = appendUniqueTypes(s.SendTypes, spec.SendTypes...)
-	s.YieldTypes = appendUniqueTypes(s.YieldTypes, spec.YieldTypes...)
-
-	s.ConfigureRoutes = extendRoutes(s.ConfigureRoutes, spec.ConfigureRoutes)
+	s.ConfigureProtocol = extendProtocol(s.ConfigureProtocol, spec.ConfigureProtocol)
 	s.Initialize = extendContextHook(s.Initialize, spec.Initialize)
 	s.Reset = extendResetHook(s.Reset, spec.Reset)
 	s.OnCheckpoint = extendContextHook(s.OnCheckpoint, spec.OnCheckpoint)
@@ -102,14 +90,14 @@ func appendUniqueTypes(dst []reflect.Type, src ...reflect.Type) []reflect.Type {
 	return dst
 }
 
-func extendRoutes(first, second func(*RouteBuilder) (*RouteBuilder, error)) func(*RouteBuilder) (*RouteBuilder, error) {
+func extendProtocol(first, second func(*ProtocolBuilder) (*ProtocolBuilder, error)) func(*ProtocolBuilder) (*ProtocolBuilder, error) {
 	if first == nil {
 		return second
 	}
 	if second == nil {
 		return first
 	}
-	return func(builder *RouteBuilder) (*RouteBuilder, error) {
+	return func(builder *ProtocolBuilder) (*ProtocolBuilder, error) {
 		builder, err := first(builder)
 		if err != nil {
 			return nil, err
@@ -165,7 +153,7 @@ func extendFinishedHook(first, second func(*Context) error) func(*Context) error
 }
 
 func (s ExecutorSpec) isConfigured() bool {
-	return s.ConfigureRoutes != nil ||
+	return s.ConfigureProtocol != nil ||
 		s.Initialize != nil ||
 		s.Reset != nil ||
 		s.OnCheckpoint != nil ||
@@ -194,9 +182,9 @@ type Executor struct {
 	// hooks. Use [ExecutorSpec.Extend] to combine multiple spec fragments.
 	Spec ExecutorSpec
 
-	routerMu     sync.Mutex
-	cachedRouter *messageRouter
-	routerErr    error
+	routerMu       sync.Mutex
+	cachedProtocol *executorProtocol
+	protocolErr    error
 
 	declaredSendTypeCache sync.Map // reflect.Type -> reflect.Type
 	canOutputCache        sync.Map // reflect.Type -> bool
@@ -249,27 +237,39 @@ func (e *Executor) Reset() error {
 	return nil
 }
 
-func (e *Executor) router() (*messageRouter, error) {
+func (e *Executor) protocol() (*executorProtocol, error) {
 	e.routerMu.Lock()
 	defer e.routerMu.Unlock()
 
-	if e.cachedRouter != nil || e.routerErr != nil {
-		return e.cachedRouter, e.routerErr
+	if e.cachedProtocol != nil || e.protocolErr != nil {
+		return e.cachedProtocol, e.protocolErr
 	}
 	if !e.Spec.isConfigured() {
-		panic(errors.New("executor has no route configuration function"))
+		panic(errors.New("executor has no protocol configuration function"))
 	}
-	bld := &RouteBuilder{}
-	if e.Spec.ConfigureRoutes != nil {
+	bld := &ProtocolBuilder{}
+	if e.Spec.ConfigureProtocol != nil {
 		var err error
-		bld, err = e.Spec.ConfigureRoutes(bld)
+		bld, err = e.Spec.ConfigureProtocol(bld)
 		if err != nil {
-			e.routerErr = err
+			e.protocolErr = err
 			return nil, err
 		}
+		if bld == nil {
+			e.protocolErr = errors.New("workflow: protocol configure function returned nil ProtocolBuilder")
+			return nil, e.protocolErr
+		}
 	}
-	e.cachedRouter, e.routerErr = bld.build()
-	return e.cachedRouter, e.routerErr
+	e.cachedProtocol, e.protocolErr = bld.build(e.Spec)
+	return e.cachedProtocol, e.protocolErr
+}
+
+func (e *Executor) router() (*messageRouter, error) {
+	protocol, err := e.protocol()
+	if err != nil {
+		return nil, err
+	}
+	return protocol.router, nil
 }
 
 func (e *Executor) Execute(ctx *Context, message any) (result any, err error) {
@@ -302,7 +302,7 @@ func (e *Executor) Execute(ctx *Context, message any) (result any, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting router for executor %q: %w", e.ID, err)
 	}
-	ret, found := router.RouteMessage(ctx, message)
+	ret, found := router.routeMessage(ctx, message)
 	if !found {
 		return nil, fmt.Errorf("no handler found for message type %T", message)
 	}
@@ -316,7 +316,7 @@ func (e *Executor) Execute(ctx *Context, message any) (result any, err error) {
 			return nil, err
 		}
 	}
-	if ret.IsVoid() {
+	if ret.isVoid() {
 		return nil, nil
 	}
 	// If we had a real return type, raise it as a SendMessage
@@ -341,15 +341,15 @@ func (e *Executor) InputTypes() []reflect.Type {
 	if err != nil {
 		return nil
 	}
-	return router.IncomingTypes()
+	return router.incomingTypes()
 }
 
 func (e *Executor) OutputTypes() []reflect.Type {
-	router, err := e.router()
+	protocol, err := e.protocol()
 	if err != nil {
 		return nil
 	}
-	return e.yieldTypes(router)
+	return appendUniqueTypes(nil, protocol.yields...)
 }
 
 // knownSentTypes are workflow system messages that every executor may send.
@@ -360,22 +360,6 @@ func knownSentTypes() []reflect.Type {
 		reflect.TypeFor[*ExternalRequest](),
 		reflect.TypeFor[*ExternalResponse](),
 	}
-}
-
-func (e *Executor) sendTypes(router *messageRouter) []reflect.Type {
-	sends := appendUniqueTypes(nil, e.Spec.SendTypes...)
-	if !e.Spec.DisableAutoSendMessageHandlerResultObject {
-		sends = appendUniqueTypes(sends, slices.Collect(router.DefaultOutputTypes())...)
-	}
-	return sends
-}
-
-func (e *Executor) yieldTypes(router *messageRouter) []reflect.Type {
-	yields := appendUniqueTypes(nil, e.Spec.YieldTypes...)
-	if !e.Spec.DisableAutoYieldOutputHandlerResultObject {
-		yields = appendUniqueTypes(yields, slices.Collect(router.DefaultOutputTypes())...)
-	}
-	return yields
 }
 
 // DeclaredSendType returns the protocol type that should be used when sending
@@ -389,15 +373,14 @@ func (e *Executor) DeclaredSendType(typ reflect.Type) (reflect.Type, bool) {
 	if cached, ok := e.declaredSendTypeCache.Load(typ); ok {
 		return cached.(reflect.Type), true
 	}
-	router, err := e.router()
+	protocol, err := e.protocol()
 	if err != nil {
 		return nil, false
 	}
-	for _, candidate := range appendUniqueTypes(e.sendTypes(router), knownSentTypes()...) {
-		if declaredSendTypeMatches(typ, candidate) {
-			e.declaredSendTypeCache.Store(typ, candidate)
-			return candidate, true
-		}
+	declaredType, ok := protocol.declaredSendType(typ)
+	if ok {
+		e.declaredSendTypeCache.Store(typ, declaredType)
+		return declaredType, true
 	}
 	return nil, false
 }
@@ -420,16 +403,11 @@ func (e *Executor) CanSendType(typ reflect.Type) bool {
 }
 
 func (e *Executor) describeProtocol() (*ProtocolDescriptor, error) {
-	router, err := e.router()
+	protocol, err := e.protocol()
 	if err != nil {
 		return nil, err
 	}
-	return &ProtocolDescriptor{
-		Accepts:    router.IncomingTypes(),
-		Yields:     e.yieldTypes(router),
-		Sends:      e.sendTypes(router),
-		AcceptsAll: router.HasCatchAll(),
-	}, nil
+	return protocol.describe(), nil
 }
 
 func (e *Executor) DescribeProtocol() *ProtocolDescriptor {
@@ -441,22 +419,30 @@ func (e *Executor) DescribeProtocol() *ProtocolDescriptor {
 }
 
 func (e *Executor) CanHandleTypeID(typ TypeID) bool {
-	router, err := e.router()
+	protocol, err := e.protocol()
 	if err != nil {
 		return false
 	}
-	return router.CanHandle(typ)
+	return protocol.canHandleTypeID(typ)
 }
 
 func (e *Executor) CanHandleType(typ reflect.Type) bool {
-	return e.CanHandleTypeID(NewTypeID(typ))
+	protocol, err := e.protocol()
+	if err != nil {
+		return false
+	}
+	return protocol.canHandleType(typ)
 }
 
 func (e *Executor) CanOutputType(typ reflect.Type) bool {
 	if cached, ok := e.canOutputCache.Load(typ); ok {
 		return cached.(bool)
 	}
-	result := slices.ContainsFunc(e.OutputTypes(), typ.AssignableTo)
+	protocol, err := e.protocol()
+	if err != nil {
+		return false
+	}
+	result := protocol.canOutputType(typ)
 	e.canOutputCache.Store(typ, result)
 	return result
 }

--- a/workflow/executor_test.go
+++ b/workflow/executor_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow/inproc"
 )
 
-func TestExecutorSpec_ExtendRoutesAndLifecycleInOrder(t *testing.T) {
+func TestExecutorSpec_ExtendProtocolAndLifecycleInOrder(t *testing.T) {
 	var calls []string
 	ctx := &workflow.Context{
 		Context:  t.Context(),
@@ -47,12 +47,13 @@ func TestExecutorSpec_ExtendRoutesAndLifecycleInOrder(t *testing.T) {
 			calls = append(calls, "finished-1")
 			return nil
 		},
-		ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
+		ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
 			calls = append(calls, "routes-1")
-			return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
+			rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
 				calls = append(calls, "handler-string")
 				return nil, nil
-			}), nil
+			})
+			return rb, nil
 		},
 	})
 	spec.Extend(workflow.ExecutorSpec{
@@ -80,12 +81,13 @@ func TestExecutorSpec_ExtendRoutesAndLifecycleInOrder(t *testing.T) {
 			calls = append(calls, "finished-2")
 			return nil
 		},
-		ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
+		ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
 			calls = append(calls, "routes-2")
-			return rb.AddHandlerRaw(reflect.TypeFor[int](), nil, func(*workflow.Context, any) (any, error) {
+			rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[int](), nil, func(*workflow.Context, any) (any, error) {
 				calls = append(calls, "handler-int")
 				return nil, nil
-			}), nil
+			})
+			return rb, nil
 		},
 	})
 	executor := &workflow.Executor{
@@ -182,10 +184,11 @@ func TestExecutorDescribeProtocol_RespectsAutoReturnOptions(t *testing.T) {
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: !testCase.autoSend,
 					DisableAutoYieldOutputHandlerResultObject: !testCase.autoYield,
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(inputType, outputType, func(*workflow.Context, any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(inputType, outputType, func(*workflow.Context, any) (any, error) {
 							return executorProtocolOutput{}, nil
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}
@@ -212,12 +215,14 @@ func TestExecutorDescribeProtocol_IncludesExplicitSendAndYieldTypes(t *testing.T
 		Spec: workflow.ExecutorSpec{
 			DisableAutoSendMessageHandlerResultObject: true,
 			DisableAutoYieldOutputHandlerResultObject: true,
-			SendTypes:  []reflect.Type{explicitSend, nil, explicitSend},
-			YieldTypes: []reflect.Type{explicitYield, nil, explicitYield},
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[executorProtocolInput](), reflect.TypeFor[executorProtocolOutput](), func(*workflow.Context, any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.
+					SendsMessageType(explicitSend, nil, explicitSend).
+					YieldsOutputType(explicitYield, nil, explicitYield)
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[executorProtocolInput](), reflect.TypeFor[executorProtocolOutput](), func(*workflow.Context, any) (any, error) {
 					return executorProtocolOutput{}, nil
-				}), nil
+				})
+				return rb, nil
 			},
 		},
 	}
@@ -300,11 +305,12 @@ func executorWithSendTypes(sendTypes ...reflect.Type) *workflow.Executor {
 		Spec: workflow.ExecutorSpec{
 			DisableAutoSendMessageHandlerResultObject: true,
 			DisableAutoYieldOutputHandlerResultObject: true,
-			SendTypes: sendTypes,
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.SendsMessageType(sendTypes...)
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
 					return nil, nil
-				}), nil
+				})
+				return rb, nil
 			},
 		},
 	}
@@ -381,14 +387,15 @@ func TestAddHandlerRaw_WithHandlerOverwrite(t *testing.T) {
 		Spec: workflow.ExecutorSpec{
 			DisableAutoSendMessageHandlerResultObject: true,
 			DisableAutoYieldOutputHandlerResultObject: true,
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.
 					AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[string](), func(*workflow.Context, any) (any, error) {
 						return "first", nil
 					}).
 					AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[string](), func(*workflow.Context, any) (any, error) {
 						return "second", nil
-					}, workflow.WithHandlerOverwrite(true)), nil
+					}, workflow.WithHandlerOverwrite(true))
+				return rb, nil
 			},
 		},
 	}
@@ -412,14 +419,15 @@ func TestAddCatchAll_WithHandlerOverwrite(t *testing.T) {
 		Spec: workflow.ExecutorSpec{
 			DisableAutoSendMessageHandlerResultObject: true,
 			DisableAutoYieldOutputHandlerResultObject: true,
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.
 					AddCatchAll(func(*workflow.Context, workflow.PortableValue) (any, error) {
 						return "first", nil
 					}).
 					AddCatchAll(func(*workflow.Context, workflow.PortableValue) (any, error) {
 						return "second", nil
-					}, workflow.WithHandlerOverwrite(true)), nil
+					}, workflow.WithHandlerOverwrite(true))
+				return rb, nil
 			},
 		},
 	}
@@ -443,10 +451,11 @@ func TestExecutorExecute_HandlerPanicReportsFailure(t *testing.T) {
 		Spec: workflow.ExecutorSpec{
 			DisableAutoSendMessageHandlerResultObject: true,
 			DisableAutoYieldOutputHandlerResultObject: true,
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
 					panic("boom")
-				}), nil
+				})
+				return rb, nil
 			},
 		},
 	}
@@ -491,8 +500,8 @@ func aggregatorBinding(id string, results *[]string) workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						s := msg.(string)
 						return nil, cache.InvokeWithState(ctx, false, func(_ *workflow.Context, state string) (string, error) {
 							var newState string
@@ -504,7 +513,8 @@ func aggregatorBinding(id string, results *[]string) workflow.ExecutorBinding {
 							*results = append(*results, newState)
 							return newState, nil
 						})
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -629,8 +639,8 @@ func nullableAggregatorBinding(id string, results *[]string) workflow.ExecutorBi
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						input := msg.(string)
 						return nil, cache.InvokeWithState(ctx, false, func(_ *workflow.Context, state *string) (*string, error) {
 							if input == "clear" {
@@ -644,7 +654,8 @@ func nullableAggregatorBinding(id string, results *[]string) workflow.ExecutorBi
 							*results = append(*results, value)
 							return &value, nil
 						})
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -661,10 +672,11 @@ func TestWorkflow_AllowsReuseSharedExecutorWithoutResetWhenNoResettableExecutors
 			return &workflow.Executor{
 				ID: "shared",
 				Spec: workflow.ExecutorSpec{
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, _ any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, _ any) (any, error) {
 							return nil, nil
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil

--- a/workflow/info_test.go
+++ b/workflow/info_test.go
@@ -51,6 +51,22 @@ func fanInEdge(srcs []string, dst string) workflow.Edge {
 	}
 }
 
+func newTestWorkflow(t *testing.T, bindings ...workflow.ExecutorBinding) *workflow.Workflow {
+	t.Helper()
+	if len(bindings) == 0 {
+		bindings = []workflow.ExecutorBinding{workflow.BindExecutor(&workflow.Executor{ID: "start"})}
+	}
+	builder := workflow.NewBuilder(bindings[0])
+	for _, binding := range bindings[1:] {
+		builder.BindExecutor(binding)
+	}
+	wf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return wf
+}
+
 func runEdgeInfoMatch(t *testing.T, name string, edge, comparator workflow.Edge, expect bool) {
 	t.Helper()
 	info := workflow.EdgeInfo{
@@ -170,7 +186,7 @@ func TestReflectExecutors_ReturnsCopy(t *testing.T) {
 		t.Errorf("missing executor b")
 	}
 	delete(got, "a")
-	if _, ok := wf.ExecutorBindings["a"]; !ok {
+	if _, ok := wf.ExecutorBinding("a"); !ok {
 		t.Errorf("ReflectExecutors did not return a copy: workflow lost binding 'a'")
 	}
 }
@@ -216,7 +232,7 @@ func TestReflectPorts_ReturnsCopy(t *testing.T) {
 		t.Fatalf("PortID = %q, want approval", info.PortID)
 	}
 	delete(got, "approval")
-	if _, ok := wf.Ports["approval"]; !ok {
+	if _, ok := wf.RequestPort("approval"); !ok {
 		t.Fatal("ReflectPorts did not return a copy: workflow lost port approval")
 	}
 }
@@ -273,10 +289,11 @@ func TestWorkflowDescribeProtocol_PropagatesAcceptsAll(t *testing.T) {
 			return &workflow.Executor{
 				ID: "start",
 				Spec: workflow.ExecutorSpec{
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddCatchAll(func(*workflow.Context, workflow.PortableValue) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddCatchAll(func(*workflow.Context, workflow.PortableValue) (any, error) {
 							return nil, nil
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil
@@ -297,7 +314,7 @@ func TestWorkflowDescribeProtocol_PropagatesAcceptsAll(t *testing.T) {
 }
 
 func TestWorkflowOwnership_UsesTokenIdentity(t *testing.T) {
-	wf := &workflow.Workflow{}
+	wf := newTestWorkflow(t)
 	owner := new(int)
 	other := new(int)
 
@@ -319,14 +336,14 @@ func TestWorkflowOwnership_UsesTokenIdentity(t *testing.T) {
 }
 
 func TestWorkflowOwnership_RejectsValueToken(t *testing.T) {
-	wf := &workflow.Workflow{}
+	wf := newTestWorkflow(t)
 	if err := wf.TakeOwnership(nil, "owner", false); err == nil {
 		t.Fatal("TakeOwnership with value token succeeded, want error")
 	}
 }
 
 func TestWorkflowReleaseOwnershipTo_RestoresPreviousOwner(t *testing.T) {
-	wf := &workflow.Workflow{}
+	wf := newTestWorkflow(t)
 	previous := new(int)
 	runner := new(int)
 
@@ -345,11 +362,7 @@ func TestWorkflowReleaseOwnershipTo_RestoresPreviousOwner(t *testing.T) {
 }
 
 func TestWorkflowReuse_AllowsSharedNonResettableWhenNoResettableExecutors(t *testing.T) {
-	wf := &workflow.Workflow{
-		ExecutorBindings: map[string]workflow.ExecutorBinding{
-			"shared": workflow.BindExecutor(&workflow.Executor{ID: "shared"}),
-		},
-	}
+	wf := newTestWorkflow(t, workflow.BindExecutor(&workflow.Executor{ID: "shared"}))
 	firstOwner := new(int)
 	secondOwner := new(int)
 
@@ -365,16 +378,16 @@ func TestWorkflowReuse_AllowsSharedNonResettableWhenNoResettableExecutors(t *tes
 }
 
 func TestWorkflowReuse_BlocksWhenResetFails(t *testing.T) {
-	wf := &workflow.Workflow{
-		ExecutorBindings: map[string]workflow.ExecutorBinding{
-			"resettable": workflow.BindExecutor(&workflow.Executor{
-				ID: "resettable",
-				Spec: workflow.ExecutorSpec{Reset: func() error {
-					return nil
-				}},
-			}),
-			"shared": workflow.BindExecutor(&workflow.Executor{ID: "shared"}),
-		},
+	resettable := workflow.BindExecutor(&workflow.Executor{
+		ID: "resettable",
+		Spec: workflow.ExecutorSpec{Reset: func() error {
+			return nil
+		}},
+	})
+	shared := workflow.BindExecutor(&workflow.Executor{ID: "shared"})
+	wf, err := workflow.NewBuilder(resettable).AddEdge(resettable, shared).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
 	}
 	firstOwner := new(int)
 	secondOwner := new(int)

--- a/workflow/inproc/binding_test.go
+++ b/workflow/inproc/binding_test.go
@@ -204,10 +204,11 @@ func polymorphicOutputBinding(id string, output polymorphicOutput) workflow.Exec
 			ID: id,
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[polymorphicOutput](), func(_ *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[polymorphicOutput](), func(_ *workflow.Context, _ any) (any, error) {
 						return output, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -226,11 +227,12 @@ func unrelatedOutputBinding(id string) workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				YieldTypes: []reflect.Type{reflect.TypeFor[polymorphicOutput]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[polymorphicOutput](), func(ctx *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[polymorphicOutput]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[polymorphicOutput](), func(ctx *workflow.Context, _ any) (any, error) {
 						return nil, ctx.YieldOutput(unrelatedOutput{})
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -249,11 +251,12 @@ func explicitYieldBinding(id string, output any) workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				YieldTypes: []reflect.Type{reflect.TypeFor[dataMessage]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[dataMessage]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
 						return nil, ctx.YieldOutput(output)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -378,11 +381,12 @@ func TestFunctionExecutor_ReturnValueAutoSendAndYieldOptions(t *testing.T) {
 					Spec: workflow.ExecutorSpec{
 						DisableAutoSendMessageHandlerResultObject: true,
 						DisableAutoYieldOutputHandlerResultObject: true,
-						ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-							return rb.AddHandlerRaw(reflect.TypeFor[dataMessage](), nil, func(_ *workflow.Context, msg any) (any, error) {
+						ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+							rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[dataMessage](), nil, func(_ *workflow.Context, msg any) (any, error) {
 								gotAtSink = append(gotAtSink, msg.(dataMessage))
 								return nil, nil
-							}), nil
+							})
+							return rb, nil
 						},
 					},
 				}, nil
@@ -435,11 +439,12 @@ func returnedDataBinding(id string, options workflow.ExecutorSpec) workflow.Exec
 	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
 		spec := options
 		spec.Extend(workflow.ExecutorSpec{
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[textMessage](), reflect.TypeFor[dataMessage](), func(_ *workflow.Context, msg any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[textMessage](), reflect.TypeFor[dataMessage](), func(_ *workflow.Context, msg any) (any, error) {
 					input := msg.(textMessage)
 					return dataMessage{Bytes: []byte(input.Text)}, nil
-				}), nil
+				})
+				return rb, nil
 			},
 		})
 		return &workflow.Executor{
@@ -478,13 +483,14 @@ func TestBindRequestPort_PostsRequestAndForwardsResponse(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				YieldTypes: []reflect.Type{reflect.TypeFor[int]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[int](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[int]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[int](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						receivedAtSink = msg.(int)
 						sawAtSink = true
 						return nil, ctx.YieldOutput(msg)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -610,14 +616,15 @@ func TestBindRequestPort_ForwardsExternalRequestAndRestoresOriginalResponse(t *t
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						request, err := workflow.NewExternalRequest("original-request", outerPort, msg)
 						if err != nil {
 							return nil, err
 						}
 						return nil, ctx.SendMessage(innerBinding.ID, request)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -634,11 +641,12 @@ func TestBindRequestPort_ForwardsExternalRequestAndRestoresOriginalResponse(t *t
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(_ *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(_ *workflow.Context, msg any) (any, error) {
 						gotResponse = msg.(*workflow.ExternalResponse)
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil

--- a/workflow/inproc/checkpoint_test.go
+++ b/workflow/inproc/checkpoint_test.go
@@ -375,18 +375,19 @@ func TestCheckpoint_RestoreClearsExecutorInstancesBeforeImport(t *testing.T) {
 			return &workflow.Executor{
 				ID: "counter",
 				Spec: workflow.ExecutorSpec{
-					YieldTypes: []reflect.Type{reflect.TypeFor[struct {
-						InstanceID int64
-						Count      int
-					}]()},
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.YieldsOutputType(reflect.TypeFor[struct {
+							InstanceID int64
+							Count      int
+						}]())
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
 							count++
 							return nil, ctx.YieldOutput(struct {
 								InstanceID int64
 								Count      int
 							}{InstanceID: instanceID, Count: count})
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil
@@ -655,12 +656,13 @@ func createCheckpointRequestWorkflow(t *testing.T) (*workflow.Workflow, *atomic.
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: true,
 					DisableAutoYieldOutputHandlerResultObject: true,
-					YieldTypes: []reflect.Type{reflect.TypeFor[string]()},
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.YieldsOutputType(reflect.TypeFor[string]())
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 							received.Add(1)
 							return nil, ctx.YieldOutput(msg)
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil
@@ -709,11 +711,12 @@ func createCheckpointChainWorkflow(t *testing.T, ids ...string) *workflow.Workfl
 					Spec: workflow.ExecutorSpec{
 						DisableAutoSendMessageHandlerResultObject: true,
 						DisableAutoYieldOutputHandlerResultObject: true,
-						SendTypes: []reflect.Type{reflect.TypeFor[string]()},
-						ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-							return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+						ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+							rb.SendsMessageType(reflect.TypeFor[string]())
+							rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 								return nil, ctx.SendMessage("", msg)
-							}), nil
+							})
+							return rb, nil
 						},
 					},
 				}, nil
@@ -866,7 +869,6 @@ func (e *checkpointHookExecutor) Bind() workflow.ExecutorBinding {
 				Spec: workflow.ExecutorSpec{
 					DisableAutoSendMessageHandlerResultObject: true,
 					DisableAutoYieldOutputHandlerResultObject: true,
-					SendTypes: []reflect.Type{reflect.TypeFor[string]()},
 					OnCheckpoint: func(_ *workflow.Context) error {
 						e.checkpointingCalls.Add(1)
 						return nil
@@ -875,13 +877,15 @@ func (e *checkpointHookExecutor) Bind() workflow.ExecutorBinding {
 						e.checkpointRestoredCall.Add(1)
 						return nil
 					},
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.SendsMessageType(reflect.TypeFor[string]())
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 							if e.forwardMessages {
 								return nil, ctx.SendMessage("", msg)
 							}
 							return nil, nil
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil

--- a/workflow/inproc/concurrent_test.go
+++ b/workflow/inproc/concurrent_test.go
@@ -24,14 +24,15 @@ func factoryConcurrentBinding(id string, sink *[]string, mu *sync.Mutex) workflo
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						mu.Lock()
 						*sink = append(*sink, id+":"+msg.(string))
 						mu.Unlock()
 						return nil, ctx.SendMessage("", msg)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -46,10 +47,11 @@ func nonConcurrentBinding(id string) workflow.ExecutorBinding {
 		Spec: workflow.ExecutorSpec{
 			DisableAutoSendMessageHandlerResultObject: true,
 			DisableAutoYieldOutputHandlerResultObject: true,
-			ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return rb.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[string](), func(_ *workflow.Context, msg any) (any, error) {
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), reflect.TypeFor[string](), func(_ *workflow.Context, msg any) (any, error) {
 					return msg, nil
-				}), nil
+				})
+				return rb, nil
 			},
 		},
 	})

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -131,7 +131,7 @@ func (proc *runnerContext) EnsureExecutor(ctx context.Context, executorID string
 		return executor, nil
 	}
 
-	registration, ok := proc.wf.ExecutorBindings[executorID]
+	registration, ok := proc.wf.ExecutorBinding(executorID)
 	if !ok {
 		return nil, fmt.Errorf("executor with ID '%s' is not registered", executorID)
 	}
@@ -490,7 +490,7 @@ func (proc *runnerContext) SendMessage(ctx context.Context, sourceID, targetID s
 	if traceContext := telemetry.ExtractTraceContext(ctx); len(traceContext) > 0 {
 		envelope.TraceContext = traceContext
 	}
-	edges := proc.wf.Edges[sourceID]
+	edges := proc.wf.OutgoingEdges(sourceID)
 	for _, edge := range edges {
 		mapping, err := proc.edgeMap.PrepareDeliveryForEdge(ctx, edge, envelope)
 		if err != nil {
@@ -526,7 +526,7 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 			if err := proc.validateOutputType(executorID, output); err != nil {
 				return err
 			}
-			if _, ok := proc.wf.OutputExecutors[executorID]; ok {
+			if proc.wf.HasOutputExecutor(executorID) {
 				return proc.AddEvent(boundCtx, workflow.OutputEvent{
 					ExecutorID: executorID,
 					Output:     output,

--- a/workflow/inproc/events_test.go
+++ b/workflow/inproc/events_test.go
@@ -28,11 +28,12 @@ func minimalEchoBinding(id string) workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				YieldTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
 						return nil, ctx.YieldOutput("ok")
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -531,7 +532,6 @@ func (te *trackingExecutor) Bind() workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[string]()},
 				OnMessageDeliveryStarting: func(_ *workflow.Context) error {
 					te.deliveryStarting.Add(1)
 					return nil
@@ -540,8 +540,9 @@ func (te *trackingExecutor) Bind() workflow.ExecutorBinding {
 					te.deliveryFinished.Add(1)
 					return nil
 				},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						s := msg.(string)
 						te.mu.Lock()
 						te.received = append(te.received, s)
@@ -550,7 +551,8 @@ func (te *trackingExecutor) Bind() workflow.ExecutorBinding {
 							return nil, ctx.SendMessage("", s)
 						}
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -616,10 +618,11 @@ func TestDeliveryEvents_FinishedRunsEvenWhenHandlerErrors(t *testing.T) {
 					finishedCalls.Add(1)
 					return nil
 				},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, _ any) (any, error) {
 						return nil, errBoom
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil

--- a/workflow/inproc/external_request_test.go
+++ b/workflow/inproc/external_request_test.go
@@ -41,9 +41,9 @@ func TestPostRequestFromExecutor(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				YieldTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[string]())
+					rb.RouteBuilder.
 						AddHandlerRaw(reflect.TypeFor[string](), nil, func(wctx *workflow.Context, msg any) (any, error) {
 							req, err := workflow.NewExternalRequest("req-1", port, "what is your name?")
 							if err != nil {
@@ -55,7 +55,8 @@ func TestPostRequestFromExecutor(t *testing.T) {
 							resp := msg.(*workflow.ExternalResponse)
 							data, _ := resp.Data.As(port.Response)
 							return nil, wctx.YieldOutput(data)
-						}), nil
+						})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -124,11 +125,12 @@ func TestPostRequestRoutingToOwner(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(wctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(wctx *workflow.Context, msg any) (any, error) {
 						return nil, wctx.SendMessage("", "go")
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -147,9 +149,9 @@ func TestPostRequestRoutingToOwner(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				YieldTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[string]())
+					rb.RouteBuilder.
 						AddHandlerRaw(reflect.TypeFor[string](), nil, func(wctx *workflow.Context, msg any) (any, error) {
 							req, err := workflow.NewExternalRequest("req-2", port, "ping")
 							if err != nil {
@@ -160,7 +162,8 @@ func TestPostRequestRoutingToOwner(t *testing.T) {
 						AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(wctx *workflow.Context, msg any) (any, error) {
 							gotResponseAtAsker = true
 							return nil, wctx.YieldOutput("done")
-						}), nil
+						})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -213,10 +216,11 @@ func TestExternalResponse_UnsolicitedResponseErrors(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(_ *workflow.Context, _ any) (any, error) {
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil

--- a/workflow/inproc/routing_test.go
+++ b/workflow/inproc/routing_test.go
@@ -25,15 +25,15 @@ func captureExecutor(id string, sink *[]string, mu *sync.Mutex) workflow.Executo
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes:  []reflect.Type{reflect.TypeFor[string]()},
-				YieldTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]()).YieldsOutputType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						mu.Lock()
 						*sink = append(*sink, id+":"+msg.(string))
 						mu.Unlock()
 						return nil, ctx.SendMessage("", msg)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -299,14 +299,15 @@ func targetingExecutor(id string, targetID string, sink *[]string, mu *sync.Mute
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						mu.Lock()
 						*sink = append(*sink, id+":"+msg.(string))
 						mu.Unlock()
 						return nil, ctx.SendMessage(targetID, msg)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -354,11 +355,12 @@ func emitsExecutor(id string, value string) workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
 						return nil, ctx.SendMessage("", value)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -377,13 +379,14 @@ func collectingExecutor(id string, deliveries *[][]string, mu *sync.Mutex) workf
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						mu.Lock()
 						*deliveries = append(*deliveries, []string{msg.(string)})
 						mu.Unlock()
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -438,16 +441,16 @@ func outputFilterExecutor(id string) workflow.ExecutorBinding {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes:  []reflect.Type{reflect.TypeFor[string]()},
-				YieldTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]()).YieldsOutputType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						s := msg.(string)
 						if err := ctx.YieldOutput("out:" + id + ":" + s); err != nil {
 							return nil, err
 						}
 						return nil, ctx.SendMessage("", s)
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -73,7 +73,7 @@ func newInProcessRunner(
 
 	if enableConcurrentRuns {
 		var nonConcurrent []string
-		for _, er := range wf.ExecutorBindings {
+		for _, er := range wf.ReflectExecutors() {
 			if !er.SupportsConcurrentSharedExecution {
 				nonConcurrent = append(nonConcurrent, er.ID)
 			}
@@ -104,7 +104,7 @@ func newInProcessRunner(
 
 	runner := &runner{
 		sessionID:            sessionID,
-		startExecutorID:      wf.StartExecutorID,
+		startExecutorID:      wf.StartExecutorID(),
 		wf:                   wf,
 		runContext:           runContext,
 		checkpointMgr:        checkpointMgr,

--- a/workflow/inproc/state_test.go
+++ b/workflow/inproc/state_test.go
@@ -43,10 +43,11 @@ func (e *StateTestExecutor[T]) Bind() workflow.ExecutorBinding {
 			return &workflow.Executor{
 				ID: e.ID,
 				Spec: workflow.ExecutorSpec{
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[TestTurnToken](), reflect.TypeFor[TestTurnToken](), func(ctx *workflow.Context, msg any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[TestTurnToken](), reflect.TypeFor[TestTurnToken](), func(ctx *workflow.Context, msg any) (any, error) {
 							return e.Execute(ctx, msg.(TestTurnToken))
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil
@@ -238,9 +239,9 @@ func TestInProcessRun_StateShouldPersist_JSONCheckpointed(t *testing.T) {
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				YieldTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
 						switch msg.(string) {
 						case "write":
 							return nil, ctx.QueueStateUpdate(stateKey, "", "persisted")
@@ -253,7 +254,8 @@ func TestInProcessRun_StateShouldPersist_JSONCheckpointed(t *testing.T) {
 						default:
 							return nil, nil
 						}
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -385,9 +387,9 @@ func stateKeysLifecycleBindings(scope string) (workflow.ExecutorBinding, workflo
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				SendTypes: []reflect.Type{reflect.TypeFor[string]()},
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, message any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[string]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, message any) (any, error) {
 						switch message.(string) {
 						case "write":
 							if err := ctx.QueueStateUpdate(key, scope, "value1"); err != nil {
@@ -412,7 +414,8 @@ func stateKeysLifecycleBindings(scope string) (workflow.ExecutorBinding, workflo
 						default:
 							return nil, nil
 						}
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -424,15 +427,16 @@ func stateKeysLifecycleBindings(scope string) (workflow.ExecutorBinding, workflo
 			Spec: workflow.ExecutorSpec{
 				DisableAutoSendMessageHandlerResultObject: true,
 				DisableAutoYieldOutputHandlerResultObject: true,
-				ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-					return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, message any) (any, error) {
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, message any) (any, error) {
 						keys, err := readWorkflowStateKeys(ctx, scope)
 						if err != nil {
 							return nil, err
 						}
 						observed["reader:"+message.(string)] = keys
 						return nil, nil
-					}), nil
+					})
+					return rb, nil
 				},
 			},
 		}, nil
@@ -510,13 +514,14 @@ func TestInProcessRun_ReadOrInitStateInitializerError(t *testing.T) {
 			return &workflow.Executor{
 				ID: "stateful",
 				Spec: workflow.ExecutorSpec{
-					ConfigureRoutes: func(rb *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-						return rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
 							_, err := ctx.ReadOrInitState("key", "", func(context.Context, string, string) (any, error) {
 								return nil, errors.New(want)
 							})
 							return nil, err
-						}), nil
+						})
+						return rb, nil
 					},
 				},
 			}, nil

--- a/workflow/internal/checkpoint/info.go
+++ b/workflow/internal/checkpoint/info.go
@@ -30,8 +30,9 @@ type WorkflowInfo struct {
 }
 
 func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
-	executors := make(map[string]executorInfo, len(wf.ExecutorBindings))
-	for id, binding := range wf.ExecutorBindings {
+	bindings := wf.ReflectExecutors()
+	executors := make(map[string]executorInfo, len(bindings))
+	for id, binding := range bindings {
 		executors[id] = executorInfo{
 			Type:       workflow.NewTypeID(binding.ExecutorType),
 			ExecutorID: binding.ID,
@@ -40,14 +41,16 @@ func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
 
 	edges := wf.ReflectEdges()
 
-	requestPorts := make(map[string]workflow.RequestPortInfo, len(wf.Ports))
-	for _, port := range wf.Ports {
+	ports := wf.RequestPorts()
+	requestPorts := make(map[string]workflow.RequestPortInfo, len(ports))
+	for _, port := range ports {
 		info := workflow.NewRequestPortInfo(port)
 		requestPorts[info.PortID] = info
 	}
 
-	outputs := make(map[string]struct{}, len(wf.OutputExecutors))
-	for id := range wf.OutputExecutors {
+	outputIDs := wf.OutputExecutorIDs()
+	outputs := make(map[string]struct{}, len(outputIDs))
+	for _, id := range outputIDs {
 		outputs[id] = struct{}{}
 	}
 
@@ -55,7 +58,7 @@ func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
 		Executors:         executors,
 		Edges:             edges,
 		RequestPorts:      requestPorts,
-		StartExecutorID:   wf.StartExecutorID,
+		StartExecutorID:   wf.StartExecutorID(),
 		OutputExecutorIDs: outputs,
 	}
 }
@@ -64,25 +67,27 @@ func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {
 	if wf == nil {
 		return false
 	}
-	if w.StartExecutorID != wf.StartExecutorID {
+	if w.StartExecutorID != wf.StartExecutorID() {
 		return false
 	}
-	if len(wf.ExecutorBindings) != len(w.Executors) {
+	bindings := wf.ReflectExecutors()
+	if len(bindings) != len(w.Executors) {
 		return false
 	}
 	// Validate the executors
 	for _, eb := range w.Executors {
-		binding, ok := wf.ExecutorBindings[eb.ExecutorID]
+		binding, ok := bindings[eb.ExecutorID]
 		if !ok || !eb.matchBinding(binding) {
 			return false
 		}
 	}
 	// Validate the edges
-	if len(wf.Edges) != len(w.Edges) {
+	workflowEdges := wf.Edges()
+	if len(workflowEdges) != len(w.Edges) {
 		return false
 	}
 	for sourceID, edges := range w.Edges {
-		other, ok := wf.Edges[sourceID]
+		other, ok := workflowEdges[sourceID]
 		if !ok || len(other) != len(edges) {
 			return false
 		}
@@ -94,11 +99,12 @@ func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {
 	}
 
 	// Validate the request ports
-	if len(wf.Ports) != len(w.RequestPorts) {
+	ports := wf.RequestPorts()
+	if len(ports) != len(w.RequestPorts) {
 		return false
 	}
 	for _, port := range w.RequestPorts {
-		other, ok := wf.Ports[port.PortID]
+		other, ok := ports[port.PortID]
 		if !ok {
 			return false
 		}
@@ -108,11 +114,12 @@ func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {
 	}
 
 	// Validate the outputs
-	if len(wf.OutputExecutors) != len(w.OutputExecutorIDs) {
+	outputIDs := wf.OutputExecutorIDs()
+	if len(outputIDs) != len(w.OutputExecutorIDs) {
 		return false
 	}
 	for outputID := range w.OutputExecutorIDs {
-		if _, ok := wf.OutputExecutors[outputID]; !ok {
+		if !wf.HasOutputExecutor(outputID) {
 			return false
 		}
 	}

--- a/workflow/internal/checkpoint/info_test.go
+++ b/workflow/internal/checkpoint/info_test.go
@@ -9,31 +9,41 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow"
 )
 
+func testBinding(id string, typ reflect.Type) workflow.ExecutorBinding {
+	return workflow.ExecutorBinding{
+		ID:           id,
+		ExecutorType: typ,
+		NewExecutorFunc: func(string) (*workflow.Executor, error) {
+			return &workflow.Executor{
+				ID:           id,
+				ExecutorType: typ,
+				Spec: workflow.ExecutorSpec{
+					ConfigureProtocol: func(builder *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						return builder, nil
+					},
+				},
+			}, nil
+		},
+	}
+}
+
 func TestWorkflowInfoMatch_PreservesEdgeMultiplicity(t *testing.T) {
-	bindings := map[string]workflow.ExecutorBinding{
-		"a": {ID: "a", ExecutorType: reflect.TypeFor[struct{}]()},
-		"b": {ID: "b", ExecutorType: reflect.TypeFor[struct{}]()},
-		"c": {ID: "c", ExecutorType: reflect.TypeFor[struct{}]()},
+	a := testBinding("a", reflect.TypeFor[struct{}]())
+	b := testBinding("b", reflect.TypeFor[struct{}]())
+	c := testBinding("c", reflect.TypeFor[struct{}]())
+	recorded, err := workflow.NewBuilder(a).
+		AddEdge(a, b).
+		AddEdge(a, c).
+		Build()
+	if err != nil {
+		t.Fatalf("Build recorded: %v", err)
 	}
-	recorded := &workflow.Workflow{
-		StartExecutorID:  "a",
-		ExecutorBindings: bindings,
-		Edges: map[string][]workflow.Edge{
-			"a": {
-				{Connection: workflow.EdgeConnection{SourceIDs: []string{"a"}, SinkIDs: []string{"b"}}},
-				{Connection: workflow.EdgeConnection{SourceIDs: []string{"a"}, SinkIDs: []string{"c"}}},
-			},
-		},
-	}
-	incompatible := &workflow.Workflow{
-		StartExecutorID:  "a",
-		ExecutorBindings: bindings,
-		Edges: map[string][]workflow.Edge{
-			"a": {
-				{Connection: workflow.EdgeConnection{SourceIDs: []string{"a"}, SinkIDs: []string{"b"}}},
-				{Connection: workflow.EdgeConnection{SourceIDs: []string{"a"}, SinkIDs: []string{"b"}}},
-			},
-		},
+	incompatible, err := workflow.NewBuilder(a).
+		AddEdge(a, b).
+		AddDirectEdge(a, b, false, func(any) bool { return true }).
+		Build()
+	if err != nil {
+		t.Fatalf("Build incompatible: %v", err)
 	}
 
 	info := NewWorkflowInfo(recorded)
@@ -43,11 +53,9 @@ func TestWorkflowInfoMatch_PreservesEdgeMultiplicity(t *testing.T) {
 }
 
 func TestWorkflowInfoMatch_AllowsNilExecutorType(t *testing.T) {
-	recorded := &workflow.Workflow{
-		StartExecutorID: "a",
-		ExecutorBindings: map[string]workflow.ExecutorBinding{
-			"a": {ID: "a"},
-		},
+	recorded, err := workflow.NewBuilder(testBinding("a", nil)).Build()
+	if err != nil {
+		t.Fatalf("Build recorded: %v", err)
 	}
 
 	info := NewWorkflowInfo(recorded)
@@ -55,11 +63,9 @@ func TestWorkflowInfoMatch_AllowsNilExecutorType(t *testing.T) {
 		t.Fatal("expected nil executor type metadata not to match because empty TypeID is unknown")
 	}
 
-	incompatible := &workflow.Workflow{
-		StartExecutorID: "a",
-		ExecutorBindings: map[string]workflow.ExecutorBinding{
-			"a": {ID: "a", ExecutorType: reflect.TypeFor[struct{}]()},
-		},
+	incompatible, err := workflow.NewBuilder(testBinding("a", reflect.TypeFor[struct{}]())).Build()
+	if err != nil {
+		t.Fatalf("Build incompatible: %v", err)
 	}
 	if info.Match(incompatible) {
 		t.Fatal("expected nil executor type metadata not to match concrete executor type")

--- a/workflow/internal/execution/edgerunner.go
+++ b/workflow/internal/execution/edgerunner.go
@@ -118,7 +118,7 @@ type EdgeRunner struct {
 // NewEdgeRunner creates a new [EdgeRunner] for the given workflow.
 func NewEdgeRunner(wf *workflow.Workflow, tracer StepTracer, ensureExecutor func(context.Context, string, StepTracer) (*workflow.Executor, error)) *EdgeRunner {
 	var statefulEdges map[int]*statefulEdgeState
-	for _, edges := range wf.Edges {
+	for _, edges := range wf.Edges() {
 		for _, edge := range edges {
 			if len(edge.Connection.SourceIDs) <= 1 {
 				continue
@@ -139,7 +139,7 @@ func NewEdgeRunner(wf *workflow.Workflow, tracer StepTracer, ensureExecutor func
 
 	return &EdgeRunner{
 		ensureExecutor:  ensureExecutor,
-		startExecutorID: wf.StartExecutorID,
+		startExecutorID: wf.StartExecutorID(),
 		statefulEdges:   statefulEdges,
 		tracer:          tracer,
 	}

--- a/workflow/internal/execution/edgerunner_observability_test.go
+++ b/workflow/internal/execution/edgerunner_observability_test.go
@@ -49,7 +49,8 @@ func TestPrepareDeliveryForDirectEdge(t *testing.T) {
 					Connection: workflow.EdgeConnection{SourceIDs: []string{"executor1"}, SinkIDs: []string{"executor2"}},
 					Condition:  condition,
 				}
-				runner := newTestEdgeRunner(edge)
+				runner, builtEdges := newTestEdgeRunner(t, edge)
+				edge = builtEdges[0]
 				mapping, err := runner.PrepareDeliveryForEdge(context.Background(), edge, mustEnvelopeTarget(t, messageVariant1, "executor1", targetID))
 				if err != nil {
 					t.Fatalf("PrepareDeliveryForEdge: %v", err)
@@ -96,7 +97,8 @@ func TestPrepareDeliveryForFanOutEdge(t *testing.T) {
 					Connection: workflow.EdgeConnection{SourceIDs: []string{"executor1"}, SinkIDs: []string{"executor2", "executor3"}},
 					Assigner:   assigner,
 				}
-				runner := newTestEdgeRunner(edge)
+				runner, builtEdges := newTestEdgeRunner(t, edge)
+				edge = builtEdges[0]
 				mapping, err := runner.PrepareDeliveryForEdge(context.Background(), edge, mustEnvelopeTarget(t, "test", "executor1", targetID))
 				if err != nil {
 					t.Fatalf("PrepareDeliveryForEdge: %v", err)
@@ -120,7 +122,8 @@ func TestPrepareDeliveryForFanOutEdge(t *testing.T) {
 
 func TestPrepareDeliveryForFanInEdge(t *testing.T) {
 	edge := workflow.Edge{Index: 42, Connection: workflow.EdgeConnection{SourceIDs: []string{"executor1", "executor2"}, SinkIDs: []string{"executor3"}}}
-	runner := newTestEdgeRunner(edge)
+	runner, builtEdges := newTestEdgeRunner(t, edge)
+	edge = builtEdges[0]
 
 	for iteration := range 2 {
 		t.Run(fmt.Sprintf("iteration-%d", iteration), func(t *testing.T) {
@@ -140,7 +143,8 @@ func TestPrepareDeliveryForFanInEdgeConcurrentProcessing(t *testing.T) {
 		sourceIDs = append(sourceIDs, fmt.Sprintf("source%d", index))
 	}
 	edge := workflow.Edge{Index: 7, Connection: workflow.EdgeConnection{SourceIDs: sourceIDs, SinkIDs: []string{"sink"}}}
-	runner := newTestEdgeRunner(edge)
+	runner, builtEdges := newTestEdgeRunner(t, edge)
+	edge = builtEdges[0]
 
 	for iteration := range iterations {
 		start := make(chan struct{})
@@ -233,15 +237,11 @@ func TestPrepareDeliveryForEdgeRecordsEdgeGroupMetadata(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			tracer := workflowtest.NewRecordingTracer()
 			ctx := runtimeobservability.ContextWithTelemetry(context.Background(), runtimeobservability.New(runtimeobservability.Options{Tracer: tracer}))
-			runner := execution.NewEdgeRunner(&workflow.Workflow{
-				StartExecutorID: "start",
-				Edges:           map[string][]workflow.Edge{"source": {testCase.edge}},
-			}, nil, func(_ context.Context, targetID string, _ execution.StepTracer) (*workflow.Executor, error) {
-				return stringExecutor(targetID), nil
-			})
+			runner, builtEdges := newTestEdgeRunner(t, testCase.edge)
+			edge := builtEdges[0]
 
 			for _, envelope := range testCase.envelopes {
-				if _, err := runner.PrepareDeliveryForEdge(ctx, testCase.edge, envelope); err != nil {
+				if _, err := runner.PrepareDeliveryForEdge(ctx, edge, envelope); err != nil {
 					t.Fatalf("PrepareDeliveryForEdge returned error: %v", err)
 				}
 			}
@@ -268,13 +268,96 @@ func mustEnvelopeTarget(t *testing.T, message string, sourceID string, targetID 
 	return envelope
 }
 
-func newTestEdgeRunner(edges ...workflow.Edge) *execution.EdgeRunner {
-	return execution.NewEdgeRunner(&workflow.Workflow{
-		StartExecutorID: "start",
-		Edges:           map[string][]workflow.Edge{"source": edges},
-	}, nil, func(_ context.Context, targetID string, _ execution.StepTracer) (*workflow.Executor, error) {
+func newTestEdgeRunner(t *testing.T, edges ...workflow.Edge) (*execution.EdgeRunner, []workflow.Edge) {
+	t.Helper()
+	wf, builtEdges := newTestWorkflow(t, edges...)
+	runner := execution.NewEdgeRunner(wf, nil, func(_ context.Context, targetID string, _ execution.StepTracer) (*workflow.Executor, error) {
 		return stringExecutor(targetID), nil
 	})
+	return runner, builtEdges
+}
+
+func newTestWorkflow(t *testing.T, edges ...workflow.Edge) (*workflow.Workflow, []workflow.Edge) {
+	t.Helper()
+	bindings := make(map[string]workflow.ExecutorBinding)
+	binding := func(id string) workflow.ExecutorBinding {
+		if existing, ok := bindings[id]; ok {
+			return existing
+		}
+		binding := workflow.ExecutorBinding{
+			ID: id,
+			NewExecutorFunc: func(string) (*workflow.Executor, error) {
+				return stringExecutor(id), nil
+			},
+		}
+		bindings[id] = binding
+		return binding
+	}
+
+	startID := "start"
+	if len(edges) > 0 && len(edges[0].Connection.SourceIDs) > 0 {
+		startID = edges[0].Connection.SourceIDs[0]
+	}
+	builder := workflow.NewBuilder(binding(startID))
+	for _, edge := range edges {
+		for _, sourceID := range edge.Connection.SourceIDs {
+			binding(sourceID)
+		}
+		for _, sinkID := range edge.Connection.SinkIDs {
+			binding(sinkID)
+		}
+
+		sources := make([]workflow.ExecutorBinding, 0, len(edge.Connection.SourceIDs))
+		for _, sourceID := range edge.Connection.SourceIDs {
+			sources = append(sources, binding(sourceID))
+		}
+		sinks := make([]workflow.ExecutorBinding, 0, len(edge.Connection.SinkIDs))
+		for _, sinkID := range edge.Connection.SinkIDs {
+			sinks = append(sinks, binding(sinkID))
+		}
+		opts := edgeOptions(edge)
+		switch {
+		case len(sources) == 1 && len(sinks) == 1:
+			builder.AddDirectEdge(sources[0], sinks[0], false, edge.Condition, opts...)
+		case len(sources) == 1:
+			builder.AddFanOutEdge(sources[0], sinks, opts...)
+		default:
+			for _, source := range sources[1:] {
+				builder.AddDirectEdge(sources[0], source, true, nil)
+			}
+			builder.AddFanInBarrierEdge(sources, sinks[0], opts...)
+		}
+	}
+	wf, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	workflowEdges := wf.Edges()
+	builtEdges := make([]workflow.Edge, 0, len(edges))
+	for _, edge := range edges {
+		for _, candidate := range workflowEdges[edge.Connection.SourceIDs[0]] {
+			if candidate.Connection.Equal(edge.Connection) {
+				builtEdges = append(builtEdges, candidate)
+				break
+			}
+		}
+	}
+	if len(builtEdges) != len(edges) {
+		t.Fatalf("built edge count = %d, want %d", len(builtEdges), len(edges))
+	}
+	return wf, builtEdges
+}
+
+func edgeOptions(edge workflow.Edge) []workflow.EdgeOption {
+	var opts []workflow.EdgeOption
+	if edge.Label != "" {
+		opts = append(opts, workflow.WithEdgeLabel(edge.Label))
+	}
+	if edge.Assigner != nil {
+		opts = append(opts, workflow.WithEdgeAssigner(edge.Assigner))
+	}
+	return opts
 }
 
 func prepareDelivery(t *testing.T, runner *execution.EdgeRunner, edge workflow.Edge, envelope *execution.MessageEnvelope) *execution.DeliveryMapping {
@@ -355,10 +438,11 @@ func stringExecutor(id string) *workflow.Executor {
 	return &workflow.Executor{
 		ID: id,
 		Spec: workflow.ExecutorSpec{
-			ConfigureRoutes: func(builder *workflow.RouteBuilder) (*workflow.RouteBuilder, error) {
-				return builder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
+			ConfigureProtocol: func(builder *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				builder.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
 					return nil, nil
-				}), nil
+				})
+				return builder, nil
 			},
 		},
 	}

--- a/workflow/internal/execution/eventstream.go
+++ b/workflow/internal/execution/eventstream.go
@@ -28,9 +28,9 @@ func workflowMetadata(wf *workflow.Workflow, sessionID string) observability.Wor
 		return observability.WorkflowMetadata{SessionID: sessionID}
 	}
 	return observability.WorkflowMetadata{
-		ID:          wf.StartExecutorID,
-		Name:        wf.Name,
-		Description: wf.Description,
+		ID:          wf.StartExecutorID(),
+		Name:        wf.Name(),
+		Description: wf.Description(),
 		SessionID:   sessionID,
 	}
 }

--- a/workflow/internal/execution/eventstream_test.go
+++ b/workflow/internal/execution/eventstream_test.go
@@ -84,7 +84,11 @@ func newTestSuperStepRunner() *testSuperStepRunner {
 func (r *testSuperStepRunner) SessionID() string { return "session" }
 
 func (r *testSuperStepRunner) Workflow() *workflow.Workflow {
-	return &workflow.Workflow{StartExecutorID: "start"}
+	wf, err := workflow.NewBuilder(workflow.BindExecutor(&workflow.Executor{ID: "start"})).Build()
+	if err != nil {
+		panic(err)
+	}
+	return wf
 }
 
 func (r *testSuperStepRunner) StartExecutorID() string { return "start" }

--- a/workflow/protocol.go
+++ b/workflow/protocol.go
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+)
+
+// ProtocolBuilder configures the routes and declared message protocol for an
+// executor.
+//
+// A ProtocolBuilder owns a [RouteBuilder] for message handlers and tracks the
+// message types that may be sent with [Context.SendMessage] or yielded with
+// [Context.YieldOutput]. The zero value is ready to use.
+type ProtocolBuilder struct {
+	RouteBuilder RouteBuilder
+
+	sendTypes  []reflect.Type
+	yieldTypes []reflect.Type
+	err        error
+}
+
+func (pb *ProtocolBuilder) routeBuilder() *RouteBuilder {
+	return &pb.RouteBuilder
+}
+
+// SendsMessageType adds messageTypes to the set of declared message types this
+// executor may send with [Context.SendMessage]. Nil and duplicate types are
+// ignored.
+func (pb *ProtocolBuilder) SendsMessageType(messageTypes ...reflect.Type) *ProtocolBuilder {
+	if pb == nil {
+		panic("workflow: cannot configure nil ProtocolBuilder")
+	}
+	pb.sendTypes = appendUniqueTypes(pb.sendTypes, messageTypes...)
+	return pb
+}
+
+// YieldsOutputType adds outputTypes to the set of declared output types this
+// executor may yield with [Context.YieldOutput]. Nil and duplicate types are
+// ignored.
+func (pb *ProtocolBuilder) YieldsOutputType(outputTypes ...reflect.Type) *ProtocolBuilder {
+	if pb == nil {
+		panic("workflow: cannot configure nil ProtocolBuilder")
+	}
+	pb.yieldTypes = appendUniqueTypes(pb.yieldTypes, outputTypes...)
+	return pb
+}
+
+// ConfigureRoutes fluently configures message handlers on this builder's route
+// builder.
+//
+// Any error returned from configure is recorded and returned later when the
+// protocol is built.
+func (pb *ProtocolBuilder) ConfigureRoutes(configure func(*RouteBuilder) (*RouteBuilder, error)) *ProtocolBuilder {
+	if configure == nil {
+		panic("workflow: route configure function cannot be nil")
+	}
+	if pb == nil {
+		panic("workflow: cannot configure nil ProtocolBuilder")
+	}
+	if pb.err != nil {
+		return pb
+	}
+	routeBuilder, err := configure(pb.routeBuilder())
+	if err != nil {
+		pb.err = err
+		return pb
+	}
+	if routeBuilder == nil {
+		pb.err = errors.New("workflow: route configure function returned nil RouteBuilder")
+		return pb
+	}
+	pb.RouteBuilder = *routeBuilder
+	return pb
+}
+
+func (pb *ProtocolBuilder) build(spec ExecutorSpec) (*executorProtocol, error) {
+	if pb == nil {
+		return nil, errors.New("workflow: cannot build nil ProtocolBuilder")
+	}
+	if pb.err != nil {
+		return nil, pb.err
+	}
+	router, err := pb.routeBuilder().build()
+	if err != nil {
+		return nil, err
+	}
+
+	sendTypes := appendUniqueTypes(nil, pb.sendTypes...)
+	if !spec.DisableAutoSendMessageHandlerResultObject {
+		sendTypes = appendUniqueTypes(sendTypes, slices.Collect(router.defaultOutputTypes())...)
+	}
+
+	yieldTypes := appendUniqueTypes(nil, pb.yieldTypes...)
+	if !spec.DisableAutoYieldOutputHandlerResultObject {
+		yieldTypes = appendUniqueTypes(yieldTypes, slices.Collect(router.defaultOutputTypes())...)
+	}
+
+	return &executorProtocol{
+		router: router,
+		sends:  sendTypes,
+		yields: yieldTypes,
+	}, nil
+}
+
+type executorProtocol struct {
+	router *messageRouter
+	sends  []reflect.Type
+	yields []reflect.Type
+}
+
+func (p *executorProtocol) describe() *ProtocolDescriptor {
+	return &ProtocolDescriptor{
+		Accepts:    p.router.incomingTypes(),
+		Yields:     appendUniqueTypes(nil, p.yields...),
+		Sends:      appendUniqueTypes(nil, p.sends...),
+		AcceptsAll: p.router.hasCatchAll(),
+	}
+}
+
+func (p *executorProtocol) canHandleTypeID(typ TypeID) bool {
+	return p.router.canHandle(typ)
+}
+
+func (p *executorProtocol) canHandleType(typ reflect.Type) bool {
+	return p.router.canHandleType(typ)
+}
+
+func (p *executorProtocol) canOutputType(typ reflect.Type) bool {
+	return slices.ContainsFunc(p.yields, typ.AssignableTo)
+}
+
+func (p *executorProtocol) declaredSendType(typ reflect.Type) (reflect.Type, bool) {
+	candidates := appendUniqueTypes(nil, p.sends...)
+	candidates = appendUniqueTypes(candidates, knownSentTypes()...)
+	for _, candidate := range candidates {
+		if declaredSendTypeMatches(typ, candidate) {
+			return candidate, true
+		}
+	}
+	return nil, false
+}

--- a/workflow/protocol_test.go
+++ b/workflow/protocol_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type protocolBuilderInput struct{}
+type protocolBuilderOutput struct{}
+type protocolBuilderSend struct{}
+type protocolBuilderYield struct{}
+
+func TestProtocolBuilderBuildIncludesDeclaredAndAutomaticTypes(t *testing.T) {
+	inputType := reflect.TypeFor[protocolBuilderInput]()
+	outputType := reflect.TypeFor[protocolBuilderOutput]()
+	explicitSend := reflect.TypeFor[protocolBuilderSend]()
+	explicitYield := reflect.TypeFor[protocolBuilderYield]()
+
+	protocol, err := newProtocolBuilderWithHandler(inputType, outputType).
+		SendsMessageType(explicitSend, nil, explicitSend).
+		YieldsOutputType(explicitYield, nil, explicitYield).
+		build(ExecutorSpec{})
+	if err != nil {
+		t.Fatalf("build error = %v", err)
+	}
+
+	if !containsReflectType(protocol.describe().Accepts, inputType) {
+		t.Fatalf("Accepts = %v, want %v", protocol.describe().Accepts, inputType)
+	}
+	if got := protocol.sends; !reflect.DeepEqual(got, []reflect.Type{explicitSend, outputType}) {
+		t.Fatalf("sends = %v, want [%v %v]", got, explicitSend, outputType)
+	}
+	if got := protocol.yields; !reflect.DeepEqual(got, []reflect.Type{explicitYield, outputType}) {
+		t.Fatalf("yields = %v, want [%v %v]", got, explicitYield, outputType)
+	}
+}
+
+func TestProtocolBuilderBuildRespectsAutoReturnOptions(t *testing.T) {
+	inputType := reflect.TypeFor[protocolBuilderInput]()
+	outputType := reflect.TypeFor[protocolBuilderOutput]()
+
+	protocol, err := newProtocolBuilderWithHandler(inputType, outputType).build(ExecutorSpec{
+		DisableAutoSendMessageHandlerResultObject: true,
+		DisableAutoYieldOutputHandlerResultObject: true,
+	})
+	if err != nil {
+		t.Fatalf("build error = %v", err)
+	}
+	if containsReflectType(protocol.sends, outputType) {
+		t.Fatalf("sends = %v, want no automatic output type %v", protocol.sends, outputType)
+	}
+	if containsReflectType(protocol.yields, outputType) {
+		t.Fatalf("yields = %v, want no automatic output type %v", protocol.yields, outputType)
+	}
+}
+
+func TestProtocolBuilderConfigureRoutesErrorReturnsFromBuild(t *testing.T) {
+	wantErr := errors.New("route setup failed")
+	var pb ProtocolBuilder
+	_, err := pb.ConfigureRoutes(func(*RouteBuilder) (*RouteBuilder, error) {
+		return nil, wantErr
+	}).build(ExecutorSpec{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("build error = %v, want %v", err, wantErr)
+	}
+}
+
+func newProtocolBuilderWithHandler(inputType, outputType reflect.Type) *ProtocolBuilder {
+	var pb ProtocolBuilder
+	pb.RouteBuilder.AddHandlerRaw(inputType, outputType, func(*Context, any) (any, error) {
+		return protocolBuilderOutput{}, nil
+	})
+	return &pb
+}
+
+func containsReflectType(types []reflect.Type, want reflect.Type) bool {
+	for _, typ := range types {
+		if typ == want {
+			return true
+		}
+	}
+	return false
+}

--- a/workflow/protocol_test.go
+++ b/workflow/protocol_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 )
 
-type protocolBuilderInput struct{}
-type protocolBuilderOutput struct{}
-type protocolBuilderSend struct{}
-type protocolBuilderYield struct{}
+type (
+	protocolBuilderInput  struct{}
+	protocolBuilderOutput struct{}
+	protocolBuilderSend   struct{}
+	protocolBuilderYield  struct{}
+)
 
 func TestProtocolBuilderBuildIncludesDeclaredAndAutomaticTypes(t *testing.T) {
 	inputType := reflect.TypeFor[protocolBuilderInput]()

--- a/workflow/route.go
+++ b/workflow/route.go
@@ -3,13 +3,14 @@
 package workflow
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"iter"
 	"maps"
 	"reflect"
 	"slices"
+
+	"github.com/microsoft/agent-framework-go/internal/concurrent"
 )
 
 // CatchAllFunc handles messages that do not match a typed route.
@@ -49,7 +50,7 @@ func WithHandlerOverwrite(overwrite bool) AddHandlerOption {
 
 // RouteBuilder configures the message routes for an executor.
 //
-// A RouteBuilder is normally used from [ExecutorSpec.ConfigureRoutes] to
+// A RouteBuilder is normally used from [ExecutorSpec.ConfigureProtocol] to
 // register typed handlers with [RouteBuilder.AddHandlerRaw] and an optional
 // fallback handler with [RouteBuilder.AddCatchAll]. The zero value is ready to
 // use, and registration methods return the builder so calls can be chained.
@@ -168,67 +169,88 @@ func (rb *RouteBuilder) build() (*messageRouter, error) {
 
 // messageRouter resolves runtime messages to their configured handlers.
 //
-// It keeps both reflect.Type keys for in-process values and TypeID keys for
-// portable values restored from serialized workflow state.
+// It keeps exact reflect.Type handlers, indexes handler metadata by TypeID for
+// portable values restored from serialized workflow state, and resolves
+// assignable interface handlers for in-process values.
 type messageRouter struct {
-	typedHandlers      map[reflect.Type]MessageHandlerFunc
-	runtimeTypeMap     map[TypeID]reflect.Type
-	catchAllFunc       CatchAllFunc
-	defaultOutputTypes map[reflect.Type]struct{}
+	typedHandlers     map[reflect.Type]MessageHandlerFunc
+	typeInfos         concurrent.Map[TypeID, typeHandlingInfo]
+	interfaceHandlers []reflect.Type
+	catchAllFunc      CatchAllFunc
+	outputTypes       map[reflect.Type]struct{}
+}
+
+type typeHandlingInfo struct {
+	runtimeType reflect.Type
+	handler     MessageHandlerFunc
 }
 
 // newMessageRouter creates a router and indexes typed handlers by TypeID.
 func newMessageRouter(handlers map[reflect.Type]MessageHandlerFunc, outputTypes map[reflect.Type]struct{}, catchAll CatchAllFunc) *messageRouter {
-	runtimeTypeMap := make(map[TypeID]reflect.Type, len(handlers))
-	for msgType := range handlers {
-		typeID := NewTypeID(msgType)
-		runtimeTypeMap[typeID] = msgType
+	router := &messageRouter{
+		typedHandlers: handlers,
+		catchAllFunc:  catchAll,
+		outputTypes:   outputTypes,
 	}
-	return &messageRouter{
-		typedHandlers:      handlers,
-		runtimeTypeMap:     runtimeTypeMap,
-		catchAllFunc:       catchAll,
-		defaultOutputTypes: outputTypes,
+	for msgType, handler := range handlers {
+		router.typeInfos.Store(NewTypeID(msgType), typeHandlingInfo{runtimeType: msgType, handler: handler})
+		if msgType.Kind() == reflect.Interface {
+			router.interfaceHandlers = append(router.interfaceHandlers, msgType)
+		}
 	}
+	return router
 }
 
-// IncomingTypes returns the concrete message types with typed handlers.
-func (mr *messageRouter) IncomingTypes() []reflect.Type {
+// incomingTypes returns the concrete message types with typed handlers.
+func (mr *messageRouter) incomingTypes() []reflect.Type {
 	return slices.Collect(maps.Keys(mr.typedHandlers))
 }
 
-// DefaultOutputTypes returns the output types declared by typed handlers.
-func (mr *messageRouter) DefaultOutputTypes() iter.Seq[reflect.Type] {
-	return maps.Keys(mr.defaultOutputTypes)
+// defaultOutputTypes returns the output types declared by typed handlers.
+func (mr *messageRouter) defaultOutputTypes() iter.Seq[reflect.Type] {
+	return maps.Keys(mr.outputTypes)
 }
 
-// HasCatchAll reports whether the router has a fallback handler.
-func (mr *messageRouter) HasCatchAll() bool {
+// hasCatchAll reports whether the router has a fallback handler.
+func (mr *messageRouter) hasCatchAll() bool {
 	return mr.catchAllFunc != nil
 }
 
-// CanHandle reports whether typ can be routed by a typed handler or catch-all.
-func (mr *messageRouter) CanHandle(typ TypeID) bool {
+// canHandle reports whether typ can be routed by a typed handler or catch-all.
+func (mr *messageRouter) canHandle(typ TypeID) bool {
 	if mr.catchAllFunc != nil {
 		return true
 	}
-	_, ok := mr.runtimeTypeMap[typ]
+	_, ok := mr.typeInfo(typ)
 	return ok
 }
 
-// RouteMessage invokes the matching typed handler or catch-all handler.
+// canHandleType reports whether typ can be routed by an exact typed handler,
+// an assignable interface handler, or catch-all.
+func (mr *messageRouter) canHandleType(typ reflect.Type) bool {
+	if typ == nil {
+		return false
+	}
+	if mr.catchAllFunc != nil {
+		return true
+	}
+	_, ok := mr.findHandler(typ)
+	return ok
+}
+
+// routeMessage invokes the matching typed handler or catch-all handler.
 //
 // Portable values are unpacked to their registered runtime type when possible.
 // Panics raised by handlers are converted to error call results so executor
 // error handling can treat them like ordinary handler failures.
-func (mr *messageRouter) RouteMessage(ctx *Context, msg any) (result callResult, handled bool) {
+func (mr *messageRouter) routeMessage(ctx *Context, msg any) (result callResult, handled bool) {
 	if msg == nil {
 		panic("nil message")
 	}
 	pvalue, isPortable := msg.(PortableValue)
 	if isPortable {
-		if typ, ok := mr.runtimeTypeMap[pvalue.TypeID]; ok {
-			if v, ok := pvalue.As(typ); ok {
+		if info, ok := mr.typeInfo(pvalue.TypeID); ok {
+			if v, ok := pvalue.As(info.runtimeType); ok {
 				// If we found a runtime type, we can use it
 				msg = v
 			}
@@ -243,7 +265,7 @@ func (mr *messageRouter) RouteMessage(ctx *Context, msg any) (result callResult,
 			result = callResult{Error: err, Result: struct{}{}}
 		}
 	}()
-	if handler, ok := mr.typedHandlers[reflect.TypeOf(msg)]; ok {
+	if handler, ok := mr.findHandler(reflect.TypeOf(msg)); ok {
 		handled = true
 		ret, err := handler(ctx, msg)
 		return callResult{ret, err}, handled
@@ -259,18 +281,44 @@ func (mr *messageRouter) RouteMessage(ctx *Context, msg any) (result callResult,
 	return callResult{}, false
 }
 
+func (mr *messageRouter) typeInfo(typeID TypeID) (typeHandlingInfo, bool) {
+	if typeID == (TypeID{}) {
+		return typeHandlingInfo{}, false
+	}
+	return mr.typeInfos.Load(typeID)
+}
+
+func (mr *messageRouter) findHandler(messageType reflect.Type) (MessageHandlerFunc, bool) {
+	if messageType == nil {
+		return nil, false
+	}
+	if handler, ok := mr.typedHandlers[messageType]; ok {
+		return handler, true
+	}
+
+	typeID := NewTypeID(messageType)
+	if info, ok := mr.typeInfo(typeID); ok {
+		return info.handler, true
+	}
+
+	for _, interfaceType := range mr.interfaceHandlers {
+		if messageType.AssignableTo(interfaceType) {
+			handler := mr.typedHandlers[interfaceType]
+			mr.typeInfos.Store(typeID, typeHandlingInfo{runtimeType: messageType, handler: handler})
+			return handler, true
+		}
+	}
+
+	return nil, false
+}
+
 // callResult captures a handler invocation result and error.
 type callResult struct {
 	Result any
 	Error  error
 }
 
-// IsVoid reports whether the handler returned the workflow void sentinel.
-func (cr callResult) IsVoid() bool {
+// isVoid reports whether the handler returned the workflow void sentinel.
+func (cr callResult) isVoid() bool {
 	return cr.Result != nil && reflect.TypeOf(cr.Result) == reflect.TypeFor[struct{}]()
-}
-
-// Canceled reports whether the handler failed because its context was canceled.
-func (cr callResult) Canceled() bool {
-	return errors.Is(cr.Error, context.Canceled)
 }

--- a/workflow/route_test.go
+++ b/workflow/route_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+type routeTestMessage interface {
+	routeMarker() string
+}
+
+type routeTestConcrete struct {
+	value string
+}
+
+func (m routeTestConcrete) routeMarker() string { return m.value }
+
+func TestMessageRouterRoutesAssignableInterfaceHandler(t *testing.T) {
+	var rb RouteBuilder
+	rb.AddHandlerRaw(reflect.TypeFor[routeTestMessage](), nil, func(_ *Context, msg any) (any, error) {
+		message, ok := msg.(routeTestMessage)
+		if !ok {
+			t.Fatalf("handler message = %T, want routeTestMessage", msg)
+		}
+		return message.routeMarker(), nil
+	})
+	router, err := rb.build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	if !router.canHandleType(reflect.TypeFor[routeTestConcrete]()) {
+		t.Fatal("CanHandleType(routeTestConcrete) = false, want true")
+	}
+	result, handled := router.routeMessage(&Context{Context: context.Background()}, routeTestConcrete{value: "handled"})
+	if !handled {
+		t.Fatal("RouteMessage handled = false, want true")
+	}
+	if result.Error != nil {
+		t.Fatalf("RouteMessage error = %v", result.Error)
+	}
+	if result.Result != "handled" {
+		t.Fatalf("RouteMessage result = %v, want handled", result.Result)
+	}
+}
+
+func TestMessageRouterPrefersExactHandlerOverInterfaceHandler(t *testing.T) {
+	var rb RouteBuilder
+	rb.AddHandlerRaw(reflect.TypeFor[routeTestMessage](), nil, func(_ *Context, msg any) (any, error) {
+		return "interface", nil
+	})
+	rb.AddHandlerRaw(reflect.TypeFor[routeTestConcrete](), nil, func(_ *Context, msg any) (any, error) {
+		return "concrete", nil
+	})
+	router, err := rb.build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	result, handled := router.routeMessage(&Context{Context: context.Background()}, routeTestConcrete{})
+	if !handled {
+		t.Fatal("RouteMessage handled = false, want true")
+	}
+	if result.Error != nil {
+		t.Fatalf("RouteMessage error = %v", result.Error)
+	}
+	if result.Result != "concrete" {
+		t.Fatalf("RouteMessage result = %v, want concrete", result.Result)
+	}
+}
+
+func TestMessageRouterRoutesPortableValueAfterInterfaceMatchIsCached(t *testing.T) {
+	var rb RouteBuilder
+	rb.AddHandlerRaw(reflect.TypeFor[routeTestMessage](), nil, func(_ *Context, msg any) (any, error) {
+		if _, ok := msg.(PortableValue); ok {
+			t.Fatalf("handler message = %T, want unwrapped concrete value", msg)
+		}
+		message, ok := msg.(routeTestMessage)
+		if !ok {
+			t.Fatalf("handler message = %T, want routeTestMessage", msg)
+		}
+		return message.routeMarker(), nil
+	})
+	router, err := rb.build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	concreteTypeID := NewTypeID(reflect.TypeFor[routeTestConcrete]())
+	if router.canHandle(concreteTypeID) {
+		t.Fatal("CanHandle(routeTestConcrete TypeID) = true before cache, want false")
+	}
+
+	if _, handled := router.routeMessage(&Context{Context: context.Background()}, routeTestConcrete{value: "first"}); !handled {
+		t.Fatal("RouteMessage concrete handled = false, want true")
+	}
+	if !router.canHandle(concreteTypeID) {
+		t.Fatal("CanHandle(routeTestConcrete TypeID) = false after cache, want true")
+	}
+	result, handled := router.routeMessage(&Context{Context: context.Background()}, AnyPortableValue(routeTestConcrete{value: "portable"}))
+	if !handled {
+		t.Fatal("RouteMessage portable handled = false, want true")
+	}
+	if result.Error != nil {
+		t.Fatalf("RouteMessage portable error = %v", result.Error)
+	}
+	if result.Result != "portable" {
+		t.Fatalf("RouteMessage portable result = %v, want portable", result.Result)
+	}
+}

--- a/workflow/telemetry.go
+++ b/workflow/telemetry.go
@@ -46,12 +46,12 @@ func workflowTelemetryDefinitionFrom(wf *Workflow) workflowTelemetryDefinition {
 	if wf == nil {
 		return workflowTelemetryDefinition{}
 	}
-	executors := make(map[string]TypeID, len(wf.ExecutorBindings))
-	for id, binding := range wf.ExecutorBindings {
+	executors := make(map[string]TypeID, len(wf.executorBindings))
+	for id, binding := range wf.executorBindings {
 		executors[id] = NewTypeID(binding.ExecutorType)
 	}
-	ports := make([]RequestPortInfo, 0, len(wf.Ports))
-	for _, port := range wf.Ports {
+	ports := make([]RequestPortInfo, 0, len(wf.ports))
+	for _, port := range wf.ports {
 		ports = append(ports, NewRequestPortInfo(port))
 	}
 	slices.SortFunc(ports, func(left, right RequestPortInfo) int {
@@ -63,8 +63,8 @@ func workflowTelemetryDefinitionFrom(wf *Workflow) workflowTelemetryDefinition {
 		}
 		return 0
 	})
-	outputs := make([]string, 0, len(wf.OutputExecutors))
-	for id := range wf.OutputExecutors {
+	outputs := make([]string, 0, len(wf.outputExecutors))
+	for id := range wf.outputExecutors {
 		outputs = append(outputs, id)
 	}
 	slices.Sort(outputs)
@@ -72,7 +72,7 @@ func workflowTelemetryDefinitionFrom(wf *Workflow) workflowTelemetryDefinition {
 		Executors:         executors,
 		Edges:             wf.ReflectEdges(),
 		RequestPorts:      ports,
-		StartExecutorID:   wf.StartExecutorID,
+		StartExecutorID:   wf.startExecutorID,
 		OutputExecutorIDs: outputs,
 	}
 }
@@ -82,9 +82,9 @@ func observabilityMetadata(wf *Workflow, sessionID string) internalobservability
 		return internalobservability.WorkflowMetadata{SessionID: sessionID}
 	}
 	return internalobservability.WorkflowMetadata{
-		ID:          wf.StartExecutorID,
-		Name:        wf.Name,
-		Description: wf.Description,
+		ID:          wf.startExecutorID,
+		Name:        wf.name,
+		Description: wf.description,
 		SessionID:   sessionID,
 	}
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -11,6 +11,7 @@ import (
 	"iter"
 	"maps"
 	"reflect"
+	"slices"
 	"sync/atomic"
 
 	"github.com/microsoft/agent-framework-go/workflow/internal/observability"
@@ -129,29 +130,17 @@ type ProtocolDescriptor struct {
 }
 
 // Workflow is an executable graph of bound executors, edges, outputs, and
-// request ports.
+// request ports. Workflows are created by [Builder].
 type Workflow struct {
-	// Name is an optional human-readable workflow name.
-	Name string
+	name        string
+	description string
 
-	// Description is optional human-readable workflow detail.
-	Description string
+	startExecutorID string
 
-	// StartExecutorID is the executor ID that receives the initial input.
-	StartExecutorID string
-
-	// ExecutorBindings contains the workflow's executor bindings keyed by ID.
-	ExecutorBindings map[string]ExecutorBinding
-
-	// Edges contains outgoing edges keyed by source executor ID.
-	Edges map[string][]Edge
-
-	// OutputExecutors contains the executor IDs whose yielded outputs are exposed
-	// as workflow outputs.
-	OutputExecutors map[string]struct{}
-
-	// Ports contains request ports exposed by the workflow keyed by port ID.
-	Ports map[string]RequestPort
+	executorBindings map[string]ExecutorBinding
+	edges            map[string][]Edge
+	outputExecutors  map[string]struct{}
+	ports            map[string]RequestPort
 
 	needsReset atomic.Bool
 	ownerToken atomic.Pointer[workflowOwner]
@@ -193,12 +182,101 @@ func sameOwnershipToken(left any, right any) bool {
 	return leftOK && rightOK && leftType == rightType && leftPtr == rightPtr
 }
 
+// Name returns the optional human-readable workflow name.
+func (w *Workflow) Name() string {
+	if w == nil {
+		return ""
+	}
+	return w.name
+}
+
+// Description returns optional human-readable workflow detail.
+func (w *Workflow) Description() string {
+	if w == nil {
+		return ""
+	}
+	return w.description
+}
+
+// StartExecutorID returns the executor ID that receives the initial input.
+func (w *Workflow) StartExecutorID() string {
+	if w == nil {
+		return ""
+	}
+	return w.startExecutorID
+}
+
+// ExecutorBinding returns the executor binding for id.
+func (w *Workflow) ExecutorBinding(id string) (ExecutorBinding, bool) {
+	if w == nil {
+		return ExecutorBinding{}, false
+	}
+	binding, ok := w.executorBindings[id]
+	return binding, ok
+}
+
+// OutgoingEdges returns the edges whose source is executorID.
+func (w *Workflow) OutgoingEdges(executorID string) []Edge {
+	if w == nil {
+		return nil
+	}
+	return slices.Clone(w.edges[executorID])
+}
+
+// Edges returns a copy of the workflow edges keyed by source executor ID.
+func (w *Workflow) Edges() map[string][]Edge {
+	if w == nil {
+		return nil
+	}
+	out := make(map[string][]Edge, len(w.edges))
+	for sourceID, edges := range w.edges {
+		out[sourceID] = slices.Clone(edges)
+	}
+	return out
+}
+
+// HasOutputExecutor reports whether executorID is exposed as a workflow output.
+func (w *Workflow) HasOutputExecutor(executorID string) bool {
+	if w == nil {
+		return false
+	}
+	_, ok := w.outputExecutors[executorID]
+	return ok
+}
+
+// OutputExecutorIDs returns the executor IDs exposed as workflow outputs.
+func (w *Workflow) OutputExecutorIDs() []string {
+	if w == nil {
+		return nil
+	}
+	return slices.Collect(maps.Keys(w.outputExecutors))
+}
+
+// RequestPort returns the workflow request port with id.
+func (w *Workflow) RequestPort(id string) (RequestPort, bool) {
+	if w == nil {
+		return RequestPort{}, false
+	}
+	port, ok := w.ports[id]
+	return port, ok
+}
+
+// RequestPorts returns a copy of the workflow request ports keyed by port ID.
+func (w *Workflow) RequestPorts() map[string]RequestPort {
+	if w == nil {
+		return nil
+	}
+	out := make(map[string]RequestPort, len(w.ports))
+	maps.Copy(out, w.ports)
+	return out
+}
+
 // DescribeProtocol returns the protocol accepted by the workflow's start
 // executor and yielded by its output executors.
 func (w *Workflow) DescribeProtocol() (*ProtocolDescriptor, error) {
-	er := w.ExecutorBindings[w.StartExecutorID]
-	if _, ok := w.ExecutorBindings[w.StartExecutorID]; !ok {
-		return nil, fmt.Errorf("workflow start executor %q has no registered binding", w.StartExecutorID)
+	er := w.executorBindings[w.startExecutorID]
+	if _, ok := w.executorBindings[w.startExecutorID]; !ok {
+		return nil, fmt.Errorf("workflow start executor %q has no registered binding", w.startExecutorID)
 	}
 	executor, err := er.CreateInstance("")
 	if err != nil {
@@ -210,8 +288,8 @@ func (w *Workflow) DescribeProtocol() (*ProtocolDescriptor, error) {
 	}
 
 	yields := make([]reflect.Type, 0)
-	for executorID := range w.OutputExecutors {
-		binding, ok := w.ExecutorBindings[executorID]
+	for executorID := range w.outputExecutors {
+		binding, ok := w.executorBindings[executorID]
 		if !ok {
 			return nil, fmt.Errorf("workflow output executor %q has no registered binding", executorID)
 		}
@@ -237,7 +315,7 @@ func (w *Workflow) DescribeProtocol() (*ProtocolDescriptor, error) {
 // HasResettableExecutors reports whether any executor binding can reset shared
 // resources between workflow runs.
 func (w *Workflow) HasResettableExecutors() bool {
-	for _, er := range w.ExecutorBindings {
+	for _, er := range w.executorBindings {
 		if er.ResetFunc != nil {
 			return true
 		}
@@ -257,7 +335,7 @@ func (w *Workflow) ContextWithTelemetry(ctx context.Context) context.Context {
 // AllowConcurrent reports whether every bound executor in the workflow
 // supports cross-run shared execution.
 func (w *Workflow) AllowConcurrent() bool {
-	for _, er := range w.ExecutorBindings {
+	for _, er := range w.executorBindings {
 		if !er.SupportsConcurrentSharedExecution {
 			return false
 		}
@@ -271,7 +349,7 @@ func (w *Workflow) TryReset() bool {
 	if !w.HasResettableExecutors() {
 		return false
 	}
-	for _, er := range w.ExecutorBindings {
+	for _, er := range w.executorBindings {
 		if !er.TryReset() {
 			return false
 		}
@@ -384,8 +462,8 @@ func (w *Workflow) ReleaseOwnershipTo(token any, targetToken any) error {
 
 // ReflectEdges returns workflow edge metadata keyed by source executor ID.
 func (w *Workflow) ReflectEdges() map[string][]EdgeInfo {
-	edgeInfos := make(map[string][]EdgeInfo, len(w.Edges))
-	for sourceID, edges := range w.Edges {
+	edgeInfos := make(map[string][]EdgeInfo, len(w.edges))
+	for sourceID, edges := range w.edges {
 		infos := make([]EdgeInfo, 0, len(edges))
 		for _, edge := range edges {
 			infos = append(infos, newEdgeInfo(edge))
@@ -397,8 +475,8 @@ func (w *Workflow) ReflectEdges() map[string][]EdgeInfo {
 
 // ReflectPorts returns workflow request port metadata keyed by port ID.
 func (w *Workflow) ReflectPorts() map[string]RequestPortInfo {
-	portInfos := make(map[string]RequestPortInfo, len(w.Ports))
-	for id, port := range w.Ports {
+	portInfos := make(map[string]RequestPortInfo, len(w.ports))
+	for id, port := range w.ports {
 		portInfos[id] = NewRequestPortInfo(port)
 	}
 	return portInfos
@@ -407,8 +485,8 @@ func (w *Workflow) ReflectPorts() map[string]RequestPortInfo {
 // ReflectExecutors returns a copy of the workflow's executor bindings keyed
 // by ID. Modifying the returned map does not affect the workflow.
 func (w *Workflow) ReflectExecutors() map[string]ExecutorBinding {
-	out := make(map[string]ExecutorBinding, len(w.ExecutorBindings))
-	maps.Copy(out, w.ExecutorBindings)
+	out := make(map[string]ExecutorBinding, len(w.executorBindings))
+	maps.Copy(out, w.executorBindings)
 	return out
 }
 


### PR DESCRIPTION
Summary:
- Add ProtocolBuilder-based protocol declaration and update call sites to use singular variadic send/yield methods.
- Align message routing with .NET behavior for exact and assignable interface handlers.
- Make Workflow topology builder-owned/private and update runtime/test access through read-only methods.

Tests:
- go test ./...