### PR TITLE
Add workflow provider session persistence

### DIFF
--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -1075,8 +1075,8 @@ func newFunctionCallAgent() *agent.Agent {
 }
 
 // approverExecutor is a downstream executor that forwards a fixed
-// FunctionApprovalResponseContent back to the binding it observes a
-// FunctionApprovalRequestContent for.
+// ToolApprovalResponseContent back to the binding it observes a
+// ToolApprovalRequestContent for.
 func approverExecutor(target workflow.ExecutorBinding, approve bool) workflow.ExecutorBinding {
 	id := "approver"
 	binding := workflow.ExecutorBinding{
@@ -1163,7 +1163,7 @@ func collectResponseOutputs(t *testing.T, ev []workflow.Event) []*agent.Response
 }
 
 // TestHostedAgent_InterceptUserInputRequests verifies that when the agent
-// emits a FunctionApprovalRequestContent and the flag is set, the request is
+// emits a ToolApprovalRequestContent and the flag is set, the request is
 // dispatched as a workflow message and the response, when routed back to the
 // host, drives a second agent invocation that observes the response.
 func TestHostedAgent_InterceptUserInputRequests(t *testing.T) {
@@ -1391,7 +1391,7 @@ func TestHostedAgent_InterceptDisabled_PostsExternalRequest(t *testing.T) {
 	}
 
 	if sawApprovalRequestMessage {
-		t.Errorf("expected no FunctionApprovalRequestContent workflow-message dispatch when InterceptUserInputRequests is false")
+		t.Errorf("expected no ToolApprovalRequestContent workflow-message dispatch when InterceptUserInputRequests is false")
 	}
 	if !sawExternalRequest {
 		t.Errorf("expected a RequestInfoEvent for the user-input port when InterceptUserInputRequests is false")
@@ -1526,12 +1526,12 @@ func TestHostedAgent_InterceptDisabled_ResumesWithExternalResponse(t *testing.T)
 	// Build the approval response from the request data.
 	reqContent, ok := req.Data.As(reflect.TypeFor[*message.ToolApprovalRequestContent]())
 	if !ok {
-		t.Fatalf("expected request data to be *FunctionApprovalRequestContent, got %T", req.Data.Any())
+		t.Fatalf("expected request data to be *ToolApprovalRequestContent, got %T", req.Data.Any())
 	}
 	approval := reqContent.(*message.ToolApprovalRequestContent).CreateResponse(true, "")
-	resp, err := req.NewResponse(approval)
+	resp, err := req.CreateResponse(approval)
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if _, err := run.Resume(ctx, resp); err != nil {
 		t.Fatalf("Resume: %v", err)
@@ -1665,9 +1665,9 @@ func TestHostedAgent_InterceptsOnlyUnpairedFunctionCalls_PortMode(t *testing.T) 
 	for _, req := range requests[:unpaired-1] {
 		v, _ := req.Data.As(reflect.TypeFor[*message.FunctionCallContent]())
 		call := v.(*message.FunctionCallContent)
-		resp, err := req.NewResponse(&message.FunctionResultContent{CallID: call.CallID, Result: "ok"})
+		resp, err := req.CreateResponse(&message.FunctionResultContent{CallID: call.CallID, Result: "ok"})
 		if err != nil {
-			t.Fatalf("NewResponse: %v", err)
+			t.Fatalf("CreateResponse: %v", err)
 		}
 		if _, err := run.Resume(ctx, resp); err != nil {
 			t.Fatalf("Resume: %v", err)
@@ -1682,9 +1682,9 @@ func TestHostedAgent_InterceptsOnlyUnpairedFunctionCalls_PortMode(t *testing.T) 
 	final := requests[unpaired-1]
 	v, _ := final.Data.As(reflect.TypeFor[*message.FunctionCallContent]())
 	call := v.(*message.FunctionCallContent)
-	resp, err := final.NewResponse(&message.FunctionResultContent{CallID: call.CallID, Result: "ok"})
+	resp, err := final.CreateResponse(&message.FunctionResultContent{CallID: call.CallID, Result: "ok"})
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if _, err := run.Resume(ctx, resp); err != nil {
 		t.Fatalf("Resume: %v", err)
@@ -2006,9 +2006,9 @@ func TestHostedAgent_HandledRequestNotReEmitted_PortMode(t *testing.T) {
 	// Resume with a matching response.
 	v, _ := firstReq.Data.As(reflect.TypeFor[*message.FunctionCallContent]())
 	call := v.(*message.FunctionCallContent)
-	resp, err := firstReq.NewResponse(&message.FunctionResultContent{CallID: call.CallID, Result: "ok"})
+	resp, err := firstReq.CreateResponse(&message.FunctionResultContent{CallID: call.CallID, Result: "ok"})
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if _, err := run.Resume(ctx, resp); err != nil {
 		t.Fatalf("Resume: %v", err)
@@ -2028,7 +2028,7 @@ func TestHostedAgent_HandledRequestNotReEmitted_PortMode(t *testing.T) {
 
 // TestHostedAgent_AlreadyPendingRequest_IsIdempotent_InterceptMode covers the
 // across-response idempotent re-emission path: when an agent emits a
-// FunctionApprovalRequestContent whose ID is already pending from a previous
+// ToolApprovalRequestContent whose ID is already pending from a previous
 // response (e.g. a re-emission), the host must not dispatch it twice nor
 // raise an error. Mirrors .NET's
 // AIContentExternalHandler.ProcessRequestContentAsync no-op-on-TryAdd-fail.
@@ -2107,7 +2107,7 @@ func TestHostedAgent_AlreadyPendingRequest_IsIdempotent_InterceptMode(t *testing
 			t.Fatalf("watch: %v", err)
 		}
 		if e, ok := evt.(workflow.ErrorEvent); ok && e.Error != nil &&
-			strings.Contains(e.Error.Error(), "duplicate FunctionApprovalRequest") {
+			strings.Contains(e.Error.Error(), "duplicate tool approval request") {
 			sawErr = true
 		}
 	}

--- a/agent/provider/workflowprovider/session.go
+++ b/agent/provider/workflowprovider/session.go
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowprovider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/checkpoint"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+const sessionStateKey = "workflowprovider_state"
+
+// providerServiceID marks sessions managed by this provider. Setting a
+// non-empty ServiceID on the session opts out of the agent package's
+// default history provider on subsequent calls. Explicitly configured
+// history providers still run. The workflow itself owns conversational
+// state across turns.
+const providerServiceID = "workflowprovider"
+
+type sessionCheckpointEntry struct {
+	CheckpointInfo workflow.CheckpointInfo  `json:"checkpointInfo"`
+	Data           json.RawMessage          `json:"data"`
+	Parent         *workflow.CheckpointInfo `json:"parent,omitempty"`
+}
+
+type sessionCheckpointStore struct {
+	Entries []sessionCheckpointEntry `json:"entries,omitempty"`
+}
+
+var _ checkpoint.Store[json.RawMessage] = (*sessionCheckpointStore)(nil)
+
+func (s *sessionCheckpointStore) CreateCheckpoint(_ context.Context, sessionID string, data json.RawMessage, parent *workflow.CheckpointInfo) (workflow.CheckpointInfo, error) {
+	if sessionID == "" {
+		return workflow.CheckpointInfo{}, fmt.Errorf("workflowprovider: sessionID cannot be empty")
+	}
+	if !json.Valid(data) {
+		return workflow.CheckpointInfo{}, fmt.Errorf("workflowprovider: checkpoint data is not valid JSON")
+	}
+	if parent != nil && *parent != (workflow.CheckpointInfo{}) && parent.SessionID != sessionID {
+		return workflow.CheckpointInfo{}, fmt.Errorf("workflowprovider: parent sessionID %q does not match sessionID %q", parent.SessionID, sessionID)
+	}
+
+	info := s.unusedCheckpointInfo(sessionID)
+	var parentCopy *workflow.CheckpointInfo
+	if parent != nil {
+		p := *parent
+		parentCopy = &p
+	}
+	s.Entries = append(s.Entries, sessionCheckpointEntry{
+		CheckpointInfo: info,
+		Data:           append(json.RawMessage(nil), data...),
+		Parent:         parentCopy,
+	})
+	return info, nil
+}
+
+func (s *sessionCheckpointStore) RetrieveCheckpoint(_ context.Context, sessionID string, info workflow.CheckpointInfo) (json.RawMessage, error) {
+	if err := validateCheckpointLookup(sessionID, info); err != nil {
+		return nil, err
+	}
+	for _, entry := range s.Entries {
+		if entry.CheckpointInfo == info {
+			return append(json.RawMessage(nil), entry.Data...), nil
+		}
+	}
+	return nil, fmt.Errorf("workflowprovider: checkpoint %s not found for session %s", info.CheckpointID, sessionID)
+}
+
+func (s *sessionCheckpointStore) RetrieveIndex(_ context.Context, sessionID string, withParent *workflow.CheckpointInfo) ([]workflow.CheckpointInfo, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("workflowprovider: sessionID cannot be empty")
+	}
+	if withParent != nil && *withParent != (workflow.CheckpointInfo{}) && withParent.SessionID != sessionID {
+		return nil, fmt.Errorf("workflowprovider: parent sessionID %q does not match sessionID %q", withParent.SessionID, sessionID)
+	}
+	var result []workflow.CheckpointInfo
+	for _, entry := range s.Entries {
+		if entry.CheckpointInfo.SessionID != sessionID {
+			continue
+		}
+		if withParent != nil {
+			if entry.Parent == nil || *entry.Parent != *withParent {
+				continue
+			}
+		}
+		result = append(result, entry.CheckpointInfo)
+	}
+	return result, nil
+}
+
+func (s *sessionCheckpointStore) unusedCheckpointInfo(sessionID string) workflow.CheckpointInfo {
+	for {
+		info := workflow.NewCheckpointInfo(sessionID)
+		if !s.contains(info) {
+			return info
+		}
+	}
+}
+
+func (s *sessionCheckpointStore) contains(info workflow.CheckpointInfo) bool {
+	for _, entry := range s.Entries {
+		if entry.CheckpointInfo == info {
+			return true
+		}
+	}
+	return false
+}
+
+func validateCheckpointLookup(sessionID string, info workflow.CheckpointInfo) error {
+	if sessionID == "" {
+		return fmt.Errorf("workflowprovider: sessionID cannot be empty")
+	}
+	if info.SessionID == "" {
+		return fmt.Errorf("workflowprovider: checkpoint sessionID cannot be empty")
+	}
+	if info.CheckpointID == "" {
+		return fmt.Errorf("workflowprovider: checkpointID cannot be empty")
+	}
+	if info.SessionID != sessionID {
+		return fmt.Errorf("workflowprovider: checkpoint sessionID %q does not match sessionID %q", info.SessionID, sessionID)
+	}
+	return nil
+}
+
+// providerState holds the workflow run state that survives across multiple
+// [agent.Agent.Run] invocations on the same session. It is stored on the
+// [agent.Session] under [sessionStateKey].
+//
+// The streaming run is an in-memory object and is not portable across process
+// boundaries. Session JSON retains the latest checkpoint, any implicit
+// checkpoint data, and pending request-tracking metadata so a later process can
+// resume the workflow.
+type providerState struct {
+	stream            *inproc.StreamingRun
+	workflowSessionID string
+	lastCheckpoint    *workflow.CheckpointInfo
+	checkpointStore   *sessionCheckpointStore
+	pending           map[string]*workflow.ExternalRequest // keyed by request content ID (e.g. CallID/RequestID)
+}
+
+type providerStateJSON struct {
+	WorkflowSessionID string                               `json:"workflowSessionID,omitempty"`
+	LastCheckpoint    *workflow.CheckpointInfo             `json:"lastCheckpoint,omitempty"`
+	CheckpointStore   *sessionCheckpointStore              `json:"checkpointStore,omitempty"`
+	Pending           map[string]*workflow.ExternalRequest `json:"pending,omitempty"`
+}
+
+func (s *providerState) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(providerStateJSON{
+		WorkflowSessionID: s.workflowSessionID,
+		LastCheckpoint:    s.lastCheckpoint,
+		CheckpointStore:   s.checkpointStore,
+		Pending:           s.pending,
+	})
+}
+
+func (s *providerState) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*s = providerState{}
+		return nil
+	}
+	var tmp providerStateJSON
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	s.stream = nil
+	s.workflowSessionID = tmp.WorkflowSessionID
+	s.lastCheckpoint = tmp.LastCheckpoint
+	s.checkpointStore = tmp.CheckpointStore
+	s.pending = tmp.Pending
+	s.ensureWorkflowSessionID()
+	if s.pending == nil {
+		s.pending = make(map[string]*workflow.ExternalRequest)
+	}
+	return nil
+}
+
+func newProviderState() *providerState {
+	state := &providerState{pending: make(map[string]*workflow.ExternalRequest)}
+	state.ensureWorkflowSessionID()
+	return state
+}
+
+// loadOrInitState fetches the per-session [providerState], creating a fresh
+// streaming workflow run on first use.
+func loadOrInitState(
+	ctx context.Context,
+	sess *agent.Session,
+	env *inproc.ExecutionEnvironment,
+	wf *workflow.Workflow,
+) (*providerState, error) {
+	var state *providerState
+	if sess != nil {
+		if ok, _ := sess.Get(sessionStateKey, &state); ok && state != nil {
+			state.ensurePending()
+			state.ensureWorkflowSessionID()
+			if state.stream != nil {
+				return state, nil
+			}
+		} else {
+			state = nil
+		}
+	}
+	if state == nil {
+		state = newProviderState()
+	}
+	state.ensureWorkflowSessionID()
+
+	effectiveEnv, err := state.executionEnvironment(env)
+	if err != nil {
+		return nil, err
+	}
+
+	if state.lastCheckpoint != nil {
+		stream, err := effectiveEnv.ResumeStreaming(ctx, wf, *state.lastCheckpoint, inproc.WithPendingRequestRepublish(false))
+		if err != nil {
+			return nil, err
+		}
+		state.stream = stream
+		return state, nil
+	}
+
+	stream, err := effectiveEnv.RunStreaming(ctx, wf, nil, inproc.WithSessionID(state.workflowSessionID))
+	if err != nil {
+		return nil, err
+	}
+	state.stream = stream
+	state.ensurePending()
+	return state, nil
+}
+
+func (s *providerState) ensurePending() {
+	if s.pending == nil {
+		s.pending = make(map[string]*workflow.ExternalRequest)
+	}
+}
+
+func (s *providerState) ensureWorkflowSessionID() {
+	if s.workflowSessionID != "" {
+		return
+	}
+	if s.lastCheckpoint != nil && s.lastCheckpoint.SessionID != "" {
+		s.workflowSessionID = s.lastCheckpoint.SessionID
+		return
+	}
+	s.workflowSessionID = uuid.NewString()
+}
+
+func (s *providerState) closeStream(ctx context.Context) error {
+	if s == nil || s.stream == nil {
+		return nil
+	}
+	stream := s.stream
+	s.stream = nil
+	return stream.Close(ctx)
+}
+
+func (s *providerState) executionEnvironment(env *inproc.ExecutionEnvironment) (*inproc.ExecutionEnvironment, error) {
+	if env.IsCheckpointingEnabled() {
+		if s.checkpointStore != nil {
+			return nil, errors.New("workflowprovider: session was saved with an externalized checkpoint store, but the configured execution environment already has checkpointing enabled")
+		}
+		return env, nil
+	}
+
+	if s.checkpointStore == nil {
+		if s.lastCheckpoint != nil {
+			return nil, errors.New("workflowprovider: session has a saved checkpoint but no checkpoint store, and the configured execution environment has no checkpoint manager")
+		}
+		s.checkpointStore = &sessionCheckpointStore{}
+	}
+	return env.WithCheckpointing(checkpoint.NewJSONManager(s.checkpointStore)), nil
+}
+
+func saveState(sess *agent.Session, state *providerState) {
+	if sess == nil || state == nil {
+		return
+	}
+	sess.Set(sessionStateKey, state)
+}

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -15,6 +15,7 @@ package workflowprovider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -31,14 +32,7 @@ import (
 
 var messagesSliceType = reflect.TypeFor[[]*message.Message]()
 
-const sessionStateKey = "workflowprovider_state"
-
-// providerServiceID marks sessions managed by this provider. Setting a
-// non-empty ServiceID on the session opts out of the agent package's
-// default history provider on subsequent calls. Explicitly configured
-// history providers still run. The workflow itself owns conversational
-// state across turns.
-const providerServiceID = "workflowprovider"
+const workflowErrorMessage = "An error occurred while executing the workflow."
 
 // Config configures a [workflow.Workflow] hosted as an [agent.Agent] via [New].
 type Config struct {
@@ -59,27 +53,6 @@ type Config struct {
 	// [workflow.ErrorEvent]s in the agent response stream. When false, a
 	// generic message is emitted instead.
 	IncludeErrorDetails bool
-}
-
-// pendingReq records a pending external request raised by the workflow so
-// that a matching response content in a subsequent agent run can be
-// translated back to a [workflow.ExternalResponse].
-type pendingReq struct {
-	portInfo          workflow.RequestPortInfo
-	externalRequestID string
-	requestContent    message.Content
-}
-
-// providerState holds the workflow run state that survives across multiple
-// [agent.Agent.Run] invocations on the same session. It is stored on the
-// [agent.Session] under [sessionStateKey].
-//
-// The streaming run is an in-memory object and is not portable across
-// process boundaries; sessions that are persisted via encoding/json retain the
-// request-tracking metadata but drop the live run.
-type providerState struct {
-	stream  *inproc.StreamingRun
-	pending map[string]pendingReq // keyed by request content ID (e.g. CallID/RequestID)
 }
 
 // New wraps a [*workflow.Workflow] as an [*agent.Agent].
@@ -125,23 +98,31 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 				yield(nil, err)
 				return
 			}
-			defer saveState(sess, state)
+			defer func() {
+				_ = state.closeStream(ctx)
+				saveState(sess, state)
+			}()
 
 			// Split incoming messages into ExternalResponses for pending
 			// requests and the remaining workflow messages.
-			remaining, responses, hasMatchedStartResponse := splitResponses(messages, state.pending, wf.StartExecutorID(), state.stream.ResponsePortExecutorID)
-
-			for _, resp := range responses {
-				if err := state.stream.SendResponse(ctx, resp); err != nil {
-					yield(nil, err)
-					return
-				}
+			remaining, responses, hasMatchedStartResponse, err := splitResponses(messages, state.pending, wf.StartExecutorID(), state.stream.ResponsePortExecutorID)
+			if err != nil {
+				yield(nil, err)
+				return
 			}
+
 			if len(remaining) > 0 {
 				if err := state.stream.SendMessage(ctx, remaining); err != nil {
 					yield(nil, err)
 					return
 				}
+			}
+			for _, matched := range responses {
+				if err := state.stream.SendResponse(ctx, matched.response); err != nil {
+					yield(nil, err)
+					return
+				}
+				delete(state.pending, matched.contentID)
 			}
 			// Suppress the TurnToken only when the only activity is a
 			// matched external response addressed to the start executor.
@@ -166,6 +147,13 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 					return
 				}
 				switch e := evt.(type) {
+				case workflow.SuperStepCompletedEvent:
+					if e.CompletionInfo != nil && e.CompletionInfo.CheckpointInfo != nil {
+						state.lastCheckpoint = e.CompletionInfo.CheckpointInfo
+					}
+					if !yield(newUpdate(responseID, e), nil) {
+						return
+					}
 				case workflow.OutputEvent:
 					switch out := e.Output.(type) {
 					case *agent.ResponseUpdate:
@@ -211,13 +199,12 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 						return
 					}
 				case workflow.ErrorEvent:
-					text := "an error occurred while executing the workflow"
-					if cfg.IncludeErrorDetails && e.Error != nil {
-						text = e.Error.Error()
+					update := newUpdate(responseID, e, workflowErrorContent(e.Error, cfg.IncludeErrorDetails))
+					if !yield(update, nil) {
+						return
 					}
-					update := newUpdate(responseID, e, &message.ErrorContent{
-						Message: text,
-					})
+				case workflow.ExecutorFailedEvent:
+					update := newUpdate(responseID, e, workflowErrorContent(e.Error, cfg.IncludeErrorDetails))
 					if !yield(update, nil) {
 						return
 					}
@@ -232,42 +219,25 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 
 	return agent.New(
 		agent.ProviderConfig{
-			ProviderName: "workflow",
-			Run:          runFn,
+			ProviderName:  "workflow",
+			Run:           runFn,
+			CreateSession: createSession,
 		},
 		cfg.Config,
 	), nil
 }
 
-// loadOrInitState fetches the per-session [providerState], creating a fresh
-// streaming workflow run on first use.
-func loadOrInitState(
-	ctx context.Context,
-	sess *agent.Session,
-	env *inproc.ExecutionEnvironment,
-	wf *workflow.Workflow,
-) (*providerState, error) {
-	if sess != nil {
-		var state *providerState
-		if ok, _ := sess.Get(sessionStateKey, &state); ok && state != nil && state.stream != nil {
-			if state.pending == nil {
-				state.pending = make(map[string]pendingReq)
-			}
-			return state, nil
-		}
+func createSession(_ context.Context, sess *agent.Session, _ ...agent.Option) error {
+	if sess != nil && sess.ServiceID() == "" {
+		sess.SetServiceID(providerServiceID)
 	}
-	stream, err := env.RunStreaming(ctx, wf, nil)
-	if err != nil {
-		return nil, err
-	}
-	return &providerState{stream: stream, pending: make(map[string]pendingReq)}, nil
+	saveState(sess, newProviderState())
+	return nil
 }
 
-func saveState(sess *agent.Session, state *providerState) {
-	if sess == nil || state == nil {
-		return
-	}
-	sess.Set(sessionStateKey, state)
+type matchedExternalResponse struct {
+	contentID string
+	response  *workflow.ExternalResponse
 }
 
 // splitResponses scans messages for response content matching pending
@@ -284,16 +254,17 @@ func saveState(sess *agent.Session, state *providerState) {
 // turn). Mirrors .NET's [WorkflowSession.HasMatchedResponseForStartExecutor].
 func splitResponses(
 	messages []*message.Message,
-	pending map[string]pendingReq,
+	pending map[string]*workflow.ExternalRequest,
 	startExecutorID string,
 	lookupPortOwner func(portID string) (string, bool),
-) ([]*message.Message, []*workflow.ExternalResponse, bool) {
+) ([]*message.Message, []matchedExternalResponse, bool, error) {
 	if len(messages) == 0 || len(pending) == 0 {
-		return messages, nil, false
+		return messages, nil, false, nil
 	}
 	var (
-		responses               []*workflow.ExternalResponse
+		responses               []matchedExternalResponse
 		hasMatchedStartResponse bool
+		matchedContentIDs       map[string]struct{}
 	)
 	out := make([]*message.Message, 0, len(messages))
 	for _, m := range messages {
@@ -303,17 +274,32 @@ func splitResponses(
 		var keep []message.Content
 		for _, c := range m.Contents {
 			if id, ok := responseContentID(c); ok {
-				if pr, found := pending[id]; found {
-					responseContent := normalizeResponseContent(c, pr.requestContent)
-					responses = append(responses, &workflow.ExternalResponse{
-						RequestID: pr.externalRequestID,
-						PortInfo:  pr.portInfo,
-						Data:      workflow.AnyPortableValue(responseContent),
+				if _, matched := matchedContentIDs[id]; matched {
+					continue
+				}
+				if request, found := pending[id]; found {
+					if request == nil {
+						return nil, nil, false, fmt.Errorf("workflowprovider: pending response %q has no external request", id)
+					}
+					responseData, err := normalizeResponseData(c, request)
+					if err != nil {
+						return nil, nil, false, err
+					}
+					response, err := request.CreateResponse(responseData)
+					if err != nil {
+						return nil, nil, false, err
+					}
+					responses = append(responses, matchedExternalResponse{
+						contentID: id,
+						response:  response,
 					})
-					if owner, ok := lookupPortOwner(pr.portInfo.PortID); ok && owner == startExecutorID {
+					if owner, ok := lookupPortOwner(request.PortInfo.PortID); ok && owner == startExecutorID {
 						hasMatchedStartResponse = true
 					}
-					delete(pending, id)
+					if matchedContentIDs == nil {
+						matchedContentIDs = make(map[string]struct{})
+					}
+					matchedContentIDs[id] = struct{}{}
 					continue
 				}
 			}
@@ -325,7 +311,7 @@ func splitResponses(
 			out = append(out, &cloned)
 		}
 	}
-	return out, responses, hasMatchedStartResponse
+	return out, responses, hasMatchedStartResponse, nil
 }
 
 // responseContentID returns the matching key for a content item if it is a
@@ -340,46 +326,113 @@ func responseContentID(c message.Content) (string, bool) {
 	return "", false
 }
 
-func normalizeResponseContent(response message.Content, originalRequest message.Content) message.Content {
+func normalizeResponseData(response message.Content, request *workflow.ExternalRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("workflowprovider: pending request has no external request")
+	}
+	originalRequest, _ := requestDataContent(request)
 	switch r := response.(type) {
 	case *message.FunctionResultContent:
 		if req, ok := originalRequest.(*message.FunctionCallContent); ok {
-			clone := *r
-			clone.CallID = req.CallID
-			return &clone
+			return cloneFunctionResultContent(r, req.CallID), nil
+		}
+		if !request.PortInfo.ResponseType.MatchPolymorphic(reflect.TypeFor[*message.FunctionResultContent]()) {
+			if r.Result == nil {
+				return nil, fmt.Errorf("workflowprovider: null result is not supported for request port %q with response type %v", request.PortInfo.PortID, request.PortInfo.ResponseType)
+			}
+			if request.PortInfo.ResponseType.MatchPolymorphic(reflect.TypeOf(r.Result)) || isPortableValueResult(r.Result) {
+				return r.Result, nil
+			}
+			return nil, fmt.Errorf("workflowprovider: unexpected result type in FunctionResultContent %T; expecting %v", r.Result, request.PortInfo.ResponseType)
 		}
 	case *message.ToolApprovalResponseContent:
 		if req, ok := originalRequest.(*message.ToolApprovalRequestContent); ok {
-			clone := *r
-			clone.RequestID = req.RequestID
-			return &clone
+			return cloneToolApprovalResponseContent(r, req.RequestID), nil
 		}
 	}
-	return response
+	return response, nil
+}
+
+func isPortableValueResult(result any) bool {
+	switch value := result.(type) {
+	case workflow.PortableValue:
+		return true
+	case *workflow.PortableValue:
+		return value != nil
+	default:
+		return false
+	}
 }
 
 // requestToUpdate translates an [*workflow.ExternalRequest] into a
 // [*agent.ResponseUpdate] that surfaces the request content to the caller.
 // The exposed content ID is rewritten to the workflow-facing external request
-// ID, while the original content is retained so the matching response can be
-// normalized before it is delivered back into the workflow.
-func requestToUpdate(req *workflow.ExternalRequest, responseID string, raw any) (*agent.ResponseUpdate, string, pendingReq, bool) {
+// ID. The original request payload stays on the persisted ExternalRequest and
+// is used to normalize the matching response before it is delivered back into
+// the workflow.
+func requestToUpdate(req *workflow.ExternalRequest, responseID string, raw any) (*agent.ResponseUpdate, string, *workflow.ExternalRequest, bool) {
 	if req == nil {
-		return nil, "", pendingReq{}, false
+		return nil, "", nil, false
 	}
-	c, ok := req.Data.Any().(message.Content)
+	c, ok := requestDataContent(req)
 	if !ok {
-		return nil, "", pendingReq{}, false
+		surfaced, err := requestToFunctionCall(req)
+		if err != nil {
+			return nil, "", nil, false
+		}
+		return newUpdate(responseID, raw, surfaced), surfaced.CallID, req, true
 	}
 	surfaced, id, ok := requestContentForDelivery(req.RequestID, c)
 	if !ok {
-		return nil, "", pendingReq{}, false
+		return nil, "", nil, false
 	}
-	return newUpdate(responseID, raw, surfaced), id, pendingReq{
-		portInfo:          req.PortInfo,
-		externalRequestID: req.RequestID,
-		requestContent:    c,
-	}, true
+	return newUpdate(responseID, raw, surfaced), id, req, true
+}
+
+func requestDataContent(req *workflow.ExternalRequest) (message.Content, bool) {
+	if req == nil {
+		return nil, false
+	}
+	if data, ok := req.Data.As(reflect.TypeFor[*message.FunctionCallContent]()); ok {
+		return data.(*message.FunctionCallContent), true
+	}
+	if data, ok := req.Data.As(reflect.TypeFor[*message.ToolApprovalRequestContent]()); ok {
+		return data.(*message.ToolApprovalRequestContent), true
+	}
+	content, ok := req.Data.Any().(message.Content)
+	return content, ok
+}
+
+func cloneFunctionResultContent(content *message.FunctionResultContent, callID string) *message.FunctionResultContent {
+	clone := *content
+	clone.CallID = callID
+	return &clone
+}
+
+func cloneToolApprovalResponseContent(content *message.ToolApprovalResponseContent, requestID string) *message.ToolApprovalResponseContent {
+	clone := *content
+	clone.RequestID = requestID
+	return &clone
+}
+
+func workflowErrorContent(err error, includeDetails bool) *message.ErrorContent {
+	text := workflowErrorMessage
+	if includeDetails && err != nil {
+		text = err.Error()
+	}
+	return &message.ErrorContent{Message: text}
+}
+
+func requestToFunctionCall(req *workflow.ExternalRequest) (*message.FunctionCallContent, error) {
+	arguments, err := json.Marshal(map[string]any{"data": req.Data})
+	if err != nil {
+		return nil, err
+	}
+	return &message.FunctionCallContent{
+		CallID:    req.RequestID,
+		Name:      req.PortInfo.PortID,
+		Arguments: string(arguments),
+	}, nil
 }
 
 // requestContentForDelivery clones a request content item with the

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -187,7 +187,14 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 						}
 					}
 				case workflow.RequestInfoEvent:
-					update, contentID, pending, ok := requestToUpdate(e.Request, responseID, e)
+					update, contentID, pending, ok, err := requestToUpdate(e.Request, responseID, e)
+					if err != nil {
+						update := newUpdate(responseID, e, workflowErrorContent(err, cfg.IncludeErrorDetails))
+						if !yield(update, nil) {
+							return
+						}
+						continue
+					}
 					if !ok {
 						if !yield(newUpdate(responseID, e), nil) {
 							return
@@ -370,23 +377,23 @@ func isPortableValueResult(result any) bool {
 // ID. The original request payload stays on the persisted ExternalRequest and
 // is used to normalize the matching response before it is delivered back into
 // the workflow.
-func requestToUpdate(req *workflow.ExternalRequest, responseID string, raw any) (*agent.ResponseUpdate, string, *workflow.ExternalRequest, bool) {
+func requestToUpdate(req *workflow.ExternalRequest, responseID string, raw any) (*agent.ResponseUpdate, string, *workflow.ExternalRequest, bool, error) {
 	if req == nil {
-		return nil, "", nil, false
+		return nil, "", nil, false, nil
 	}
 	c, ok := requestDataContent(req)
 	if !ok {
 		surfaced, err := requestToFunctionCall(req)
 		if err != nil {
-			return nil, "", nil, false
+			return nil, "", nil, false, fmt.Errorf("workflowprovider: failed to surface external request %q: %w", req.RequestID, err)
 		}
-		return newUpdate(responseID, raw, surfaced), surfaced.CallID, req, true
+		return newUpdate(responseID, raw, surfaced), surfaced.CallID, req, true, nil
 	}
 	surfaced, id, ok := requestContentForDelivery(req.RequestID, c)
 	if !ok {
-		return nil, "", nil, false
+		return nil, "", nil, false, nil
 	}
-	return newUpdate(responseID, raw, surfaced), id, req, true
+	return newUpdate(responseID, raw, surfaced), id, req, true, nil
 }
 
 func requestDataContent(req *workflow.ExternalRequest) (message.Content, bool) {

--- a/agent/provider/workflowprovider/workflow_test.go
+++ b/agent/provider/workflowprovider/workflow_test.go
@@ -194,6 +194,7 @@ func TestNew_SerializedSessionResumesFromCheckpoint(t *testing.T) {
 		t.Fatalf("final response text = %q, want %q", finalText, "got:42")
 	}
 }
+
 func TestNew_EmitsDefaultUpdatesForUnhandledWorkflowEvents(t *testing.T) {
 	binding := echoExecutorBinding("echo")
 	wf, err := workflow.NewBuilder(binding).Build()

--- a/agent/provider/workflowprovider/workflow_test.go
+++ b/agent/provider/workflowprovider/workflow_test.go
@@ -4,6 +4,7 @@ package workflowprovider_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"iter"
 	"reflect"
@@ -100,7 +101,7 @@ func TestNew_StreamsResponseUpdates(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	resp, err := ag.RunText(context.Background(), "ping").Collect()
+	resp, err := ag.RunText(t.Context(), "ping").Collect()
 	if err != nil {
 		t.Fatalf("RunText: %v", err)
 	}
@@ -119,6 +120,80 @@ func TestNew_StreamsResponseUpdates(t *testing.T) {
 	}
 }
 
+func TestNew_SerializedSessionResumesFromCheckpoint(t *testing.T) {
+	wf1 := newCallRequestWorkflow(t, "persisted")
+	ag1, err := workflowprovider.New(wf1, workflowprovider.Config{
+		IncludeOutputsInResponse: true,
+	})
+	if err != nil {
+		t.Fatalf("New first agent: %v", err)
+	}
+	session, err := ag1.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	first, err := ag1.RunText(t.Context(), "hi", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	var requestID string
+	for _, m := range first.Messages {
+		for _, c := range m.Contents {
+			if fc, ok := c.(*message.FunctionCallContent); ok {
+				requestID = fc.CallID
+			}
+		}
+	}
+	if requestID != "persisted_FunctionCall:abc" {
+		t.Fatalf("first run request ID = %q, want %q", requestID, "persisted_FunctionCall:abc")
+	}
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("Marshal session: %v", err)
+	}
+	if !strings.Contains(string(data), "checkpointStore") || !strings.Contains(string(data), "lastCheckpoint") {
+		t.Fatalf("serialized session did not include workflow checkpoint state: %s", string(data))
+	}
+	if !strings.Contains(string(data), "\"pending\"") || !strings.Contains(string(data), "\"RequestID\"") || !strings.Contains(string(data), "workflowSessionID") {
+		t.Fatalf("serialized session missing pending ExternalRequest/workflowSessionID: %s", string(data))
+	}
+	if strings.Contains(string(data), "\"requestContent\"") {
+		t.Fatalf("serialized session should store pending ExternalRequest directly without request content cache: %s", string(data))
+	}
+
+	var restored agent.Session
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("Unmarshal session: %v", err)
+	}
+	wf2 := newCallRequestWorkflow(t, "persisted")
+	ag2, err := workflowprovider.New(wf2, workflowprovider.Config{
+		IncludeOutputsInResponse: true,
+	})
+	if err != nil {
+		t.Fatalf("New restored agent: %v", err)
+	}
+	resumeMsg := []*message.Message{{
+		Role: message.RoleTool,
+		Contents: []message.Content{
+			&message.FunctionResultContent{CallID: requestID, Result: "42"},
+		},
+	}}
+	second, err := ag2.Run(t.Context(), resumeMsg, agent.WithSession(&restored)).Collect()
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	var finalText string
+	for _, m := range second.Messages {
+		if t := m.Contents.Text(); strings.HasPrefix(t, "got:") {
+			finalText = t
+		}
+	}
+	if finalText != "got:42" {
+		t.Fatalf("final response text = %q, want %q", finalText, "got:42")
+	}
+}
 func TestNew_EmitsDefaultUpdatesForUnhandledWorkflowEvents(t *testing.T) {
 	binding := echoExecutorBinding("echo")
 	wf, err := workflow.NewBuilder(binding).Build()
@@ -131,7 +206,7 @@ func TestNew_EmitsDefaultUpdatesForUnhandledWorkflowEvents(t *testing.T) {
 	}
 
 	var sawUnhandled bool
-	for update, err := range ag.RunText(context.Background(), "ping") {
+	for update, err := range ag.RunText(t.Context(), "ping") {
 		if err != nil {
 			t.Fatalf("RunText: %v", err)
 		}
@@ -166,7 +241,7 @@ func TestNew_StampsEverySurfacedUpdate(t *testing.T) {
 	}
 
 	updates := 0
-	for update, err := range ag.RunText(context.Background(), "ping") {
+	for update, err := range ag.RunText(t.Context(), "ping") {
 		if err != nil {
 			t.Fatalf("RunText: %v", err)
 		}
@@ -203,7 +278,7 @@ func TestNew_IncludeOutputsInResponse(t *testing.T) {
 	}
 
 	var updates int
-	for range ag.RunText(context.Background(), "ping") {
+	for range ag.RunText(t.Context(), "ping") {
 		updates++
 	}
 	// One update from *agent.ResponseUpdate output, one from message output translation.
@@ -258,7 +333,7 @@ func TestNew_ConvertsResponseOutputWithResponseMetadata(t *testing.T) {
 
 	var sawMessage bool
 	var sawMetadata bool
-	for update, err := range ag.RunText(context.Background(), "ping") {
+	for update, err := range ag.RunText(t.Context(), "ping") {
 		if err != nil {
 			t.Fatalf("RunText: %v", err)
 		}
@@ -376,7 +451,7 @@ func TestNew_ErrorContentOutputStreamedOut(t *testing.T) {
 				t.Fatalf("New: %v", err)
 			}
 
-			resp, err := ag.RunText(context.Background(), "hi").Collect()
+			resp, err := ag.RunText(t.Context(), "hi").Collect()
 			if err != nil {
 				t.Fatalf("RunText: %v", err)
 			}
@@ -419,14 +494,56 @@ func TestNew_ErrorEvent_DefaultMessage(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	resp, err := ag.RunText(context.Background(), "hi").Collect()
+	resp, err := ag.RunText(t.Context(), "hi").Collect()
 	if err != nil {
 		t.Fatalf("RunText: %v", err)
 	}
 
-	const want = "an error occurred while executing the workflow"
+	const want = "An error occurred while executing the workflow."
 	if !containsErrorContent(resp, want) {
 		t.Errorf("expected ErrorContent with %q, response = %+v", want, resp)
+	}
+}
+
+func TestNew_ExecutorFailedEvent_DefaultMessage(t *testing.T) {
+	binding := workflow.ExecutorBinding{
+		ID:           "executor-failed",
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: binding.ID,
+			Spec: newMessageSpec(&messageworkflow.Options{
+				StateKey: "executor_failed_msgs",
+				TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, _ []*message.Message) error {
+					return ctx.AddEvent(workflow.ExecutorFailedEvent{
+						ExecutorID: "secret-executor",
+						Error:      fmt.Errorf("secret failure details"),
+					})
+				},
+			}),
+		}, nil
+	}
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := ag.RunText(t.Context(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+
+	const want = "An error occurred while executing the workflow."
+	if !containsErrorContent(resp, want) {
+		t.Errorf("expected ErrorContent with %q, response = %+v", want, resp)
+	}
+	if containsErrorContent(resp, "secret failure details") || containsErrorContent(resp, "secret-executor") {
+		t.Errorf("default executor failure response exposed details: %+v", resp)
 	}
 }
 
@@ -441,7 +558,7 @@ func TestNew_ErrorEvent_IncludeDetails(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	resp, err := ag.RunText(context.Background(), "hi").Collect()
+	resp, err := ag.RunText(t.Context(), "hi").Collect()
 	if err != nil {
 		t.Fatalf("RunText: %v", err)
 	}
@@ -529,6 +646,18 @@ func callRequestExecutorBinding(t *testing.T, id string) workflow.ExecutorBindin
 	return binding
 }
 
+func newCallRequestWorkflow(t *testing.T, id string) *workflow.Workflow {
+	t.Helper()
+	binding := callRequestExecutorBinding(t, id)
+	wf, err := workflow.NewBuilder(binding).
+		WithOutputFrom(binding).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return wf
+}
+
 // TestNew_SurfacesRequestInfoAndAcceptsResponse verifies the multi-turn
 // external-request round trip:
 //
@@ -552,14 +681,13 @@ func TestNew_SurfacesRequestInfoAndAcceptsResponse(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	ctx := context.Background()
-	session, err := ag.CreateSession(ctx)
+	session, err := ag.CreateSession(t.Context())
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
 	// First turn.
-	first, err := ag.RunText(ctx, "hi", agent.WithSession(session)).Collect()
+	first, err := ag.RunText(t.Context(), "hi", agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("first run: %v", err)
 	}
@@ -585,7 +713,7 @@ func TestNew_SurfacesRequestInfoAndAcceptsResponse(t *testing.T) {
 			&message.FunctionResultContent{CallID: sawCall.CallID, Result: "42"},
 		},
 	}}
-	second, err := ag.Run(ctx, resumeMsg, agent.WithSession(session)).Collect()
+	second, err := ag.Run(t.Context(), resumeMsg, agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("second run: %v", err)
 	}
@@ -600,10 +728,106 @@ func TestNew_SurfacesRequestInfoAndAcceptsResponse(t *testing.T) {
 	}
 }
 
+func TestNew_ResponsePortInterfaceTypeIsValidatedPolymorphically(t *testing.T) {
+	const id = "poly-response"
+	port := workflow.RequestPort{
+		ID:       id + "_FunctionCall",
+		Request:  reflect.TypeFor[*message.FunctionCallContent](),
+		Response: reflect.TypeFor[message.Content](),
+	}
+	step := 0
+	binding := workflow.ExecutorBinding{
+		ID:           id,
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+		Ports:        []workflow.RequestPort{port},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		spec := newMessageSpec(&messageworkflow.Options{
+			StateKey: "poly_response_msgs",
+			TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, _ []*message.Message) error {
+				defer func() { step++ }()
+				if step == 0 {
+					call := &message.FunctionCallContent{CallID: "abc", Name: "do"}
+					req, err := workflow.NewExternalRequest(port.ID+":abc", port, call)
+					if err != nil {
+						return err
+					}
+					return ctx.PostRequest(req)
+				}
+				return nil
+			},
+		})
+		spec.Extend(workflow.ExecutorSpec{
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+					resp := msg.(*workflow.ExternalResponse)
+					data, ok := resp.Data.As(reflect.TypeFor[*message.FunctionResultContent]())
+					if !ok {
+						return nil, nil
+					}
+					result := data.(*message.FunctionResultContent)
+					out := &message.Message{
+						Role:     message.RoleAssistant,
+						Contents: []message.Content{&message.TextContent{Text: "poly:" + result.Result.(string)}},
+					}
+					return nil, ctx.YieldOutput(out)
+				})
+				return rb, nil
+			},
+		})
+		return &workflow.Executor{ID: id, Spec: spec}, nil
+	}
+	wf, err := workflow.NewBuilder(binding).WithOutputFrom(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{IncludeOutputsInResponse: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	session, err := ag.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	first, err := ag.RunText(t.Context(), "hi", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	var requestID string
+	for _, msg := range first.Messages {
+		for _, content := range msg.Contents {
+			if call, ok := content.(*message.FunctionCallContent); ok {
+				requestID = call.CallID
+			}
+		}
+	}
+	if requestID != "poly-response_FunctionCall:abc" {
+		t.Fatalf("request ID = %q, want %q", requestID, "poly-response_FunctionCall:abc")
+	}
+	second, err := ag.Run(t.Context(), []*message.Message{{
+		Role: message.RoleTool,
+		Contents: []message.Content{
+			&message.FunctionResultContent{CallID: requestID, Result: "42"},
+		},
+	}}, agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	var finalText string
+	for _, msg := range second.Messages {
+		if text := msg.Contents.Text(); strings.HasPrefix(text, "poly:") {
+			finalText = text
+		}
+	}
+	if finalText != "poly:42" {
+		t.Fatalf("final text = %q, want %q", finalText, "poly:42")
+	}
+}
+
 // approvalRequestExecutorBinding builds a workflow executor that, on its
-// first turn, posts a *FunctionApprovalRequestContent as an ExternalRequest
-// via a static port; on receipt of a *FunctionApprovalResponseContent it
-// yields a final text reflecting whether the call was approved.
+// first turn, posts a *ToolApprovalRequestContent as an ExternalRequest
+// via a static port; on receipt of a *ToolApprovalResponseContent it yields
+// a final text reflecting whether the call was approved.
 func approvalRequestExecutorBinding(t *testing.T, id string) workflow.ExecutorBinding {
 	t.Helper()
 	port := workflow.RequestPort{
@@ -644,7 +868,7 @@ func approvalRequestExecutorBinding(t *testing.T, id string) workflow.ExecutorBi
 					}
 					r := v.(*message.ToolApprovalResponseContent)
 					if r.RequestID != "req-1" {
-						t.Errorf("FunctionApprovalResponseContent.ID delivered to workflow = %q, want %q", r.RequestID, "req-1")
+						t.Errorf("ToolApprovalResponseContent.ID delivered to workflow = %q, want %q", r.RequestID, "req-1")
 					}
 					text := "denied"
 					if r.Approved {
@@ -681,7 +905,7 @@ func TestNew_RequestInfoContentUsesExternalRequestID(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	resp, err := ag.RunText(context.Background(), "hi").Collect()
+	resp, err := ag.RunText(t.Context(), "hi").Collect()
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -715,7 +939,7 @@ func TestNew_ApprovalRequestInfoContentUsesExternalRequestID(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	resp, err := ag.RunText(context.Background(), "hi").Collect()
+	resp, err := ag.RunText(t.Context(), "hi").Collect()
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -745,8 +969,8 @@ func TestNew_ApprovalRequestInfoContentUsesExternalRequestID(t *testing.T) {
 	}
 }
 
-// The workflow raises a FunctionApprovalRequestContent, the caller resumes with the
-// matching FunctionApprovalResponseContent, and the workflow yields a final
+// The workflow raises a ToolApprovalRequestContent, the caller resumes with the
+// matching ToolApprovalResponseContent, and the workflow yields a final
 // text reflecting the approval.
 func TestNew_ApprovalRoundtrip_ResponseIsProcessed(t *testing.T) {
 	binding := approvalRequestExecutorBinding(t, "approval")
@@ -761,13 +985,12 @@ func TestNew_ApprovalRoundtrip_ResponseIsProcessed(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	ctx := context.Background()
-	session, err := ag.CreateSession(ctx)
+	session, err := ag.CreateSession(t.Context())
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
-	first, err := ag.RunText(ctx, "hi", agent.WithSession(session)).Collect()
+	first, err := ag.RunText(t.Context(), "hi", agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("first: %v", err)
 	}
@@ -790,7 +1013,7 @@ func TestNew_ApprovalRoundtrip_ResponseIsProcessed(t *testing.T) {
 		Role:     message.RoleUser,
 		Contents: []message.Content{req.CreateResponse(true, "")},
 	}}
-	second, err := ag.Run(ctx, resumeMsg, agent.WithSession(session)).Collect()
+	second, err := ag.Run(t.Context(), resumeMsg, agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("second: %v", err)
 	}
@@ -885,13 +1108,12 @@ func TestNew_MixedResponseAndRegularMessage_BothProcessed(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	ctx := context.Background()
-	session, err := ag.CreateSession(ctx)
+	session, err := ag.CreateSession(t.Context())
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
-	first, err := ag.RunText(ctx, "kick", agent.WithSession(session)).Collect()
+	first, err := ag.RunText(t.Context(), "kick", agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("first: %v", err)
 	}
@@ -915,7 +1137,7 @@ func TestNew_MixedResponseAndRegularMessage_BothProcessed(t *testing.T) {
 			&message.TextContent{Text: "extra"},
 		},
 	}}
-	second, err := ag.Run(ctx, resumeMsg, agent.WithSession(session)).Collect()
+	second, err := ag.Run(t.Context(), resumeMsg, agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("second: %v", err)
 	}
@@ -938,6 +1160,236 @@ func TestNew_MixedResponseAndRegularMessage_BothProcessed(t *testing.T) {
 	}
 }
 
+func TestNew_MixedResponseDispatchesRegularMessageBeforeResponse(t *testing.T) {
+	id := "order"
+	port := workflow.RequestPort{
+		ID:       id + "_FunctionCall",
+		Request:  reflect.TypeFor[*message.FunctionCallContent](),
+		Response: reflect.TypeFor[*message.FunctionResultContent](),
+	}
+	var postedRequest bool
+	var sawRegularBeforeResponse bool
+	binding := workflow.ExecutorBinding{
+		ID:           id,
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+		Ports:        []workflow.RequestPort{port},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: id,
+			Spec: workflow.ExecutorSpec{
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					pb.YieldsOutputType(reflect.TypeFor[*message.Message]())
+					pb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(_ *workflow.Context, msg any) (any, error) {
+						if !postedRequest {
+							return nil, nil
+						}
+						for _, m := range msg.([]*message.Message) {
+							if m.Contents.Text() == "extra" {
+								sawRegularBeforeResponse = true
+							}
+						}
+						return nil, nil
+					})
+					pb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+						if postedRequest {
+							return nil, nil
+						}
+						postedRequest = true
+						call := &message.FunctionCallContent{CallID: "abc", Name: "do"}
+						req, err := workflow.NewExternalRequest(port.ID+":abc", port, call)
+						if err != nil {
+							return nil, err
+						}
+						return nil, ctx.PostRequest(req)
+					})
+					pb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+						resp := msg.(*workflow.ExternalResponse)
+						if _, ok := resp.Data.As(port.Response); !ok {
+							return nil, nil
+						}
+						text := "response-before-regular"
+						if sawRegularBeforeResponse {
+							text = "regular-before-response"
+						}
+						out := &message.Message{
+							Role:     message.RoleAssistant,
+							Contents: []message.Content{&message.TextContent{Text: text}},
+						}
+						return nil, ctx.YieldOutput(out)
+					})
+					return pb, nil
+				},
+			},
+		}, nil
+	}
+
+	wf, err := workflow.NewBuilder(binding).WithOutputFrom(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{IncludeOutputsInResponse: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	session, err := ag.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	first, err := ag.RunText(t.Context(), "kick", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	var requestID string
+	for _, m := range first.Messages {
+		for _, c := range m.Contents {
+			if fc, ok := c.(*message.FunctionCallContent); ok {
+				requestID = fc.CallID
+			}
+		}
+	}
+	if requestID != "order_FunctionCall:abc" {
+		t.Fatalf("first run request ID = %q, want %q", requestID, "order_FunctionCall:abc")
+	}
+
+	second, err := ag.Run(t.Context(), []*message.Message{{
+		Role: message.RoleUser,
+		Contents: []message.Content{
+			&message.TextContent{Text: "extra"},
+			&message.FunctionResultContent{CallID: requestID, Result: "42"},
+		},
+	}}, agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	var finalText string
+	for _, m := range second.Messages {
+		if text := m.Contents.Text(); text == "regular-before-response" || text == "response-before-regular" {
+			finalText = text
+		}
+	}
+	if finalText != "regular-before-response" {
+		t.Fatalf("dispatch order output = %q, want %q; response = %+v", finalText, "regular-before-response", second)
+	}
+}
+
+func TestNew_DuplicateMatchedResponseContentIsDropped(t *testing.T) {
+	id := "duplicate"
+	port := workflow.RequestPort{
+		ID:       id + "_FunctionCall",
+		Request:  reflect.TypeFor[*message.FunctionCallContent](),
+		Response: reflect.TypeFor[*message.FunctionResultContent](),
+	}
+	var postedRequest bool
+	var duplicateForwardedAsRegular bool
+	binding := workflow.ExecutorBinding{
+		ID:           id,
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+		Ports:        []workflow.RequestPort{port},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: id,
+			Spec: workflow.ExecutorSpec{
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					pb.YieldsOutputType(reflect.TypeFor[*message.Message]())
+					pb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(_ *workflow.Context, msg any) (any, error) {
+						if !postedRequest {
+							return nil, nil
+						}
+						for _, m := range msg.([]*message.Message) {
+							for _, c := range m.Contents {
+								if r, ok := c.(*message.FunctionResultContent); ok && r.CallID == "duplicate_FunctionCall:abc" {
+									duplicateForwardedAsRegular = true
+								}
+							}
+						}
+						return nil, nil
+					})
+					pb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+						if postedRequest {
+							return nil, nil
+						}
+						postedRequest = true
+						call := &message.FunctionCallContent{CallID: "abc", Name: "do"}
+						req, err := workflow.NewExternalRequest(port.ID+":abc", port, call)
+						if err != nil {
+							return nil, err
+						}
+						return nil, ctx.PostRequest(req)
+					})
+					pb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+						resp := msg.(*workflow.ExternalResponse)
+						if _, ok := resp.Data.As(port.Response); !ok {
+							return nil, nil
+						}
+						text := "duplicate-dropped"
+						if duplicateForwardedAsRegular {
+							text = "duplicate-forwarded"
+						}
+						out := &message.Message{
+							Role:     message.RoleAssistant,
+							Contents: []message.Content{&message.TextContent{Text: text}},
+						}
+						return nil, ctx.YieldOutput(out)
+					})
+					return pb, nil
+				},
+			},
+		}, nil
+	}
+
+	wf, err := workflow.NewBuilder(binding).WithOutputFrom(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{IncludeOutputsInResponse: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	session, err := ag.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	first, err := ag.RunText(t.Context(), "kick", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	var requestID string
+	for _, m := range first.Messages {
+		for _, c := range m.Contents {
+			if fc, ok := c.(*message.FunctionCallContent); ok {
+				requestID = fc.CallID
+			}
+		}
+	}
+	if requestID != "duplicate_FunctionCall:abc" {
+		t.Fatalf("first run request ID = %q, want %q", requestID, "duplicate_FunctionCall:abc")
+	}
+
+	second, err := ag.Run(t.Context(), []*message.Message{{
+		Role: message.RoleTool,
+		Contents: []message.Content{
+			&message.FunctionResultContent{CallID: requestID, Result: "42"},
+			&message.FunctionResultContent{CallID: requestID, Result: "42"},
+		},
+	}}, agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	var finalText string
+	for _, m := range second.Messages {
+		if text := m.Contents.Text(); text == "duplicate-dropped" || text == "duplicate-forwarded" {
+			finalText = text
+		}
+	}
+	if finalText != "duplicate-dropped" {
+		t.Fatalf("duplicate handling output = %q, want %q; response = %+v", finalText, "duplicate-dropped", second)
+	}
+}
+
 // requestEmittingAgent always emits the same FunctionCallContent, regardless
 // of the messages it receives. Mirrors .NET's
 // `RequestEmittingAgent(completeOnResponse: false)`.
@@ -956,6 +1408,199 @@ func requestEmittingAgent(callID, name string) *agent.Agent {
 		agent.ProviderConfig{ProviderName: "request-emitting", Run: run},
 		agent.Config{ID: "rep-id", Name: "rep-name", DisableFuncAutoCall: true},
 	)
+}
+
+func requestCompletingAgent(callID, name string) *agent.Agent {
+	run := func(_ context.Context, messages []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			if containsFunctionResult(messages) {
+				yield(&agent.ResponseUpdate{
+					Role:     message.RoleAssistant,
+					Contents: []message.Content{&message.TextContent{Text: "Request processed"}},
+				}, nil)
+				return
+			}
+			yield(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.FunctionCallContent{CallID: callID, Name: name},
+				},
+			}, nil)
+		}
+	}
+	return agent.New(
+		agent.ProviderConfig{ProviderName: "request-completing", Run: run},
+		agent.Config{ID: "complete-id", Name: "complete-name", DisableFuncAutoCall: true},
+	)
+}
+
+func containsFunctionResult(messages []*message.Message) bool {
+	for _, msg := range messages {
+		for _, content := range msg.Contents {
+			if _, ok := content.(*message.FunctionResultContent); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func kickoffOnStartExecutorBinding(id, downstreamExecutorID, kickoffInputText, kickoffMessageText, regularResumeText, regularProcessedText string) workflow.ExecutorBinding {
+	binding := workflow.ExecutorBinding{
+		ID:           id,
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+		RawValue:     struct{}{},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		spec := newMessageSpec(&messageworkflow.Options{
+			StateKey:                 id + "_msgs",
+			DisableAutoSendTurnToken: true,
+			TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, messages []*message.Message) error {
+				if containsTextContent(messages, kickoffInputText) {
+					kickoff := []*message.Message{{
+						Role:     message.RoleUser,
+						Contents: []message.Content{&message.TextContent{Text: kickoffMessageText}},
+					}}
+					if err := ctx.SendMessage(downstreamExecutorID, kickoff); err != nil {
+						return err
+					}
+					if err := ctx.SendMessage(downstreamExecutorID, turnTokenWithEvents()); err != nil {
+						return err
+					}
+				}
+				if containsTextContent(messages, regularResumeText) {
+					return emitTextUpdate(ctx, id, regularProcessedText)
+				}
+				return nil
+			},
+		})
+		spec.Extend(sendMessagesAndTurnTokensSpec())
+		return &workflow.Executor{ID: id, Spec: spec}, nil
+	}
+	return binding
+}
+
+func turnTrackingStartExecutorBinding(id, downstreamExecutorID, activatedMarker string) workflow.ExecutorBinding {
+	binding := workflow.ExecutorBinding{
+		ID:           id,
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+		RawValue:     struct{}{},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		spec := newMessageSpec(&messageworkflow.Options{
+			StateKey:                 id + "_msgs",
+			DisableAutoSendTurnToken: true,
+			TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, messages []*message.Message) error {
+				if hasUserMessage(messages) {
+					if err := ctx.SendMessage(downstreamExecutorID, messages); err != nil {
+						return err
+					}
+					if err := ctx.SendMessage(downstreamExecutorID, turnTokenWithEvents()); err != nil {
+						return err
+					}
+				}
+				return emitTextUpdate(ctx, id, activatedMarker)
+			},
+		})
+		spec.Extend(sendMessagesAndTurnTokensSpec())
+		return &workflow.Executor{ID: id, Spec: spec}, nil
+	}
+	return binding
+}
+
+func sendMessagesAndTurnTokensSpec() workflow.ExecutorSpec {
+	return workflow.ExecutorSpec{
+		ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+			return pb.SendsMessageType(
+				reflect.TypeFor[[]*message.Message](),
+				reflect.TypeFor[workflow.TurnToken](),
+			), nil
+		},
+	}
+}
+
+func containsTextContent(messages []*message.Message, text string) bool {
+	for _, msg := range messages {
+		for _, content := range msg.Contents {
+			if textContent, ok := content.(*message.TextContent); ok && textContent.Text == text {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasUserMessage(messages []*message.Message) bool {
+	for _, msg := range messages {
+		if msg.Role == message.RoleUser {
+			return true
+		}
+	}
+	return false
+}
+
+func turnTokenWithEvents() workflow.TurnToken {
+	emitEvents := true
+	return workflow.TurnToken{EmitEvents: &emitEvents}
+}
+
+func emitTextUpdate(ctx *workflow.Context, executorID, text string) error {
+	return ctx.AddEvent(workflow.OutputEvent{
+		ExecutorID: executorID,
+		Output: &agent.ResponseUpdate{
+			Role:     message.RoleAssistant,
+			Contents: []message.Content{&message.TextContent{Text: text}},
+		},
+	})
+}
+
+func addCrossExecutorEdges(builder *workflow.Builder, startBinding, downstreamBinding workflow.ExecutorBinding) *workflow.Builder {
+	return builder.
+		AddDirectEdge(startBinding, downstreamBinding, false, func(value any) bool {
+			_, ok := value.([]*message.Message)
+			return ok
+		}).
+		AddDirectEdge(startBinding, downstreamBinding, false, func(value any) bool {
+			_, ok := value.(workflow.TurnToken)
+			return ok
+		})
+}
+
+func requireWorkflowFunctionCallID(t *testing.T, response *agent.Response) string {
+	t.Helper()
+	for _, msg := range response.Messages {
+		for _, content := range msg.Contents {
+			if call, ok := content.(*message.FunctionCallContent); ok && strings.Contains(call.CallID, "_FunctionCall:") {
+				return call.CallID
+			}
+		}
+	}
+	t.Fatalf("expected workflow-facing FunctionCallContent in response, got %+v", response)
+	return ""
+}
+
+func responseTexts(response *agent.Response) []string {
+	var texts []string
+	for _, msg := range response.Messages {
+		for _, content := range msg.Contents {
+			if textContent, ok := content.(*message.TextContent); ok {
+				texts = append(texts, textContent.Text)
+			}
+		}
+	}
+	return texts
+}
+
+func responseErrorMessages(response *agent.Response) []string {
+	var messages []string
+	for _, msg := range response.Messages {
+		for _, content := range msg.Contents {
+			if errorContent, ok := content.(*message.ErrorContent); ok {
+				messages = append(messages, errorContent.Message)
+			}
+		}
+	}
+	return messages
 }
 
 // TestNew_MatchingResponse_DoesNotCauseExtraTurn mirrors .NET's
@@ -980,13 +1625,12 @@ func TestNew_MatchingResponse_DoesNotCauseExtraTurn(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	ctx := context.Background()
-	session, err := ag.CreateSession(ctx)
+	session, err := ag.CreateSession(t.Context())
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
-	first, err := ag.RunText(ctx, "Start", agent.WithSession(session)).Collect()
+	first, err := ag.RunText(t.Context(), "Start", agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("first: %v", err)
 	}
@@ -1014,7 +1658,7 @@ func TestNew_MatchingResponse_DoesNotCauseExtraTurn(t *testing.T) {
 			&message.FunctionResultContent{CallID: emitted.CallID, Result: "tool output"},
 		},
 	}}
-	second, err := ag.Run(ctx, resumeMsg, agent.WithSession(session)).Collect()
+	second, err := ag.Run(t.Context(), resumeMsg, agent.WithSession(session)).Collect()
 	if err != nil {
 		t.Fatalf("second: %v", err)
 	}
@@ -1032,5 +1676,170 @@ func TestNew_MatchingResponse_DoesNotCauseExtraTurn(t *testing.T) {
 	// TurnToken-driven turn would double the second-turn count.
 	if secondCount != firstCount {
 		t.Errorf("FunctionCallContent count: first=%d, second=%d (extra TurnToken-driven turn detected)", firstCount, secondCount)
+	}
+}
+
+func TestNew_UnmatchedResponse_TriggersTurnAndKeepsProgressing(t *testing.T) {
+	host := workflowhosting.New(
+		requestEmittingAgent("unmatched-response-call-id", "unmatchedResponseFunction"),
+		workflowhosting.Config{EmitUpdateEvents: true},
+	)
+	wf, err := workflow.NewBuilder(host).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	session, err := ag.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	first, err := ag.RunText(t.Context(), "Start", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	_ = requireWorkflowFunctionCallID(t, first)
+
+	second, err := ag.Run(t.Context(), []*message.Message{{
+		Role: message.RoleTool,
+		Contents: []message.Content{
+			&message.FunctionResultContent{CallID: "different-call-id", Result: "tool output"},
+		},
+	}}, agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	functionCallCount := 0
+	for _, msg := range second.Messages {
+		for _, content := range msg.Contents {
+			if call, ok := content.(*message.FunctionCallContent); ok && call.CallID == "unmatched-response-call-id" {
+				functionCallCount++
+			}
+		}
+	}
+	if functionCallCount != 1 {
+		t.Fatalf("FunctionCallContent count = %d, want 1; response = %+v", functionCallCount, second)
+	}
+	if errors := responseErrorMessages(second); len(errors) != 0 {
+		t.Fatalf("unexpected ErrorContent messages: %v", errors)
+	}
+}
+
+func TestNew_MixedResponseAndRegularMessage_CrossExecutorStartExecutorIsReawakened(t *testing.T) {
+	const (
+		startExecutorID    = "start-executor"
+		kickoffInputText   = "Start"
+		kickoffMessageText = "kickoff downstream"
+		resumeRegularText  = "resume regular"
+		resumeProcessed    = "regular message processed"
+	)
+	downstream := workflowhosting.New(
+		requestCompletingAgent("cross-executor-call-id", "crossExecutorFunction"),
+		workflowhosting.Config{EmitUpdateEvents: true},
+	)
+	start := kickoffOnStartExecutorBinding(
+		startExecutorID,
+		downstream.ID,
+		kickoffInputText,
+		kickoffMessageText,
+		resumeRegularText,
+		resumeProcessed,
+	)
+	wf, err := addCrossExecutorEdges(workflow.NewBuilder(start), start, downstream).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	session, err := ag.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	first, err := ag.RunText(t.Context(), kickoffInputText, agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	requestID := requireWorkflowFunctionCallID(t, first)
+
+	second, err := ag.Run(t.Context(), []*message.Message{
+		{
+			Role: message.RoleTool,
+			Contents: []message.Content{
+				&message.FunctionResultContent{CallID: requestID, Result: "tool output"},
+			},
+		},
+		{
+			Role:     message.RoleUser,
+			Contents: []message.Content{&message.TextContent{Text: resumeRegularText}},
+		},
+	}, agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	texts := strings.Join(responseTexts(second), "\n")
+	if !strings.Contains(texts, resumeProcessed) {
+		t.Fatalf("second response text = %q, want %q", texts, resumeProcessed)
+	}
+	if !strings.Contains(texts, "Request processed") {
+		t.Fatalf("second response text = %q, want Request processed", texts)
+	}
+	if errors := responseErrorMessages(second); len(errors) != 0 {
+		t.Fatalf("unexpected ErrorContent messages: %v", errors)
+	}
+}
+
+func TestNew_ResponseOnlyToNonStartExecutor_StartExecutorIsStillActivated(t *testing.T) {
+	const (
+		startExecutorID = "start-executor"
+		activatedMarker = "start-executor-activated"
+	)
+	downstream := workflowhosting.New(
+		requestCompletingAgent("response-only-call-id", "responseOnlyFunction"),
+		workflowhosting.Config{EmitUpdateEvents: true},
+	)
+	start := turnTrackingStartExecutorBinding(startExecutorID, downstream.ID, activatedMarker)
+	wf, err := addCrossExecutorEdges(workflow.NewBuilder(start), start, downstream).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	session, err := ag.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	first, err := ag.RunText(t.Context(), "Start", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	requestID := requireWorkflowFunctionCallID(t, first)
+
+	second, err := ag.Run(t.Context(), []*message.Message{{
+		Role: message.RoleTool,
+		Contents: []message.Content{
+			&message.FunctionResultContent{CallID: requestID, Result: "tool output"},
+		},
+	}}, agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	texts := strings.Join(responseTexts(second), "\n")
+	if !strings.Contains(texts, "Request processed") {
+		t.Fatalf("second response text = %q, want Request processed", texts)
+	}
+	if !strings.Contains(texts, activatedMarker) {
+		t.Fatalf("second response text = %q, want %q", texts, activatedMarker)
+	}
+	if errors := responseErrorMessages(second); len(errors) != 0 {
+		t.Fatalf("unexpected ErrorContent messages: %v", errors)
 	}
 }

--- a/agent/provider/workflowprovider/workflow_test.go
+++ b/agent/provider/workflowprovider/workflow_test.go
@@ -728,6 +728,55 @@ func TestNew_SurfacesRequestInfoAndAcceptsResponse(t *testing.T) {
 	}
 }
 
+func TestNew_RequestInfoFallbackMarshalErrorIsObservable(t *testing.T) {
+	const id = "bad-request"
+	port := workflow.RequestPort{
+		ID:       id + "_Any",
+		Request:  reflect.TypeFor[any](),
+		Response: reflect.TypeFor[string](),
+	}
+	binding := workflow.ExecutorBinding{
+		ID:           id,
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+		Ports:        []workflow.RequestPort{port},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: id,
+			Spec: newMessageSpec(&messageworkflow.Options{
+				StateKey: "bad_request_msgs",
+				TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, _ []*message.Message) error {
+					req, err := workflow.NewExternalRequest(port.ID+":chan", port, make(chan int))
+					if err != nil {
+						return err
+					}
+					return ctx.PostRequest(req)
+				},
+			}),
+		}, nil
+	}
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{IncludeErrorDetails: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := ag.RunText(t.Context(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+
+	if !containsErrorContent(resp, "failed to surface external request") {
+		t.Fatalf("expected request surfacing error in response, got %+v", resp)
+	}
+	if !containsErrorContent(resp, "unsupported type: chan int") {
+		t.Fatalf("expected JSON marshal error details in response, got %+v", resp)
+	}
+}
+
 func TestNew_ResponsePortInterfaceTypeIsValidatedPolymorphically(t *testing.T) {
 	const id = "poly-response"
 	port := workflow.RequestPort{

--- a/examples/03-workflows/checkpoint/checkpoint_and_rehydrate/main.go
+++ b/examples/03-workflows/checkpoint/checkpoint_and_rehydrate/main.go
@@ -150,7 +150,7 @@ func main() {
 	}
 
 	// Deliver the approval response to the rehydrated run.
-	response, err := request.NewResponse("approved-after-rehydration")
+	response, err := request.CreateResponse("approved-after-rehydration")
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/03-workflows/checkpoint/checkpoint_and_resume/main.go
+++ b/examples/03-workflows/checkpoint/checkpoint_and_resume/main.go
@@ -62,7 +62,7 @@ func main() {
 	}
 	demo.Assistantf("Resumed from checkpoint %s", checkpointInfo.CheckpointID)
 
-	response, err := request.NewResponse("approved")
+	response, err := request.CreateResponse("approved")
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/03-workflows/human-in-the-loop/human_in_the_loop_basic/main.go
+++ b/examples/03-workflows/human-in-the-loop/human_in_the_loop_basic/main.go
@@ -54,7 +54,7 @@ func main() {
 		demo.Panic("expected approval request")
 	}
 
-	response, err := request.NewResponse(true)
+	response, err := request.CreateResponse(true)
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -344,28 +344,28 @@ func (wb *Builder) edgeIdx() int {
 // send type annotations), the edge is silently skipped.
 func (wb *Builder) validateTypeCompatibility() error {
 	type protocolInfo struct {
-		protocol *ProtocolDescriptor
+		protocol ProtocolDescriptor
 		ok       bool
 	}
 	cache := make(map[string]protocolInfo, len(wb.executorsBindings))
-	getProtocol := func(id string) (*ProtocolDescriptor, bool) {
+	getProtocol := func(id string) (ProtocolDescriptor, bool) {
 		if info, cached := cache[id]; cached {
 			return info.protocol, info.ok
 		}
 		binding, exists := wb.executorsBindings[id]
 		if !exists || binding.isPlaceholder() {
 			cache[id] = protocolInfo{}
-			return nil, false
+			return ProtocolDescriptor{}, false
 		}
 		ex, err := binding.CreateInstance("")
 		if err != nil {
 			cache[id] = protocolInfo{}
-			return nil, false
+			return ProtocolDescriptor{}, false
 		}
 		protocol, err := ex.describeProtocol()
 		if err != nil {
 			cache[id] = protocolInfo{}
-			return nil, false
+			return ProtocolDescriptor{}, false
 		}
 		cache[id] = protocolInfo{protocol: protocol, ok: true}
 		return protocol, true
@@ -399,7 +399,7 @@ func (wb *Builder) validateTypeCompatibility() error {
 				compatible := false
 				for _, outType := range sourceSendTypes {
 					for _, inType := range targetInputTypes {
-						if outType == inType || outType.AssignableTo(inType) || (inType.Kind() == reflect.Interface && outType.Implements(inType)) {
+						if sendTypeCompatibleWithInput(outType, inType) {
 							compatible = true
 							break
 						}
@@ -418,6 +418,16 @@ func (wb *Builder) validateTypeCompatibility() error {
 		}
 	}
 	return nil
+}
+
+func sendTypeCompatibleWithInput(outType, inType reflect.Type) bool {
+	if outType == nil || inType == nil {
+		return false
+	}
+	if outType == reflect.TypeFor[any]() {
+		return true
+	}
+	return outType == inType || outType.AssignableTo(inType) || (inType.Kind() == reflect.Interface && outType.Implements(inType))
 }
 
 func (wb *Builder) trackInputPort(port RequestPort) {

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -185,9 +185,6 @@ type Executor struct {
 	routerMu       sync.Mutex
 	cachedProtocol *executorProtocol
 	protocolErr    error
-
-	declaredSendTypeCache sync.Map // reflect.Type -> reflect.Type
-	canOutputCache        sync.Map // reflect.Type -> bool
 }
 
 func (e *Executor) Initialize(ctx *Context) error {
@@ -336,115 +333,20 @@ func (e *Executor) Execute(ctx *Context, message any) (result any, err error) {
 	return ret.Result, nil
 }
 
-func (e *Executor) InputTypes() []reflect.Type {
-	router, err := e.router()
-	if err != nil {
-		return nil
-	}
-	return router.incomingTypes()
-}
-
-func (e *Executor) OutputTypes() []reflect.Type {
+func (e *Executor) describeProtocol() (ProtocolDescriptor, error) {
 	protocol, err := e.protocol()
 	if err != nil {
-		return nil
-	}
-	return appendUniqueTypes(nil, protocol.yields...)
-}
-
-// knownSentTypes are workflow system messages that every executor may send.
-// They mirror .NET's MessageTypeTranslator.KnownSentTypes so executors can
-// forward request-port control messages without declaring them as user protocol.
-func knownSentTypes() []reflect.Type {
-	return []reflect.Type{
-		reflect.TypeFor[*ExternalRequest](),
-		reflect.TypeFor[*ExternalResponse](),
-	}
-}
-
-// DeclaredSendType returns the protocol type that should be used when sending
-// a message of typ from this executor. It reports false when typ is not allowed
-// by the executor's declared send protocol. Interface send declarations match
-// only that exact interface type, except any, which accepts every non-nil type.
-func (e *Executor) DeclaredSendType(typ reflect.Type) (reflect.Type, bool) {
-	if typ == nil {
-		return nil, false
-	}
-	if cached, ok := e.declaredSendTypeCache.Load(typ); ok {
-		return cached.(reflect.Type), true
-	}
-	protocol, err := e.protocol()
-	if err != nil {
-		return nil, false
-	}
-	declaredType, ok := protocol.declaredSendType(typ)
-	if ok {
-		e.declaredSendTypeCache.Store(typ, declaredType)
-		return declaredType, true
-	}
-	return nil, false
-}
-
-func declaredSendTypeMatches(typ reflect.Type, candidate reflect.Type) bool {
-	if typ == nil || candidate == nil {
-		return false
-	}
-	if typ == candidate || candidate == reflect.TypeFor[any]() {
-		return true
-	}
-	return candidate.Kind() != reflect.Interface && typ.AssignableTo(candidate)
-}
-
-// CanSendType reports whether this executor can send messages of typ according
-// to its declared send protocol.
-func (e *Executor) CanSendType(typ reflect.Type) bool {
-	_, ok := e.DeclaredSendType(typ)
-	return ok
-}
-
-func (e *Executor) describeProtocol() (*ProtocolDescriptor, error) {
-	protocol, err := e.protocol()
-	if err != nil {
-		return nil, err
+		return ProtocolDescriptor{}, err
 	}
 	return protocol.describe(), nil
 }
 
-func (e *Executor) DescribeProtocol() *ProtocolDescriptor {
+func (e *Executor) DescribeProtocol() ProtocolDescriptor {
 	protocol, err := e.describeProtocol()
 	if err != nil {
-		return &ProtocolDescriptor{}
+		return ProtocolDescriptor{}
 	}
 	return protocol
-}
-
-func (e *Executor) CanHandleTypeID(typ TypeID) bool {
-	protocol, err := e.protocol()
-	if err != nil {
-		return false
-	}
-	return protocol.canHandleTypeID(typ)
-}
-
-func (e *Executor) CanHandleType(typ reflect.Type) bool {
-	protocol, err := e.protocol()
-	if err != nil {
-		return false
-	}
-	return protocol.canHandleType(typ)
-}
-
-func (e *Executor) CanOutputType(typ reflect.Type) bool {
-	if cached, ok := e.canOutputCache.Load(typ); ok {
-		return cached.(bool)
-	}
-	protocol, err := e.protocol()
-	if err != nil {
-		return false
-	}
-	result := protocol.canOutputType(typ)
-	e.canOutputCache.Store(typ, result)
-	return result
 }
 
 // StatefulExecutorCache helps an executor read, update, and cache typed state.

--- a/workflow/executor_test.go
+++ b/workflow/executor_test.go
@@ -236,51 +236,12 @@ func TestExecutorDescribeProtocol_IncludesExplicitSendAndYieldTypes(t *testing.T
 	}
 }
 
-func TestExecutorDeclaredSendType_IncludesKnownSystemSendTypes(t *testing.T) {
-	executor := executorWithSendTypes()
-	systemTypes := []reflect.Type{
-		reflect.TypeFor[*workflow.ExternalRequest](),
-		reflect.TypeFor[*workflow.ExternalResponse](),
-	}
+func TestExecutorDescribeProtocol_ValueReturnIsAllocFreeAfterBuild(t *testing.T) {
+	executor := executorWithSendTypes(reflect.TypeFor[protocolSent]())
+	_ = executor.DescribeProtocol()
 
-	for _, systemType := range systemTypes {
-		if got, ok := executor.DeclaredSendType(systemType); !ok || got != systemType {
-			t.Fatalf("DeclaredSendType(%v) = %v, %v; want %v, true", systemType, got, ok, systemType)
-		}
-		if !executor.CanSendType(systemType) {
-			t.Fatalf("CanSendType(%v) = false, want true", systemType)
-		}
-	}
-
-	protocol := executor.DescribeProtocol()
-	for _, systemType := range systemTypes {
-		if hasReflectType(protocol.Sends, systemType) {
-			t.Fatalf("Sends = %v, want no implicit system send type %v", protocol.Sends, systemType)
-		}
-	}
-}
-
-func TestExecutorDeclaredSendType_TightensInterfaceMatching(t *testing.T) {
-	concreteType := reflect.TypeFor[protocolSendConcrete]()
-	interfaceType := reflect.TypeFor[protocolSendInterface]()
-	anyType := reflect.TypeFor[any]()
-
-	exactExecutor := executorWithSendTypes(concreteType)
-	if got, ok := exactExecutor.DeclaredSendType(concreteType); !ok || got != concreteType {
-		t.Fatalf("DeclaredSendType(concrete) = %v, %v; want %v, true", got, ok, concreteType)
-	}
-
-	interfaceExecutor := executorWithSendTypes(interfaceType)
-	if got, ok := interfaceExecutor.DeclaredSendType(concreteType); ok {
-		t.Fatalf("DeclaredSendType(concrete with interface declaration) = %v, true; want false", got)
-	}
-	if got, ok := interfaceExecutor.DeclaredSendType(interfaceType); !ok || got != interfaceType {
-		t.Fatalf("DeclaredSendType(interface) = %v, %v; want %v, true", got, ok, interfaceType)
-	}
-
-	anyExecutor := executorWithSendTypes(anyType)
-	if got, ok := anyExecutor.DeclaredSendType(concreteType); !ok || got != anyType {
-		t.Fatalf("DeclaredSendType(concrete with any declaration) = %v, %v; want %v, true", got, ok, anyType)
+	if allocations := testing.AllocsPerRun(1000, func() { _ = executor.DescribeProtocol() }); allocations != 0 {
+		t.Fatalf("DescribeProtocol allocations = %v, want 0", allocations)
 	}
 }
 
@@ -290,14 +251,6 @@ type (
 	protocolSent           struct{}
 	protocolYielded        struct{}
 )
-
-type protocolSendInterface interface {
-	ProtocolSendMarker()
-}
-
-type protocolSendConcrete struct{}
-
-func (protocolSendConcrete) ProtocolSendMarker() {}
 
 func executorWithSendTypes(sendTypes ...reflect.Type) *workflow.Executor {
 	return &workflow.Executor{

--- a/workflow/inproc/binding_test.go
+++ b/workflow/inproc/binding_test.go
@@ -176,6 +176,27 @@ func TestWorkflowOutput_ExplicitYieldTypesValidateContextYieldOutput(t *testing.
 	}
 }
 
+func TestWorkflowOutput_ExplicitYieldTypeAllowsPointerToDeclaredValueType(t *testing.T) {
+	binding := explicitYieldBinding("yield", &dataMessage{Bytes: []byte("ok")})
+	wf, err := workflow.NewBuilder(binding).WithOutputFrom(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	events := runAndCollectEvents(t, wf, "input")
+	if errors := errorEvents(events); len(errors) != 0 {
+		t.Fatalf("unexpected error events: %#v", errors)
+	}
+	outputs := outputEvents(events)
+	if len(outputs) != 1 {
+		t.Fatalf("output count = %d, want 1; events: %#v", len(outputs), events)
+	}
+	got, ok := outputs[0].Output.(*dataMessage)
+	if !ok || string(got.Bytes) != "ok" {
+		t.Fatalf("OutputEvent.Output = %#v, want *dataMessage ok", outputs[0].Output)
+	}
+}
+
 type polymorphicOutput interface {
 	OutputName() string
 }
@@ -527,9 +548,9 @@ func TestBindRequestPort_PostsRequestAndForwardsResponse(t *testing.T) {
 		t.Errorf("request data = %v, want %q", req.Data.Any(), "what")
 	}
 
-	resp, err := req.NewResponse(int(42))
+	resp, err := req.CreateResponse(int(42))
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if _, err := run.Resume(ctx, resp); err != nil {
 		t.Fatalf("Resume: %v", err)
@@ -682,9 +703,9 @@ func TestBindRequestPort_ForwardsExternalRequestAndRestoresOriginalResponse(t *t
 		t.Fatalf("forwarded request ID = %q, want original-request", request.RequestID)
 	}
 
-	response, err := request.NewResponse(42)
+	response, err := request.CreateResponse(42)
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if _, err := run.Resume(ctx, response); err != nil {
 		t.Fatalf("Resume: %v", err)

--- a/workflow/inproc/checkpoint_test.go
+++ b/workflow/inproc/checkpoint_test.go
@@ -203,9 +203,9 @@ func TestCheckpoint_ResumeRespondToPendingRequest_CompletesWithoutDuplicate(t *t
 				t.Fatalf("status before response = %v, want PendingRequests", status)
 			}
 
-			response, err := pendingRequest.NewResponse("World")
+			response, err := pendingRequest.CreateResponse("World")
 			if err != nil {
-				t.Fatalf("NewResponse: %v", err)
+				t.Fatalf("CreateResponse: %v", err)
 			}
 			if _, err := resumed.Resume(ctx, response); err != nil {
 				t.Fatalf("Resume with response: %v", err)
@@ -248,9 +248,9 @@ func TestCheckpoint_RestoreWithPendingRequests_RepublishesRequestInfoEvents(t *t
 				t.Fatal("expected checkpoint")
 			}
 
-			response, err := pendingRequest.NewResponse("World")
+			response, err := pendingRequest.CreateResponse("World")
 			if err != nil {
-				t.Fatalf("NewResponse: %v", err)
+				t.Fatalf("CreateResponse: %v", err)
 			}
 			if _, err := run.Resume(ctx, response); err != nil {
 				t.Fatalf("Resume with first response: %v", err)
@@ -270,9 +270,9 @@ func TestCheckpoint_RestoreWithPendingRequests_RepublishesRequestInfoEvents(t *t
 				t.Fatalf("replayed request ID = %q, want %q", replayedRequests[0].RequestID, pendingRequest.RequestID)
 			}
 
-			response, err = replayedRequests[0].NewResponse("Again")
+			response, err = replayedRequests[0].CreateResponse("Again")
 			if err != nil {
-				t.Fatalf("NewResponse after restore: %v", err)
+				t.Fatalf("CreateResponse after restore: %v", err)
 			}
 			if _, err := run.Resume(ctx, response); err != nil {
 				t.Fatalf("Resume with restored response: %v", err)
@@ -306,9 +306,9 @@ func TestCheckpoint_RestoreClearsQueuedExternalResponsesBeforeImport(t *testing.
 	}
 	pendingRequest, checkpointInfo := capturePendingRequestAndCheckpointFromStream(t, ctx, stream)
 
-	response, err := pendingRequest.NewResponse("World")
+	response, err := pendingRequest.CreateResponse("World")
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if err := stream.SendResponse(ctx, response); err != nil {
 		t.Fatalf("SendResponse before restore: %v", err)
@@ -339,9 +339,9 @@ func TestCheckpoint_RestoreClearsQueuedExternalResponsesBeforeImport(t *testing.
 		t.Fatalf("status after restore = %v, want PendingRequests", status)
 	}
 
-	response, err = replayedRequests[0].NewResponse("Again")
+	response, err = replayedRequests[0].CreateResponse("Again")
 	if err != nil {
-		t.Fatalf("NewResponse after restore: %v", err)
+		t.Fatalf("CreateResponse after restore: %v", err)
 	}
 	if err := stream.SendResponse(ctx, response); err != nil {
 		t.Fatalf("SendResponse after restore: %v", err)
@@ -520,9 +520,9 @@ func TestCheckpoint_AfterResumeUsesResumedCheckpointAsParent(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Resume: %v", err)
 			}
-			response, err := pendingRequest.NewResponse("World")
+			response, err := pendingRequest.CreateResponse("World")
 			if err != nil {
-				t.Fatalf("NewResponse: %v", err)
+				t.Fatalf("CreateResponse: %v", err)
 			}
 			if _, err := resumed.Resume(ctx, response); err != nil {
 				t.Fatalf("Resume with response: %v", err)

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -149,8 +149,6 @@ func (proc *runnerContext) EnsureExecutor(ctx context.Context, executorID string
 		tracer.TraceInstantiated(executorID)
 	}
 
-	// TODO: Handle special executor types (RequestInfoExecutor, WorkflowHostExecutor)
-
 	proc.executors[executorID] = executor
 
 	return executor, nil
@@ -475,7 +473,7 @@ func (proc *runnerContext) SendMessage(ctx context.Context, sourceID, targetID s
 		span.CaptureError(err)
 		return err
 	}
-	declaredType, ok := sourceExecutor.DeclaredSendType(messageType)
+	declaredType, ok := execution.DeclaredSendType(sourceExecutor, messageType)
 	if !ok {
 		err := fmt.Errorf("executor %q cannot send messages of type %s", sourceID, messageType)
 		span.CaptureError(err)
@@ -620,9 +618,9 @@ func (proc *runnerContext) validateOutputType(executorID string, output any) err
 		return fmt.Errorf("executor %q is not instantiated", executorID)
 	}
 
-	declaredTypes := executor.OutputTypes()
+	declaredTypes := executor.DescribeProtocol().Yields
 	outputType := reflect.TypeOf(output)
-	if slices.ContainsFunc(declaredTypes, outputType.AssignableTo) {
+	if execution.CanOutputType(executor, outputType) {
 		return nil
 	}
 	return fmt.Errorf("executor %q cannot output object of type %s; expected one of %v", executorID, outputType, sortedTypeNames(declaredTypes))

--- a/workflow/inproc/external_request_test.go
+++ b/workflow/inproc/external_request_test.go
@@ -16,6 +16,8 @@ type requestPortStringer string
 
 func (s requestPortStringer) String() string { return string(s) }
 
+type requestNilPayload struct{}
+
 // TestPostRequestFromExecutor verifies that an executor can raise an
 // ExternalRequest via Context.PostRequest, that the matching ExternalResponse
 // is routed back to that executor (not to the start executor), and that the
@@ -85,9 +87,9 @@ func TestPostRequestFromExecutor(t *testing.T) {
 	if req == nil {
 		t.Fatalf("expected RequestInfoEvent, got none")
 	}
-	resp, err := req.NewResponse("Alice")
+	resp, err := req.CreateResponse("Alice")
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if _, err := run.Resume(ctx, resp); err != nil {
 		t.Fatalf("Resume: %v", err)
@@ -194,7 +196,7 @@ func TestPostRequestRoutingToOwner(t *testing.T) {
 	if req == nil {
 		t.Fatalf("expected a RequestInfoEvent, got none")
 	}
-	resp, _ := req.NewResponse("pong")
+	resp, _ := req.CreateResponse("pong")
 	if _, err := run.Resume(ctx, resp); err != nil {
 		t.Fatalf("Resume: %v", err)
 	}
@@ -281,6 +283,21 @@ func TestExternalRequest_NewRequest_TypeValidation(t *testing.T) {
 	}
 }
 
+func TestExternalRequest_NewRequest_RejectsNil(t *testing.T) {
+	port := workflow.RequestPort{
+		ID:       "p",
+		Request:  reflect.TypeFor[*requestNilPayload](),
+		Response: reflect.TypeFor[int](),
+	}
+	if _, err := workflow.NewExternalRequest("", port, nil); err == nil {
+		t.Fatal("nil request data should fail")
+	}
+	var typedNil *requestNilPayload
+	if _, err := workflow.NewExternalRequest("", port, typedNil); err == nil {
+		t.Fatal("typed nil request data should fail")
+	}
+}
+
 func TestExternalRequest_NewRequest_AssignableTypeValidation(t *testing.T) {
 	port := workflow.RequestPort{
 		ID:       "p",
@@ -295,23 +312,15 @@ func TestExternalRequest_NewRequest_AssignableTypeValidation(t *testing.T) {
 	}
 }
 
-func TestExternalRequest_NewRequest_PortableValuePointerStoresUnderlyingValue(t *testing.T) {
+func TestExternalRequest_NewRequest_PortableValuePointerIsValidatedAsWrapper(t *testing.T) {
 	port := workflow.RequestPort{
 		ID:       "p",
 		Request:  reflect.TypeFor[string](),
 		Response: reflect.TypeFor[int](),
 	}
 	pv := workflow.AnyPortableValue("ok")
-	req, err := workflow.NewExternalRequest("", port, &pv)
-	if err != nil {
-		t.Fatalf("NewExternalRequest: %v", err)
-	}
-	data, ok := req.Data.As(port.Request)
-	if !ok {
-		t.Fatal("request Data could not be read as the request type")
-	}
-	if data != "ok" {
-		t.Fatalf("data = %v, want ok", data)
+	if _, err := workflow.NewExternalRequest("", port, &pv); err == nil {
+		t.Fatal("NewExternalRequest should validate *PortableValue as its concrete wrapper type")
 	}
 }
 
@@ -325,11 +334,30 @@ func TestExternalRequest_NewResponse_TypeValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExternalRequest: %v", err)
 	}
-	if _, err := req.NewResponse(int(42)); err != nil {
+	if _, err := req.CreateResponse(int(42)); err != nil {
 		t.Errorf("matching response type should succeed: %v", err)
 	}
-	if _, err := req.NewResponse("wrong"); err == nil {
+	if _, err := req.CreateResponse("wrong"); err == nil {
 		t.Error("non-matching response type should fail")
+	}
+}
+
+func TestExternalRequest_NewResponse_RejectsNil(t *testing.T) {
+	port := workflow.RequestPort{
+		ID:       "p",
+		Request:  reflect.TypeFor[string](),
+		Response: reflect.TypeFor[*requestNilPayload](),
+	}
+	req, err := workflow.NewExternalRequest("rid", port, "hi")
+	if err != nil {
+		t.Fatalf("NewExternalRequest: %v", err)
+	}
+	if _, err := req.CreateResponse(nil); err == nil {
+		t.Fatal("nil response data should fail")
+	}
+	var typedNil *requestNilPayload
+	if _, err := req.CreateResponse(typedNil); err == nil {
+		t.Fatal("typed nil response data should fail")
 	}
 }
 
@@ -346,9 +374,9 @@ func TestExternalRequest_UsesPortInfo(t *testing.T) {
 	if got, want := req.PortInfo, workflow.NewRequestPortInfo(port); got != want {
 		t.Fatalf("PortInfo = %#v, want %#v", got, want)
 	}
-	resp, err := req.NewResponse(int(42))
+	resp, err := req.CreateResponse(int(42))
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 	if got, want := resp.PortInfo, req.PortInfo; got != want {
 		t.Errorf("response PortInfo = %#v, want %#v", got, want)

--- a/workflow/inproc/routing_test.go
+++ b/workflow/inproc/routing_test.go
@@ -154,6 +154,51 @@ func TestDirectEdgeRouting_TargetedMessageDeliversOnlyToMatchingSink(t *testing.
 	}
 }
 
+func TestDirectEdgeRouting_BroadDeclaredSendTypeRoutesByRuntimeType(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		trace []string
+	)
+	source := workflow.ExecutorBinding{
+		ID:           "source",
+		ExecutorType: reflect.TypeFor[*workflow.Executor](),
+	}
+	source.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: source.ID,
+			Spec: workflow.ExecutorSpec{
+				DisableAutoSendMessageHandlerResultObject: true,
+				DisableAutoYieldOutputHandlerResultObject: true,
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.SendsMessageType(reflect.TypeFor[any]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+						return nil, ctx.SendMessage("", msg)
+					})
+					return rb, nil
+				},
+			},
+		}, nil
+	}
+	target := captureExecutor("target", &trace, &mu)
+
+	wf, err := workflow.NewBuilder(source).
+		AddEdge(source, target).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, err := inproc.Default.Run(context.Background(), wf, "hello"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"target:hello"}
+	if !slices.Equal(trace, want) {
+		t.Fatalf("trace = %v, want %v", trace, want)
+	}
+}
+
 func TestFanOutEdgeRouting_NoAssigner_DeliversToAll(t *testing.T) {
 	var (
 		mu    sync.Mutex

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -175,7 +175,7 @@ func (r *runner) IsValidInputType(ctx context.Context, messageType reflect.Type)
 		return false
 	}
 
-	if startingExecutor.CanHandleType(messageType) {
+	if execution.CanHandleType(startingExecutor, messageType) {
 		r.knownValidInputTypes[messageType] = struct{}{}
 		return true
 	}

--- a/workflow/internal/execution/edgerunner.go
+++ b/workflow/internal/execution/edgerunner.go
@@ -276,17 +276,29 @@ func (em *EdgeRunner) PrepareDeliveryForEdge(ctx context.Context, edge workflow.
 	}
 	if len(edge.Connection.SourceIDs) == 1 {
 		// Filter targets that can handle the message type.
+		runtimeType, err := em.messageRuntimeType(ctx, envelope)
+		if err != nil {
+			return nil, err
+		}
 		targets = slices.DeleteFunc(targets, func(target *workflow.Executor) bool {
-			return !target.CanHandleTypeID(envelope.MessageType())
+			return !canHandleRuntimeType(target, runtimeType)
 		})
 	} else {
 		if len(targets) != 1 {
 			panic("stateful edges only support single target executor")
 		}
 		// Filter envelopes whose message type is not handled by any target.
-		envelopes = slices.DeleteFunc(envelopes, func(env *MessageEnvelope) bool {
-			return !targets[0].CanHandleTypeID(env.MessageType())
-		})
+		filtered := envelopes[:0]
+		for _, env := range envelopes {
+			runtimeType, err := em.messageRuntimeType(ctx, env)
+			if err != nil {
+				return nil, err
+			}
+			if canHandleRuntimeType(targets[0], runtimeType) {
+				filtered = append(filtered, env)
+			}
+		}
+		envelopes = filtered
 	}
 	if len(targets) == 0 || len(envelopes) == 0 {
 		// Type mismatch.
@@ -298,6 +310,30 @@ func (em *EdgeRunner) PrepareDeliveryForEdge(ctx context.Context, edge workflow.
 		Targets:   targets,
 		Envelopes: envelopes,
 	}, nil
+}
+
+func (em *EdgeRunner) messageRuntimeType(ctx context.Context, envelope *MessageEnvelope) (reflect.Type, error) {
+	if portable, ok := envelope.Message.(workflow.PortableValue); ok {
+		if envelope.SourceID == "" {
+			return nil, nil
+		}
+		source, err := em.ensureExecutor(ctx, envelope.SourceID, em.tracer)
+		if err != nil {
+			return nil, err
+		}
+		if typ, ok := SentRuntimeType(source, portable.TypeID); ok {
+			return typ, nil
+		}
+		return nil, nil
+	}
+	return reflect.TypeOf(envelope.Message), nil
+}
+
+func canHandleRuntimeType(target *workflow.Executor, runtimeType reflect.Type) bool {
+	if runtimeType != nil {
+		return CanHandleType(target, runtimeType)
+	}
+	return target.DescribeProtocol().AcceptsAll
 }
 
 // PrepareDeliveryForInput prepares delivery of an external input message.
@@ -319,7 +355,7 @@ func (em *EdgeRunner) PrepareDeliveryForInput(ctx context.Context, envelope *Mes
 	if err != nil {
 		return nil, err
 	}
-	if !target.CanHandleTypeID(envelope.MessageType()) {
+	if !CanHandleTypeID(target, envelope.MessageType()) {
 		// Type mismatch.
 		span.SetDeliveryStatus(observability.DeliveryStatusDroppedTypeMismatch)
 		return nil, nil
@@ -354,7 +390,7 @@ func (em *EdgeRunner) PrepareDeliveryForResponse(ctx context.Context, response *
 	if err != nil {
 		return nil, err
 	}
-	if !target.CanHandleTypeID(envelope.MessageType()) {
+	if !CanHandleTypeID(target, envelope.MessageType()) {
 		// Type mismatch.
 		span.SetDeliveryStatus(observability.DeliveryStatusDroppedTypeMismatch)
 		return nil, nil

--- a/workflow/internal/execution/protocol.go
+++ b/workflow/internal/execution/protocol.go
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package execution
+
+import (
+	"reflect"
+	"slices"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+// DeclaredSendType returns the protocol type that should be used when sending
+// a message of typ from source. Exact declarations win over broad any
+// declarations. Other interface send declarations match only that exact
+// interface type.
+func DeclaredSendType(source *workflow.Executor, typ reflect.Type) (reflect.Type, bool) {
+	if source == nil || typ == nil {
+		return nil, false
+	}
+	return declaredSendType(sentTypes(source), typ)
+}
+
+// SentRuntimeType returns the runtime type declared by source's send protocol
+// for typeID. It includes workflow system messages that are always sendable but
+// omitted from public protocol descriptors.
+func SentRuntimeType(source *workflow.Executor, typeID workflow.TypeID) (reflect.Type, bool) {
+	if source == nil || typeID == (workflow.TypeID{}) {
+		return nil, false
+	}
+	return sentRuntimeType(sentTypes(source), typeID)
+}
+
+// CanHandleType reports whether target's protocol accepts typ.
+func CanHandleType(target *workflow.Executor, typ reflect.Type) bool {
+	if target == nil || typ == nil {
+		return false
+	}
+	return canHandleType(target.DescribeProtocol(), typ)
+}
+
+// CanHandleTypeID reports whether target's protocol accepts typeID.
+func CanHandleTypeID(target *workflow.Executor, typeID workflow.TypeID) bool {
+	if target == nil || typeID == (workflow.TypeID{}) {
+		return false
+	}
+	return canHandleTypeID(target.DescribeProtocol(), typeID)
+}
+
+// CanOutputType reports whether source's protocol can yield typ as workflow output.
+func CanOutputType(source *workflow.Executor, typ reflect.Type) bool {
+	if source == nil || typ == nil {
+		return false
+	}
+	return canOutputType(source.DescribeProtocol(), typ)
+}
+
+func sentTypes(source *workflow.Executor) []reflect.Type {
+	descriptor := source.DescribeProtocol()
+	types := slices.Clone(descriptor.Sends)
+	return appendUniqueTypes(types, knownSentTypes()...)
+}
+
+func canHandleType(descriptor workflow.ProtocolDescriptor, typ reflect.Type) bool {
+	if typ == nil {
+		return false
+	}
+	if descriptor.AcceptsAll {
+		return true
+	}
+	return slices.ContainsFunc(descriptor.Accepts, func(candidate reflect.Type) bool {
+		return workflow.NewTypeID(candidate).MatchPolymorphic(typ)
+	})
+}
+
+func canHandleTypeID(descriptor workflow.ProtocolDescriptor, typeID workflow.TypeID) bool {
+	if typeID == (workflow.TypeID{}) {
+		return false
+	}
+	if descriptor.AcceptsAll {
+		return true
+	}
+	return slices.ContainsFunc(descriptor.Accepts, func(candidate reflect.Type) bool {
+		return workflow.NewTypeID(candidate) == typeID
+	})
+}
+
+func canOutputType(descriptor workflow.ProtocolDescriptor, typ reflect.Type) bool {
+	if typ == nil {
+		return false
+	}
+	return slices.ContainsFunc(descriptor.Yields, func(candidate reflect.Type) bool {
+		return workflow.NewTypeID(candidate).MatchPolymorphic(typ)
+	})
+}
+
+func knownSentTypes() []reflect.Type {
+	return []reflect.Type{
+		reflect.TypeFor[*workflow.ExternalRequest](),
+		reflect.TypeFor[*workflow.ExternalResponse](),
+	}
+}
+
+func declaredSendType(sentTypes []reflect.Type, typ reflect.Type) (reflect.Type, bool) {
+	for _, candidate := range sentTypes {
+		if typ == candidate {
+			return candidate, true
+		}
+	}
+	for _, candidate := range sentTypes {
+		if declaredSendTypeAssignableTo(typ, candidate) {
+			return candidate, true
+		}
+	}
+	for _, candidate := range sentTypes {
+		if candidate == reflect.TypeFor[any]() {
+			return candidate, true
+		}
+	}
+	return nil, false
+}
+
+func declaredSendTypeAssignableTo(typ reflect.Type, candidate reflect.Type) bool {
+	if typ == nil || candidate == nil || candidate.Kind() == reflect.Interface {
+		return false
+	}
+	return typ.AssignableTo(candidate)
+}
+
+func sentRuntimeType(sentTypes []reflect.Type, typeID workflow.TypeID) (reflect.Type, bool) {
+	var result reflect.Type
+	found := false
+	for _, typ := range sentTypes {
+		if workflow.NewTypeID(typ) != typeID {
+			continue
+		}
+		if !found || preferRuntimeType(typ, result) {
+			result = typ
+			found = true
+		}
+	}
+	return result, found
+}
+
+func preferRuntimeType(candidate, current reflect.Type) bool {
+	if candidate == nil {
+		return false
+	}
+	if current == nil {
+		return true
+	}
+	if candidate.Kind() == reflect.Interface {
+		return current.Kind() != reflect.Interface
+	}
+	if current.Kind() == reflect.Interface {
+		return false
+	}
+	return candidate.Kind() == reflect.Pointer && current.Kind() != reflect.Pointer
+}
+
+func appendUniqueTypes(dst []reflect.Type, src ...reflect.Type) []reflect.Type {
+	for _, typ := range src {
+		if typ == nil || slices.Contains(dst, typ) {
+			continue
+		}
+		dst = append(dst, typ)
+	}
+	return dst
+}

--- a/workflow/internal/execution/protocol_test.go
+++ b/workflow/internal/execution/protocol_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package execution
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+func TestDeclaredSendTypeIncludesKnownSystemSendTypes(t *testing.T) {
+	executor := executorWithSendTypes()
+	systemTypes := []reflect.Type{
+		reflect.TypeFor[*workflow.ExternalRequest](),
+		reflect.TypeFor[*workflow.ExternalResponse](),
+	}
+
+	for _, systemType := range systemTypes {
+		if got, ok := DeclaredSendType(executor, systemType); !ok || got != systemType {
+			t.Fatalf("DeclaredSendType(%v) = %v, %v; want %v, true", systemType, got, ok, systemType)
+		}
+	}
+
+	protocol := executor.DescribeProtocol()
+	for _, systemType := range systemTypes {
+		if slicesContains(protocol.Sends, systemType) {
+			t.Fatalf("Sends = %v, want no implicit system send type %v", protocol.Sends, systemType)
+		}
+	}
+}
+
+func TestDeclaredSendTypeTightensInterfaceMatching(t *testing.T) {
+	concreteType := reflect.TypeFor[protocolSendConcrete]()
+	interfaceType := reflect.TypeFor[protocolSendInterface]()
+	anyType := reflect.TypeFor[any]()
+
+	exactExecutor := executorWithSendTypes(concreteType)
+	if got, ok := DeclaredSendType(exactExecutor, concreteType); !ok || got != concreteType {
+		t.Fatalf("DeclaredSendType(concrete) = %v, %v; want %v, true", got, ok, concreteType)
+	}
+
+	interfaceExecutor := executorWithSendTypes(interfaceType)
+	if got, ok := DeclaredSendType(interfaceExecutor, concreteType); ok {
+		t.Fatalf("DeclaredSendType(concrete with interface declaration) = %v, true; want false", got)
+	}
+	if got, ok := DeclaredSendType(interfaceExecutor, interfaceType); !ok || got != interfaceType {
+		t.Fatalf("DeclaredSendType(interface) = %v, %v; want %v, true", got, ok, interfaceType)
+	}
+
+	anyExecutor := executorWithSendTypes(anyType)
+	if got, ok := DeclaredSendType(anyExecutor, concreteType); !ok || got != anyType {
+		t.Fatalf("DeclaredSendType(concrete with any declaration) = %v, %v; want %v, true", got, ok, anyType)
+	}
+}
+
+func TestDeclaredSendTypePrefersExactDeclarationOverAny(t *testing.T) {
+	concreteType := reflect.TypeFor[protocolSendConcrete]()
+	executor := executorWithSendTypes(reflect.TypeFor[any](), concreteType)
+
+	got, ok := DeclaredSendType(executor, concreteType)
+	if !ok || got != concreteType {
+		t.Fatalf("DeclaredSendType(concrete with any and concrete declarations) = %v, %v; want %v, true", got, ok, concreteType)
+	}
+}
+
+func TestSentRuntimeTypeIncludesDeclaredAndKnownSendTypes(t *testing.T) {
+	concreteType := reflect.TypeFor[protocolSendConcrete]()
+	executor := executorWithSendTypes(concreteType)
+
+	for _, typ := range []reflect.Type{concreteType, reflect.TypeFor[*workflow.ExternalRequest](), reflect.TypeFor[*workflow.ExternalResponse]()} {
+		got, ok := SentRuntimeType(executor, workflow.NewTypeID(typ))
+		if !ok || got != typ {
+			t.Fatalf("SentRuntimeType(%v) = %v, %v; want %v, true", typ, got, ok, typ)
+		}
+	}
+}
+
+func TestCanHandleTypeUsesProtocolDescriptorPolymorphicMatch(t *testing.T) {
+	interfaceType := reflect.TypeFor[protocolInputInterface]()
+	executor := executorWithInputTypes(interfaceType)
+
+	if !CanHandleType(executor, reflect.TypeFor[*protocolInputImpl]()) {
+		t.Fatal("interface input should polymorphically match implementing pointer input")
+	}
+	if !CanHandleTypeID(executor, workflow.NewTypeID(interfaceType)) {
+		t.Fatal("interface TypeID should match declared input")
+	}
+	if CanHandleType(executor, reflect.TypeFor[protocolSendConcrete]()) {
+		t.Fatal("unrelated input type should not match declared inputs")
+	}
+	if CanHandleType(executor, nil) {
+		t.Fatal("nil input type should not match declared inputs")
+	}
+}
+
+func TestCanHandleTypeUsesCatchAllDescriptor(t *testing.T) {
+	executor := &workflow.Executor{
+		ID: "catch-all",
+		Spec: workflow.ExecutorSpec{
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddCatchAll(func(*workflow.Context, workflow.PortableValue) (any, error) {
+					return nil, nil
+				})
+				return rb, nil
+			},
+		},
+	}
+
+	if !CanHandleType(executor, reflect.TypeFor[protocolSendConcrete]()) {
+		t.Fatal("catch-all should match runtime type")
+	}
+	if !CanHandleTypeID(executor, workflow.NewTypeID(reflect.TypeFor[protocolSendConcrete]())) {
+		t.Fatal("catch-all should match TypeID")
+	}
+}
+
+func TestCanOutputTypeUsesProtocolDescriptorPolymorphicMatch(t *testing.T) {
+	executor := executorWithYieldTypes(
+		reflect.TypeFor[protocolYield](),
+		reflect.TypeFor[protocolYieldInterface](),
+	)
+
+	if !CanOutputType(executor, reflect.TypeFor[*protocolYield]()) {
+		t.Fatal("value TypeID yield should match pointer output")
+	}
+	if !CanOutputType(executor, reflect.TypeFor[*protocolYieldImpl]()) {
+		t.Fatal("interface TypeID yield should polymorphically match implementing pointer output")
+	}
+	if CanOutputType(executor, reflect.TypeFor[protocolSendConcrete]()) {
+		t.Fatal("unrelated output type should not match declared yields")
+	}
+	if CanOutputType(executor, nil) {
+		t.Fatal("nil output type should not match declared yields")
+	}
+}
+
+type protocolSendInterface interface {
+	ProtocolSendMarker()
+}
+
+type protocolSendConcrete struct{}
+
+func (protocolSendConcrete) ProtocolSendMarker() {}
+
+type protocolInputInterface interface {
+	ProtocolInputMarker()
+}
+
+type protocolInputImpl struct{}
+
+func (*protocolInputImpl) ProtocolInputMarker() {}
+
+type protocolYield struct{}
+
+type protocolYieldInterface interface {
+	ProtocolYieldMarker()
+}
+
+type protocolYieldImpl struct{}
+
+func (*protocolYieldImpl) ProtocolYieldMarker() {}
+
+func executorWithSendTypes(sendTypes ...reflect.Type) *workflow.Executor {
+	return &workflow.Executor{
+		ID: "send-protocol",
+		Spec: workflow.ExecutorSpec{
+			DisableAutoSendMessageHandlerResultObject: true,
+			DisableAutoYieldOutputHandlerResultObject: true,
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.SendsMessageType(sendTypes...)
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*workflow.Context, any) (any, error) {
+					return nil, nil
+				})
+				return rb, nil
+			},
+		},
+	}
+}
+
+func executorWithInputTypes(inputTypes ...reflect.Type) *workflow.Executor {
+	return &workflow.Executor{
+		ID: "input-protocol",
+		Spec: workflow.ExecutorSpec{
+			DisableAutoSendMessageHandlerResultObject: true,
+			DisableAutoYieldOutputHandlerResultObject: true,
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				for _, inputType := range inputTypes {
+					rb.RouteBuilder.AddHandlerRaw(inputType, nil, func(*workflow.Context, any) (any, error) {
+						return nil, nil
+					})
+				}
+				return rb, nil
+			},
+		},
+	}
+}
+
+func executorWithYieldTypes(yieldTypes ...reflect.Type) *workflow.Executor {
+	return &workflow.Executor{
+		ID: "yield-protocol",
+		Spec: workflow.ExecutorSpec{
+			DisableAutoSendMessageHandlerResultObject: true,
+			DisableAutoYieldOutputHandlerResultObject: true,
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.YieldsOutputType(yieldTypes...)
+				return rb, nil
+			},
+		},
+	}
+}
+
+func slicesContains(types []reflect.Type, typ reflect.Type) bool {
+	for _, candidate := range types {
+		if candidate == typ {
+			return true
+		}
+	}
+	return false
+}

--- a/workflow/json_test.go
+++ b/workflow/json_test.go
@@ -7,56 +7,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/workflow"
 )
-
-func TestTypeID_JsonRoundtrip(t *testing.T) {
-	cases := []reflect.Type{
-		reflect.TypeFor[string](),
-		reflect.TypeFor[int](),
-		reflect.TypeFor[*workflow.Executor](),
-		reflect.TypeFor[workflow.RequestPort](),
-		reflect.TypeFor[map[string]int](),
-	}
-	for _, typ := range cases {
-		t.Run(typ.String(), func(t *testing.T) {
-			id := workflow.NewTypeID(typ)
-			data, err := json.Marshal(id)
-			if err != nil {
-				t.Fatalf("Marshal: %v", err)
-			}
-			var got workflow.TypeID
-			if err := json.Unmarshal(data, &got); err != nil {
-				t.Fatalf("Unmarshal: %v", err)
-			}
-			if got != id {
-				t.Errorf("roundtrip = %+v, want %+v", got, id)
-			}
-			if !got.Match(typ) {
-				t.Errorf("roundtripped TypeID does not match original type %v", typ)
-			}
-		})
-	}
-}
-
-func TestTypeID_String(t *testing.T) {
-	id := workflow.NewTypeID(reflect.TypeFor[workflow.RequestPort]())
-	if got, want := id.String(), "RequestPort, github.com/microsoft/agent-framework-go/workflow"; got != want {
-		t.Fatalf("String() = %q, want %q", got, want)
-	}
-}
-
-func TestTypeID_NilType(t *testing.T) {
-	if got := workflow.NewTypeID(nil); got != (workflow.TypeID{}) {
-		t.Fatalf("NewTypeID(nil) = %+v, want zero TypeID", got)
-	}
-	if (workflow.TypeID{}).Match(nil) {
-		t.Fatal("zero TypeID should not match nil type")
-	}
-	if (workflow.TypeID{}).Match(reflect.TypeFor[string]()) {
-		t.Fatal("zero TypeID should not match concrete type")
-	}
-}
 
 func TestEdgeConnection_JsonRoundtrip(t *testing.T) {
 	cases := []workflow.EdgeConnection{
@@ -107,6 +60,21 @@ func TestRequestPortInfo_JsonRoundtrip(t *testing.T) {
 	}
 }
 
+func TestRequestPortInfo_CachesRuntimeTypes(t *testing.T) {
+	port := workflow.RequestPort{
+		ID:       "ContentPort",
+		Request:  reflect.TypeFor[*message.FunctionCallContent](),
+		Response: reflect.TypeFor[message.Content](),
+	}
+	info := workflow.NewRequestPortInfo(port)
+
+	if !info.RequestType.Match(reflect.TypeFor[*message.FunctionCallContent]()) {
+		t.Fatal("request TypeID should match pointer request type")
+	}
+	if !info.ResponseType.MatchPolymorphic(reflect.TypeFor[*message.FunctionResultContent]()) {
+		t.Fatal("response TypeID should polymorphically match concrete content")
+	}
+}
 func TestExternalRequest_JsonRoundtrip(t *testing.T) {
 	port := workflow.RequestPort{
 		ID:       "MyPort",
@@ -148,9 +116,9 @@ func TestExternalResponse_JsonRoundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExternalRequest: %v", err)
 	}
-	response, err := request.NewResponse(13)
+	response, err := request.CreateResponse(13)
 	if err != nil {
-		t.Fatalf("NewResponse: %v", err)
+		t.Fatalf("CreateResponse: %v", err)
 	}
 
 	data, err := json.Marshal(response)
@@ -170,6 +138,30 @@ func TestExternalResponse_JsonRoundtrip(t *testing.T) {
 	value, ok := workflow.PortableValueAs[int](got.Data)
 	if !ok || value != 13 {
 		t.Fatalf("Data = %d, %v; want 13, true", value, ok)
+	}
+}
+
+func TestExternalRequest_NewResponse_PolymorphicResponseType(t *testing.T) {
+	port := workflow.RequestPort{
+		ID:       "MyPort",
+		Request:  reflect.TypeFor[string](),
+		Response: reflect.TypeFor[message.Content](),
+	}
+	request, err := workflow.NewExternalRequest("request-1", port, "payload")
+	if err != nil {
+		t.Fatalf("NewExternalRequest: %v", err)
+	}
+	response, err := request.CreateResponse(&message.FunctionResultContent{CallID: "call-1", Result: "ok"})
+	if err != nil {
+		t.Fatalf("CreateResponse concrete content for interface port: %v", err)
+	}
+	if _, ok := response.Data.As(reflect.TypeFor[*message.FunctionResultContent]()); !ok {
+		t.Fatal("response data could not be read as *message.FunctionResultContent")
+	}
+
+	portable := workflow.AnyPortableValue(&message.FunctionResultContent{CallID: "call-2", Result: "portable"})
+	if _, err := request.CreateResponse(portable); err == nil {
+		t.Fatal("CreateResponse should validate PortableValue as its concrete wrapper type")
 	}
 }
 

--- a/workflow/json_test.go
+++ b/workflow/json_test.go
@@ -141,7 +141,7 @@ func TestExternalResponse_JsonRoundtrip(t *testing.T) {
 	}
 }
 
-func TestExternalRequest_NewResponse_PolymorphicResponseType(t *testing.T) {
+func TestExternalRequest_CreateResponse_PolymorphicResponseType(t *testing.T) {
 	port := workflow.RequestPort{
 		ID:       "MyPort",
 		Request:  reflect.TypeFor[string](),

--- a/workflow/json_test.go
+++ b/workflow/json_test.go
@@ -75,6 +75,7 @@ func TestRequestPortInfo_CachesRuntimeTypes(t *testing.T) {
 		t.Fatal("response TypeID should polymorphically match concrete content")
 	}
 }
+
 func TestExternalRequest_JsonRoundtrip(t *testing.T) {
 	port := workflow.RequestPort{
 		ID:       "MyPort",

--- a/workflow/portable.go
+++ b/workflow/portable.go
@@ -74,41 +74,55 @@ func (v *PortableValue) Any() any {
 }
 
 func decodeKnownPortableType(typeID TypeID, raw json.RawMessage) (any, bool) {
-	if typeID.PackageName != "" {
+	if typeID.PackageName == "" {
+		switch typeID.TypeName {
+		case "string":
+			return decodePortableJSON[string](raw)
+		case "bool":
+			return decodePortableJSON[bool](raw)
+		case "int":
+			return decodePortableJSON[int](raw)
+		case "int8":
+			return decodePortableJSON[int8](raw)
+		case "int16":
+			return decodePortableJSON[int16](raw)
+		case "int32":
+			return decodePortableJSON[int32](raw)
+		case "int64":
+			return decodePortableJSON[int64](raw)
+		case "uint":
+			return decodePortableJSON[uint](raw)
+		case "uint8":
+			return decodePortableJSON[uint8](raw)
+		case "uint16":
+			return decodePortableJSON[uint16](raw)
+		case "uint32":
+			return decodePortableJSON[uint32](raw)
+		case "uint64":
+			return decodePortableJSON[uint64](raw)
+		case "float32":
+			return decodePortableJSON[float32](raw)
+		case "float64":
+			return decodePortableJSON[float64](raw)
+		}
+	}
+	if typ, ok := runtimeTypeForTypeID(typeID); ok {
+		if decoded, ok := decodePortableJSONType(typ, raw); ok {
+			return decoded, true
+		}
+	}
+	return nil, false
+}
+
+func decodePortableJSONType(typ reflect.Type, raw json.RawMessage) (any, bool) {
+	if typ == nil {
 		return nil, false
 	}
-	switch typeID.TypeName {
-	case "string":
-		return decodePortableJSON[string](raw)
-	case "bool":
-		return decodePortableJSON[bool](raw)
-	case "int":
-		return decodePortableJSON[int](raw)
-	case "int8":
-		return decodePortableJSON[int8](raw)
-	case "int16":
-		return decodePortableJSON[int16](raw)
-	case "int32":
-		return decodePortableJSON[int32](raw)
-	case "int64":
-		return decodePortableJSON[int64](raw)
-	case "uint":
-		return decodePortableJSON[uint](raw)
-	case "uint8":
-		return decodePortableJSON[uint8](raw)
-	case "uint16":
-		return decodePortableJSON[uint16](raw)
-	case "uint32":
-		return decodePortableJSON[uint32](raw)
-	case "uint64":
-		return decodePortableJSON[uint64](raw)
-	case "float32":
-		return decodePortableJSON[float32](raw)
-	case "float64":
-		return decodePortableJSON[float64](raw)
-	default:
+	target := reflect.New(typ)
+	if err := json.Unmarshal(raw, target.Interface()); err != nil {
 		return nil, false
 	}
+	return target.Elem().Interface(), true
 }
 
 func decodePortableJSON[T any](raw json.RawMessage) (any, bool) {

--- a/workflow/portable_test.go
+++ b/workflow/portable_test.go
@@ -119,6 +119,42 @@ func TestAnyPortableValue_DereferencesPortableValuePointer(t *testing.T) {
 
 func TestPortableValueAny_DecodesDelayedPrimitive(t *testing.T) {
 	pv := workflow.AnyPortableValue("hello")
+	delayed := delayedPortableValue(t, pv)
+	if got := delayed.Any(); got != "hello" {
+		t.Fatalf("Any() = %v (%T), want hello (string)", got, got)
+	}
+}
+
+func TestPortableValueAny_DecodesDelayedRuntimeType(t *testing.T) {
+	delayed := delayedPortableValue(t, workflow.AnyPortableValue(message.RoleAssistant))
+	got := delayed.Any()
+	role, ok := got.(message.Role)
+	if !ok {
+		t.Fatalf("Any() = %v (%T), want message.Role", got, got)
+	}
+	if role != message.RoleAssistant {
+		t.Fatalf("Any() = %q, want %q", role, message.RoleAssistant)
+	}
+}
+
+func TestPortableValueAny_DecodesDelayedPointerRuntimeType(t *testing.T) {
+	delayed := delayedPortableValue(t, workflow.AnyPortableValue(&message.FunctionCallContent{
+		CallID:    "call-1",
+		Name:      "lookup",
+		Arguments: `{"city":"Seattle"}`,
+	}))
+	got := delayed.Any()
+	call, ok := got.(*message.FunctionCallContent)
+	if !ok {
+		t.Fatalf("Any() = %v (%T), want *message.FunctionCallContent", got, got)
+	}
+	if call.CallID != "call-1" || call.Name != "lookup" || call.Arguments != `{"city":"Seattle"}` {
+		t.Fatalf("Any() = %+v, want decoded function call", call)
+	}
+}
+
+func delayedPortableValue(t *testing.T, pv workflow.PortableValue) workflow.PortableValue {
+	t.Helper()
 	data, err := json.Marshal(pv)
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
@@ -127,9 +163,7 @@ func TestPortableValueAny_DecodesDelayedPrimitive(t *testing.T) {
 	if err := json.Unmarshal(data, &delayed); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if got := delayed.Any(); got != "hello" {
-		t.Fatalf("Any() = %v (%T), want hello (string)", got, got)
-	}
+	return delayed
 }
 
 func TestPortableValue_RejectsNil(t *testing.T) {

--- a/workflow/protocol.go
+++ b/workflow/protocol.go
@@ -92,53 +92,28 @@ func (pb *ProtocolBuilder) build(spec ExecutorSpec) (*executorProtocol, error) {
 	if !spec.DisableAutoSendMessageHandlerResultObject {
 		sendTypes = appendUniqueTypes(sendTypes, slices.Collect(router.defaultOutputTypes())...)
 	}
-
 	yieldTypes := appendUniqueTypes(nil, pb.yieldTypes...)
 	if !spec.DisableAutoYieldOutputHandlerResultObject {
 		yieldTypes = appendUniqueTypes(yieldTypes, slices.Collect(router.defaultOutputTypes())...)
 	}
+	descriptor := ProtocolDescriptor{
+		Accepts:    router.incomingTypes(),
+		Yields:     slices.Clone(yieldTypes),
+		Sends:      slices.Clone(sendTypes),
+		AcceptsAll: router.hasCatchAll(),
+	}
 
 	return &executorProtocol{
-		router: router,
-		sends:  sendTypes,
-		yields: yieldTypes,
+		router:     router,
+		descriptor: descriptor,
 	}, nil
 }
 
 type executorProtocol struct {
-	router *messageRouter
-	sends  []reflect.Type
-	yields []reflect.Type
+	router     *messageRouter
+	descriptor ProtocolDescriptor
 }
 
-func (p *executorProtocol) describe() *ProtocolDescriptor {
-	return &ProtocolDescriptor{
-		Accepts:    p.router.incomingTypes(),
-		Yields:     appendUniqueTypes(nil, p.yields...),
-		Sends:      appendUniqueTypes(nil, p.sends...),
-		AcceptsAll: p.router.hasCatchAll(),
-	}
-}
-
-func (p *executorProtocol) canHandleTypeID(typ TypeID) bool {
-	return p.router.canHandle(typ)
-}
-
-func (p *executorProtocol) canHandleType(typ reflect.Type) bool {
-	return p.router.canHandleType(typ)
-}
-
-func (p *executorProtocol) canOutputType(typ reflect.Type) bool {
-	return slices.ContainsFunc(p.yields, typ.AssignableTo)
-}
-
-func (p *executorProtocol) declaredSendType(typ reflect.Type) (reflect.Type, bool) {
-	candidates := appendUniqueTypes(nil, p.sends...)
-	candidates = appendUniqueTypes(candidates, knownSentTypes()...)
-	for _, candidate := range candidates {
-		if declaredSendTypeMatches(typ, candidate) {
-			return candidate, true
-		}
-	}
-	return nil, false
+func (p *executorProtocol) describe() ProtocolDescriptor {
+	return p.descriptor
 }

--- a/workflow/protocol_test.go
+++ b/workflow/protocol_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 type (
-	protocolBuilderInput  struct{}
-	protocolBuilderOutput struct{}
-	protocolBuilderSend   struct{}
-	protocolBuilderYield  struct{}
+	protocolBuilderInput     struct{}
+	protocolBuilderOutput    struct{}
+	protocolBuilderSend      struct{}
+	protocolBuilderYield     struct{}
+	protocolBuilderYieldImpl struct{}
 )
 
 func TestProtocolBuilderBuildIncludesDeclaredAndAutomaticTypes(t *testing.T) {
@@ -32,11 +33,30 @@ func TestProtocolBuilderBuildIncludesDeclaredAndAutomaticTypes(t *testing.T) {
 	if !containsReflectType(protocol.describe().Accepts, inputType) {
 		t.Fatalf("Accepts = %v, want %v", protocol.describe().Accepts, inputType)
 	}
-	if got := protocol.sends; !reflect.DeepEqual(got, []reflect.Type{explicitSend, outputType}) {
+	if got := protocol.describe().Sends; !reflect.DeepEqual(got, []reflect.Type{explicitSend, outputType}) {
 		t.Fatalf("sends = %v, want [%v %v]", got, explicitSend, outputType)
 	}
-	if got := protocol.yields; !reflect.DeepEqual(got, []reflect.Type{explicitYield, outputType}) {
+	if got := protocol.describe().Yields; !reflect.DeepEqual(got, []reflect.Type{explicitYield, outputType}) {
 		t.Fatalf("yields = %v, want [%v %v]", got, explicitYield, outputType)
+	}
+}
+
+func TestExecutorProtocolDescribeReturnsCachedDescriptorValue(t *testing.T) {
+	protocol, err := newProtocolBuilderWithHandler(reflect.TypeFor[protocolBuilderInput](), reflect.TypeFor[protocolBuilderOutput]()).
+		SendsMessageType(reflect.TypeFor[protocolBuilderSend]()).
+		YieldsOutputType(reflect.TypeFor[protocolBuilderYield]()).
+		build(ExecutorSpec{})
+	if err != nil {
+		t.Fatalf("build error = %v", err)
+	}
+
+	first := protocol.describe()
+	second := protocol.describe()
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("describe returned different descriptors: %+v != %+v", first, second)
+	}
+	if allocations := testing.AllocsPerRun(1000, func() { _ = protocol.describe() }); allocations != 0 {
+		t.Fatalf("describe allocations = %v, want 0", allocations)
 	}
 }
 
@@ -51,11 +71,11 @@ func TestProtocolBuilderBuildRespectsAutoReturnOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build error = %v", err)
 	}
-	if containsReflectType(protocol.sends, outputType) {
-		t.Fatalf("sends = %v, want no automatic output type %v", protocol.sends, outputType)
+	if containsReflectType(protocol.describe().Sends, outputType) {
+		t.Fatalf("sends = %v, want no automatic output type %v", protocol.describe().Sends, outputType)
 	}
-	if containsReflectType(protocol.yields, outputType) {
-		t.Fatalf("yields = %v, want no automatic output type %v", protocol.yields, outputType)
+	if containsReflectType(protocol.describe().Yields, outputType) {
+		t.Fatalf("yields = %v, want no automatic output type %v", protocol.describe().Yields, outputType)
 	}
 }
 

--- a/workflow/protocol_test.go
+++ b/workflow/protocol_test.go
@@ -9,11 +9,10 @@ import (
 )
 
 type (
-	protocolBuilderInput     struct{}
-	protocolBuilderOutput    struct{}
-	protocolBuilderSend      struct{}
-	protocolBuilderYield     struct{}
-	protocolBuilderYieldImpl struct{}
+	protocolBuilderInput  struct{}
+	protocolBuilderOutput struct{}
+	protocolBuilderSend   struct{}
+	protocolBuilderYield  struct{}
 )
 
 func TestProtocolBuilderBuildIncludesDeclaredAndAutomaticTypes(t *testing.T) {

--- a/workflow/requestport.go
+++ b/workflow/requestport.go
@@ -69,14 +69,14 @@ func NewExternalRequest(id string, port RequestPort, data any) (*ExternalRequest
 	}, nil
 }
 
-// NewResponse creates a new [ExternalResponse] corresponding to r, with the
+// CreateResponse creates a new [ExternalResponse] corresponding to r, with the
 // specified data payload.
 //
-// NewResponse returns an error when data does not match the expected response
+// CreateResponse returns an error when data does not match the expected response
 // type.
-func (r *ExternalRequest) NewResponse(data any) (*ExternalResponse, error) {
-	if typ := reflect.TypeOf(data); typ == nil || !r.PortInfo.ResponseType.Match(typ) {
-		return nil, fmt.Errorf("invalid response type: expected %v, got %v", r.PortInfo.ResponseType, typ)
+func (r *ExternalRequest) CreateResponse(data any) (*ExternalResponse, error) {
+	if !valueMatchesTypeID(data, r.PortInfo.ResponseType) {
+		return nil, fmt.Errorf("invalid response type: expected %v, got %v", r.PortInfo.ResponseType, reflect.TypeOf(data))
 	}
 	return &ExternalResponse{
 		PortInfo:  r.PortInfo,
@@ -87,17 +87,30 @@ func (r *ExternalRequest) NewResponse(data any) (*ExternalResponse, error) {
 
 // valueAssignableTo reports whether data can be used as a value of typ.
 //
-// Portable values are checked by their recorded type ID, while ordinary Go
-// values use assignability from their concrete runtime type.
+// Values use assignability from their concrete runtime type.
 func valueAssignableTo(data any, typ reflect.Type) bool {
-	if data == nil || typ == nil {
+	if isNilValue(data) || typ == nil {
 		return false
 	}
-	if value, ok := data.(PortableValue); ok {
-		return value.Is(typ)
-	}
-	if value, ok := data.(*PortableValue); ok {
-		return value.Is(typ)
-	}
 	return reflect.TypeOf(data).AssignableTo(typ)
+}
+
+func valueMatchesTypeID(data any, typeID TypeID) bool {
+	if isNilValue(data) {
+		return false
+	}
+	return typeID.MatchPolymorphic(reflect.TypeOf(data))
+}
+
+func isNilValue(data any) bool {
+	if data == nil {
+		return true
+	}
+	value := reflect.ValueOf(data)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }

--- a/workflow/typeid.go
+++ b/workflow/typeid.go
@@ -5,10 +5,13 @@ package workflow
 import (
 	"fmt"
 	"reflect"
+	"sync"
 )
 
+var typeIDRegistry sync.Map
+
 // TypeID is a representation of a type's identity, including its package and
-// type names.
+// type names. Pointer types are identified by their element type.
 type TypeID struct {
 	// PackageName is the package path for named Go types. It is empty for
 	// built-in and unnamed types.
@@ -19,19 +22,98 @@ type TypeID struct {
 	TypeName string
 }
 
-// NewTypeID creates a TypeID for typ. A nil type returns the zero TypeID.
+// NewTypeID creates a TypeID for typ and caches typ as a runtime type that can
+// be resolved from that identity. A nil type returns the zero TypeID. Pointer
+// types are identified by their element type.
 func NewTypeID(typ reflect.Type) TypeID {
-	if typ == nil {
+	id := typeIDOf(typ)
+	cacheRuntimeType(id, typ)
+	return id
+}
+
+func typeIDOf(typ reflect.Type) TypeID {
+	var ok bool
+	typ, ok = dereferencePointerType(typ)
+	if !ok || typ == nil {
 		return TypeID{}
 	}
 	name := typ.Name()
 	if name == "" {
 		name = typ.String()
 	}
-	return TypeID{
+	id := TypeID{
 		PackageName: typ.PkgPath(),
 		TypeName:    name,
 	}
+	return id
+}
+
+func cacheRuntimeType(id TypeID, typ reflect.Type) {
+	if id == (TypeID{}) || typ == nil {
+		return
+	}
+	candidate := runtimeTypeForCache(typ)
+	if candidate == nil {
+		return
+	}
+	current, loaded := typeIDRegistry.LoadOrStore(id, candidate)
+	if !loaded || preferRuntimeType(candidate, current.(reflect.Type)) {
+		typeIDRegistry.Store(id, candidate)
+	}
+}
+
+func runtimeTypeForCache(typ reflect.Type) reflect.Type {
+	if typ == nil {
+		return nil
+	}
+	wasPointer := typ.Kind() == reflect.Pointer
+	base, ok := dereferencePointerType(typ)
+	if !ok || base == nil {
+		return nil
+	}
+	if !wasPointer || base.Kind() == reflect.Interface {
+		return base
+	}
+	return reflect.PointerTo(base)
+}
+
+func dereferencePointerType(typ reflect.Type) (reflect.Type, bool) {
+	if typ == nil {
+		return nil, true
+	}
+	slowpoke := typ
+	indir := 0
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+		if typ == slowpoke {
+			return nil, false
+		}
+		if indir%2 == 0 {
+			slowpoke = slowpoke.Elem()
+		}
+		indir++
+	}
+	return typ, true
+}
+
+// preferRuntimeType reports whether candidate should replace current in the
+// TypeID runtime cache. Interface types are preferred because they enable
+// polymorphic matching, and pointer concrete types are preferred over value
+// concrete types because TypeID canonicalizes both to the element identity.
+func preferRuntimeType(candidate, current reflect.Type) bool {
+	if candidate == nil {
+		return false
+	}
+	if current == nil {
+		return true
+	}
+	if candidate.Kind() == reflect.Interface {
+		return current.Kind() != reflect.Interface
+	}
+	if current.Kind() == reflect.Interface {
+		return false
+	}
+	return candidate.Kind() == reflect.Pointer && current.Kind() != reflect.Pointer
 }
 
 // Match reports whether typ has the same package and type names as t.
@@ -41,6 +123,42 @@ func (t TypeID) Match(typ reflect.Type) bool {
 		return false
 	}
 	return NewTypeID(typ) == t
+}
+
+// MatchPolymorphic reports whether typ either matches this type identity
+// exactly or can be assigned to the runtime type cached or discovered for this
+// identity. Concrete types can match interface response ports when the interface
+// type has been cached through [NewTypeID] or discovered from runtime type
+// metadata.
+func (t TypeID) MatchPolymorphic(typ reflect.Type) bool {
+	if t.Match(typ) {
+		return true
+	}
+	if typ == nil || t == (TypeID{}) {
+		return false
+	}
+	target, ok := runtimeTypeForTypeID(t)
+	return ok && typ.AssignableTo(target)
+}
+
+func runtimeTypeForTypeID(id TypeID) (reflect.Type, bool) {
+	if id == (TypeID{}) {
+		return nil, false
+	}
+	typ, ok := typeIDRegistry.Load(id)
+	if ok {
+		return typ.(reflect.Type), true
+	}
+	fallback, ok := lookupRuntimeTypeByID(id)
+	if !ok {
+		return nil, false
+	}
+	cacheRuntimeType(id, fallback)
+	typ, ok = typeIDRegistry.Load(id)
+	if ok {
+		return typ.(reflect.Type), true
+	}
+	return fallback, true
 }
 
 // String returns the type identity in a compact diagnostic form.

--- a/workflow/typeid_reflect2_gc.go
+++ b/workflow/typeid_reflect2_gc.go
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+//go:build gc
+
+package workflow
+
+import (
+	"reflect"
+	"sync"
+	"unsafe"
+)
+
+//go:linkname reflectTypeLinks reflect.typelinks
+func reflectTypeLinks() (sections []unsafe.Pointer, offsets [][]int32)
+
+//go:linkname reflectResolveTypeOff reflect.resolveTypeOff
+func reflectResolveTypeOff(rtype unsafe.Pointer, off int32) unsafe.Pointer
+
+func lookupRuntimeTypeByID(id TypeID) (reflect.Type, bool) {
+	typ, ok := runtimeTypes()[id]
+	return typ, ok
+}
+
+var runtimeTypes = sync.OnceValue(func() map[TypeID]reflect.Type {
+	types := make(map[TypeID]reflect.Type)
+	var obj any = reflect.TypeFor[int]()
+	sections, offsets := reflectTypeLinks()
+	for sectionIndex, sectionOffsets := range offsets {
+		section := sections[sectionIndex]
+		for _, offset := range sectionOffsets {
+			(*emptyInterface)(unsafe.Pointer(&obj)).word = reflectResolveTypeOff(section, offset)
+			typ, ok := obj.(reflect.Type)
+			if !ok {
+				continue
+			}
+			rememberRuntimeType(types, typ)
+		}
+	}
+	return types
+})
+
+func rememberRuntimeType(types map[TypeID]reflect.Type, typ reflect.Type) {
+	base, ok := dereferencePointerType(typ)
+	if !ok || base == nil {
+		return
+	}
+	if base.Kind() == reflect.Interface {
+		storeRuntimeType(types, base)
+		return
+	}
+	storeRuntimeType(types, base)
+	storeRuntimeType(types, reflect.PointerTo(base))
+}
+
+func storeRuntimeType(types map[TypeID]reflect.Type, typ reflect.Type) {
+	if typ == nil {
+		return
+	}
+	id := typeIDOf(typ)
+	if id == (TypeID{}) {
+		return
+	}
+	if current, ok := types[id]; !ok || preferRuntimeType(typ, current) {
+		types[id] = typ
+	}
+}
+
+type emptyInterface struct {
+	typ  unsafe.Pointer
+	word unsafe.Pointer
+}

--- a/workflow/typeid_reflect2_other.go
+++ b/workflow/typeid_reflect2_other.go
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+//go:build !gc
+
+package workflow
+
+import "reflect"
+
+func lookupRuntimeTypeByID(TypeID) (reflect.Type, bool) {
+	return nil, false
+}

--- a/workflow/typeid_test.go
+++ b/workflow/typeid_test.go
@@ -1,0 +1,401 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+type typeIDPayload struct {
+	Value string `json:"value"`
+}
+
+type typeIDPayloadAlias = typeIDPayload
+
+type typeIDOtherPayload struct {
+	Value string `json:"value"`
+}
+
+type typeIDNamedPointer *typeIDPayload
+
+type typeIDRecursivePointer *typeIDRecursivePointer
+
+type (
+	typeIDMutualPointerA *typeIDMutualPointerB
+	typeIDMutualPointerB *typeIDMutualPointerA
+)
+
+type typeIDNamedInt int
+
+type typeIDOtherNamedInt int
+
+type RequestPort struct{}
+
+type typeIDPointerOnlyMarker interface {
+	pointerOnlyMarker()
+}
+
+type typeIDPointerOnlyValue struct{}
+
+func (*typeIDPointerOnlyValue) pointerOnlyMarker() {}
+
+type typeIDValueMarker interface {
+	valueMarker()
+}
+
+type typeIDValueMarkerValue struct{}
+
+func (typeIDValueMarkerValue) valueMarker() {}
+
+type typeIDCustomError struct{}
+
+func (*typeIDCustomError) Error() string { return "type id error" }
+
+func TestTypeIDNewTypeIDIdentifiesNamedAndBuiltinTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{name: "builtin int", typ: reflect.TypeFor[int]()},
+		{name: "builtin string", typ: reflect.TypeFor[string]()},
+		{name: "unsafe pointer", typ: reflect.TypeFor[unsafe.Pointer]()},
+		{name: "workflow named type", typ: reflect.TypeFor[workflow.RequestPort]()},
+		{name: "local named struct", typ: reflect.TypeFor[typeIDPayload]()},
+		{name: "local named int", typ: reflect.TypeFor[typeIDNamedInt]()},
+		{name: "local alias", typ: reflect.TypeFor[typeIDPayloadAlias]()},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			id := workflow.NewTypeID(testCase.typ)
+			want := expectedTypeID(testCase.typ)
+			if id != want {
+				t.Fatalf("NewTypeID(%v) = %+v, want %+v", testCase.typ, id, want)
+			}
+			if !id.Match(testCase.typ) {
+				t.Fatalf("%v should match its source type %v", id, testCase.typ)
+			}
+		})
+	}
+}
+
+func TestTypeIDNewTypeIDIdentifiesUnnamedTypesByString(t *testing.T) {
+	anonymousStruct := reflect.TypeOf(struct {
+		Name string `json:"name"`
+		Next *int   `json:"next,omitempty"`
+	}{})
+	cases := []reflect.Type{
+		reflect.TypeFor[[]string](),
+		reflect.TypeFor[[3]*int](),
+		reflect.TypeFor[map[string][]*workflow.Executor](),
+		reflect.TypeFor[chan<- string](),
+		reflect.TypeFor[func(int, ...string) (bool, error)](),
+		anonymousStruct,
+		reflect.PointerTo(anonymousStruct),
+	}
+
+	for _, typ := range cases {
+		t.Run(typ.String(), func(t *testing.T) {
+			id := workflow.NewTypeID(typ)
+			want := expectedTypeID(typ)
+			if id != want {
+				t.Fatalf("NewTypeID(%v) = %+v, want %+v", typ, id, want)
+			}
+			if id.PackageName != "" {
+				t.Fatalf("PackageName = %q, want empty for unnamed type %v", id.PackageName, typ)
+			}
+			if id.TypeName != dereferenceType(typ).String() {
+				t.Fatalf("TypeName = %q, want %q", id.TypeName, dereferenceType(typ).String())
+			}
+			if id.String() != id.TypeName {
+				t.Fatalf("String() = %q, want %q", id.String(), id.TypeName)
+			}
+		})
+	}
+}
+
+func TestTypeIDNewTypeIDDereferencesPointersAtAnyDepth(t *testing.T) {
+	valueID := workflow.NewTypeID(reflect.TypeFor[typeIDPayload]())
+	cases := []reflect.Type{
+		reflect.TypeFor[*typeIDPayload](),
+		reflect.TypeFor[**typeIDPayload](),
+		reflect.TypeFor[***typeIDPayload](),
+		reflect.TypeFor[********typeIDPayload](),
+		reflect.TypeFor[typeIDNamedPointer](),
+		reflect.TypeFor[*typeIDNamedPointer](),
+	}
+
+	for _, typ := range cases {
+		t.Run(typ.String(), func(t *testing.T) {
+			id := workflow.NewTypeID(typ)
+			if id != valueID {
+				t.Fatalf("NewTypeID(%v) = %+v, want %+v", typ, id, valueID)
+			}
+			if !id.Match(typ) {
+				t.Fatalf("%+v should match %v", id, typ)
+			}
+		})
+	}
+
+	intID := workflow.NewTypeID(reflect.TypeFor[int]())
+	deepIntID := workflow.NewTypeID(reflect.TypeFor[********int]())
+	if deepIntID != intID {
+		t.Fatalf("NewTypeID(********int) = %+v, want %+v", deepIntID, intID)
+	}
+	if !intID.Match(reflect.TypeFor[********int]()) {
+		t.Fatal("int TypeID should match deeply nested int pointer")
+	}
+}
+
+func TestTypeIDNewTypeIDRejectsRecursivePointerTypes(t *testing.T) {
+	cases := []reflect.Type{
+		reflect.TypeFor[typeIDRecursivePointer](),
+		reflect.TypeFor[*typeIDRecursivePointer](),
+		reflect.TypeFor[typeIDMutualPointerA](),
+		reflect.TypeFor[typeIDMutualPointerB](),
+	}
+
+	for _, typ := range cases {
+		t.Run(typ.String(), func(t *testing.T) {
+			if got := workflow.NewTypeID(typ); got != (workflow.TypeID{}) {
+				t.Fatalf("NewTypeID(%v) = %+v, want zero TypeID", typ, got)
+			}
+			if (workflow.TypeID{}).Match(typ) {
+				t.Fatalf("zero TypeID should not match recursive pointer type %v", typ)
+			}
+			if workflow.NewTypeID(reflect.TypeFor[typeIDPayload]()).Match(typ) {
+				t.Fatalf("unrelated TypeID should not match recursive pointer type %v", typ)
+			}
+		})
+	}
+}
+
+func TestTypeIDNewTypeIDKeepsPackageInIdentity(t *testing.T) {
+	workflowRequestPortID := workflow.NewTypeID(reflect.TypeFor[workflow.RequestPort]())
+	localRequestPortID := workflow.NewTypeID(reflect.TypeFor[RequestPort]())
+
+	if workflowRequestPortID.TypeName != localRequestPortID.TypeName {
+		t.Fatalf("test setup expected matching type names, got %q and %q", workflowRequestPortID.TypeName, localRequestPortID.TypeName)
+	}
+	if workflowRequestPortID.PackageName == localRequestPortID.PackageName {
+		t.Fatalf("test setup expected different packages, both were %q", workflowRequestPortID.PackageName)
+	}
+	if workflowRequestPortID == localRequestPortID {
+		t.Fatal("TypeID should distinguish same type name from different packages")
+	}
+	if workflowRequestPortID.Match(reflect.TypeFor[RequestPort]()) {
+		t.Fatal("workflow RequestPort TypeID should not match local RequestPort")
+	}
+}
+
+func TestTypeIDZeroAndUnknownDoNotMatch(t *testing.T) {
+	zero := workflow.TypeID{}
+	if got := workflow.NewTypeID(nil); got != zero {
+		t.Fatalf("NewTypeID(nil) = %+v, want zero", got)
+	}
+	if zero.String() != "" {
+		t.Fatalf("zero String() = %q, want empty", zero.String())
+	}
+	if zero.Match(nil) {
+		t.Fatal("zero TypeID should not match nil")
+	}
+	if zero.Match(reflect.TypeFor[string]()) {
+		t.Fatal("zero TypeID should not match concrete types")
+	}
+	if zero.MatchPolymorphic(reflect.TypeFor[string]()) {
+		t.Fatal("zero TypeID should not polymorphically match concrete types")
+	}
+
+	unknown := workflow.TypeID{PackageName: "example.invalid/missing", TypeName: "Missing"}
+	if unknown.Match(reflect.TypeFor[typeIDPayload]()) {
+		t.Fatal("unknown TypeID should not match unrelated concrete type")
+	}
+	if unknown.MatchPolymorphic(reflect.TypeFor[typeIDPayload]()) {
+		t.Fatal("unknown TypeID should not polymorphically match unrelated concrete type")
+	}
+	if unknown.MatchPolymorphic(nil) {
+		t.Fatal("unknown TypeID should not polymorphically match nil")
+	}
+}
+
+func TestTypeIDString(t *testing.T) {
+	cases := []struct {
+		name string
+		id   workflow.TypeID
+		want string
+	}{
+		{name: "zero", id: workflow.TypeID{}, want: ""},
+		{name: "builtin", id: workflow.NewTypeID(reflect.TypeFor[int]()), want: "int"},
+		{name: "unnamed", id: workflow.NewTypeID(reflect.TypeFor[map[string]int]()), want: "map[string]int"},
+		{name: "workflow named", id: workflow.NewTypeID(reflect.TypeFor[workflow.RequestPort]()), want: "RequestPort, github.com/microsoft/agent-framework-go/workflow"},
+		{name: "unsafe pointer", id: workflow.NewTypeID(reflect.TypeFor[unsafe.Pointer]()), want: "Pointer, unsafe"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.id.String(); got != testCase.want {
+				t.Fatalf("String() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestTypeIDJSONRoundtrip(t *testing.T) {
+	cases := []workflow.TypeID{
+		{},
+		workflow.NewTypeID(reflect.TypeFor[string]()),
+		workflow.NewTypeID(reflect.TypeFor[*workflow.Executor]()),
+		workflow.NewTypeID(reflect.TypeFor[workflow.RequestPort]()),
+		workflow.NewTypeID(reflect.TypeFor[map[string]int]()),
+		workflow.NewTypeID(reflect.TypeFor[func(int) (string, error)]()),
+		workflow.NewTypeID(reflect.TypeFor[typeIDPointerOnlyMarker]()),
+	}
+
+	for _, id := range cases {
+		t.Run(id.String(), func(t *testing.T) {
+			data, err := json.Marshal(id)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var got workflow.TypeID
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got != id {
+				t.Fatalf("roundtrip = %+v, want %+v", got, id)
+			}
+		})
+	}
+}
+
+func TestTypeIDManualJSONCanMatchRuntimeType(t *testing.T) {
+	var id workflow.TypeID
+	if err := json.Unmarshal([]byte(`{"PackageName":"","TypeName":"int"}`), &id); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !id.Match(reflect.TypeFor[int]()) {
+		t.Fatal("manual int TypeID should match int")
+	}
+	if id.Match(reflect.TypeFor[string]()) {
+		t.Fatal("manual int TypeID should not match string")
+	}
+}
+
+func TestTypeIDMatchUsesCanonicalIdentity(t *testing.T) {
+	namedIntID := workflow.NewTypeID(reflect.TypeFor[typeIDNamedInt]())
+	if !namedIntID.Match(reflect.TypeFor[*typeIDNamedInt]()) {
+		t.Fatal("named int TypeID should match pointer to the same named type")
+	}
+	if namedIntID.Match(reflect.TypeFor[int]()) {
+		t.Fatal("named int TypeID should not match builtin int")
+	}
+	if namedIntID.Match(reflect.TypeFor[typeIDOtherNamedInt]()) {
+		t.Fatal("named int TypeID should not match a different named int type")
+	}
+
+	payloadID := workflow.NewTypeID(reflect.TypeFor[typeIDPayload]())
+	if payloadID.Match(reflect.TypeFor[typeIDOtherPayload]()) {
+		t.Fatal("payload TypeID should not match a different named struct with the same fields")
+	}
+}
+
+func TestTypeIDMatchPolymorphicWithCachedInterfaces(t *testing.T) {
+	pointerOnlyID := workflow.NewTypeID(reflect.TypeFor[typeIDPointerOnlyMarker]())
+	if pointerOnlyID.Match(reflect.TypeFor[*typeIDPointerOnlyValue]()) {
+		t.Fatal("interface TypeID should not exactly match implementing pointer type")
+	}
+	if !pointerOnlyID.MatchPolymorphic(reflect.TypeFor[*typeIDPointerOnlyValue]()) {
+		t.Fatal("interface TypeID should polymorphically match implementing pointer type")
+	}
+	if pointerOnlyID.MatchPolymorphic(reflect.TypeFor[typeIDPointerOnlyValue]()) {
+		t.Fatal("pointer-receiver implementation should not match by value")
+	}
+	if pointerOnlyID.MatchPolymorphic(reflect.TypeFor[string]()) {
+		t.Fatal("interface TypeID should not polymorphically match unrelated string")
+	}
+
+	valueID := workflow.NewTypeID(reflect.TypeFor[typeIDValueMarker]())
+	if !valueID.MatchPolymorphic(reflect.TypeFor[typeIDValueMarkerValue]()) {
+		t.Fatal("interface TypeID should polymorphically match value implementation")
+	}
+	if !valueID.MatchPolymorphic(reflect.TypeFor[*typeIDValueMarkerValue]()) {
+		t.Fatal("interface TypeID should polymorphically match pointer to value implementation")
+	}
+}
+
+func TestTypeIDMatchPolymorphicWithStandardInterfaces(t *testing.T) {
+	anyID := workflow.NewTypeID(reflect.TypeFor[any]())
+	if !anyID.MatchPolymorphic(reflect.TypeFor[string]()) {
+		t.Fatal("any TypeID should polymorphically match string")
+	}
+	if !anyID.MatchPolymorphic(reflect.TypeFor[*typeIDPayload]()) {
+		t.Fatal("any TypeID should polymorphically match pointer payload")
+	}
+	if anyID.MatchPolymorphic(nil) {
+		t.Fatal("any TypeID should not polymorphically match nil")
+	}
+
+	errorID := workflow.NewTypeID(reflect.TypeFor[error]())
+	if !errorID.MatchPolymorphic(reflect.TypeFor[*typeIDCustomError]()) {
+		t.Fatal("error TypeID should polymorphically match custom error pointer")
+	}
+	if errorID.MatchPolymorphic(reflect.TypeFor[typeIDCustomError]()) {
+		t.Fatal("error TypeID should not match custom error value without Error method")
+	}
+}
+
+func TestTypeIDMatchPolymorphicFromPointerToInterface(t *testing.T) {
+	interfaceID := workflow.NewTypeID(reflect.TypeFor[*typeIDPointerOnlyMarker]())
+	if interfaceID != workflow.NewTypeID(reflect.TypeFor[typeIDPointerOnlyMarker]()) {
+		t.Fatal("pointer to interface should share the interface TypeID")
+	}
+	if !interfaceID.MatchPolymorphic(reflect.TypeFor[*typeIDPointerOnlyValue]()) {
+		t.Fatal("pointer-to-interface TypeID should cache the interface runtime type")
+	}
+}
+
+func TestTypeIDRequestPortInfoCachesRuntimeTypes(t *testing.T) {
+	port := workflow.RequestPort{
+		ID:       "ContentPort",
+		Request:  reflect.TypeFor[*message.FunctionCallContent](),
+		Response: reflect.TypeFor[message.Content](),
+	}
+	info := workflow.NewRequestPortInfo(port)
+
+	if !info.RequestType.Match(reflect.TypeFor[*message.FunctionCallContent]()) {
+		t.Fatal("request TypeID should match pointer request type")
+	}
+	if !info.ResponseType.MatchPolymorphic(reflect.TypeFor[*message.FunctionResultContent]()) {
+		t.Fatal("response TypeID should polymorphically match concrete content")
+	}
+}
+
+func expectedTypeID(typ reflect.Type) workflow.TypeID {
+	typ = dereferenceType(typ)
+	if typ == nil {
+		return workflow.TypeID{}
+	}
+	typeName := typ.Name()
+	if typeName == "" {
+		typeName = typ.String()
+	}
+	return workflow.TypeID{PackageName: typ.PkgPath(), TypeName: typeName}
+}
+
+func dereferenceType(typ reflect.Type) reflect.Type {
+	seen := make(map[reflect.Type]struct{})
+	for typ != nil && typ.Kind() == reflect.Pointer {
+		if _, ok := seen[typ]; ok {
+			return nil
+		}
+		seen[typ] = struct{}{}
+		typ = typ.Elem()
+	}
+	return typ
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -273,38 +273,38 @@ func (w *Workflow) RequestPorts() map[string]RequestPort {
 
 // DescribeProtocol returns the protocol accepted by the workflow's start
 // executor and yielded by its output executors.
-func (w *Workflow) DescribeProtocol() (*ProtocolDescriptor, error) {
+func (w *Workflow) DescribeProtocol() (ProtocolDescriptor, error) {
 	er := w.executorBindings[w.startExecutorID]
 	if _, ok := w.executorBindings[w.startExecutorID]; !ok {
-		return nil, fmt.Errorf("workflow start executor %q has no registered binding", w.startExecutorID)
+		return ProtocolDescriptor{}, fmt.Errorf("workflow start executor %q has no registered binding", w.startExecutorID)
 	}
 	executor, err := er.CreateInstance("")
 	if err != nil {
-		return nil, err
+		return ProtocolDescriptor{}, err
 	}
 	inputProtocol, err := executor.describeProtocol()
 	if err != nil {
-		return nil, err
+		return ProtocolDescriptor{}, err
 	}
 
 	yields := make([]reflect.Type, 0)
 	for executorID := range w.outputExecutors {
 		binding, ok := w.executorBindings[executorID]
 		if !ok {
-			return nil, fmt.Errorf("workflow output executor %q has no registered binding", executorID)
+			return ProtocolDescriptor{}, fmt.Errorf("workflow output executor %q has no registered binding", executorID)
 		}
 		outputExecutor, err := binding.CreateInstance("")
 		if err != nil {
-			return nil, err
+			return ProtocolDescriptor{}, err
 		}
 		outputProtocol, err := outputExecutor.describeProtocol()
 		if err != nil {
-			return nil, err
+			return ProtocolDescriptor{}, err
 		}
 		yields = append(yields, outputProtocol.Yields...)
 	}
 
-	return &ProtocolDescriptor{
+	return ProtocolDescriptor{
 		Accepts:    inputProtocol.Accepts,
 		Yields:     yields,
 		Sends:      nil,


### PR DESCRIPTION
## Summary
- Add workflow provider session state backed by agent sessions, including a JSON checkpoint store, last checkpoint tracking, pending external requests, and workflow session IDs.
- Resume workflow-as-agent runs from persisted checkpoints and route pending external responses alongside regular messages, including normalized function and tool-approval responses.
- Align workflow protocol/type behavior with runtime TypeID matching, polymorphic CreateResponse validation, delayed PortableValue decoding, internal protocol matching helpers, and runtime-based edge routing.
- Update workflow hosting/provider tests and workflow examples for the CreateResponse API and persisted-session behavior.

## Testing
- `go test ./...`