### PR TITLE
[dotnet-port] Populate MessageID from TaskStatusUpdateEvent.Status.Message in A2A agent

### DIFF
--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -179,10 +179,14 @@ func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func
 				return
 			}
 		case *a2a.TaskStatusUpdateEvent:
+			messageID := string(e.TaskID)
+			if e.Status.Message != nil {
+				messageID = e.Status.Message.ID
+			}
 			if !yield(&agent.ResponseUpdate{
 				RawRepresentation:    e,
 				AdditionalProperties: e.Metadata,
-				MessageID:            string(e.TaskID),
+				MessageID:            messageID,
 				ResponseID:           string(e.TaskID),
 				Role:                 message.RoleAssistant,
 				CreatedAt:            time.Now(),

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -1338,6 +1338,55 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 	}
 }
 
+// TestRunStreamingWithTaskStatusUpdateEvent_WithMessage tests that MessageID is populated
+// from Status.Message.ID when the status update contains a message, aligning with the .NET
+// fix in microsoft/agent-framework#6043.
+func TestRunStreamingWithTaskStatusUpdateEvent_WithMessage(t *testing.T) {
+	const taskID = "task-status-msg-123"
+	const contextID = "ctx-status-msg-456"
+	const msgID = "msg-abc-789"
+
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
+			TaskID:    a2a.TaskID(taskID),
+			ContextID: contextID,
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateWorking,
+				Message: &a2a.Message{
+					ID:   msgID,
+					Role: a2a.MessageRoleAgent,
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var updates []*agent.ResponseUpdate
+	for update, err := range a.RunText(t.Context(), "Check task status", agent.WithSession(session), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+
+	update := updates[0]
+	if update.MessageID != msgID {
+		t.Errorf("update.MessageID = %q, want %q (from Status.Message.ID)", update.MessageID, msgID)
+	}
+	if update.ResponseID != taskID {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
+	}
+}
+
 // TestRunStreamingWithTaskArtifactUpdateEvent tests handling of TaskArtifactUpdateEvent
 func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	const taskID = "task-artifact-123"


### PR DESCRIPTION
When the Go A2A agent receives a TaskStatusUpdateEvent during streaming, ResponseUpdate.MessageID is now set from Status.Message.ID when the message is present, falling back to the TaskID otherwise.

This aligns with the .NET fix in microsoft/agent-framework#6043.