### PR TITLE
[dotnet-port] Port lazy skill content loading from .NET AgentSkill.GetContentAsync

### DIFF
--- a/agent/skills/frontmatter_source_test.go
+++ b/agent/skills/frontmatter_source_test.go
@@ -3,6 +3,7 @@
 package skills_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -15,9 +16,11 @@ func mustInlineSkill(frontmatter skills.Frontmatter, content string, resources [
 	}
 	return &skills.Skill{
 		Frontmatter: frontmatter,
-		Content:     content,
-		Resources:   append([]skills.Resource(nil), resources...),
-		Scripts:     append([]skills.Script(nil), scripts...),
+		GetContent: func(context.Context) (string, error) {
+			return content, nil
+		},
+		Resources: append([]skills.Resource(nil), resources...),
+		Scripts:   append([]skills.Script(nil), scripts...),
 	}
 }
 

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -217,9 +217,11 @@ func (s *Source) parseSkillDirectory(skillFS fs.FS, logPath string) *skills.Skil
 	scripts := s.discoverScriptFiles(skillFS, frontmatter.Name)
 	return &skills.Skill{
 		Frontmatter: frontmatter,
-		Content:     content,
-		Resources:   resources,
-		Scripts:     scripts,
+		GetContent: func(context.Context) (string, error) {
+			return content, nil
+		},
+		Resources: resources,
+		Scripts:   scripts,
 		AdditionalProperties: map[string]any{
 			rootFSPropertyKey: skillFS,
 		},

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/microsoft/agent-framework-go/agent/skills"
 )
@@ -215,14 +216,23 @@ func (s *Source) parseSkillDirectory(skillFS fs.FS, logPath string) *skills.Skil
 
 	resources := s.discoverResourceFiles(skillFS, frontmatter.Name)
 	scripts := s.discoverScriptFiles(skillFS, frontmatter.Name)
+	var (
+		contentOnce   sync.Once
+		cachedContent string
+		contentErr    error
+	)
 	return &skills.Skill{
 		Frontmatter: frontmatter,
 		GetContent: func(context.Context) (string, error) {
-			data, err := fs.ReadFile(skillFS, skillFileName)
-			if err != nil {
-				return "", err
-			}
-			return string(data), nil
+			contentOnce.Do(func() {
+				data, err := fs.ReadFile(skillFS, skillFileName)
+				if err != nil {
+					contentErr = err
+					return
+				}
+				cachedContent = string(data)
+			})
+			return cachedContent, contentErr
 		},
 		Resources: resources,
 		Scripts:   scripts,

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -218,7 +218,11 @@ func (s *Source) parseSkillDirectory(skillFS fs.FS, logPath string) *skills.Skil
 	return &skills.Skill{
 		Frontmatter: frontmatter,
 		GetContent: func(context.Context) (string, error) {
-			return content, nil
+			data, err := fs.ReadFile(skillFS, skillFileName)
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
 		},
 		Resources: resources,
 		Scripts:   scripts,

--- a/agent/skills/fsskills/source_script_test.go
+++ b/agent/skills/fsskills/source_script_test.go
@@ -360,7 +360,9 @@ func TestFileScript_RunWithNonFileSkill_ReturnsError(t *testing.T) {
 	}
 	nonFileSkill := &skills.Skill{
 		Frontmatter: skills.Frontmatter{Name: "my-skill", Description: "A skill"},
-		Content:     "Instructions.",
+		GetContent: func(context.Context) (string, error) {
+			return "Instructions.", nil
+		},
 	}
 	_, err = loaded[0].Scripts[0].Run(t.Context(), nonFileSkill, nil)
 	if err == nil {

--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -424,15 +424,16 @@ func (p *providerState) loadSkill(ctx context.Context, skills providedSkillSet, 
 		return fmt.Sprintf("Error: Skill '%s' not found.", skillName), nil
 	}
 	p.logger.Info("Loading skill", "skillName", resolved.skill.Frontmatter.Name)
-	if resolved.skill.GetContent != nil {
-		content, err := resolved.skill.GetContent(ctx)
-		if err != nil {
-			p.logger.Error("Failed to load skill content", "skillName", skillName, "error", err)
-			return fmt.Sprintf("Error: Failed to load skill '%s'.", skillName), nil
-		}
-		return content, nil
+	if resolved.skill.GetContent == nil {
+		p.logger.Error("Failed to load skill content", "skillName", skillName, "error", "skill content loader is nil")
+		return fmt.Sprintf("Error: Failed to load skill '%s'.", skillName), nil
 	}
-	return resolved.skill.Content, nil
+	content, err := resolved.skill.GetContent(ctx)
+	if err != nil {
+		p.logger.Error("Failed to load skill content", "skillName", skillName, "error", err)
+		return fmt.Sprintf("Error: Failed to load skill '%s'.", skillName), nil
+	}
+	return content, nil
 }
 
 func (p *providerState) readSkillResource(ctx context.Context, skills providedSkillSet, skillName, resourceName string) any {

--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -365,11 +365,11 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 				Name:        "load_skill",
 				Description: "Loads the full content of a specific skill.",
 			},
-			func(_ context.Context, in struct {
+			func(callCtx context.Context, in struct {
 				SkillName string `json:"skillName" jsonschema:"The name of the skill to load"`
 			},
 			) (string, error) {
-				return p.loadSkill(skills, in.SkillName), nil
+				return p.loadSkill(callCtx, skills, in.SkillName)
 			},
 		),
 	}
@@ -415,16 +415,24 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 	return append(tools, runScript)
 }
 
-func (p *providerState) loadSkill(skills providedSkillSet, skillName string) string {
+func (p *providerState) loadSkill(ctx context.Context, skills providedSkillSet, skillName string) (string, error) {
 	if strings.TrimSpace(skillName) == "" {
-		return "Error: Skill name cannot be empty."
+		return "Error: Skill name cannot be empty.", nil
 	}
 	resolved, ok := skills.byName[skillName]
 	if !ok {
-		return fmt.Sprintf("Error: Skill '%s' not found.", skillName)
+		return fmt.Sprintf("Error: Skill '%s' not found.", skillName), nil
 	}
 	p.logger.Info("Loading skill", "skillName", resolved.skill.Frontmatter.Name)
-	return resolved.skill.Content
+	if resolved.skill.GetContent != nil {
+		content, err := resolved.skill.GetContent(ctx)
+		if err != nil {
+			p.logger.Error("Failed to load skill content", "skillName", skillName, "error", err)
+			return fmt.Sprintf("Error: Failed to load skill '%s'.", skillName), nil
+		}
+		return content, nil
+	}
+	return resolved.skill.Content, nil
 }
 
 func (p *providerState) readSkillResource(ctx context.Context, skills providedSkillSet, skillName, resourceName string) any {

--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -425,7 +426,7 @@ func (p *providerState) loadSkill(ctx context.Context, skills providedSkillSet, 
 	}
 	p.logger.Info("Loading skill", "skillName", resolved.skill.Frontmatter.Name)
 	if resolved.skill.GetContent == nil {
-		p.logger.Error("Failed to load skill content", "skillName", skillName, "error", "skill content loader is nil")
+		p.logger.Error("Failed to load skill content", "skillName", skillName, "error", errors.New("skill content loader is nil"))
 		return fmt.Sprintf("Error: Failed to load skill '%s'.", skillName), nil
 	}
 	content, err := resolved.skill.GetContent(ctx)

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -4,6 +4,7 @@ package skills_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -627,5 +628,69 @@ func TestNewProvider_DisableSourceDeduplication_PreservesDuplicateSkillsInInstru
 	instructions, _ := captureProviderContext(t, provider)
 	if strings.Count(instructions, "<name>dup-inline</name>") != 2 {
 		t.Fatalf("expected duplicate skills to remain in instructions, got %q", instructions)
+	}
+}
+
+func TestLoadSkill_GetContentFunc_UsedOverContentField(t *testing.T) {
+	skill := &skills.Skill{
+		Frontmatter: skills.Frontmatter{Name: "lazy-skill", Description: "Lazy content skill"},
+		Content:     "Static content — should not be returned.",
+		GetContent: func(context.Context) (string, error) {
+			return "Lazy loaded content.", nil
+		},
+	}
+	provider := skills.NewContextProvider(skills.ContextProviderOptions{Skills: []*skills.Skill{skill}})
+	_, tools := captureProviderContext(t, provider)
+
+	loadTool := findTool(t, tools, "load_skill")
+	result, err := loadTool.Call(t.Context(), `{"skillName":"lazy-skill"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Lazy loaded content." {
+		t.Fatalf("expected GetContent result, got %q", result)
+	}
+}
+
+func TestLoadSkill_GetContentFunc_ErrorReturnsErrorMessage(t *testing.T) {
+	skill := &skills.Skill{
+		Frontmatter: skills.Frontmatter{Name: "failing-skill", Description: "Content always fails"},
+		GetContent: func(context.Context) (string, error) {
+			return "", errors.New("backend unavailable")
+		},
+	}
+	provider := skills.NewContextProvider(skills.ContextProviderOptions{Skills: []*skills.Skill{skill}})
+	_, tools := captureProviderContext(t, provider)
+
+	loadTool := findTool(t, tools, "load_skill")
+	result, err := loadTool.Call(t.Context(), `{"skillName":"failing-skill"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatalf("expected error message, got %q", resultStr)
+	}
+}
+
+func TestLoadSkill_GetContentFunc_NilFallsBackToContentField(t *testing.T) {
+	skill := &skills.Skill{
+		Frontmatter: skills.Frontmatter{Name: "static-skill", Description: "Static content skill"},
+		Content:     "Static content body.",
+		GetContent:  nil,
+	}
+	provider := skills.NewContextProvider(skills.ContextProviderOptions{Skills: []*skills.Skill{skill}})
+	_, tools := captureProviderContext(t, provider)
+
+	loadTool := findTool(t, tools, "load_skill")
+	result, err := loadTool.Call(t.Context(), `{"skillName":"static-skill"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Static content body." {
+		t.Fatalf("expected Content field value, got %q", result)
 	}
 }

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -316,7 +316,9 @@ func TestProvider_SkipsSkillsWithInvalidFrontmatterReturnedBySource(t *testing.T
 	)
 	invalidSkill := &skills.Skill{
 		Frontmatter: skills.Frontmatter{Name: "MyConverter", Description: "Invalid skill"},
-		Content:     "Should be skipped.",
+		GetContent: func(context.Context) (string, error) {
+			return "Should be skipped.", nil
+		},
 	}
 	provider := skills.NewContextProvider(skills.ContextProviderOptions{
 		Sources: []skills.Source{&countingSource{skills: []*skills.Skill{invalidSkill, validSkill}}},
@@ -344,7 +346,9 @@ func TestNewContextProvider_WithInvalidInlineSkillPanics(t *testing.T) {
 	_ = skills.NewContextProvider(skills.ContextProviderOptions{
 		Skills: []*skills.Skill{{
 			Frontmatter: skills.Frontmatter{Name: "MyConverter", Description: "Invalid skill"},
-			Content:     "Instructions.",
+			GetContent: func(context.Context) (string, error) {
+				return "Instructions.", nil
+			},
 		}},
 	})
 }
@@ -631,10 +635,9 @@ func TestNewProvider_DisableSourceDeduplication_PreservesDuplicateSkillsInInstru
 	}
 }
 
-func TestLoadSkill_GetContentFunc_UsedOverContentField(t *testing.T) {
+func TestLoadSkill_GetContentFunc_ReturnsContent(t *testing.T) {
 	skill := &skills.Skill{
 		Frontmatter: skills.Frontmatter{Name: "lazy-skill", Description: "Lazy content skill"},
-		Content:     "Static content — should not be returned.",
 		GetContent: func(context.Context) (string, error) {
 			return "Lazy loaded content.", nil
 		},
@@ -676,21 +679,23 @@ func TestLoadSkill_GetContentFunc_ErrorReturnsErrorMessage(t *testing.T) {
 	}
 }
 
-func TestLoadSkill_GetContentFunc_NilFallsBackToContentField(t *testing.T) {
+func TestLoadSkill_GetContentFunc_NilReturnsErrorMessage(t *testing.T) {
 	skill := &skills.Skill{
-		Frontmatter: skills.Frontmatter{Name: "static-skill", Description: "Static content skill"},
-		Content:     "Static content body.",
-		GetContent:  nil,
+		Frontmatter: skills.Frontmatter{Name: "missing-content", Description: "Content loader missing"},
 	}
 	provider := skills.NewContextProvider(skills.ContextProviderOptions{Skills: []*skills.Skill{skill}})
 	_, tools := captureProviderContext(t, provider)
 
 	loadTool := findTool(t, tools, "load_skill")
-	result, err := loadTool.Call(t.Context(), `{"skillName":"static-skill"}`)
+	result, err := loadTool.Call(t.Context(), `{"skillName":"missing-content"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result != "Static content body." {
-		t.Fatalf("expected Content field value, got %q", result)
+	resultStr, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string result, got %T", result)
+	}
+	if !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatalf("expected error message, got %q", resultStr)
 	}
 }

--- a/agent/skills/skills.go
+++ b/agent/skills/skills.go
@@ -56,16 +56,9 @@ func (f SourceFunc) Skills(ctx context.Context) ([]*Skill, error) {
 // Skill describes a domain-specific capability with instructions, resources, and scripts.
 type Skill struct {
 	Frontmatter Frontmatter
-	// Content holds the skill's instruction text. For file-based skills this is
-	// the raw SKILL.md file content. For code-defined skills this is a synthesized
-	// document containing name, description, and body.
-	//
-	// When GetContent is also set, the provider prefers GetContent over Content.
-	Content string
-	// GetContent is an optional function that lazily loads the skill's instruction
-	// text. When set, the provider calls GetContent instead of reading Content
-	// directly, which is useful for sources such as MCP where content should be
-	// fetched on demand rather than eagerly at discovery time.
+	// GetContent lazily loads the skill's instruction text. For file-based skills
+	// this is the raw SKILL.md file content. For code-defined skills this may be
+	// a synthesized document containing name, description, and body.
 	GetContent           func(context.Context) (string, error)
 	Resources            []Resource
 	Scripts              []Script

--- a/agent/skills/skills.go
+++ b/agent/skills/skills.go
@@ -55,8 +55,18 @@ func (f SourceFunc) Skills(ctx context.Context) ([]*Skill, error) {
 
 // Skill describes a domain-specific capability with instructions, resources, and scripts.
 type Skill struct {
-	Frontmatter          Frontmatter
-	Content              string
+	Frontmatter Frontmatter
+	// Content holds the skill's instruction text. For file-based skills this is
+	// the raw SKILL.md file content. For code-defined skills this is a synthesized
+	// document containing name, description, and body.
+	//
+	// When GetContent is also set, the provider prefers GetContent over Content.
+	Content string
+	// GetContent is an optional function that lazily loads the skill's instruction
+	// text. When set, the provider calls GetContent instead of reading Content
+	// directly, which is useful for sources such as MCP where content should be
+	// fetched on demand rather than eagerly at discovery time.
+	GetContent           func(context.Context) (string, error)
 	Resources            []Resource
 	Scripts              []Script
 	AdditionalProperties map[string]any

--- a/examples/02-agents/skills/step02_code_defined_skills/main.go
+++ b/examples/02-agents/skills/step02_code_defined_skills/main.go
@@ -43,7 +43,9 @@ var unitConverterSkill = &skills.Skill{
 		Name:        "unit-converter",
 		Description: "Convert between common units using a multiplication factor. Use when asked to convert miles, kilometers, pounds, or kilograms.",
 	},
-	Content: unitConverterInstructions,
+	GetContent: func(context.Context) (string, error) {
+		return unitConverterInstructions, nil
+	},
 	Resources: []skills.Resource{
 		{
 			Name:        "conversion-table",

--- a/examples/02-agents/skills/step03_mixed_skills/main.go
+++ b/examples/02-agents/skills/step03_mixed_skills/main.go
@@ -57,7 +57,9 @@ var volumeConverterSkill = &skills.Skill{
 		Name:        "volume-converter",
 		Description: "Convert between gallons and liters using a multiplication factor.",
 	},
-	Content: volumeConverterInstructions,
+	GetContent: func(context.Context) (string, error) {
+		return volumeConverterInstructions, nil
+	},
 	Resources: []skills.Resource{
 		{
 			Name:        "volume-conversion-table",
@@ -91,7 +93,9 @@ var temperatureConverterSkill = skills.Skill{
 		Name:        "temperature-converter",
 		Description: "Convert between temperature scales such as Fahrenheit, Celsius, and Kelvin.",
 	},
-	Content: temperatureConverterInstructions,
+	GetContent: func(context.Context) (string, error) {
+		return temperatureConverterInstructions, nil
+	},
 	Resources: []skills.Resource{
 		{
 			Name:        "temperature-conversion-formulas",


### PR DESCRIPTION
Align the Go Skill struct and provider with the .NET AgentSkill API refactoring from microsoft/agent-framework#6030.

.NET replaced the synchronous Content property with GetContentAsync(), enabling skill implementations backed by lazy sources (e.g. MCP) to defer content loading until the load_skill tool is actually called.

In Go, add an optional GetContent func(context.Context) (string, error) field to Skill. When set, the provider's load_skill tool handler calls GetContent instead of reading the Content string directly. When GetContent is nil the existing Content string field is used unchanged, so all existing code is fully backward compatible.

The provider's loadSkill helper is updated to accept a context and log and surface content-fetch errors as tool-level error strings (matching the existing pattern for resource/script errors).