### PR TITLE
[dotnet-port] Always register all skill tools unconditionally

### DIFF
--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -256,12 +256,11 @@ func (p *providerState) buildContext(ctx context.Context) (providerContext, erro
 	}
 
 	indexed := indexSkills(skills)
-	hasResources, hasScripts := indexed.hasResourcesAndScripts()
 	out := providerContext{
-		Options: toolOptions(p.buildTools(indexed, hasResources, hasScripts)),
+		Options: toolOptions(p.buildTools(indexed)),
 	}
 
-	instructions := buildProviderSkillsInstructionPrompt(p.options.SkillsInstructionPrompt, skills, hasResources, hasScripts)
+	instructions := buildProviderSkillsInstructionPrompt(p.options.SkillsInstructionPrompt, skills)
 	if instructions != "" {
 		out.Instructions = instructions
 	}
@@ -343,23 +342,7 @@ func indexSkills(skills []*Skill) providedSkillSet {
 	return providedSkillSet{byName: indexed}
 }
 
-func (p providedSkillSet) hasResourcesAndScripts() (bool, bool) {
-	var hasResources, hasScripts bool
-	for _, skill := range p.byName {
-		if len(skill.resources) > 0 {
-			hasResources = true
-		}
-		if len(skill.scripts) > 0 {
-			hasScripts = true
-		}
-		if hasResources && hasScripts {
-			return true, true
-		}
-	}
-	return hasResources, hasScripts
-}
-
-func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScripts bool) []tool.Tool {
+func (p *providerState) buildTools(skills providedSkillSet) []tool.Tool {
 	tools := []tool.Tool{
 		functool.MustNew(
 			functool.Config{
@@ -373,10 +356,7 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 				return p.loadSkill(callCtx, skills, in.SkillName)
 			},
 		),
-	}
-
-	if hasResources {
-		tools = append(tools, functool.MustNew(
+		functool.MustNew(
 			functool.Config{
 				Name:        "read_skill_resource",
 				Description: "Reads a resource associated with a skill, such as references, assets, or dynamic data.",
@@ -388,11 +368,7 @@ func (p *providerState) buildTools(skills providedSkillSet, hasResources, hasScr
 			) (any, error) {
 				return p.readSkillResource(callCtx, skills, in.SkillName, in.ResourceName), nil
 			},
-		))
-	}
-
-	if !hasScripts {
-		return tools
+		),
 	}
 
 	runScript := functool.MustNew(
@@ -491,7 +467,7 @@ func (p *providerState) runSkillScript(ctx context.Context, skills providedSkill
 	return result
 }
 
-func buildProviderSkillsInstructionPrompt(template string, skills []*Skill, includeResources, includeScripts bool) string {
+func buildProviderSkillsInstructionPrompt(template string, skills []*Skill) string {
 	if len(skills) == 0 {
 		return ""
 	}
@@ -513,15 +489,8 @@ func buildProviderSkillsInstructionPrompt(template string, skills []*Skill, incl
 	}
 
 	skillList := strings.TrimRight(sb.String(), "\n")
-	resourceInstruction := ""
-	if includeResources {
-		resourceInstruction = "- Use `read_skill_resource` to read any referenced resources, using the name exactly as listed\n   (e.g. `\"style-guide\"` not `\"style-guide.md\"`, `\"references/FAQ.md\"` not `\"FAQ.md\"`)."
-	}
-
-	scriptInstruction := ""
-	if includeScripts {
-		scriptInstruction = "- Use `run_skill_script` to run referenced scripts, using the name exactly as listed."
-	}
+	resourceInstruction := "- Use `read_skill_resource` to read any referenced resources, using the name exactly as listed\n   (e.g. `\"style-guide\"` not `\"style-guide.md\"`, `\"references/FAQ.md\"` not `\"FAQ.md\"`)."
+	scriptInstruction := "- Use `run_skill_script` to run referenced scripts, using the name exactly as listed."
 
 	replacer := strings.NewReplacer(
 		skillsPlaceholder, skillList,

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -479,8 +479,17 @@ func TestNewProvider_ProvidesInlineSkills(t *testing.T) {
 	if !strings.Contains(instructions, "inline-skill") {
 		t.Fatal("expected inline skill to be advertised")
 	}
-	if len(tools) != 1 || tools[0].Name() != "load_skill" {
-		t.Fatal("expected only load_skill tool for inline skills without resources or scripts")
+	if len(tools) != 3 {
+		t.Fatalf("expected load_skill, read_skill_resource, and run_skill_script tools, got %d tools", len(tools))
+	}
+	toolNames := make([]string, len(tools))
+	for i, t2 := range tools {
+		toolNames[i] = t2.Name()
+	}
+	for _, name := range []string{"load_skill", "read_skill_resource", "run_skill_script"} {
+		if !slices.Contains(toolNames, name) {
+			t.Fatalf("expected %s tool to be present, got %v", name, toolNames)
+		}
 	}
 }
 
@@ -512,8 +521,8 @@ func TestNewProvider_ProvideExtendsInput(t *testing.T) {
 		t.Fatal("expected original session option to be preserved")
 	}
 	tools := slices.Collect(agent.AllOptions(options, agent.WithTool))
-	if len(tools) != 1 || tools[0].Name() != "load_skill" {
-		t.Fatal("expected skills provider to append load_skill tool")
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 skill tools (load_skill, read_skill_resource, run_skill_script), got %d", len(tools))
 	}
 }
 

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -274,8 +274,15 @@ func TestDiscovery_ResourceOutsideConfiguredDirectory_NotDiscoverable(t *testing
 		t.Fatal("expected skill to be discovered")
 	}
 	_, tools := captureProviderContext(t, p)
-	if hasTool(tools, "read_skill_resource") {
-		t.Fatal("expected no read_skill_resource tool when no resources were discovered")
+	// read_skill_resource is always registered; ../secret.txt must not be accessible via it.
+	readTool := findTool(t, tools, "read_skill_resource")
+	result, err := readTool.Call(t.Context(), `{"skillName":"traversal-skill","resourceName":"../secret.txt"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok || !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatalf("expected error for inaccessible resource, got %#v", result)
 	}
 }
 
@@ -285,8 +292,8 @@ func TestProvider_WithSkills_ReturnsInstructionsAndTools(t *testing.T) {
 
 	p := newProvider(t, root)
 	_, tools := captureProviderContext(t, p)
-	if len(tools) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(tools))
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools (load_skill, read_skill_resource, run_skill_script), got %d", len(tools))
 	}
 	toolNames := make(map[string]bool)
 	for _, tl := range tools {
@@ -295,8 +302,11 @@ func TestProvider_WithSkills_ReturnsInstructionsAndTools(t *testing.T) {
 	if !toolNames["load_skill"] {
 		t.Error("expected load_skill tool")
 	}
-	if toolNames["read_skill_resource"] {
-		t.Error("did not expect read_skill_resource tool without discovered resources")
+	if !toolNames["read_skill_resource"] {
+		t.Error("expected read_skill_resource tool to always be registered")
+	}
+	if !toolNames["run_skill_script"] {
+		t.Error("expected run_skill_script tool to always be registered")
 	}
 }
 
@@ -557,8 +567,15 @@ func TestDiscovery_ResourceInNonSpecDirectory_NotDiscoveredByDefault(t *testing.
 		t.Fatal("expected skill to be discovered")
 	}
 	_, tools := captureProviderContext(t, p)
-	if hasTool(tools, "read_skill_resource") {
-		t.Fatal("expected no read_skill_resource tool when only non-default resource directories exist")
+	// read_skill_resource is always registered; docs/readme.md is in a non-default dir and must not be accessible.
+	readTool := findTool(t, tools, "read_skill_resource")
+	result, err := readTool.Call(t.Context(), `{"skillName":"non-spec-skill","resourceName":"docs/readme.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok || !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatalf("expected error for non-default resource directory, got %#v", result)
 	}
 }
 
@@ -573,8 +590,15 @@ func TestDiscovery_ResourceInSkillRoot_NotDiscoveredByDefault(t *testing.T) {
 
 	p := newProvider(t, root)
 	_, tools := captureProviderContext(t, p)
-	if hasTool(tools, "read_skill_resource") {
-		t.Fatal("expected no read_skill_resource tool when only root-level resources exist and '.' is not configured")
+	// read_skill_resource is always registered; root-level guide.md is not accessible without '.' configured.
+	readTool := findTool(t, tools, "read_skill_resource")
+	result, err := readTool.Call(t.Context(), `{"skillName":"root-resource-skill","resourceName":"guide.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok || !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatalf("expected error for root-level resource without '.' configured, got %#v", result)
 	}
 }
 
@@ -624,8 +648,15 @@ func TestDiscovery_SkillMdNotIncludedAsResource(t *testing.T) {
 	}, nil, root)
 
 	_, tools := captureProviderContext(t, p)
-	if hasTool(tools, "read_skill_resource") {
-		t.Fatal("expected no read_skill_resource tool when the only root-level file is SKILL.md")
+	// read_skill_resource is always registered; SKILL.md must not be accessible even with '.' configured.
+	readTool := findTool(t, tools, "read_skill_resource")
+	result, err := readTool.Call(t.Context(), `{"skillName":"selfref-skill","resourceName":"SKILL.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultStr, ok := result.(string)
+	if !ok || !strings.HasPrefix(resultStr, "Error:") {
+		t.Fatalf("expected SKILL.md to be excluded from resources, got %#v", result)
 	}
 }
 

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -118,15 +118,6 @@ func findTool(t *testing.T, tools []tool.Tool, name string) tool.FuncTool {
 	return nil
 }
 
-func hasTool(tools []tool.Tool, name string) bool {
-	for _, tl := range tools {
-		if tl.Name() == name {
-			return true
-		}
-	}
-	return false
-}
-
 func hasSkill(t *testing.T, provider *agent.ContextProvider, name string) bool {
 	t.Helper()
 	instructions, _ := captureProviderContext(t, provider)

--- a/docs/dotnet-go-sdk-feature-comparison.md
+++ b/docs/dotnet-go-sdk-feature-comparison.md
@@ -113,7 +113,7 @@ Within overlapping features, the main misalignments are API shape and ecosystem 
 
 - The file/inline skill model is similar: frontmatter, content, resources, scripts, sources/providers.
 - .NET adds class-based skills, attribute-based resources/scripts, and DI-backed skill construction. Go has programmatic in-memory skills and script runners, but no class/DI reflection equivalent.
-- Both Go and .NET now always register all three skill tools (`load_skill`, `read_skill_resource`, `run_skill_script`) unconditionally; the tools return descriptive errors when the requested resource or script is not found.
+- Both Go and .NET support the three skill tools (`load_skill`, `read_skill_resource`, `run_skill_script`); in Go, they are registered when skills are discovered or provided, and when present the tools return descriptive errors if the requested resource or script is not found.
 
 ### Workflows
 

--- a/docs/dotnet-go-sdk-feature-comparison.md
+++ b/docs/dotnet-go-sdk-feature-comparison.md
@@ -113,6 +113,7 @@ Within overlapping features, the main misalignments are API shape and ecosystem 
 
 - The file/inline skill model is similar: frontmatter, content, resources, scripts, sources/providers.
 - .NET adds class-based skills, attribute-based resources/scripts, and DI-backed skill construction. Go has programmatic in-memory skills and script runners, but no class/DI reflection equivalent.
+- Both Go and .NET now always register all three skill tools (`load_skill`, `read_skill_resource`, `run_skill_script`) unconditionally; the tools return descriptive errors when the requested resource or script is not found.
 
 ### Workflows
 


### PR DESCRIPTION
Align Go AgentSkillsProvider with .NET #6030: register load_skill, read_skill_resource, and run_skill_script for every skills context, regardless of whether any resources or scripts are currently present. The tools return descriptive error strings for missing resources or scripts, so the behavior is safe even with no resources/scripts.

Remove the hasResources/hasScripts check that previously gated tool registration, remove the now-unused hasResourcesAndScripts method, and always include resource and script instruction lines in the generated system prompt.

Update tests that previously asserted the absence of read_skill_resource or run_skill_script when no resources/scripts were discovered: these now assert the tools are present and return errors for unknown names.