### PR TITLE
Group OpenTelemetry gomod updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  groups:
+    opentelemetry:
+      patterns:
+        - "go.opentelemetry.io/otel"
+        - "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+        - "go.opentelemetry.io/otel/sdk"
+        - "go.opentelemetry.io/otel/trace"
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,7 @@ updates:
   groups:
     opentelemetry:
       patterns:
-        - "go.opentelemetry.io/otel"
-        - "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
-        - "go.opentelemetry.io/otel/sdk"
-        - "go.opentelemetry.io/otel/trace"
+        - "go.opentelemetry.io/*"
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
## Summary
- add a Dependabot gomod group named opentelemetry
- include OpenTelemetry root, sdk, trace, and stdouttrace modules
- keep existing update cadence and PR limits unchanged

## Why
This keeps related OpenTelemetry dependency bumps in a single PR for easier review and testing.