### PR TITLE
Align provider middleware pipeline

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -25,8 +25,12 @@ type ProviderConfig struct {
 	// Run executes a request and streams response updates.
 	Run RunFunc
 
+	// Middlewares wrap Run after agent history and context providers.
+	Middlewares []Middleware
+
 	// Format creates a provider response format for a structured output value.
 	Format func(v any) (ResponseFormat, error)
+
 	// Unmarshal decodes provider structured output into v using format.
 	Unmarshal func(format ResponseFormat, data []byte, v any) error
 
@@ -46,12 +50,15 @@ type Config struct {
 	// HistoryProvider injects and persists conversation history around each agent run.
 	// When nil, New uses a default in-memory history provider for local sessions.
 	HistoryProvider *HistoryProvider
+
 	// AllowHistoryProviderConflict prevents returning an error when a configured
 	// HistoryProvider conflicts with service-managed history.
 	AllowHistoryProviderConflict bool
+
 	// SuppressHistoryProviderConflictWarning prevents logging a warning when a
 	// configured HistoryProvider conflicts with service-managed history.
 	SuppressHistoryProviderConflictWarning bool
+
 	// KeepHistoryProviderOnConflict prevents clearing the configured HistoryProvider
 	// when it conflicts with service-managed history. Returning an error takes precedence.
 	KeepHistoryProviderOnConflict bool
@@ -64,15 +71,19 @@ type Config struct {
 
 	// Logger receives run, middleware, and provider diagnostics.
 	Logger *slog.Logger
+
 	// LogSensitiveData enables logging of sensitive request and response payloads.
 	LogSensitiveData bool
+
 	// DisableRunLogs disables automatic run logging when Logger is set.
 	DisableRunLogs bool
 
-	// Middlewares wrap the provider run function.
+	// Middlewares wrap the agent lifecycle before history and context providers.
 	Middlewares []Middleware
+
 	// Tools are added to every run.
 	Tools []tool.Tool
+
 	// RunOptions are prepended to the options for every run.
 	RunOptions []Option
 }
@@ -97,8 +108,9 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 	if cfg.Logger != nil && !cfg.DisableRunLogs {
 		cfg.Middlewares = append([]Middleware{newRunLoggerMiddleware(cfg.Logger, cfg.LogSensitiveData)}, cfg.Middlewares...)
 	}
+	prov.Middlewares = slices.Clone(prov.Middlewares)
 	if prov.Format != nil || prov.Unmarshal != nil {
-		cfg.Middlewares = append(cfg.Middlewares, &structuredOutputMiddleware{
+		prov.Middlewares = append(prov.Middlewares, &structuredOutputMiddleware{
 			format:    prov.Format,
 			unmarshal: prov.Unmarshal,
 		})
@@ -115,7 +127,7 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 		historyProvider = NewInMemoryHistoryProvider("")
 		hasDefaultHistoryProvider = true
 	}
-	cfg.Middlewares = append(cfg.Middlewares, authorMiddleware(cfg.ID, cfg.Name))
+	prov.Middlewares = append(prov.Middlewares, authorMiddleware(cfg.ID, cfg.Name))
 	return &Agent{
 		id:                        cfg.ID,
 		name:                      cfg.Name,
@@ -225,6 +237,10 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 }
 
 func (a *Agent) run(ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
+	return runChain(ctx, a.invoke, a.middlewares, messages, options...)
+}
+
+func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
 	return func(yield func(*ResponseUpdate, error) bool) {
 		session, _ := GetOption(options, WithSession)
 		rawContinuationToken, _ := GetOption(options, WithContinuationToken)
@@ -272,7 +288,7 @@ func (a *Agent) run(ctx context.Context, messages []*message.Message, options ..
 		var runErr error
 		var stopped bool
 
-		for update, err := range runChain(ctx, a.provider.Run, a.middlewares, messages, options...) {
+		for update, err := range runChain(ctx, a.provider.Run, a.provider.Middlewares, messages, options...) {
 			if update != nil {
 				continuationUpdates = append(continuationUpdates, cloneResponseUpdate(update))
 				historyResponse.Update(update)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1952,3 +1952,99 @@ func TestAgent_Run_UsesContextProvidersInOrder(t *testing.T) {
 		t.Fatalf("expected sequence %v, got %v", expected, sequence)
 	}
 }
+
+func TestAgent_Run_PipelineOrder_AgentHistoryContextProviderMiddlewareRun(t *testing.T) {
+	contextTool := stubTool{name: "context-tool"}
+	sequence := make([]string, 0, 5)
+	var agentTools []tool.Tool
+	var historyMessages []string
+	var contextMessages []string
+	var providerMessages []string
+	var providerTools []tool.Tool
+	var runMessages []string
+
+	agentMiddleware := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		sequence = append(sequence, "agent")
+		agentTools = slices.Collect(agent.AllOptions(options, agent.WithTool))
+		messages = append(slices.Clone(messages), message.NewText("agent"))
+		return next(ctx, messages, options...)
+	})
+	historyProvider := &agent.HistoryProvider{
+		SourceID: "history",
+		Provide: func(_ context.Context, messages []*message.Message, _ ...agent.Option) ([]*message.Message, error) {
+			sequence = append(sequence, "history")
+			historyMessages = messageStrings(messages)
+			return append(slices.Clone(messages), message.NewText("history")), nil
+		},
+	}
+	contextProvider := &agent.ContextProvider{
+		SourceID: "context",
+		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+			sequence = append(sequence, "context")
+			contextMessages = messageStrings(messages)
+			messages = append(slices.Clone(messages), message.NewText("context"))
+			options = append(slices.Clone(options), agent.WithTool(contextTool))
+			return messages, options, nil
+		},
+	}
+	providerMiddleware := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		sequence = append(sequence, "provider")
+		providerMessages = messageStrings(messages)
+		providerTools = slices.Collect(agent.AllOptions(options, agent.WithTool))
+		return next(ctx, messages, options...)
+	})
+	runFn := func(_ context.Context, messages []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		sequence = append(sequence, "run")
+		runMessages = messageStrings(messages)
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+
+	a := agent.New(agent.ProviderConfig{
+		Run:         runFn,
+		Middlewares: []agent.Middleware{providerMiddleware},
+	}, agent.Config{
+		ID:               "test-agent",
+		Name:             "test-agent",
+		Middlewares:      []agent.Middleware{agentMiddleware},
+		HistoryProvider:  historyProvider,
+		ContextProviders: []*agent.ContextProvider{contextProvider},
+	})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedSequence := []string{"agent", "history", "context", "provider", "run"}
+	if !slices.Equal(sequence, expectedSequence) {
+		t.Fatalf("expected sequence %v, got %v", expectedSequence, sequence)
+	}
+	if len(agentTools) != 0 {
+		t.Fatalf("expected agent middleware not to see context provider tools, got %d", len(agentTools))
+	}
+	if got, want := toolNames(providerTools), []string{"context-tool"}; !slices.Equal(got, want) {
+		t.Fatalf("expected provider middleware tools %v, got %v", want, got)
+	}
+	if got, want := historyMessages, []string{"input", "agent"}; !slices.Equal(got, want) {
+		t.Fatalf("expected history messages %v, got %v", want, got)
+	}
+	if got, want := contextMessages, []string{"input", "agent", "history"}; !slices.Equal(got, want) {
+		t.Fatalf("expected context messages %v, got %v", want, got)
+	}
+	if got, want := providerMessages, []string{"input", "agent", "history", "context"}; !slices.Equal(got, want) {
+		t.Fatalf("expected provider middleware messages %v, got %v", want, got)
+	}
+	if got, want := runMessages, []string{"input", "agent", "history", "context"}; !slices.Equal(got, want) {
+		t.Fatalf("expected run messages %v, got %v", want, got)
+	}
+}
+
+func toolNames(tools []tool.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name())
+	}
+	return names
+}

--- a/agent/provider/aguiagent/agui.go
+++ b/agent/provider/aguiagent/agui.go
@@ -50,9 +50,9 @@ func New(aclient *aguiSSEClient.Client, config Config) *agent.Agent {
 	} else {
 		p.decoder = aguiEvents.NewEventDecoder(nil)
 	}
+	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
-		config.Middlewares = slices.Clone(config.Middlewares)
-		config.Middlewares = append(config.Middlewares, toolautocall.New(toolautocall.Config{
+		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
 			Logger:           config.Logger,
 			LogSensitiveData: config.LogSensitiveData,
 		}))
@@ -60,6 +60,7 @@ func New(aclient *aguiSSEClient.Client, config Config) *agent.Agent {
 	return agent.New(agent.ProviderConfig{
 		ProviderName: "agui",
 		Run:          p.run,
+		Middlewares:  providerMiddlewares,
 	}, config.Config)
 }
 

--- a/agent/provider/anthropicagent/agent.go
+++ b/agent/provider/anthropicagent/agent.go
@@ -54,9 +54,9 @@ func New(aclient anthropic.Client, config Config) *agent.Agent {
 	if config.Instructions != "" {
 		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
+	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
-		config.Middlewares = slices.Clone(config.Middlewares)
-		config.Middlewares = append(config.Middlewares, toolautocall.New(toolautocall.Config{
+		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
 			Logger:           config.Logger,
 			LogSensitiveData: config.LogSensitiveData,
 		}))
@@ -64,6 +64,7 @@ func New(aclient anthropic.Client, config Config) *agent.Agent {
 	return agent.New(agent.ProviderConfig{
 		Run:          c.run,
 		ProviderName: "anthropic",
+		Middlewares:  providerMiddlewares,
 		Format:       c.formatOf,
 		Unmarshal:    c.unmarshal,
 	}, config.Config)

--- a/agent/provider/geminiagent/agent.go
+++ b/agent/provider/geminiagent/agent.go
@@ -54,9 +54,9 @@ func New(gclient *genai.Client, config Config) *agent.Agent {
 	if config.Instructions != "" {
 		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
+	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
-		config.Middlewares = slices.Clone(config.Middlewares)
-		config.Middlewares = append(config.Middlewares, toolautocall.New(toolautocall.Config{
+		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
 			Logger:           config.Logger,
 			LogSensitiveData: config.LogSensitiveData,
 		}))
@@ -64,6 +64,7 @@ func New(gclient *genai.Client, config Config) *agent.Agent {
 	return agent.New(agent.ProviderConfig{
 		Run:          c.run,
 		ProviderName: "gemini",
+		Middlewares:  providerMiddlewares,
 		Format:       c.formatOf,
 		Unmarshal:    c.unmarshal,
 	}, config.Config)

--- a/agent/provider/openaiagent/chat.go
+++ b/agent/provider/openaiagent/chat.go
@@ -58,9 +58,9 @@ func NewChatCompletions(oclient openai.Client, config Config) *agent.Agent {
 	if config.Instructions != "" {
 		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
+	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
-		config.Middlewares = slices.Clone(config.Middlewares)
-		config.Middlewares = append(config.Middlewares, toolautocall.New(toolautocall.Config{
+		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
 			Logger:           config.Logger,
 			LogSensitiveData: config.LogSensitiveData,
 		}))
@@ -68,6 +68,7 @@ func NewChatCompletions(oclient openai.Client, config Config) *agent.Agent {
 	return agent.New(agent.ProviderConfig{
 		ProviderName: "openai",
 		Run:          c.run,
+		Middlewares:  providerMiddlewares,
 		Format:       c.formatOf,
 		Unmarshal:    c.unmarshal,
 	}, config.Config)

--- a/agent/provider/openaiagent/responses.go
+++ b/agent/provider/openaiagent/responses.go
@@ -38,9 +38,9 @@ func NewResponses(oclient openai.Client, config Config) *agent.Agent {
 	if config.Instructions != "" {
 		config.RunOptions = append(config.RunOptions, agent.WithInstructions(config.Instructions))
 	}
+	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
-		config.Middlewares = slices.Clone(config.Middlewares)
-		config.Middlewares = append(config.Middlewares, toolautocall.New(toolautocall.Config{
+		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
 			Logger:           config.Logger,
 			LogSensitiveData: config.LogSensitiveData,
 		}))
@@ -49,6 +49,7 @@ func NewResponses(oclient openai.Client, config Config) *agent.Agent {
 		agent.ProviderConfig{
 			ProviderName: "openai",
 			Run:          c.run,
+			Middlewares:  providerMiddlewares,
 			Format:       c.formatOf,
 			Unmarshal:    c.unmarshal,
 		}, config.Config)


### PR DESCRIPTION
## Motivation

Better align the Go agent pipeline with the .NET and Python agent pipeline by separating agent-level middleware from provider-owned middleware. This lets agent middleware run before history/context providers while provider middleware still runs after context providers have contributed messages and options.

## Changes

- Add optional provider middleware support through `agent.ProviderConfig.Middlewares`.
- Run the pipeline as: agent middlewares -> agent chat history -> agent context providers -> provider middlewares -> provider run.
- Move provider-added tool auto-call middleware into the provider middleware pipeline for OpenAI, Anthropic, Gemini, and AG-UI providers.
- Add coverage for ordering and for context-provider-added tools being visible to provider middleware.

## Validation

- `go test ./agent ./agent/provider/openaiagent ./agent/provider/anthropicagent ./agent/provider/geminiagent ./agent/provider/aguiagent`
- `go test ./...`