### PR TITLE
[dotnet-port] Port depth-based fsskills discovery with predicate filters from .NET

### DIFF
--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -493,13 +493,7 @@ func (s *Source) scanForFiles(
 			continue
 		}
 
-		// Compute relative path (strip leading "./" from root)
 		relativePath := entryPath
-		if strings.HasPrefix(relativePath, "./") {
-			relativePath = relativePath[2:]
-		} else if relativePath == "." {
-			relativePath = entry.Name()
-		}
 
 		if filter != nil && !filter(FilterContext{SkillName: skillName, RelativeFilePath: relativePath}) {
 			continue

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -18,16 +17,10 @@ import (
 )
 
 const (
-	skillFileName          = "SKILL.md"
-	maxSearchDepth         = 2
-	rootDirectoryIndicator = "."
+	skillFileName      = "SKILL.md"
+	defaultSearchDepth = 2
 
 	rootFSPropertyKey = "fsskills.rootFS"
-)
-
-var (
-	defaultResourceDirectories = []string{"references", "assets"}
-	defaultScriptDirectories   = []string{"scripts"}
 )
 
 var (
@@ -42,37 +35,39 @@ var (
 	yamlIndentedKeyValueRegex = regexp.MustCompile(`(?m)^\s+([\w-]+)\s*:\s*(?:["'](.+?)["']|(.+?))\s*$`)
 )
 
+// FilterContext provides contextual information about a discovered file to the
+// ScriptFilter and ResourceFilter predicates.
+type FilterContext struct {
+	// SkillName is the name of the skill as declared in the SKILL.md frontmatter.
+	SkillName string
+
+	// RelativeFilePath is the path to the file relative to the skill directory,
+	// using forward slashes. For root-level files this is just the filename;
+	// for nested files it includes the subdirectory (e.g. "scripts/run.py").
+	RelativeFilePath string
+}
+
 // SourceOptions configures file-based skill discovery.
 //
 // Use this struct to configure discovery without relying on positional
 // constructor parameters. Additional options can be added here without
 // changing the zero-options NewSource convenience API.
 type SourceOptions struct {
-	// ResourceDirectories specifies relative directory paths to scan for resource
-	// files within each skill directory.
-	//
-	// Values may be single-segment names such as "references" or multi-segment
-	// relative paths such as "sub/resources". Use "." to include files directly
-	// at the skill root. Leading "./" prefixes, trailing separators, and
-	// backslashes are normalized automatically; absolute paths and paths
-	// containing ".." segments are rejected.
-	//
-	// When nil, defaults to "references" and "assets" per the Agent Skills
-	// specification. When set, replaces the defaults entirely.
-	ResourceDirectories []string
+	// SearchDepth controls the maximum depth to search for resource and script
+	// files within each skill directory. A value of 1 searches only the skill
+	// root; a value of 2 (the default) also searches one level of subdirectories.
+	// Values less than 1 are treated as the default.
+	SearchDepth int
 
-	// ScriptDirectories specifies relative directory paths to scan for script
-	// files within each skill directory.
-	//
-	// Values may be single-segment names such as "scripts" or multi-segment
-	// relative paths such as "sub/scripts". Use "." to include files directly
-	// at the skill root. Leading "./" prefixes, trailing separators, and
-	// backslashes are normalized automatically; absolute paths and paths
-	// containing ".." segments are rejected.
-	//
-	// When nil, defaults to "scripts" per the Agent Skills specification. When
-	// set, replaces the defaults entirely.
-	ScriptDirectories []string
+	// ResourceFilter is an optional predicate applied to each candidate resource
+	// file after extension filtering. Return true to include the file or false to
+	// skip it. When nil, all files matching AllowedResourceExtensions are included.
+	ResourceFilter func(FilterContext) bool
+
+	// ScriptFilter is an optional predicate applied to each candidate script file
+	// after extension filtering. Return true to include the file or false to skip
+	// it. When nil, all files matching AllowedScriptExtensions are included.
+	ScriptFilter func(FilterContext) bool
 
 	// AllowedResourceExtensions specifies the allowed file extensions for skill
 	// resources.
@@ -105,8 +100,9 @@ type SourceOptions struct {
 type Source struct {
 	filesystems               []fs.FS
 	logger                    *slog.Logger
-	resourceDirectories       []string
-	scriptDirectories         []string
+	searchDepth               int
+	resourceFilter            func(FilterContext) bool
+	scriptFilter              func(FilterContext) bool
 	allowedResourceExtensions map[string]bool
 	allowedScriptExtensions   map[string]bool
 	scriptRunner              skills.ScriptRunner
@@ -138,11 +134,16 @@ func NewSourceOptions(opts SourceOptions, filesystems ...fs.FS) *Source {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
+	searchDepth := opts.SearchDepth
+	if searchDepth < 1 {
+		searchDepth = defaultSearchDepth
+	}
 	return &Source{
 		filesystems:               append([]fs.FS(nil), filesystems...),
 		logger:                    logger,
-		resourceDirectories:       validateAndNormalizeDirectoryNames(opts.ResourceDirectories, defaultResourceDirectories, logger),
-		scriptDirectories:         validateAndNormalizeDirectoryNames(opts.ScriptDirectories, defaultScriptDirectories, logger),
+		searchDepth:               searchDepth,
+		resourceFilter:            opts.ResourceFilter,
+		scriptFilter:              opts.ScriptFilter,
 		allowedResourceExtensions: buildExtensionSet(opts.AllowedResourceExtensions, defaultResourceExtensions),
 		allowedScriptExtensions:   buildExtensionSet(opts.AllowedScriptExtensions, defaultScriptExtensions),
 		scriptRunner:              opts.ScriptRunner,
@@ -187,7 +188,7 @@ func searchForSkills(filesystem fs.FS, dir string, results *[]discoveredSkillDir
 			*results = append(*results, discoveredSkillDir{fsys: sub, path: dir})
 		}
 	}
-	if currentDepth >= maxSearchDepth {
+	if currentDepth >= defaultSearchDepth {
 		return
 	}
 	entries, err := fs.ReadDir(filesystem, dir)
@@ -410,118 +411,102 @@ func leadingWhitespaceCount(line string) int {
 func (s *Source) discoverResourceFiles(skillFS fs.FS, skillName string) []skills.Resource {
 	seen := make(map[string]bool)
 	var resources []skills.Resource
-	for _, directory := range s.resourceDirectories {
-		for _, fileName := range s.walkConfiguredDirectory(skillFS, directory, skillName, s.allowedResourceExtensions, "resource") {
-			key := strings.ToLower(fileName)
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			resources = append(resources, skills.Resource{
-				Name: fileName,
-				Read: func(context.Context) (any, error) {
-					data, err := fs.ReadFile(skillFS, fileName)
-					if err != nil {
-						return nil, err
-					}
-					return string(data), nil
-				},
-			})
+	s.scanForFiles(skillFS, ".", skillName, 1, s.allowedResourceExtensions, s.resourceFilter, "resource", func(filePath string) {
+		key := strings.ToLower(filePath)
+		if seen[key] {
+			return
 		}
-	}
+		seen[key] = true
+		resources = append(resources, skills.Resource{
+			Name: filePath,
+			Read: func(context.Context) (any, error) {
+				data, err := fs.ReadFile(skillFS, filePath)
+				if err != nil {
+					return nil, err
+				}
+				return string(data), nil
+			},
+		})
+	})
 	return resources
 }
 
 func (s *Source) discoverScriptFiles(skillFS fs.FS, skillName string) []skills.Script {
 	seen := make(map[string]bool)
-	scripts := make([]skills.Script, 0)
-	for _, directory := range s.scriptDirectories {
-		for _, fileName := range s.walkConfiguredDirectory(skillFS, directory, skillName, s.allowedScriptExtensions, "script") {
-			key := strings.ToLower(fileName)
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			scripts = append(scripts, newScript(fileName, skillFS, s.scriptRunner))
+	var scripts []skills.Script
+	s.scanForFiles(skillFS, ".", skillName, 1, s.allowedScriptExtensions, s.scriptFilter, "script", func(filePath string) {
+		key := strings.ToLower(filePath)
+		if seen[key] {
+			return
 		}
-	}
+		seen[key] = true
+		scripts = append(scripts, newScript(filePath, skillFS, s.scriptRunner))
+	})
 	return scripts
 }
 
-func (s *Source) walkConfiguredDirectory(skillFS fs.FS, directory, skillName string, allowedExtensions map[string]bool, kind string) []string {
-	fsDir := directory
-	if fsDir == rootDirectoryIndicator {
-		fsDir = "."
+// scanForFiles recursively scans the skill filesystem up to searchDepth levels deep,
+// collecting files matching allowedExtensions and the optional predicate filter.
+func (s *Source) scanForFiles(
+	skillFS fs.FS,
+	dir string,
+	skillName string,
+	currentDepth int,
+	allowedExtensions map[string]bool,
+	filter func(FilterContext) bool,
+	kind string,
+	collect func(string),
+) {
+	if currentDepth > s.searchDepth {
+		return
 	}
 
-	if _, err := fs.Stat(skillFS, fsDir); err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			s.logger.Warn("Failed to read configured skill directory", "skillName", skillName, "directory", fsDir, "kind", kind, "error", err)
-		}
-		return nil
-	}
-
-	entries, err := fs.ReadDir(skillFS, fsDir)
+	entries, err := fs.ReadDir(skillFS, dir)
 	if err != nil {
-		s.logger.Warn("Failed while scanning configured skill directory", "skillName", skillName, "directory", fsDir, "kind", kind, "error", err)
-		return nil
+		if !errors.Is(err, fs.ErrNotExist) {
+			s.logger.Warn("Failed to read skill directory", "skillName", skillName, "directory", dir, "kind", kind, "error", err)
+		}
+		return
 	}
 
-	files := make([]string, 0, len(entries))
 	for _, entry := range entries {
+		entryPath := path.Join(dir, entry.Name())
 		if entry.IsDir() {
-			continue
-		}
-
-		normalized := normalizePath(path.Join(fsDir, entry.Name()))
-		if strings.EqualFold(path.Base(normalized), skillFileName) {
-			continue
-		}
-
-		ext := strings.ToLower(path.Ext(normalized))
-		if ext == "" || !allowedExtensions[ext] {
-			s.logger.Debug("Skipping file: extension not in the allowed list", "skillName", skillName, "filePath", normalized, "extension", ext, "kind", kind)
-			continue
-		}
-
-		files = append(files, normalized)
-	}
-	return files
-}
-
-func validateAndNormalizeDirectoryNames(directories []string, defaults []string, logger *slog.Logger) []string {
-	if directories == nil {
-		return append([]string(nil), defaults...)
-	}
-
-	normalized := make([]string, 0, len(directories))
-	seen := make(map[string]bool, len(directories))
-	for _, directory := range directories {
-		if strings.TrimSpace(directory) == "" {
-			panic("directory names must not be empty or whitespace")
-		}
-		if directory == rootDirectoryIndicator {
-			if !seen[directory] {
-				seen[directory] = true
-				normalized = append(normalized, directory)
+			if currentDepth < s.searchDepth {
+				s.scanForFiles(skillFS, entryPath, skillName, currentDepth+1, allowedExtensions, filter, kind, collect)
 			}
 			continue
 		}
-		if !filepath.IsLocal(directory) {
-			logger.Warn("Skipping invalid directory name: must be a relative path with no '..' segments", "directoryName", directory)
+
+		// Exclude SKILL.md itself
+		if strings.EqualFold(entry.Name(), skillFileName) {
 			continue
 		}
-		norm := normalizePath(directory)
-		if !seen[norm] {
-			seen[norm] = true
-			normalized = append(normalized, norm)
-		}
-	}
-	return normalized
-}
 
-func normalizePath(value string) string {
-	return path.Clean(filepath.ToSlash(value))
+		ext := strings.ToLower(path.Ext(entry.Name()))
+		if ext == "" || !allowedExtensions[ext] {
+			if ext == "" {
+				s.logger.Debug("Skipping file: extension not in the allowed list", "skillName", skillName, "filePath", entryPath, "extension", "(none)", "kind", kind)
+			} else {
+				s.logger.Debug("Skipping file: extension not in the allowed list", "skillName", skillName, "filePath", entryPath, "extension", ext, "kind", kind)
+			}
+			continue
+		}
+
+		// Compute relative path (strip leading "./" from root)
+		relativePath := entryPath
+		if strings.HasPrefix(relativePath, "./") {
+			relativePath = relativePath[2:]
+		} else if relativePath == "." {
+			relativePath = entry.Name()
+		}
+
+		if filter != nil && !filter(FilterContext{SkillName: skillName, RelativeFilePath: relativePath}) {
+			continue
+		}
+
+		collect(relativePath)
+	}
 }
 
 func buildExtensionSet(extensions []string, defaults []string) map[string]bool {

--- a/agent/skills/fsskills/source_script_test.go
+++ b/agent/skills/fsskills/source_script_test.go
@@ -108,7 +108,7 @@ func TestFileSource_NoScriptFiles_ReturnsEmptyScripts(t *testing.T) {
 	}
 }
 
-func TestFileSource_ScriptsOutsideScriptsDir_AreNotDiscovered(t *testing.T) {
+func TestFileSource_ScriptsInAnyDirectory_AreDiscovered(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "root-scripts", "Root scripts skill", "Body.")
 	skillDir := filepath.Join(root, "root-scripts")
@@ -122,8 +122,9 @@ func TestFileSource_ScriptsOutsideScriptsDir_AreNotDiscovered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(loaded[0].Scripts) != 0 {
-		t.Fatalf("expected no scripts, got %d", len(loaded[0].Scripts))
+	// With depth-based scanning, scripts in any directory within search depth are discovered.
+	if len(loaded[0].Scripts) != 2 {
+		t.Fatalf("expected 2 scripts, got %d: %v", len(loaded[0].Scripts), loaded[0].Scripts)
 	}
 }
 
@@ -228,12 +229,12 @@ func TestFileSource_ExecutorReceivesArguments(t *testing.T) {
 	}
 }
 
-func TestFileSource_ScriptDirectoriesWithNestedPath_DiscoversScripts(t *testing.T) {
+func TestFileSource_ScriptAtConfigurableDepth_DiscoversWithSearchDepth(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "nested-script-skill", "Nested script directory", "Body.")
 	createRelativeFile(t, filepath.Join(root, "nested-script-skill"), "f1/f2/f3/run.py", "print('nested')")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
-		ScriptDirectories: []string{"f1/f2/f3"},
+		SearchDepth: 4,
 		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
@@ -252,16 +253,14 @@ func TestFileSource_ScriptDirectoriesWithNestedPath_DiscoversScripts(t *testing.
 	}
 }
 
-func TestFileSource_ScriptDirectoryWithDotSlashPrefix_DiscoversScripts(t *testing.T) {
-	directories := []string{"./scripts", "./scripts/f1", "./f2"}
+func TestFileSource_ScriptsInMultipleSubdirectories_AllDiscovered(t *testing.T) {
 	root := t.TempDir()
-	createSkillDir(t, root, "dotslash-script-skill", "Dot-slash prefix", "Body.")
-	skillDir := filepath.Join(root, "dotslash-script-skill")
-	for _, directory := range directories {
-		createRelativeFile(t, skillDir, directory[2:]+"/run.py", "print('dotslash')")
-	}
+	createSkillDir(t, root, "multidir-script-skill", "Multi-dir scripts", "Body.")
+	skillDir := filepath.Join(root, "multidir-script-skill")
+	// Create scripts at root and one subdirectory level (within default depth 2)
+	createRelativeFile(t, skillDir, "scripts/run.py", "print('scripts')")
+	createRelativeFile(t, skillDir, "f2/run.py", "print('f2')")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
-		ScriptDirectories: directories,
 		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
@@ -271,20 +270,14 @@ func TestFileSource_ScriptDirectoryWithDotSlashPrefix_DiscoversScripts(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(loaded[0].Scripts) != len(directories) {
-		t.Fatalf("expected %d scripts, got %d", len(directories), len(loaded[0].Scripts))
+	expected := []string{"f2/run.py", "scripts/run.py"}
+	found := make(map[string]bool)
+	for _, s := range loaded[0].Scripts {
+		found[s.Name] = true
 	}
-	for _, directory := range directories {
-		expected := directory[2:] + "/run.py"
-		found := false
-		for _, script := range loaded[0].Scripts {
-			if script.Name == expected {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("expected script %q to be discovered", expected)
+	for _, name := range expected {
+		if !found[name] {
+			t.Fatalf("expected script %q to be discovered; got %v", name, loaded[0].Scripts)
 		}
 	}
 }
@@ -299,12 +292,11 @@ func TestFileSource_InvalidScriptExtension_Panics(t *testing.T) {
 	_ = fsskills.NewSourceOptions(fsskills.SourceOptions{AllowedScriptExtensions: []string{"txt"}}, os.DirFS(t.TempDir()))
 }
 
-func TestFileSource_ScriptInSkillRoot_DiscoveredWhenRootDirectoryConfigured(t *testing.T) {
+func TestFileSource_ScriptAtSkillRoot_Discovered(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "root-script-skill", "Root script", "Body.")
 	createRelativeFile(t, filepath.Join(root, "root-script-skill"), "run.py", "print('hello')")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
-		ScriptDirectories: []string{"."},
 		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},
@@ -323,12 +315,15 @@ func TestFileSource_ScriptInSkillRoot_DiscoveredWhenRootDirectoryConfigured(t *t
 	}
 }
 
-func TestFileSource_BackslashDirectoryNormalized_NoDuplicateScripts(t *testing.T) {
+func TestFileSource_ScriptFilter_IncludesOnlyMatchingScripts(t *testing.T) {
 	root := t.TempDir()
-	createSkillDir(t, root, "backslash-skill", "Backslash test", "Body.")
+	createSkillDir(t, root, "backslash-skill", "Script filter test", "Body.")
 	createRelativeFile(t, filepath.Join(root, "backslash-skill"), "scripts/run.py", "print('hello')")
+	createRelativeFile(t, filepath.Join(root, "backslash-skill"), "scripts/skip.py", "print('skip')")
 	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
-		ScriptDirectories: []string{"scripts", ".\\scripts"},
+		ScriptFilter: func(ctx fsskills.FilterContext) bool {
+			return ctx.RelativeFilePath == "scripts/run.py"
+		},
 		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return nil, nil
 		},

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -318,42 +318,11 @@ func TestFileSource_NoOptionalFields_DefaultZeroValues(t *testing.T) {
 	}
 }
 
-func TestFileSource_ResourceDirectoryWithDotSlashPrefix_DiscoversResources(t *testing.T) {
-	for _, directory := range []string{"./references", "./assets/docs"} {
-		t.Run(directory, func(t *testing.T) {
-			root := t.TempDir()
-			directoryWithoutDotSlash := directory[2:]
-			createSkillDir(t, root, "dotslash-res-skill", "Dot-slash prefix", "Body.")
-			skillDir := filepath.Join(root, "dotslash-res-skill")
-			targetDir := filepath.Join(skillDir, filepath.FromSlash(directoryWithoutDotSlash))
-			if err := os.MkdirAll(targetDir, 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(filepath.Join(targetDir, "data.json"), []byte("{}"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-
-			source := fsskills.NewSourceOptions(fsskills.SourceOptions{ResourceDirectories: []string{directory}}, os.DirFS(root))
-			loaded, err := source.Skills(t.Context())
-			if err != nil {
-				t.Fatal(err)
-			}
-			resources := loaded[0].Resources
-			if len(resources) != 1 {
-				t.Fatalf("expected 1 resource, got %d", len(resources))
-			}
-			expected := directoryWithoutDotSlash + "/data.json"
-			if resources[0].Name != expected {
-				t.Fatalf("expected %q, got %q", expected, resources[0].Name)
-			}
-		})
-	}
-}
-
-func TestFileSource_TrailingSlashDirectoryNormalized_NoDuplicateResources(t *testing.T) {
+func TestFileSource_ResourcesInSubdirectory_DiscoveredWithDefaultDepth(t *testing.T) {
 	root := t.TempDir()
-	createSkillDir(t, root, "trailing-slash-skill", "Trailing slash test", "Body.")
-	refsDir := filepath.Join(root, "trailing-slash-skill", "references")
+	createSkillDir(t, root, "sub-res-skill", "Subdirectory resources", "Body.")
+	skillDir := filepath.Join(root, "sub-res-skill")
+	refsDir := filepath.Join(skillDir, "references")
 	if err := os.MkdirAll(refsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +330,95 @@ func TestFileSource_TrailingSlashDirectoryNormalized_NoDuplicateResources(t *tes
 		t.Fatal(err)
 	}
 
-	source := fsskills.NewSourceOptions(fsskills.SourceOptions{ResourceDirectories: []string{"references", "references/"}}, os.DirFS(root))
+	source := fsskills.NewSource(os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources := loaded[0].Resources
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	if resources[0].Name != "references/data.json" {
+		t.Fatalf("expected references/data.json, got %q", resources[0].Name)
+	}
+}
+
+func TestFileSource_ResourceFilter_IncludesOnlyMatchingFiles(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "filter-skill", "Filter test", "Body.")
+	skillDir := filepath.Join(root, "filter-skill")
+	refsDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "keep.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "skip.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
+		ResourceFilter: func(ctx fsskills.FilterContext) bool {
+			return ctx.RelativeFilePath == "references/keep.json"
+		},
+	}, os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources := loaded[0].Resources
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d; resources: %v", len(resources), resources)
+	}
+	if resources[0].Name != "references/keep.json" {
+		t.Fatalf("expected references/keep.json, got %q", resources[0].Name)
+	}
+}
+
+func TestFileSource_SearchDepth1_DoesNotDiscoverSubdirectoryResources(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "depth-skill", "Depth test", "Body.")
+	skillDir := filepath.Join(root, "depth-skill")
+	rootFile := filepath.Join(skillDir, "root.json")
+	subDir := filepath.Join(skillDir, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rootFile, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "nested.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{SearchDepth: 1}, os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources := loaded[0].Resources
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource (root only), got %d", len(resources))
+	}
+	if resources[0].Name != "root.json" {
+		t.Fatalf("expected root.json, got %q", resources[0].Name)
+	}
+}
+
+func TestFileSource_NoDuplicateResourcesFromSamePath(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "dedup-skill", "Dedup test", "Body.")
+	refsDir := filepath.Join(root, "dedup-skill", "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := fsskills.NewSource(os.DirFS(root))
 	loaded, err := source.Skills(t.Context())
 	if err != nil {
 		t.Fatal(err)

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -548,7 +548,6 @@ func TestProvider_AggregatesMultipleSources(t *testing.T) {
 		Skills: []*skills.Skill{inline},
 		Sources: []skills.Source{
 			fsskills.NewSourceOptions(fsskills.SourceOptions{
-				ScriptDirectories: []string{"unused-scripts"},
 				ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 					return "ok", nil
 				},

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -4,6 +4,7 @@ package skills_test
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -824,7 +825,21 @@ func TestDiscovery_SearchDepth_CanReachDeepNestedPath(t *testing.T) {
 func TestConfig_InvalidSearchDepth_UsesDefault(t *testing.T) {
 	tests := []int{0, -1, -5}
 	for _, depth := range tests {
-		t.Run("depth", func(t *testing.T) {
+		t.Run(fmt.Sprintf("depth_%d", depth), func(t *testing.T) {
+			p := newProviderWithConfig(t, &fsskills.SourceOptions{
+				SearchDepth: depth,
+			}, nil, t.TempDir())
+			if p == nil {
+				t.Fatal("expected non-nil provider")
+			}
+		})
+	}
+}
+
+func TestConfig_ValidSearchDepth(t *testing.T) {
+	tests := []int{1, 2, 4}
+	for _, depth := range tests {
+		t.Run(fmt.Sprintf("depth_%d", depth), func(t *testing.T) {
 			p := newProviderWithConfig(t, &fsskills.SourceOptions{
 				SearchDepth: depth,
 			}, nil, t.TempDir())

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -592,7 +592,7 @@ func TestDiscovery_ResourceInSkillRoot_DiscoveredByDefault(t *testing.T) {
 	}
 }
 
-func TestDiscovery_ResourceInSkillRoot_ExplicitDepthOne(t *testing.T) {
+func TestDiscovery_ResourceInSkillRoot_AccessibleWithDepthOne(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "root-opt-in-skill", "Root opt-in", "Body.")
 	skillDir := filepath.Join(root, "root-opt-in-skill")
@@ -886,7 +886,7 @@ func TestConfig_ValidExtensions(t *testing.T) {
 	}
 }
 
-func TestDiscovery_DefaultResourceDiscovery_ReferenceResourceReadable(t *testing.T) {
+func TestDiscovery_ReferenceResource_ReadableByDefault(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "dedup-directory-skill", "Dedup test", "Body.")
 	skillDir := filepath.Join(root, "dedup-directory-skill")

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -672,8 +672,8 @@ func TestDiscovery_ResourceFilter_CanRestrictDefaultDiscovery(t *testing.T) {
 
 	// Restrict discovery to only files under docs/
 	p := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ResourceFilter: func(ctx fsskills.FilterContext) bool {
-			return strings.HasPrefix(ctx.RelativeFilePath, "docs/")
+		ResourceFilter: func(filterCtx fsskills.FilterContext) bool {
+			return strings.HasPrefix(filterCtx.RelativeFilePath, "docs/")
 		},
 	}, nil, root)
 

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -592,7 +592,7 @@ func TestDiscovery_ResourceInSkillRoot_DiscoveredByDefault(t *testing.T) {
 	}
 }
 
-func TestDiscovery_ResourceInSkillRoot_DiscoveredWithDepthOne(t *testing.T) {
+func TestDiscovery_ResourceInSkillRoot_ExplicitDepthOne(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "root-opt-in-skill", "Root opt-in", "Body.")
 	skillDir := filepath.Join(root, "root-opt-in-skill")
@@ -886,7 +886,7 @@ func TestConfig_ValidExtensions(t *testing.T) {
 	}
 }
 
-func TestDiscovery_DefaultResourceDiscovery_NoDuplicateResources(t *testing.T) {
+func TestDiscovery_DefaultResourceDiscovery_ReferenceResourceReadable(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "dedup-directory-skill", "Dedup test", "Body.")
 	skillDir := filepath.Join(root, "dedup-directory-skill")

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -539,7 +539,7 @@ func TestDiscovery_ResourcesInDefaultDirectories(t *testing.T) {
 	}
 }
 
-func TestDiscovery_ResourceInNonSpecDirectory_NotDiscoveredByDefault(t *testing.T) {
+func TestDiscovery_ResourceInAnySubdirectory_DiscoveredByDefault(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "non-spec-skill", "Non-spec directory", "Body.")
 	skillDir := filepath.Join(root, "non-spec-skill")
@@ -558,19 +558,18 @@ func TestDiscovery_ResourceInNonSpecDirectory_NotDiscoveredByDefault(t *testing.
 		t.Fatal("expected skill to be discovered")
 	}
 	_, tools := captureProviderContext(t, p)
-	// read_skill_resource is always registered; docs/readme.md is in a non-default dir and must not be accessible.
+	// read_skill_resource is always registered; docs/readme.md is discovered by default depth-based scanning.
 	readTool := findTool(t, tools, "read_skill_resource")
 	result, err := readTool.Call(t.Context(), `{"skillName":"non-spec-skill","resourceName":"docs/readme.md"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resultStr, ok := result.(string)
-	if !ok || !strings.HasPrefix(resultStr, "Error:") {
-		t.Fatalf("expected error for non-default resource directory, got %#v", result)
+	if result != "docs content" {
+		t.Fatalf("expected docs content, got %#v", result)
 	}
 }
 
-func TestDiscovery_ResourceInSkillRoot_NotDiscoveredByDefault(t *testing.T) {
+func TestDiscovery_ResourceInSkillRoot_DiscoveredByDefault(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "root-resource-skill", "Root resource", "Body.")
 	skillDir := filepath.Join(root, "root-resource-skill")
@@ -581,19 +580,18 @@ func TestDiscovery_ResourceInSkillRoot_NotDiscoveredByDefault(t *testing.T) {
 
 	p := newProvider(t, root)
 	_, tools := captureProviderContext(t, p)
-	// read_skill_resource is always registered; root-level guide.md is not accessible without '.' configured.
+	// read_skill_resource is always registered; root-level files are discovered by default depth-based scanning.
 	readTool := findTool(t, tools, "read_skill_resource")
 	result, err := readTool.Call(t.Context(), `{"skillName":"root-resource-skill","resourceName":"guide.md"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resultStr, ok := result.(string)
-	if !ok || !strings.HasPrefix(resultStr, "Error:") {
-		t.Fatalf("expected error for root-level resource without '.' configured, got %#v", result)
+	if result != "guide content" {
+		t.Fatalf("expected guide content, got %#v", result)
 	}
 }
 
-func TestDiscovery_ResourceInSkillRoot_DiscoveredWhenRootDirectoryConfigured(t *testing.T) {
+func TestDiscovery_ResourceInSkillRoot_DiscoveredWithDepthOne(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "root-opt-in-skill", "Root opt-in", "Body.")
 	skillDir := filepath.Join(root, "root-opt-in-skill")
@@ -606,7 +604,7 @@ func TestDiscovery_ResourceInSkillRoot_DiscoveredWhenRootDirectoryConfigured(t *
 	}
 
 	p := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ResourceDirectories: []string{"references", "assets", "."},
+		SearchDepth: 1,
 	}, nil, root)
 
 	_, tools := captureProviderContext(t, p)
@@ -635,7 +633,7 @@ func TestDiscovery_SkillMdNotIncludedAsResource(t *testing.T) {
 
 	// Opt into root scanning — SKILL.md should still be excluded
 	p := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ResourceDirectories: []string{"."},
+		SearchDepth: 1,
 	}, nil, root)
 
 	_, tools := captureProviderContext(t, p)
@@ -651,7 +649,7 @@ func TestDiscovery_SkillMdNotIncludedAsResource(t *testing.T) {
 	}
 }
 
-func TestDiscovery_CustomResourceDirectories_ReplacesDefaults(t *testing.T) {
+func TestDiscovery_ResourceFilter_CanRestrictDefaultDiscovery(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "custom-directory-skill", "Custom directory", "Body.")
 	skillDir := filepath.Join(root, "custom-directory-skill")
@@ -671,9 +669,11 @@ func TestDiscovery_CustomResourceDirectories_ReplacesDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Set custom directories — only "docs" should be scanned
+	// Restrict discovery to only files under docs/
 	p := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ResourceDirectories: []string{"docs"},
+		ResourceFilter: func(ctx fsskills.FilterContext) bool {
+			return strings.HasPrefix(ctx.RelativeFilePath, "docs/")
+		},
 	}, nil, root)
 
 	_, tools := captureProviderContext(t, p)
@@ -688,7 +688,7 @@ func TestDiscovery_CustomResourceDirectories_ReplacesDefaults(t *testing.T) {
 		t.Errorf("expected docs content, got %#v", result)
 	}
 
-	// references/ref.md should NOT be readable (defaults replaced)
+	// references/ref.md should NOT be readable (filtered out)
 	result, err = readTool.Call(t.Context(), `{"skillName":"custom-directory-skill","resourceName":"references/ref.md"}`)
 	if err != nil {
 		t.Fatal(err)
@@ -792,7 +792,7 @@ func TestDiscovery_NestedResourceFiles_NotDiscovered(t *testing.T) {
 	}
 }
 
-func TestDiscovery_ResourceDirectoriesWithNestedPath(t *testing.T) {
+func TestDiscovery_SearchDepth_CanReachDeepNestedPath(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "nested-directory-skill", "Nested directory", "Body.")
 	skillDir := filepath.Join(root, "nested-directory-skill")
@@ -806,7 +806,7 @@ func TestDiscovery_ResourceDirectoriesWithNestedPath(t *testing.T) {
 	}
 
 	p := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ResourceDirectories: []string{"f1/f2/f3"},
+		SearchDepth: 4,
 	}, nil, root)
 
 	_, tools := captureProviderContext(t, p)
@@ -821,13 +821,12 @@ func TestDiscovery_ResourceDirectoriesWithNestedPath(t *testing.T) {
 	}
 }
 
-func TestConfig_InvalidDirectoryName_Skipped(t *testing.T) {
-	tests := []string{"..", "../escape", "sub/../escape", "/absolute"}
-	for _, bad := range tests {
-		t.Run(bad, func(t *testing.T) {
-			// Invalid directories are skipped with a warning, not a panic
+func TestConfig_InvalidSearchDepth_UsesDefault(t *testing.T) {
+	tests := []int{0, -1, -5}
+	for _, depth := range tests {
+		t.Run("depth", func(t *testing.T) {
 			p := newProviderWithConfig(t, &fsskills.SourceOptions{
-				ResourceDirectories: []string{bad},
+				SearchDepth: depth,
 			}, nil, t.TempDir())
 			if p == nil {
 				t.Fatal("expected non-nil provider")
@@ -836,10 +835,10 @@ func TestConfig_InvalidDirectoryName_Skipped(t *testing.T) {
 	}
 }
 
-func TestConfig_EmptyDirectoryName_Panics(t *testing.T) {
+func TestConfig_InvalidExtension_Panics(t *testing.T) {
 	tests := []struct {
 		name string
-		dir  string
+		ext  string
 	}{
 		{"empty", ""},
 		{"spaces", "   "},
@@ -848,22 +847,22 @@ func TestConfig_EmptyDirectoryName_Panics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
 				if r := recover(); r == nil {
-					t.Fatal("expected panic for empty/whitespace directory name")
+					t.Fatal("expected panic for empty/whitespace extension")
 				}
 			}()
 			newProviderWithConfig(t, &fsskills.SourceOptions{
-				ResourceDirectories: []string{tt.dir},
+				AllowedResourceExtensions: []string{tt.ext},
 			}, nil, t.TempDir())
 		})
 	}
 }
 
-func TestConfig_ValidDirectoryNames(t *testing.T) {
-	tests := []string{"scripts", "my-scripts", "sub/directory", ".", "./scripts", "./scripts/f1", "my..scripts"}
-	for _, valid := range tests {
-		t.Run(valid, func(t *testing.T) {
+func TestConfig_ValidExtensions(t *testing.T) {
+	tests := []string{".md", ".json", ".custom"}
+	for _, ext := range tests {
+		t.Run(ext, func(t *testing.T) {
 			p := newProviderWithConfig(t, &fsskills.SourceOptions{
-				ResourceDirectories: []string{valid},
+				AllowedResourceExtensions: []string{ext},
 			}, nil, t.TempDir())
 			if p == nil {
 				t.Fatal("expected non-nil provider")
@@ -872,7 +871,7 @@ func TestConfig_ValidDirectoryNames(t *testing.T) {
 	}
 }
 
-func TestDiscovery_DuplicateDirectoriesAfterNormalization_NoDuplicateResources(t *testing.T) {
+func TestDiscovery_DefaultResourceDiscovery_NoDuplicateResources(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "dedup-directory-skill", "Dedup test", "Body.")
 	skillDir := filepath.Join(root, "dedup-directory-skill")
@@ -885,10 +884,7 @@ func TestDiscovery_DuplicateDirectoriesAfterNormalization_NoDuplicateResources(t
 		t.Fatal(err)
 	}
 
-	// "references" and "./references" should be deduplicated
-	p := newProviderWithConfig(t, &fsskills.SourceOptions{
-		ResourceDirectories: []string{"references", "./references"},
-	}, nil, root)
+	p := newProvider(t, root)
 
 	_, tools := captureProviderContext(t, p)
 	readTool := findTool(t, tools, "read_skill_resource")


### PR DESCRIPTION
Replace ScriptDirectories/ResourceDirectories with depth-based recursive scanning and optional ScriptFilter/ResourceFilter predicates, aligning with .NET AgentFileSkillsSource refactoring in microsoft/agent-framework#6109.

- Remove SourceOptions.ScriptDirectories and ResourceDirectories
- Add SourceOptions.SearchDepth (default 2), ScriptFilter, ResourceFilter
- Add FilterContext type providing SkillName and RelativeFilePath to predicates
- Discovery now recursively scans all directories up to SearchDepth levels deep
- Extension-based filtering still applied before the optional predicate
- Update tests to reflect new depth-based and predicate-filter behavior