### PR TITLE
[dotnet-port] Align Response.ToUpdates to prefer per-message CreatedAt

### DIFF
--- a/agent/response.go
+++ b/agent/response.go
@@ -115,6 +115,10 @@ func (resp *Response) ToUpdates() []*ResponseUpdate {
 
 	updates := make([]*ResponseUpdate, 0, len(resp.Messages)+1)
 	for _, msg := range resp.Messages {
+		createdAt := msg.CreatedAt
+		if createdAt.IsZero() {
+			createdAt = resp.CreatedAt
+		}
 		updates = append(updates, &ResponseUpdate{
 			RawRepresentation:    msg.RawRepresentation,
 			AdditionalProperties: msg.AdditionalProperties,
@@ -124,7 +128,7 @@ func (resp *Response) ToUpdates() []*ResponseUpdate {
 			FinishReason:         resp.FinishReason,
 			AuthorName:           msg.AuthorName,
 			Role:                 msg.Role,
-			CreatedAt:            resp.CreatedAt,
+			CreatedAt:            createdAt,
 			Contents:             msg.Contents,
 		})
 	}

--- a/agent/response_test.go
+++ b/agent/response_test.go
@@ -676,6 +676,56 @@ func TestResponse_ToUpdates_WithUsageOnlyProducesSingleUpdate(t *testing.T) {
 	}
 }
 
+func TestResponse_ToUpdates_PropagatesMessageCreatedAtOverResponseCreatedAt(t *testing.T) {
+	responseCreatedAt := time.Date(2024, 11, 10, 9, 20, 0, 0, time.UTC)
+	messageCreatedAt := time.Date(2024, 11, 11, 9, 20, 0, 0, time.UTC)
+	resp := &agent.Response{
+		AgentID:   "agentId",
+		ID:        "12345",
+		CreatedAt: responseCreatedAt,
+		Messages: []*message.Message{
+			{
+				Role:      message.Role("customRole"),
+				ID:        "someMessage",
+				CreatedAt: messageCreatedAt,
+				Contents:  message.Contents{&message.TextContent{Text: "Text"}},
+			},
+		},
+	}
+
+	updates := resp.ToUpdates()
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updates))
+	}
+	if !updates[0].CreatedAt.Equal(messageCreatedAt) {
+		t.Errorf("expected per-message CreatedAt %v, got %v", messageCreatedAt, updates[0].CreatedAt)
+	}
+}
+
+func TestResponse_ToUpdates_FallsBackToResponseCreatedAtWhenMessageCreatedAtIsZero(t *testing.T) {
+	responseCreatedAt := time.Date(2024, 11, 10, 9, 20, 0, 0, time.UTC)
+	resp := &agent.Response{
+		AgentID:   "agentId",
+		ID:        "12345",
+		CreatedAt: responseCreatedAt,
+		Messages: []*message.Message{
+			{
+				Role:     message.Role("customRole"),
+				ID:       "someMessage",
+				Contents: message.Contents{&message.TextContent{Text: "Text"}},
+			},
+		},
+	}
+
+	updates := resp.ToUpdates()
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updates))
+	}
+	if !updates[0].CreatedAt.Equal(responseCreatedAt) {
+		t.Errorf("expected response-level CreatedAt %v, got %v", responseCreatedAt, updates[0].CreatedAt)
+	}
+}
+
 func TestResponse_ToUpdates_WithAdditionalPropertiesOnlyProducesSingleUpdate(t *testing.T) {
 	resp := &agent.Response{
 		AdditionalProperties: map[string]any{"key": "value"},


### PR DESCRIPTION
Prefer message.CreatedAt over response.CreatedAt when building ResponseUpdate items in Response.ToUpdates, aligning with the upstream .NET fix in microsoft/agent-framework#3930.