### PR TITLE
[dotnet-port] Preserve AGUI session history across multi-turn runs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -36,6 +36,14 @@ type ProviderConfig struct {
 
 	// CreateSession configures a provider-specific session.
 	CreateSession func(ctx context.Context, session *Session, options ...Option) error
+
+	// ServiceDoesNotManageHistory indicates that this provider never manages
+	// conversation history server-side, even when a ServiceID is set on the
+	// session. When true, the agent's HistoryProvider is always preserved
+	// regardless of session service ID. Use this for providers like AGUI that
+	// require the caller to supply the full conversation history on every turn
+	// even after the service assigns a session or thread identifier.
+	ServiceDoesNotManageHistory bool
 }
 
 // Config configures an Agent instance.
@@ -129,20 +137,21 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 	}
 	prov.Middlewares = append(prov.Middlewares, authorMiddleware(cfg.ID, cfg.Name))
 	return &Agent{
-		id:                        cfg.ID,
-		name:                      cfg.Name,
-		description:               cfg.Description,
-		provider:                  prov,
-		runOptions:                cfg.RunOptions,
-		middlewares:               cfg.Middlewares,
-		logger:                    cfg.Logger,
-		historyProvider:           historyProvider,
-		hasConfiguredHistory:      cfg.HistoryProvider != nil,
-		hasDefaultHistoryProvider: hasDefaultHistoryProvider,
-		allowHistoryConflict:      cfg.AllowHistoryProviderConflict,
-		suppressHistoryWarning:    cfg.SuppressHistoryProviderConflictWarning,
-		keepHistoryOnConflict:     cfg.KeepHistoryProviderOnConflict,
-		contextProviders:          contextProviders,
+		id:                           cfg.ID,
+		name:                         cfg.Name,
+		description:                  cfg.Description,
+		provider:                     prov,
+		runOptions:                   cfg.RunOptions,
+		middlewares:                  cfg.Middlewares,
+		logger:                       cfg.Logger,
+		historyProvider:              historyProvider,
+		hasConfiguredHistory:         cfg.HistoryProvider != nil,
+		hasDefaultHistoryProvider:    hasDefaultHistoryProvider,
+		allowHistoryConflict:         cfg.AllowHistoryProviderConflict,
+		suppressHistoryWarning:       cfg.SuppressHistoryProviderConflictWarning,
+		keepHistoryOnConflict:        cfg.KeepHistoryProviderOnConflict,
+		providerDoesNotManageHistory: prov.ServiceDoesNotManageHistory,
+		contextProviders:             contextProviders,
 	}
 }
 
@@ -163,11 +172,12 @@ type Agent struct {
 	// history provider because Config.HistoryProvider was nil. The synthesized
 	// provider is a local-session convenience and backs off for implicit per-run
 	// sessions and service-managed sessions.
-	hasDefaultHistoryProvider bool
-	allowHistoryConflict      bool
-	suppressHistoryWarning    bool
-	keepHistoryOnConflict     bool
-	contextProviders          []*ContextProvider
+	hasDefaultHistoryProvider    bool
+	allowHistoryConflict         bool
+	suppressHistoryWarning       bool
+	keepHistoryOnConflict        bool
+	providerDoesNotManageHistory bool
+	contextProviders             []*ContextProvider
 }
 
 // ID returns the agent's unique identifier.
@@ -394,7 +404,7 @@ func (a *Agent) historyProviderForRun(session *Session, continuationToken string
 		return nil
 	}
 	if !a.hasDefaultHistoryProvider {
-		if session.ServiceID() != "" {
+		if session.ServiceID() != "" && !a.providerDoesNotManageHistory {
 			return nil
 		}
 		return a.historyProvider
@@ -403,7 +413,9 @@ func (a *Agent) historyProviderForRun(session *Session, continuationToken string
 	// The default in-memory provider only owns caller-provided local sessions.
 	// Auto-created sessions are per-run and cannot preserve history across calls;
 	// service-managed sessions use the provider service as the source of history.
-	if noSession || session.ServiceID() != "" {
+	// Providers that never manage history server-side (e.g. AGUI) set
+	// providerDoesNotManageHistory so the in-memory provider is kept regardless.
+	if noSession || (session.ServiceID() != "" && !a.providerDoesNotManageHistory) {
 		return nil
 	}
 	return a.historyProvider
@@ -414,12 +426,12 @@ func (a *Agent) historyProviderForContinuationStore(session *Session, noSession 
 		return nil
 	}
 	if !a.hasDefaultHistoryProvider {
-		if session.ServiceID() != "" {
+		if session.ServiceID() != "" && !a.providerDoesNotManageHistory {
 			return nil
 		}
 		return a.historyProvider
 	}
-	if noSession || session.ServiceID() != "" {
+	if noSession || (session.ServiceID() != "" && !a.providerDoesNotManageHistory) {
 		return nil
 	}
 	return a.historyProvider
@@ -432,6 +444,10 @@ func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session *S
 	if !a.hasDefaultHistoryProvider {
 		return true
 	}
+	if a.providerDoesNotManageHistory {
+		// Provider never uses server-side history; always persist locally.
+		return true
+	}
 
 	// A provider can promote a local session to a service-managed one during the
 	// run. Once that happens, the default in-memory provider should stop storing.
@@ -439,7 +455,7 @@ func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session *S
 }
 
 func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider *HistoryProvider, session *Session) (bool, error) {
-	if provider == nil || !a.hasConfiguredHistory || session == nil || session.ServiceID() == "" {
+	if provider == nil || !a.hasConfiguredHistory || session == nil || session.ServiceID() == "" || a.providerDoesNotManageHistory {
 		return true, nil
 	}
 

--- a/agent/provider/aguiagent/agui.go
+++ b/agent/provider/aguiagent/agui.go
@@ -58,9 +58,10 @@ func New(aclient *aguiSSEClient.Client, config Config) *agent.Agent {
 		}))
 	}
 	return agent.New(agent.ProviderConfig{
-		ProviderName: "agui",
-		Run:          p.run,
-		Middlewares:  providerMiddlewares,
+		ProviderName:                "agui",
+		Run:                         p.run,
+		Middlewares:                 providerMiddlewares,
+		ServiceDoesNotManageHistory: true,
 	}, config.Config)
 }
 

--- a/agent/provider/aguiagent/agui_test.go
+++ b/agent/provider/aguiagent/agui_test.go
@@ -180,6 +180,67 @@ func TestAGUIAgentRun_GeneratesUniqueRunIDPerInvocation(t *testing.T) {
 	}
 }
 
+// TestAGUIAgentRun_WithSession_PreservesHistoryAcrossMultipleTurns verifies
+// that subsequent runs with the same session include the full conversation
+// history, even after the provider assigns a thread ID to the session on the
+// first run. This mirrors the .NET fix in ChatClientAgent (PR #5904) that
+// ensures the ChatHistoryProvider is not discarded when a ConversationId
+// (thread ID) is present for an AGUI provider.
+func TestAGUIAgentRun_WithSession_PreservesHistoryAcrossMultipleTurns(t *testing.T) {
+	var mu sync.Mutex
+	var captured []aguiTypes.RunAgentInput
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input aguiTypes.RunAgentInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		mu.Lock()
+		captured = append(captured, input)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent(input.ThreadID, input.RunID))
+		writeSSE(t, w, aguiEvents.NewTextMessageStartEvent("msg-1", aguiEvents.WithRole("assistant")))
+		writeSSE(t, w, aguiEvents.NewTextMessageContentEvent("msg-1", "Hello"))
+		writeSSE(t, w, aguiEvents.NewTextMessageEndEvent("msg-1"))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent(input.ThreadID, input.RunID))
+	}))
+	defer server.Close()
+
+	a := aguiagent.New(newTestClient(server.URL), aguiagent.Config{})
+	session, err := a.CreateSession(context.Background())
+	if err != nil {
+		t.Fatalf("create session error: %v", err)
+	}
+
+	if _, err := a.Run(context.Background(), []*message.Message{message.NewText("First")}, agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+
+	if _, err := a.Run(context.Background(), []*message.Message{message.NewText("Second")}, agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(captured))
+	}
+	// First run: only the user message.
+	if len(captured[0].Messages) != 1 {
+		t.Fatalf("first run message count = %d, want 1", len(captured[0].Messages))
+	}
+	// Second run: history (user + assistant) plus new user message = 3.
+	if len(captured[1].Messages) != 3 {
+		t.Fatalf("second run message count = %d, want 3 (history + new message)", len(captured[1].Messages))
+	}
+	// Both runs share the same thread ID.
+	if captured[0].ThreadID == "" || captured[0].ThreadID != captured[1].ThreadID {
+		t.Fatalf("thread IDs do not match: first=%q second=%q", captured[0].ThreadID, captured[1].ThreadID)
+	}
+}
+
 func TestAGUIAgentRun_InvokesTools_WhenFunctionCallsReturned(t *testing.T) {
 	var mu sync.Mutex
 	requestCount := 0


### PR DESCRIPTION
The AG-UI provider assigns a thread ID to the session on the first run by calling session.SetServiceID(threadID). The agent's history machinery interpreted any non-empty ServiceID as a signal that the service manages history server-side, and therefore disabled the local HistoryProvider for every subsequent run. This caused conversation history to be dropped after the first turn.

Add ServiceDoesNotManageHistory bool to ProviderConfig. Providers that never delegate history to the service (e.g. AGUI) set this flag true; the agent then preserves the HistoryProvider across runs regardless of whether the session has a ServiceID. This also prevents the provider from being flagged as a conflict when a user-configured HistoryProvider is present.

Set ServiceDoesNotManageHistory: true in the AGUI provider constructor.

Add TestAGUIAgentRun_WithSession_PreservesHistoryAcrossMultipleTurns to verify that the second run sends the full conversation history (3 messages) rather than only the new user message.

Ports behavior fix from microsoft/agent-framework#5904.