### PR TITLE
Simplify .NET-to-Go code portability workflow

### DIFF
--- a/.github/workflows/dotnet-code-portability-nightly.lock.yml
+++ b/.github/workflows/dotnet-code-portability-nightly.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"000b93bd5194e1448eaedfcd6b0601500eba1c22193065ae2284988bfef4c934","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3cd0995ac7360f887d8570040c0ad78bc6ee733e7a8a2ef3dae62ed73f7df3e9","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Nightly agent that refactors Go internals to make .NET-to-Go ports easier without public API or behavior changes
+# Nightly agent that proactively refactors Go internals to make .NET-to-Go ports easier without public API or behavior changes
 #
 # Secrets used:
 #   - GH_AW_CI_TRIGGER_TOKEN
@@ -189,24 +189,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_edeb172eaa899775_EOF'
+          cat << 'GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF'
           <system>
-          GH_AW_PROMPT_edeb172eaa899775_EOF
+          GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_edeb172eaa899775_EOF'
+          cat << 'GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_edeb172eaa899775_EOF
+          GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_edeb172eaa899775_EOF'
+          cat << 'GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_edeb172eaa899775_EOF
+          GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_edeb172eaa899775_EOF'
+          cat << 'GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -238,12 +238,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_edeb172eaa899775_EOF
+          GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_edeb172eaa899775_EOF'
+          cat << 'GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF'
           </system>
           {{#runtime-import .github/workflows/dotnet-code-portability-nightly.md}}
-          GH_AW_PROMPT_edeb172eaa899775_EOF
+          GH_AW_PROMPT_e7c10f8fb1dbbefe_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -473,9 +473,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_571bb771086643db_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d03ed033b1da04ec_EOF'
           {"create_pull_request":{"auto_close_issue":true,"base_branch":"main","draft":true,"if_no_changes":"ignore","max":1,"max_patch_files":100,"max_patch_size":4096,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"allowed","title_prefix":"[dotnet-code] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_571bb771086643db_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d03ed033b1da04ec_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -683,7 +683,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_d8c1f70d9ce8cbfa_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4290ca2881bd971c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -724,7 +724,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d8c1f70d9ce8cbfa_EOF
+          GH_AW_MCP_CONFIG_4290ca2881bd971c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1242,7 +1242,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: ".NET-to-Go Code Portability Refactoring Agent"
-          WORKFLOW_DESCRIPTION: "Nightly agent that refactors Go internals to make .NET-to-Go ports easier without public API or behavior changes"
+          WORKFLOW_DESCRIPTION: "Nightly agent that proactively refactors Go internals to make .NET-to-Go ports easier without public API or behavior changes"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/dotnet-code-portability-nightly.md
+++ b/.github/workflows/dotnet-code-portability-nightly.md
@@ -108,7 +108,7 @@ Use `upstream-agent-framework/main` as the .NET reference. Inspect commits with 
 
 ## Work Loop
 
-1. Pick a focus area from `${{ inputs.focus }}`, recent .NET commits since `${{ inputs.since_ref }}` or cached state, or one of: workflow, agents, skills, messages, tools, providers, compaction.
+1. Pick a focus area from `${{ inputs.focus }}` (or choose one of: workflow, agents, skills, messages, tools, providers, compaction). Determine the upstream .NET lower bound: use `${{ inputs.since_ref }}` if set; otherwise read `/tmp/gh-aw/cache-memory/state.json` (if present) and use its last inspected upstream commit; if neither exists, inspect a practical recent window and record the baseline you chose in memory.
 2. Check for open `[dotnet-code]` PRs. If one already covers the same target, call `noop` with the PR link.
 3. Make one tiny internal change that helps porting future .NET diffs. Good changes include extracting an unexported helper, consolidating duplicate internal logic, simplifying control flow, table-driving repeated cases, clarifying an unexported name, or adding a preservation test.
 4. Run `gofmt` and targeted `go test` packages. Use broader `go test ./...` for shared runtime changes.

--- a/.github/workflows/dotnet-code-portability-nightly.md
+++ b/.github/workflows/dotnet-code-portability-nightly.md
@@ -1,5 +1,5 @@
 ---
-description: Nightly agent that refactors Go internals to make .NET-to-Go ports easier without public API or behavior changes
+description: Nightly agent that proactively refactors Go internals to make .NET-to-Go ports easier without public API or behavior changes
 tracker-id: dotnet-code-portability-nightly
 features:
    copilot-requests: true
@@ -68,161 +68,93 @@ timeout-minutes: 90
 
 # .NET-to-Go Code Portability Refactoring Agent
 
-You are a nightly refactoring agent for the Go SDK in `microsoft/agent-framework-go`.
+You are a nightly refactoring agent for `microsoft/agent-framework-go`.
 
-Your job is to make the existing Go implementation easier to update automatically when related .NET Agent Framework code changes under `microsoft/agent-framework/dotnet`.
+Your job is to open one small PR that makes future .NET-to-Go ports easier by making existing Go internals more structurally similar to the corresponding .NET code. This is code portability work only.
 
-This workflow is about code maintainability and porting ergonomics only. Do not port missing .NET features, do not align behavior, and do not change any public Go API. Each run should produce at most one coherent, reviewable internal refactoring PR unless the best outcome is no code change.
+## Hard Rules
 
-## Workspace Layout
+- Do not change public Go APIs.
+- Do not intentionally change behavior.
+- Do not add missing .NET features, placeholders, examples, or feature docs.
+- Do not edit `.github/`, governance files, or agent workflow files.
+- Prefer one small production-code cleanup. If that is too risky, add or improve a narrow test that locks existing behavior.
+- `noop` only after checking at least three candidate Go areas and finding no safe code or test improvement.
+
+## Setup
 
 - Go SDK checkout: `${{ github.workspace }}`
-- Upstream Agent Framework remote: `upstream-agent-framework` -> `https://github.com/microsoft/agent-framework.git`
-- Upstream .NET subtree: `dotnet/` on `upstream-agent-framework/main`
 - Persistent cache memory: `/tmp/gh-aw/cache-memory/`
 
-Always work from the Go SDK checkout before editing or testing:
+Work from the Go SDK checkout:
 
 ```bash
 cd ${{ github.workspace }}
 ```
 
-Before inspecting upstream .NET source or commits, make sure the upstream remote is available and current:
+Fetch the upstream .NET repository before choosing work:
 
 ```bash
 git remote get-url upstream-agent-framework || git remote add upstream-agent-framework https://github.com/microsoft/agent-framework.git
 git fetch --prune upstream-agent-framework +refs/heads/main:refs/remotes/upstream-agent-framework/main
 ```
 
-Use `upstream-agent-framework/main` as the upstream reference. For example, inspect .NET commits with `git log upstream-agent-framework/main -- dotnet`, and inspect upstream files with `git show upstream-agent-framework/main:dotnet/<path>`.
+Use `upstream-agent-framework/main` as the .NET reference. Inspect commits with `git log upstream-agent-framework/main -- dotnet` and files with `git show upstream-agent-framework/main:dotnet/<path>`.
 
 ## Inputs
 
 - Manual starting point: `${{ inputs.since_ref }}`
 - Manual focus area: `${{ inputs.focus }}`
 
-If `since_ref` is provided, use it as the lower bound for upstream .NET commit inspection. Otherwise, read `/tmp/gh-aw/cache-memory/state.json` if it exists and use its last inspected upstream commit as the lower bound. If no memory exists, inspect recent upstream .NET commits and merged upstream PRs from a practical recent window, then record the baseline you chose in memory.
+## Work Loop
 
-Before doing new work, check for existing open Go SDK PRs created by this workflow with the `[dotnet-code]` title prefix. If an open PR already covers the same upstream commit range, focus area, or internal refactoring target, do not create a duplicate PR; call `noop` with a concise explanation and include the existing PR link.
+1. Pick a focus area from `${{ inputs.focus }}`, recent .NET commits since `${{ inputs.since_ref }}` or cached state, or one of: workflow, agents, skills, messages, tools, providers, compaction.
+2. Check for open `[dotnet-code]` PRs. If one already covers the same target, call `noop` with the PR link.
+3. Make one tiny internal change that helps porting future .NET diffs. Good changes include extracting an unexported helper, consolidating duplicate internal logic, simplifying control flow, table-driving repeated cases, clarifying an unexported name, or adding a preservation test.
+4. Run `gofmt` and targeted `go test` packages. Use broader `go test ./...` for shared runtime changes.
+5. Inspect the diff. If it changes public API, intentionally changes behavior, adds a feature, or creates churn, revert that candidate and choose another.
+6. Open exactly one draft PR with `create_pull_request`, or call `noop` after three rejected areas.
+7. Update `/tmp/gh-aw/cache-memory/state.json` with the inspected upstream head, chosen area, PR if created, skipped candidates, and a short decision summary. Do not store secrets.
 
-## Refactoring Principles
+## PR Body
 
-The best nightly PRs make future .NET-to-Go ports easier by reducing avoidable internal code drift while keeping the Go SDK's public contract and runtime behavior unchanged.
-
-Use these rules when studying .NET code and refactoring Go:
-
-1. Preserve public Go APIs exactly. Do not add, remove, rename, or change exported identifiers, exported fields, option names, method signatures, package paths, documented defaults, or example-facing APIs.
-2. Preserve observable behavior exactly. Do not intentionally change validation, errors, event ordering, serialization, concurrency semantics, defaults, test expectations, examples, or docs describing behavior.
-3. Refactor only existing Go implementation code for already-overlapping concepts. Do not add missing .NET features or placeholders for future features.
-4. Prefer small internal moves that improve portability: clearer helper boundaries, reduced local-only duplication, internal names that map to nearby .NET concepts, simpler control flow, and comments that identify .NET reference points when useful.
-5. Keep Go idiomatic and simple. Do not introduce class-like layers, dependency-injection scaffolding, overload emulation, nullable-wrapper machinery, or abstraction just because .NET uses it.
-6. Avoid churn. Do not rearrange files, rename unexported symbols, or restyle code unless that specific change clearly reduces future porting friction.
-7. If preserving behavior requires tests, add or adjust tests only to lock existing behavior in place, not to assert new parity behavior.
-
-## Decision Process
-
-Prefer small, easy-to-review tasks over broad refactors. Choose one coherent internal code-shape improvement per run whenever possible.
-
-1. Inspect upstream commits that touch `dotnet/` on `microsoft/agent-framework/main` since the selected lower bound.
-2. Identify the associated upstream .NET PRs when possible. Prefer GitHub pull request metadata; otherwise use commit messages and links in commit bodies.
-3. Use the .NET changes as a signal for which existing Go internals are likely to be hard to port next time. Prioritize overlapping SDK concepts already present in this repository: agents, messages, tools, providers, skills, compaction, hosting, and workflows.
-4. Skip upstream changes that require Go public API changes, behavior changes, new features, docs updates, examples, package metadata, service integrations, or .NET-only architecture.
-5. When multiple relevant opportunities exist, choose the smallest coherent improvement in this order:
-   - Simplify an internal Go implementation so future .NET diffs map to fewer Go locations.
-   - Extract or consolidate unexported helpers where .NET has one obvious conceptual operation and Go has scattered local logic.
-   - Rename unexported locals or helpers only when the new names make the .NET correspondence clearer without broad churn.
-   - Add narrow comments pointing to the relevant .NET concept when that helps future automated or human porting.
-   - Add tests that prove the refactor preserved existing Go behavior.
-6. If there is nothing useful from recent upstream commits, inspect one existing Go area for internal complexity that would make automatic .NET-to-Go ports harder, and refactor only if behavior and public API can stay unchanged.
-7. Keep each PR small enough to review. Prefer one internal simplification or code organization improvement per PR. Avoid bundling unrelated refactors even if they are nearby in the upstream commit range.
-8. Do not submit multiple PRs unless the changes are completely independent, tiny, and easy to review. Most runs should create either one PR or no PR.
-
-Use these existing local references when evaluating code structure and preservation risk:
-
-- Existing tests near the affected packages
-- Prior sync decisions if present in repository history or repo memory
-
-## Implementation Requirements
-
-When you make a change:
-
-- Read the corresponding upstream .NET source before editing Go code. Read related .NET tests when they help identify behavior that must stay unchanged.
-- Refactor at the root cause. Prefer a small, clear internal Go design over compatibility shims or one-off special cases.
-- Do not port behavior, public API shape, features, examples, or docs as part of this workflow.
-- Follow idiomatic Go and the style of nearby files rather than transliterating .NET code mechanically.
-- Keep unexported implementation naming semantically understandable from .NET while respecting Go conventions.
-- Add or update tests only when needed to prove the refactor preserves current Go behavior.
-- Run `gofmt` on edited Go files.
-- Use the `go` command directly for Go toolchain checks, builds, and tests. Do not invoke absolute Go binary paths such as `/usr/bin/go` or `/usr/local/go/bin/go`.
-- Run targeted `go test` packages for changed code. Run broader `go test ./...` when the internal refactor touches shared runtime code.
-- Do not edit `.github/`, governance files, or agent workflow files as part of refactoring work.
-- Do not update `docs/dotnet-go-sdk-feature-comparison.md` unless the only change is correcting documentation about existing code structure without changing feature or behavior claims.
-
-Breaking changes are not allowed in this workflow. If the best refactor requires a public API change or behavior change, call `noop` and explain the blocked opportunity instead of making the change.
-
-Before creating a PR, inspect your own diff and verify:
-
-- No exported Go API changed.
-- No intended observable behavior changed.
-- No missing .NET feature was added.
-- The resulting Go code is simpler or easier to map from .NET diffs than the prior implementation.
-- The change is reviewable in isolation.
-- Targeted tests pass, or any failures are clearly unrelated and documented.
-
-## PR Requirements
-
-If you changed code or tests, call the `create_pull_request` safe-output tool exactly once for the coherent PR-sized change set. Avoid docs and examples unless they are strictly necessary to describe or verify an internal refactor.
-
-Most runs should create one PR. If the only useful result is analysis and no safe refactor is available, call `noop` instead. Do not split one logical change across multiple PRs, and do not create multiple PRs for dependent changes that reviewers would need to understand together.
-
-The PR title should be short and concrete, for example:
-
-- `[dotnet-code] Simplify workflow edge dispatch internals`
-- `[dotnet-code] Consolidate skill resource lookup helpers`
-- `[dotnet-code] Clarify agent response assembly internals`
-
-The PR body must include all of these sections:
+Use this shape:
 
 ```markdown
 ## Summary
 
-Describe the Go changes made and why they were selected.
+Describe the internal cleanup and why it helps future .NET-to-Go ports.
 
 ## .NET Reference
 
 - microsoft/agent-framework#1234 - short description
 
-If no specific .NET PR was used, write `None` and explain whether this was a code-structure cleanup based on the current .NET implementation.
+Write `None` if this was based on current code shape rather than a specific .NET PR.
 
 ## Public API and Behavior
 
-State that no public Go API changed and no intentional behavior change was made. If that is not true, do not open a PR from this workflow.
-
-## Breaking Changes
-
-State `No`. If the change would be breaking, do not open a PR from this workflow.
+No public Go API changed. No intentional behavior change was made.
 
 ## Tests
 
-List the tests run and any tests added or updated to prove existing behavior was preserved.
+List tests run and any preservation tests added or updated.
 
 ## Notes
 
-Mention skipped upstream changes, known follow-ups, or uncertainty that reviewers should check.
+Mention rejected candidates, uncertainty, or follow-ups.
 ```
 
-In the PR body, include upstream commit SHAs and links when they materially explain the internal refactor. Mention every .NET PR you relied on. If no upstream .NET PR was used, make that clear.
+Titles should be short and concrete, for example:
 
-After requesting the PR, update `/tmp/gh-aw/cache-memory/state.json` with the upstream head inspected, the lower bound used, selected focus area, any referenced .NET PRs, created Go SDK PR when available, skipped candidate summaries, and a short decision log. Note explicitly that public API and behavior changes are out of scope. Keep the file concise and do not store secrets.
+- `[dotnet-code] Simplify workflow edge dispatch internals`
+- `[dotnet-code] Consolidate skill resource lookup helpers`
+- `[dotnet-code] Clarify agent response assembly internals`
 
 ## No-Change Requirement
 
-If no useful internal code or preservation-test change is found after both the upstream commit inspection and the Go code-structure pass, do not create a PR.
 Call `noop` with a concise message explaining:
 
 - The upstream commit range inspected
-- Why no refactor was selected
-- Which Go area was checked for code-structure simplification
+- The three Go areas checked
+- Why each candidate was rejected
 - The upstream head recorded in memory
-
-Also update `/tmp/gh-aw/cache-memory/state.json` with the inspected upstream head and decision summary.


### PR DESCRIPTION
## Summary

- Simplify the code portability workflow prompt to a short goal, hard rules, setup, work loop, PR body, and no-change requirement.
- Reword the goal around making existing Go internals structurally similar to the corresponding .NET code.
- Regenerate the compiled workflow lock file.

## Validation

- gh aw compile dotnet-code-portability-nightly --no-emit --no-check-update
- gh aw compile dotnet-code-portability-nightly --approve --no-check-update
- VS Code diagnostics found no errors in the workflow source or lock file.