### PR TITLE
[dotnet-code] Consolidate tool-approval auto-approve classification

### DIFF
--- a/agent/harness/toolapproval/toolapproval.go
+++ b/agent/harness/toolapproval/toolapproval.go
@@ -155,19 +155,15 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 			var autoApproved []*message.ToolApprovalResponseContent
 			var needsApproval []*message.ToolApprovalRequestContent
 			for _, req := range approvalRequests {
-				if matchesRule(st.Rules, req) || isNotApprovalRequired(req, opts) {
+				approved, err := isAutoApprovable(ctx, cfg, st.Rules, opts, req)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				if approved {
 					autoApproved = append(autoApproved, req.CreateResponse(true, ""))
 				} else {
-					matches, err := matchesAutoApprovalRules(ctx, cfg.AutoApprovalRules, req)
-					if err != nil {
-						yield(nil, err)
-						return
-					}
-					if matches {
-						autoApproved = append(autoApproved, req.CreateResponse(true, ""))
-					} else {
-						needsApproval = append(needsApproval, req)
-					}
+					needsApproval = append(needsApproval, req)
 				}
 			}
 
@@ -274,11 +270,11 @@ func drainAutoApprovable(ctx context.Context, cfg Config, st *state, opts []agen
 	}
 	var remaining []*message.ToolApprovalRequestContent
 	for _, req := range st.QueuedRequests {
-		matches, err := matchesAutoApprovalRules(ctx, cfg.AutoApprovalRules, req)
+		approved, err := isAutoApprovable(ctx, cfg, st.Rules, opts, req)
 		if err != nil {
 			return err
 		}
-		if matchesRule(st.Rules, req) || isNotApprovalRequired(req, opts) || matches {
+		if approved {
 			st.CollectedResponses = append(st.CollectedResponses, req.CreateResponse(true, ""))
 		} else {
 			remaining = append(remaining, req)
@@ -325,6 +321,19 @@ func isNotApprovalRequired(req *message.ToolApprovalRequestContent, opts []agent
 		return true
 	}
 	return false
+}
+
+// isAutoApprovable reports whether a tool approval request should be automatically approved
+// without surfacing it to the caller.
+//
+// Standing rules and tools not requiring approval are checked first (cheaply), before evaluating
+// configured auto-approval rules. This matches the .NET MatchesRule || MatchesAutoApprovalRule
+// evaluation pattern used in ToolApprovalAgent.
+func isAutoApprovable(ctx context.Context, cfg Config, rules []Rule, opts []agent.Option, req *message.ToolApprovalRequestContent) (bool, error) {
+	if matchesRule(rules, req) || isNotApprovalRequired(req, opts) {
+		return true, nil
+	}
+	return matchesAutoApprovalRules(ctx, cfg.AutoApprovalRules, req)
 }
 
 // matchesAutoApprovalRules returns true if any configured auto-approval rule

--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -832,3 +832,76 @@ func TestToolApproval_AutoApprovalRule_ErrorFailsRun(t *testing.T) {
 		t.Fatalf("expected rule error %v, got %v", ruleErr, gotErr)
 	}
 }
+
+func TestToolApproval_QueuedStandingRuleShortCircuitsAutoApprovalRuleError(t *testing.T) {
+	tool1 := &message.FunctionCallContent{CallID: "c1", Name: "MyTool", Arguments: `{}`}
+	tool2 := &message.FunctionCallContent{CallID: "c2", Name: "MyTool", Arguments: `{}`}
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: tool1},
+					&message.ToolApprovalRequestContent{RequestID: "r2", ToolCall: tool2},
+				},
+			}).
+			NewTurn().
+			AddText("done").
+			Build(),
+	}
+
+	ruleErr := errors.New("auto-approval rule should be skipped")
+	ruleCalls := 0
+	mw := toolapproval.New(toolapproval.Config{
+		AutoApprovalRules: []func(context.Context, *message.FunctionCallContent) (bool, error){
+			func(_ context.Context, _ *message.FunctionCallContent) (bool, error) {
+				ruleCalls++
+				if ruleCalls <= 2 {
+					return false, nil
+				}
+				return false, ruleErr
+			},
+		},
+	})
+
+	session := agenttest.CreateSession()
+	opts := []agent.Option{agent.WithSession(session)}
+
+	turn1 := collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
+		opts...,
+	)
+
+	var req *message.ToolApprovalRequestContent
+	for _, u := range turn1 {
+		for _, c := range u.Contents {
+			if r, ok := c.(*message.ToolApprovalRequestContent); ok && r.RequestID == "r1" {
+				req = r
+			}
+		}
+	}
+	if req == nil {
+		t.Fatal("expected first approval request to be surfaced")
+	}
+
+	turn2 := collectUpdates(t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolResponse()}}},
+		opts...,
+	)
+
+	var gotDone bool
+	for _, u := range turn2 {
+		for _, c := range u.Contents {
+			if tc, ok := c.(*message.TextContent); ok && tc.Text == "done" {
+				gotDone = true
+			}
+		}
+	}
+	if !gotDone {
+		t.Fatal("expected done after queued request was auto-approved by standing rule")
+	}
+	if ruleCalls != 2 {
+		t.Fatalf("expected auto-approval rule to be called only in turn 1, got %d calls", ruleCalls)
+	}
+}

--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -833,7 +833,7 @@ func TestToolApproval_AutoApprovalRule_ErrorFailsRun(t *testing.T) {
 	}
 }
 
-func TestToolApproval_QueuedStandingRuleShortCircuitsAutoApprovalRuleError(t *testing.T) {
+func TestToolApproval_QueuedStandingRuleShortCircuitsAutoApprovalEvaluation(t *testing.T) {
 	tool1 := &message.FunctionCallContent{CallID: "c1", Name: "MyTool", Arguments: `{}`}
 	tool2 := &message.FunctionCallContent{CallID: "c2", Name: "MyTool", Arguments: `{}`}
 
@@ -885,10 +885,15 @@ func TestToolApproval_QueuedStandingRuleShortCircuitsAutoApprovalRuleError(t *te
 		t.Fatal("expected first approval request to be surfaced")
 	}
 
-	turn2 := collectUpdates(t, mw, runner.Run,
-		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolResponse()}}},
-		opts...,
-	)
+	var turn2 []*agent.ResponseUpdate
+	for u, err := range mw.Run(runner.Run, context.Background(), []*message.Message{
+		{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolResponse()}},
+	}, opts...) {
+		if err != nil {
+			t.Fatalf("expected queued standing-rule match to short-circuit auto-approval rule errors, got %v", err)
+		}
+		turn2 = append(turn2, u)
+	}
 
 	var gotDone bool
 	for _, u := range turn2 {


### PR DESCRIPTION
Both run and drainAutoApprovable classify tool-approval requests using the same criteria: a standing rule match, a not-approval-required flag, or a configured auto-approval rule. Previously the two call sites differed in evaluation order and structure:

- run checked cheap conditions first, then called matchesAutoApprovalRules only when they did not match.
- drainAutoApprovable called matchesAutoApprovalRules first, then combined the result with the cheap checks.

Extract isAutoApprovable to encode the single authoritative order (cheap checks short-circuit before auto-approval rules) and reuse it in both call sites. This aligns with the .NET ToolApprovalAgent pattern, where both classification paths call the same MatchesRule || MatchesAutoApprovalRuleAsync expression.

No public API change. No intentional behavior change.