### PR TITLE
[dotnet-port] Align tool approval response snapshots

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -616,10 +616,37 @@ func (t *ToolApprovalRequestContent) CreateResponse(approved bool, reason string
 		RequestID: t.RequestID,
 		Approved:  approved,
 		Reason:    reason,
-		ToolCall:  t.ToolCall,
+		ToolCall:  cloneToolCallContent(t.ToolCall),
 		ContentHeader: ContentHeader{
-			AdditionalProperties: t.AdditionalProperties,
+			AdditionalProperties: maps.Clone(t.AdditionalProperties),
+			Annotations:          slices.Clone(t.Annotations),
+			RawRepresentation:    t.RawRepresentation,
 		},
+	}
+}
+
+func cloneToolCallContent(toolCall ToolCallContent) ToolCallContent {
+	switch toolCall := toolCall.(type) {
+	case nil:
+		return nil
+	case *FunctionCallContent:
+		cloned := *toolCall
+		cloned.ContentHeader = cloneContentHeader(toolCall.ContentHeader)
+		return &cloned
+	case *MCPServerToolCallContent:
+		cloned := *toolCall
+		cloned.ContentHeader = cloneContentHeader(toolCall.ContentHeader)
+		return &cloned
+	default:
+		return toolCall
+	}
+}
+
+func cloneContentHeader(header ContentHeader) ContentHeader {
+	return ContentHeader{
+		AdditionalProperties: maps.Clone(header.AdditionalProperties),
+		Annotations:          slices.Clone(header.Annotations),
+		RawRepresentation:    header.RawRepresentation,
 	}
 }
 

--- a/message/content.go
+++ b/message/content.go
@@ -630,10 +630,16 @@ func cloneToolCallContent(toolCall ToolCallContent) ToolCallContent {
 	case nil:
 		return nil
 	case *FunctionCallContent:
+		if toolCall == nil {
+			return nil
+		}
 		cloned := *toolCall
 		cloned.ContentHeader = cloneContentHeader(toolCall.ContentHeader)
 		return &cloned
 	case *MCPServerToolCallContent:
+		if toolCall == nil {
+			return nil
+		}
 		cloned := *toolCall
 		cloned.ContentHeader = cloneContentHeader(toolCall.ContentHeader)
 		return &cloned

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -183,6 +183,88 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestToolApprovalRequestContent_CreateResponseSnapshotsFunctionCall(t *testing.T) {
+	toolCall := &message.FunctionCallContent{
+		ContentHeader: message.ContentHeader{
+			AdditionalProperties: map[string]any{"key": "value"},
+		},
+		CallID:    "call-1",
+		Name:      "deploy",
+		Arguments: `{"environment":"prod"}`,
+	}
+	request := &message.ToolApprovalRequestContent{
+		ContentHeader: message.ContentHeader{
+			AdditionalProperties: map[string]any{"request": "value"},
+		},
+		RequestID: "approval-1",
+		ToolCall:  toolCall,
+	}
+
+	response := request.CreateResponse(true, "approved")
+
+	toolCall.Name = "destroy"
+	toolCall.Arguments = `{"environment":"dev"}`
+	toolCall.AdditionalProperties["key"] = "changed"
+	request.AdditionalProperties["request"] = "changed"
+
+	responseToolCall, ok := response.ToolCall.(*message.FunctionCallContent)
+	if !ok {
+		t.Fatalf("expected FunctionCallContent, got %T", response.ToolCall)
+	}
+	if responseToolCall.Name != "deploy" {
+		t.Fatalf("expected response tool name to be snapshotted, got %q", responseToolCall.Name)
+	}
+	if responseToolCall.Arguments != `{"environment":"prod"}` {
+		t.Fatalf("expected response tool arguments to be snapshotted, got %q", responseToolCall.Arguments)
+	}
+	if responseToolCall.AdditionalProperties["key"] != "value" {
+		t.Fatalf("expected response tool additional properties to be snapshotted, got %v", responseToolCall.AdditionalProperties["key"])
+	}
+	if response.AdditionalProperties["request"] != "value" {
+		t.Fatalf("expected response additional properties to be snapshotted, got %v", response.AdditionalProperties["request"])
+	}
+}
+
+func TestToolApprovalRequestContent_CreateResponseSnapshotsMCPServerToolCall(t *testing.T) {
+	toolCall := &message.MCPServerToolCallContent{
+		ContentHeader: message.ContentHeader{
+			AdditionalProperties: map[string]any{"key": "value"},
+		},
+		CallID:     "call-1",
+		Name:       "lookup",
+		ServerName: "server-a",
+		Arguments:  `{"query":"alpha"}`,
+	}
+	request := &message.ToolApprovalRequestContent{
+		RequestID: "approval-1",
+		ToolCall:  toolCall,
+	}
+
+	response := request.CreateResponse(true, "approved")
+
+	toolCall.Name = "delete"
+	toolCall.ServerName = "server-b"
+	toolCall.Arguments = `{"query":"beta"}`
+	toolCall.AdditionalProperties["key"] = "changed"
+
+	responseToolCall, ok := response.ToolCall.(*message.MCPServerToolCallContent)
+	if !ok {
+		t.Fatalf("expected MCPServerToolCallContent, got %T", response.ToolCall)
+	}
+	if responseToolCall.Name != "lookup" {
+		t.Fatalf("expected response tool name to be snapshotted, got %q", responseToolCall.Name)
+	}
+	if responseToolCall.ServerName != "server-a" {
+		t.Fatalf("expected response server name to be snapshotted, got %q", responseToolCall.ServerName)
+	}
+	if responseToolCall.Arguments != `{"query":"alpha"}` {
+		t.Fatalf("expected response tool arguments to be snapshotted, got %q", responseToolCall.Arguments)
+	}
+	if responseToolCall.AdditionalProperties["key"] != "value" {
+		t.Fatalf("expected response tool additional properties to be snapshotted, got %v", responseToolCall.AdditionalProperties["key"])
+	}
+}
+
 func TestCoalesceContents(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Snapshot tool-call content when creating approval responses so the approved call remains stable if the original request content is mutated before execution or serialization. This mirrors the upstream .NET workflow approval snapshot behavior from microsoft/agent-framework#6427.