### PR TITLE
[dotnet-port] Align A2A status update message IDs

### DIFF
--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -179,9 +179,18 @@ func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func
 				return
 			}
 		case *a2a.TaskStatusUpdateEvent:
-			messageID := string(e.TaskID)
+			var (
+				messageID string
+				contents  []message.Content
+			)
 			if e.Status.Message != nil {
 				messageID = e.Status.Message.ID
+				var err error
+				contents, err = partsToContents(e.Status.Message.Parts, nil)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
 			}
 			if !yield(&agent.ResponseUpdate{
 				RawRepresentation:    e,
@@ -189,6 +198,7 @@ func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func
 				MessageID:            messageID,
 				ResponseID:           string(e.TaskID),
 				Role:                 message.RoleAssistant,
+				Contents:             contents,
 				CreatedAt:            time.Now(),
 			}, nil) {
 				return

--- a/agent/provider/a2aagent/a2a.go
+++ b/agent/provider/a2aagent/a2a.go
@@ -185,11 +185,13 @@ func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func
 			)
 			if e.Status.Message != nil {
 				messageID = e.Status.Message.ID
-				var err error
-				contents, err = partsToContents(e.Status.Message.Parts, nil)
-				if err != nil {
-					yield(nil, err)
-					return
+				if e.Status.State == a2a.TaskStateInputRequired || e.Status.State.Terminal() {
+					var err error
+					contents, err = partsToContents(e.Status.Message.Parts, nil)
+					if err != nil {
+						yield(nil, err)
+						return
+					}
 				}
 			}
 			if !yield(&agent.ResponseUpdate{

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -547,6 +547,80 @@ func TestRunStreamingWithSessionHavingDifferentContextID(t *testing.T) {
 	}
 }
 
+func TestRunStreamingWithTaskStatusUpdateAndMessageIDYieldsMessageID(t *testing.T) {
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
+			TaskID:    "task-status-msg-123",
+			ContextID: "ctx-status-msg-456",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateWorking,
+				Message: &a2a.Message{
+					ID:    "msg-status-789",
+					Parts: a2a.ContentParts{a2a.NewTextPart("Processing your request...")},
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var updates []*agent.ResponseUpdate
+	for update, err := range a.RunText(t.Context(), "Check task status", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+	update := updates[0]
+	if update.MessageID != "msg-status-789" {
+		t.Errorf("update.MessageID = %q, want %q", update.MessageID, "msg-status-789")
+	}
+	if update.ResponseID != "task-status-msg-123" {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, "task-status-msg-123")
+	}
+	if got := update.String(); got != "Processing your request..." {
+		t.Errorf("update.String() = %q, want %q", got, "Processing your request...")
+	}
+	if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
+		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
+	}
+}
+
+func TestRunStreamingWithTaskStatusUpdateWithoutMessageLeavesMessageIDEmpty(t *testing.T) {
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
+			TaskID:    "task-status-123",
+			ContextID: "ctx-status-456",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateWorking,
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var updates []*agent.ResponseUpdate
+	for update, err := range a.RunText(t.Context(), "Check task status", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+	update := updates[0]
+	if update.MessageID != "" {
+		t.Errorf("update.MessageID = %q, want empty", update.MessageID)
+	}
+	if update.ResponseID != "task-status-123" {
+		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, "task-status-123")
+	}
+}
+
 // TestRunStreamingAllowsNonUserRoleMessages tests that streaming allows non-user messages
 func TestRunStreamingAllowsNonUserRoleMessages(t *testing.T) {
 	transport := &mockA2ATransport{

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -547,80 +547,6 @@ func TestRunStreamingWithSessionHavingDifferentContextID(t *testing.T) {
 	}
 }
 
-func TestRunStreamingWithTaskStatusUpdateAndMessageIDYieldsMessageID(t *testing.T) {
-	transport := &mockA2ATransport{
-		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
-			TaskID:    "task-status-msg-123",
-			ContextID: "ctx-status-msg-456",
-			Status: a2a.TaskStatus{
-				State: a2a.TaskStateWorking,
-				Message: &a2a.Message{
-					ID:    "msg-status-789",
-					Parts: a2a.ContentParts{a2a.NewTextPart("Processing your request...")},
-				},
-			},
-		},
-	}
-	a := newTestAgent(transport, agent.Config{})
-
-	var updates []*agent.ResponseUpdate
-	for update, err := range a.RunText(t.Context(), "Check task status", agent.Stream(true)) {
-		if err != nil {
-			t.Fatalf("error = %v, want nil", err)
-		}
-		updates = append(updates, update)
-	}
-
-	if len(updates) != 1 {
-		t.Fatalf("len(updates) = %d, want 1", len(updates))
-	}
-	update := updates[0]
-	if update.MessageID != "msg-status-789" {
-		t.Errorf("update.MessageID = %q, want %q", update.MessageID, "msg-status-789")
-	}
-	if update.ResponseID != "task-status-msg-123" {
-		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, "task-status-msg-123")
-	}
-	if got := update.String(); got != "Processing your request..." {
-		t.Errorf("update.String() = %q, want %q", got, "Processing your request...")
-	}
-	if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
-		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
-	}
-}
-
-func TestRunStreamingWithTaskStatusUpdateWithoutMessageLeavesMessageIDEmpty(t *testing.T) {
-	transport := &mockA2ATransport{
-		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
-			TaskID:    "task-status-123",
-			ContextID: "ctx-status-456",
-			Status: a2a.TaskStatus{
-				State: a2a.TaskStateWorking,
-			},
-		},
-	}
-	a := newTestAgent(transport, agent.Config{})
-
-	var updates []*agent.ResponseUpdate
-	for update, err := range a.RunText(t.Context(), "Check task status", agent.Stream(true)) {
-		if err != nil {
-			t.Fatalf("error = %v, want nil", err)
-		}
-		updates = append(updates, update)
-	}
-
-	if len(updates) != 1 {
-		t.Fatalf("len(updates) = %d, want 1", len(updates))
-	}
-	update := updates[0]
-	if update.MessageID != "" {
-		t.Errorf("update.MessageID = %q, want empty", update.MessageID)
-	}
-	if update.ResponseID != "task-status-123" {
-		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, "task-status-123")
-	}
-}
-
 // TestRunStreamingAllowsNonUserRoleMessages tests that streaming allows non-user messages
 func TestRunStreamingAllowsNonUserRoleMessages(t *testing.T) {
 	transport := &mockA2ATransport{
@@ -1400,6 +1326,9 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 	if update.ResponseID != taskID {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
 	}
+	if update.MessageID != "" {
+		t.Errorf("update.MessageID = %q, want empty (Status.Message is nil)", update.MessageID)
+	}
 	if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
 		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
 	}
@@ -1419,6 +1348,7 @@ func TestRunStreamingWithTaskStatusUpdateEvent_WithMessage(t *testing.T) {
 	const taskID = "task-status-msg-123"
 	const contextID = "ctx-status-msg-456"
 	const msgID = "msg-abc-789"
+	const msgText = "Processing your request..."
 
 	transport := &mockA2ATransport{
 		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
@@ -1427,8 +1357,9 @@ func TestRunStreamingWithTaskStatusUpdateEvent_WithMessage(t *testing.T) {
 			Status: a2a.TaskStatus{
 				State: a2a.TaskStateWorking,
 				Message: &a2a.Message{
-					ID:   msgID,
-					Role: a2a.MessageRoleAgent,
+					ID:    msgID,
+					Role:  a2a.MessageRoleAgent,
+					Parts: a2a.ContentParts{a2a.NewTextPart(msgText)},
 				},
 			},
 		},
@@ -1458,6 +1389,12 @@ func TestRunStreamingWithTaskStatusUpdateEvent_WithMessage(t *testing.T) {
 	}
 	if update.ResponseID != taskID {
 		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
+	}
+	if got := update.String(); got != msgText {
+		t.Errorf("update.String() = %q, want %q", got, msgText)
+	}
+	if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
+		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
 	}
 }
 

--- a/agent/provider/a2aagent/a2a_test.go
+++ b/agent/provider/a2aagent/a2a_test.go
@@ -1343,59 +1343,108 @@ func TestRunStreamingWithTaskStatusUpdateEvent(t *testing.T) {
 
 // TestRunStreamingWithTaskStatusUpdateEvent_WithMessage tests that MessageID is populated
 // from Status.Message.ID when the status update contains a message, aligning with the .NET
-// fix in microsoft/agent-framework#6043.
+// fix in microsoft/agent-framework#6043. Contents are only populated for InputRequired or
+// terminal states.
 func TestRunStreamingWithTaskStatusUpdateEvent_WithMessage(t *testing.T) {
 	const taskID = "task-status-msg-123"
 	const contextID = "ctx-status-msg-456"
 	const msgID = "msg-abc-789"
 	const msgText = "Processing your request..."
 
-	transport := &mockA2ATransport{
-		streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
-			TaskID:    a2a.TaskID(taskID),
-			ContextID: contextID,
-			Status: a2a.TaskStatus{
-				State: a2a.TaskStateWorking,
-				Message: &a2a.Message{
-					ID:    msgID,
-					Role:  a2a.MessageRoleAgent,
-					Parts: a2a.ContentParts{a2a.NewTextPart(msgText)},
+	t.Run("InputRequired_populatesContents", func(t *testing.T) {
+		transport := &mockA2ATransport{
+			streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
+				TaskID:    a2a.TaskID(taskID),
+				ContextID: contextID,
+				Status: a2a.TaskStatus{
+					State: a2a.TaskStateInputRequired,
+					Message: &a2a.Message{
+						ID:    msgID,
+						Role:  a2a.MessageRoleAgent,
+						Parts: a2a.ContentParts{a2a.NewTextPart(msgText)},
+					},
 				},
 			},
-		},
-	}
-	a := newTestAgent(transport, agent.Config{})
-
-	session, err := a.CreateSession(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var updates []*agent.ResponseUpdate
-	for update, err := range a.RunText(t.Context(), "Check task status", agent.WithSession(session), agent.Stream(true)) {
-		if err != nil {
-			t.Fatalf("error = %v, want nil", err)
 		}
-		updates = append(updates, update)
-	}
+		a := newTestAgent(transport, agent.Config{})
 
-	if len(updates) != 1 {
-		t.Fatalf("len(updates) = %d, want 1", len(updates))
-	}
+		session, err := a.CreateSession(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	update := updates[0]
-	if update.MessageID != msgID {
-		t.Errorf("update.MessageID = %q, want %q (from Status.Message.ID)", update.MessageID, msgID)
-	}
-	if update.ResponseID != taskID {
-		t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
-	}
-	if got := update.String(); got != msgText {
-		t.Errorf("update.String() = %q, want %q", got, msgText)
-	}
-	if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
-		t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
-	}
+		var updates []*agent.ResponseUpdate
+		for update, err := range a.RunText(t.Context(), "Check task status", agent.WithSession(session), agent.Stream(true)) {
+			if err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+			updates = append(updates, update)
+		}
+
+		if len(updates) != 1 {
+			t.Fatalf("len(updates) = %d, want 1", len(updates))
+		}
+
+		update := updates[0]
+		if update.MessageID != msgID {
+			t.Errorf("update.MessageID = %q, want %q (from Status.Message.ID)", update.MessageID, msgID)
+		}
+		if update.ResponseID != taskID {
+			t.Errorf("update.ResponseID = %q, want %q", update.ResponseID, taskID)
+		}
+		if got := update.String(); got != msgText {
+			t.Errorf("update.String() = %q, want %q", got, msgText)
+		}
+		if _, ok := update.RawRepresentation.(*a2a.TaskStatusUpdateEvent); !ok {
+			t.Errorf("update.RawRepresentation type = %T, want *a2a.TaskStatusUpdateEvent", update.RawRepresentation)
+		}
+	})
+
+	t.Run("Working_doesNotPopulateContents", func(t *testing.T) {
+		transport := &mockA2ATransport{
+			streamingResponseToReturn: &a2a.TaskStatusUpdateEvent{
+				TaskID:    a2a.TaskID(taskID),
+				ContextID: contextID,
+				Status: a2a.TaskStatus{
+					State: a2a.TaskStateWorking,
+					Message: &a2a.Message{
+						ID:    msgID,
+						Role:  a2a.MessageRoleAgent,
+						Parts: a2a.ContentParts{a2a.NewTextPart(msgText)},
+					},
+				},
+			},
+		}
+		a := newTestAgent(transport, agent.Config{})
+
+		session, err := a.CreateSession(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var updates []*agent.ResponseUpdate
+		for update, err := range a.RunText(t.Context(), "Check task status", agent.WithSession(session), agent.Stream(true)) {
+			if err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+			updates = append(updates, update)
+		}
+
+		if len(updates) != 1 {
+			t.Fatalf("len(updates) = %d, want 1", len(updates))
+		}
+
+		update := updates[0]
+		if update.MessageID != msgID {
+			t.Errorf("update.MessageID = %q, want %q (from Status.Message.ID)", update.MessageID, msgID)
+		}
+		if len(update.Contents) != 0 {
+			t.Errorf("update.Contents = %v, want empty (Working state should not populate contents)", update.Contents)
+		}
+		if got := update.String(); got != "" {
+			t.Errorf("update.String() = %q, want empty (Working state should not populate contents)", got)
+		}
+	})
 }
 
 // TestRunStreamingWithTaskArtifactUpdateEvent tests handling of TaskArtifactUpdateEvent


### PR DESCRIPTION
Port .NET A2A `TaskStatusUpdateEvent` handling so streaming status updates use the embedded status message ID instead of falling back to the task ID, and only populate `ResponseUpdate.Contents` from the status message parts when the task state is `InputRequired` or a terminal state — matching the behavior of the .NET and Python SDKs.