### PR TITLE
[dotnet-code] Align nil state update delete marker

### DIFF
--- a/workflow/internal/execution/state.go
+++ b/workflow/internal/execution/state.go
@@ -97,7 +97,7 @@ type StateUpdate struct {
 
 // UpdateStateUpdate creates an update operation.
 func UpdateStateUpdate(key string, value any) StateUpdate {
-	return StateUpdate{Key: key, Value: value, IsDelete: false}
+	return StateUpdate{Key: key, Value: value, IsDelete: value == nil}
 }
 
 // DeleteStateUpdate creates a delete operation.

--- a/workflow/internal/execution/state_test.go
+++ b/workflow/internal/execution/state_test.go
@@ -15,6 +15,13 @@ func mustSucceed(t *testing.T, err error) {
 	}
 }
 
+func TestUpdateStateUpdateNilValueIsDelete(t *testing.T) {
+	update := UpdateStateUpdate("key", nil)
+	if !update.IsDelete {
+		t.Fatal("nil state update should be marked as delete")
+	}
+}
+
 func TestScopeSharedScope_ReadKeys(t *testing.T) {
 	scopeName := "sharedScope"
 	runScopeKeysTest(t, scopeName, true)


### PR DESCRIPTION
Mark nil-valued internal state updates as deletes when they are created, matching the existing publish/read behavior and the .NET StateUpdate shape.