### PR TITLE
[dotnet-code] Consolidate shell clean environment preservation

### DIFF
--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -670,21 +670,7 @@ func commandEnvironment(clean bool, overrides map[string]string, removals []stri
 	if !clean && len(overrides) == 0 && len(removals) == 0 {
 		return nil
 	}
-	env := make(map[string]string)
-	if clean {
-		for _, name := range preservedEnvironmentVariables {
-			if value, ok := lookupEnvFold(name); ok {
-				env[name] = value
-			}
-		}
-	} else {
-		for _, entry := range os.Environ() {
-			name, value, ok := strings.Cut(entry, "=")
-			if ok {
-				env[name] = value
-			}
-		}
-	}
+	env := inheritedCommandEnvironment(clean)
 
 	for _, name := range removals {
 		deleteEnvironmentValue(env, name)
@@ -705,8 +691,35 @@ func commandEnvironment(clean bool, overrides map[string]string, removals []stri
 	return result
 }
 
-func lookupEnvFold(name string) (string, bool) {
+func inheritedCommandEnvironment(clean bool) map[string]string {
+	env := make(map[string]string)
+	if clean {
+		preserveEnvironmentValues(env, os.Environ())
+		return env
+	}
 	for _, entry := range os.Environ() {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[name] = value
+		}
+	}
+	return env
+}
+
+func preserveEnvironmentValues(env map[string]string, source []string) {
+	for _, name := range preservedEnvironmentVariables {
+		if value, ok := lookupEnvListFold(source, name); ok {
+			env[name] = value
+		}
+	}
+}
+
+func lookupEnvFold(name string) (string, bool) {
+	return lookupEnvListFold(os.Environ(), name)
+}
+
+func lookupEnvListFold(source []string, name string) (string, bool) {
+	for _, entry := range source {
 		envName, envValue, found := strings.Cut(entry, "=")
 		if found && strings.EqualFold(envName, name) {
 			return envValue, true

--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -714,10 +714,6 @@ func preserveEnvironmentValues(env map[string]string, source []string) {
 	}
 }
 
-func lookupEnvFold(name string) (string, bool) {
-	return lookupEnvListFold(os.Environ(), name)
-}
-
 func lookupEnvListFold(source []string, name string) (string, bool) {
 	for _, entry := range source {
 		envName, envValue, found := strings.Cut(entry, "=")

--- a/tool/shelltool/localshell_internal_test.go
+++ b/tool/shelltool/localshell_internal_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package shelltool
+
+import "testing"
+
+func TestPreserveEnvironmentValuesKeepsOnlyAllowlist(t *testing.T) {
+	source := []string{
+		"PATH=/bin",
+		"HOME=/home/test",
+		"AF_SHELL_PARENT_VAR=should-not-leak",
+		"tmp=/tmp/test",
+	}
+	env := make(map[string]string)
+
+	preserveEnvironmentValues(env, source)
+
+	if got := env["PATH"]; got != "/bin" {
+		t.Fatalf("PATH = %q, want /bin", got)
+	}
+	if got := env["HOME"]; got != "/home/test" {
+		t.Fatalf("HOME = %q, want /home/test", got)
+	}
+	if got := env["TMP"]; got != "/tmp/test" {
+		t.Fatalf("TMP = %q, want /tmp/test", got)
+	}
+	if _, ok := env["AF_SHELL_PARENT_VAR"]; ok {
+		t.Fatal("unexpected non-preserved variable copied")
+	}
+}


### PR DESCRIPTION
Extract the clean-environment preservation path into an internal helper and cover the preserved-variable filtering behavior. This keeps the Go shelltool internals closer to the .NET EnvironmentSanitizer shape without changing public APIs or behavior.