### PR TITLE
Port workflow output tagging and group chat builders

### DIFF
--- a/agent/hosting/workflowhosting/builders.go
+++ b/agent/hosting/workflowhosting/builders.go
@@ -3,55 +3,11 @@
 package workflowhosting
 
 import (
-	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/microsoft/agent-framework-go/agent"
-	"github.com/microsoft/agent-framework-go/message"
-	"github.com/microsoft/agent-framework-go/message/messageworkflow"
 	"github.com/microsoft/agent-framework-go/workflow"
 )
-
-const (
-	aggregateTurnMessagesStateKey = "workflowhosting.AggregateTurnMessagesExecutor.State"
-	concurrentEndExecutorID       = "workflowhosting.ConcurrentEnd"
-	outputMessagesExecutorID      = "workflowhosting.OutputMessages"
-	outputMessagesStateKey        = "workflowhosting.OutputMessagesExecutor.State"
-)
-
-// BuildSequential builds a [workflow.Workflow] with the given name that runs agents in order:
-// each agent's output (and incoming messages) is forwarded as input to the
-// next, forming a linear pipeline.
-//
-// The name may be empty.
-//
-// Agents are hosted with the default [Config], which enables incoming-message
-// forwarding and role reassignment so that each agent in the chain sees the
-// full conversation in the correct roles.
-func BuildSequential(name string, agents ...*agent.Agent) (*workflow.Workflow, error) {
-	if err := validateBuilderAgents("BuildSequential", agents); err != nil {
-		return nil, err
-	}
-
-	// Default Config: message forwarding and role reassignment are both
-	// enabled (zero-value booleans = false means "do NOT disable").
-	cfg := Config{}
-	bindings := make([]workflow.ExecutorBinding, len(agents))
-	for index, currentAgent := range agents {
-		bindings[index] = New(currentAgent, cfg)
-	}
-
-	bld := workflow.NewBuilder(bindings[0]).WithName(name)
-	previous := bindings[0]
-	for _, next := range bindings[1:] {
-		bld = bld.AddEdge(previous, next)
-		previous = next
-	}
-	outputMessages := newOutputMessagesBinding()
-	bld = bld.AddEdge(previous, outputMessages).WithOutputFrom(outputMessages)
-	return bld.Build()
-}
 
 func validateBuilderAgents(builderName string, agents []*agent.Agent) error {
 	if len(agents) == 0 {
@@ -65,158 +21,79 @@ func validateBuilderAgents(builderName string, agents []*agent.Agent) error {
 	return nil
 }
 
-// MessageAggregator combines per-agent message batches into a single batch.
-type MessageAggregator func(context.Context, [][]*message.Message) []*message.Message
+type outputDesignations map[*agent.Agent]map[workflow.OutputTag]struct{}
 
-// BuildConcurrent builds a [workflow.Workflow] with the given name that fans a
-// single input out to all agents simultaneously. Each agent runs independently;
-// the workflow output is the last message in each non-empty per-agent batch.
-//
-// The name may be empty.
-//
-// Agents are hosted with the default [Config], which enables incoming-message
-// forwarding and role reassignment.
-func BuildConcurrent(name string, agents ...*agent.Agent) (*workflow.Workflow, error) {
-	return BuildConcurrentWithAggregator(name, nil, agents...)
+func (d outputDesignations) explicit() bool {
+	return d != nil
 }
 
-// BuildConcurrentWithAggregator builds a concurrent agent workflow using
-// aggregator to combine each agent's turn-message batch into the final workflow
-// output. If aggregator is nil, the default behavior returns the last message
-// in each non-empty batch.
-func BuildConcurrentWithAggregator(name string, aggregator MessageAggregator, agents ...*agent.Agent) (*workflow.Workflow, error) {
-	if err := validateBuilderAgents("BuildConcurrentWithAggregator", agents); err != nil {
-		return nil, err
+func (d outputDesignations) withOutputFrom(agents ...*agent.Agent) (outputDesignations, error) {
+	if d == nil {
+		d = make(outputDesignations)
 	}
-
-	cfg := Config{}
-	bindings := make([]workflow.ExecutorBinding, len(agents))
 	for index, currentAgent := range agents {
-		bindings[index] = New(currentAgent, cfg)
-	}
-
-	start := newMessageForwardingBinding("Start")
-	accumulators := make([]workflow.ExecutorBinding, len(bindings))
-	for i, binding := range bindings {
-		accumulators[i] = newAggregateTurnMessagesBinding("Batcher/" + binding.ID)
-	}
-	end := newConcurrentEndBinding(len(bindings), aggregator)
-
-	bld := workflow.NewBuilder(start).WithName(name)
-	bld = bld.AddFanOutEdge(start, bindings)
-	for i, binding := range bindings {
-		bld = bld.AddEdge(binding, accumulators[i])
-	}
-	bld = bld.AddFanInBarrierEdge(accumulators, end)
-	bld = bld.WithOutputFrom(end)
-	return bld.Build()
-}
-
-func newMessageForwardingBinding(id string) workflow.ExecutorBinding {
-	return workflow.ExecutorBinding{
-		ID:                                id,
-		SupportsConcurrentSharedExecution: true,
-		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
-			executor := workflow.Executor{ID: id}
-			messageworkflow.ConfigureForwarding(&executor, nil)
-			return &executor, nil
-		},
-	}
-}
-
-func newAggregateTurnMessagesBinding(id string) workflow.ExecutorBinding {
-	return workflow.ExecutorBinding{
-		ID:                                id,
-		SupportsConcurrentSharedExecution: true,
-		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
-			executor := workflow.Executor{
-				ID: id,
-				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
-					return pb.SendsMessageType(reflect.TypeFor[[]*message.Message]()), nil
-				},
-			}
-			messageworkflow.Configure(&executor, &messageworkflow.Options{
-				StateKey:                 aggregateTurnMessagesStateKey,
-				DisableAutoSendTurnToken: true,
-				TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, messages []*message.Message) error {
-					return ctx.SendMessage("", messages)
-				},
-			})
-			return &executor, nil
-		},
-	}
-}
-
-func newOutputMessagesBinding() workflow.ExecutorBinding {
-	return workflow.ExecutorBinding{
-		ID:                                outputMessagesExecutorID,
-		SupportsConcurrentSharedExecution: true,
-		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
-			executor := workflow.Executor{
-				ID: outputMessagesExecutorID,
-				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
-					return pb.YieldsOutputType(reflect.TypeFor[[]*message.Message]()), nil
-				},
-			}
-			messageworkflow.Configure(&executor, &messageworkflow.Options{
-				StateKey:                 outputMessagesStateKey,
-				DisableAutoSendTurnToken: true,
-				TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, messages []*message.Message) error {
-					return ctx.YieldOutput(messages)
-				},
-			})
-			return &executor, nil
-		},
-	}
-}
-
-func newConcurrentEndBinding(expectedInputs int, aggregator MessageAggregator) workflow.ExecutorBinding {
-	if aggregator == nil {
-		aggregator = defaultConcurrentMessageAggregator
-	}
-	return workflow.ExecutorBinding{
-		ID:                                concurrentEndExecutorID,
-		SupportsConcurrentSharedExecution: true,
-		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
-			allResults := make([][]*message.Message, 0, expectedInputs)
-			remaining := expectedInputs
-			reset := func() {
-				allResults = make([][]*message.Message, 0, expectedInputs)
-				remaining = expectedInputs
-			}
-			return &workflow.Executor{
-				ID: concurrentEndExecutorID,
-				ResetFunc: func() error {
-					reset()
-					return nil
-				},
-				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
-					rb.YieldsOutputType(reflect.TypeFor[[]*message.Message]())
-					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-						allResults = append(allResults, msg.([]*message.Message))
-						remaining--
-						if remaining == 0 {
-							results := allResults
-							reset()
-							if err := ctx.YieldOutput(aggregator(ctx, results)); err != nil {
-								return nil, err
-							}
-						}
-						return struct{}{}, nil
-					})
-					return rb, nil
-				},
-			}, nil
-		},
-	}
-}
-
-func defaultConcurrentMessageAggregator(_ context.Context, lists [][]*message.Message) []*message.Message {
-	results := make([]*message.Message, 0, len(lists))
-	for _, list := range lists {
-		if len(list) > 0 {
-			results = append(results, list[len(list)-1])
+		if currentAgent == nil {
+			return d, fmt.Errorf("workflowhosting: output agent at index %d is nil", index)
+		}
+		if _, ok := d[currentAgent]; !ok {
+			d[currentAgent] = make(map[workflow.OutputTag]struct{})
 		}
 	}
-	return results
+	return d, nil
+}
+
+func (d outputDesignations) withIntermediateOutputFrom(agents ...*agent.Agent) (outputDesignations, error) {
+	d, err := d.withOutputFrom(agents...)
+	if err != nil {
+		return d, err
+	}
+	for _, currentAgent := range agents {
+		d[currentAgent][workflow.OutputTagIntermediate] = struct{}{}
+	}
+	return d, nil
+}
+
+func applyOutputDesignations(
+	bld *workflow.Builder,
+	designations outputDesignations,
+	bindingsByAgent map[*agent.Agent]workflow.ExecutorBinding,
+	orchestrationKind string,
+	applyDefaults func(),
+) (*workflow.Builder, error) {
+	if !designations.explicit() {
+		applyDefaults()
+		return bld, nil
+	}
+	for currentAgent, tags := range designations {
+		binding, ok := bindingsByAgent[currentAgent]
+		if !ok {
+			return bld, fmt.Errorf("workflowhosting: output designation references agent %q, which is not a participant in this %s workflow", agentNameForError(currentAgent), orchestrationKind)
+		}
+		if len(tags) == 0 {
+			bld = bld.WithOutputFrom(binding)
+			continue
+		}
+		bld = bld.WithIntermediateOutputFrom(binding)
+	}
+	return bld, nil
+}
+
+func agentNameForError(a *agent.Agent) string {
+	if a == nil {
+		return ""
+	}
+	if name := a.Name(); name != "" {
+		return name
+	}
+	return a.ID()
+}
+
+func applyBuilderMetadata(bld *workflow.Builder, name string, description string) *workflow.Builder {
+	if name != "" {
+		bld = bld.WithName(name)
+	}
+	if description != "" {
+		bld = bld.WithDescription(description)
+	}
+	return bld
 }

--- a/agent/hosting/workflowhosting/builders_test.go
+++ b/agent/hosting/workflowhosting/builders_test.go
@@ -4,16 +4,13 @@ package workflowhosting_test
 
 import (
 	"context"
-	"fmt"
 	"iter"
-	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
-	"github.com/microsoft/agent-framework-go/agent/hosting/workflowhosting"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/workflow"
 	"github.com/microsoft/agent-framework-go/workflow/inproc"
@@ -151,7 +148,8 @@ func runBuiltWorkflowWithText(t *testing.T, wf *workflow.Workflow, inputText str
 	if err := stream.SendMessage(ctx, userMsg); err != nil {
 		t.Fatalf("SendMessage user msg: %v", err)
 	}
-	if err := stream.SendMessage(ctx, workflow.TurnToken{EmitEvents: boolPtr(true)}); err != nil {
+	emitEvents := true
+	if err := stream.SendMessage(ctx, workflow.TurnToken{EmitEvents: &emitEvents}); err != nil {
 		t.Fatalf("SendMessage turn token: %v", err)
 	}
 
@@ -173,7 +171,8 @@ func runStreamingWorkflowTurn(t *testing.T, ctx context.Context, stream *inproc.
 	if err := stream.SendMessage(ctx, userMsg); err != nil {
 		t.Fatalf("SendMessage user msg: %v", err)
 	}
-	if err := stream.SendMessage(ctx, workflow.TurnToken{EmitEvents: boolPtr(true)}); err != nil {
+	emitEvents := true
+	if err := stream.SendMessage(ctx, workflow.TurnToken{EmitEvents: &emitEvents}); err != nil {
 		t.Fatalf("SendMessage turn token: %v", err)
 	}
 
@@ -235,328 +234,13 @@ func collectOutputTexts(events []workflow.Event) []string {
 	return texts
 }
 
-// TestBuildSequential_ReturnsErrorForNoAgents checks that BuildSequential
-// rejects an empty agent list.
-func TestBuildSequential_ReturnsErrorForNoAgents(t *testing.T) {
-	_, err := workflowhosting.BuildSequential("")
-	if err == nil {
-		t.Fatal("expected error for zero agents, got nil")
+func outputExecutorTags(wf *workflow.Workflow, executorID string) []workflow.OutputTag {
+	if wf == nil {
+		return nil
 	}
-}
-
-func TestBuildSequential_ReturnsErrorForNilAgent(t *testing.T) {
-	validAgent := newLabeledEchoAgent("a", "A", "from-a")
-	for _, tt := range []struct {
-		name   string
-		agents []*agent.Agent
-	}{
-		{name: "only_nil", agents: []*agent.Agent{nil}},
-		{name: "second_nil", agents: []*agent.Agent{validAgent, nil}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := workflowhosting.BuildSequential("", tt.agents...)
-			if err == nil {
-				t.Fatal("expected error for nil agent, got nil")
-			}
-			if !strings.Contains(err.Error(), "nil") {
-				t.Fatalf("error = %q, want it to mention nil", err.Error())
-			}
-		})
+	tags, ok := wf.OutputExecutors()[executorID]
+	if !ok {
+		return nil
 	}
-}
-
-// TestBuildConcurrent_ReturnsErrorForNoAgents checks that BuildConcurrent
-// rejects an empty agent list.
-func TestBuildConcurrent_ReturnsErrorForNoAgents(t *testing.T) {
-	_, err := workflowhosting.BuildConcurrent("")
-	if err == nil {
-		t.Fatal("expected error for zero agents, got nil")
-	}
-}
-
-func TestBuildConcurrent_ReturnsErrorForNilAgent(t *testing.T) {
-	validAgent := newLabeledEchoAgent("a", "A", "from-a")
-	for _, tt := range []struct {
-		name   string
-		agents []*agent.Agent
-	}{
-		{name: "only_nil", agents: []*agent.Agent{nil}},
-		{name: "second_nil", agents: []*agent.Agent{validAgent, nil}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := workflowhosting.BuildConcurrent("", tt.agents...)
-			if err == nil {
-				t.Fatal("expected error for nil agent, got nil")
-			}
-			if !strings.Contains(err.Error(), "nil") {
-				t.Fatalf("error = %q, want it to mention nil", err.Error())
-			}
-		})
-	}
-}
-
-// TestBuildSequential_SingleAgent verifies that a single-agent sequential
-// workflow builds successfully and emits the agent's output.
-func TestBuildSequential_SingleAgent(t *testing.T) {
-	a := newLabeledEchoAgent("a", "A", "from-a")
-	wf, err := workflowhosting.BuildSequential("single-agent", a)
-	if err != nil {
-		t.Fatalf("BuildSequential: %v", err)
-	}
-	if wf.Name() != "single-agent" {
-		t.Fatalf("workflow name = %q, want %q", wf.Name(), "single-agent")
-	}
-
-	texts := collectOutputTexts(runBuiltWorkflow(t, wf))
-	if len(texts) != 1 || texts[0] != "from-a" {
-		t.Errorf("got texts %v, want [from-a]", texts)
-	}
-}
-
-// TestBuildSequential_MultiAgent verifies that a multi-agent sequential
-// workflow builds successfully and that the last agent's output is emitted.
-func TestBuildSequential_MultiAgent(t *testing.T) {
-	a := newLabeledEchoAgent("a", "A", "from-a")
-	b := newLabeledEchoAgent("b", "B", "from-b")
-	c := newLabeledEchoAgent("c", "C", "from-c")
-	wf, err := workflowhosting.BuildSequential("", a, b, c)
-	if err != nil {
-		t.Fatalf("BuildSequential: %v", err)
-	}
-	if wf.Name() != "" {
-		t.Fatalf("workflow name = %q, want empty", wf.Name())
-	}
-
-	texts := collectOutputTexts(runBuiltWorkflow(t, wf))
-	// Only the last agent (c) is the output node, so we expect "from-c".
-	if len(texts) == 0 {
-		t.Fatal("expected at least one output text")
-	}
-	last := texts[len(texts)-1]
-	if last != "from-c" {
-		t.Errorf("last output text = %q, want %q", last, "from-c")
-	}
-}
-
-// TestBuildSequential_AgentsRunInOrder verifies that each agent receives the
-// accumulated conversation produced by the agents before it.
-func TestBuildSequential_AgentsRunInOrder(t *testing.T) {
-	for _, numAgents := range []int{1, 2, 3, 4, 5} {
-		t.Run(fmt.Sprintf("%d_agents", numAgents), func(t *testing.T) {
-			agents := make([]*agent.Agent, 0, numAgents)
-			for agentNumber := 1; agentNumber <= numAgents; agentNumber++ {
-				agents = append(agents, newDoubleEchoAgent(fmt.Sprintf("agent%d", agentNumber)))
-			}
-
-			wf, err := workflowhosting.BuildSequential("", agents...)
-			if err != nil {
-				t.Fatalf("BuildSequential: %v", err)
-			}
-
-			for range 3 {
-				const inputText = "abc"
-				events := runBuiltWorkflowWithText(t, wf, inputText)
-				texts := collectOutputTexts(events)
-				want := expectedSequentialDoubleEchoOutputs(numAgents, inputText)
-				if !slices.Equal(texts, want) {
-					t.Fatalf("output texts = %v, want %v", texts, want)
-				}
-
-				resultMessages := collectOutputMessages(events)
-				wantResultTexts := append([]string{inputText}, want...)
-				if gotResultTexts := collectMessageTexts(resultMessages); !slices.Equal(gotResultTexts, wantResultTexts) {
-					t.Fatalf("result texts = %v, want %v", gotResultTexts, wantResultTexts)
-				}
-				if len(resultMessages) != numAgents+1 {
-					t.Fatalf("result count = %d, want %d", len(resultMessages), numAgents+1)
-				}
-				if resultMessages[0].Role != message.RoleUser {
-					t.Fatalf("result[0].Role = %q, want %q", resultMessages[0].Role, message.RoleUser)
-				}
-				for resultIndex, resultMessage := range resultMessages[1:] {
-					wantAuthorName := fmt.Sprintf("agent%d", resultIndex+1)
-					if resultMessage.Role != message.RoleAssistant {
-						t.Fatalf("result[%d].Role = %q, want %q", resultIndex+1, resultMessage.Role, message.RoleAssistant)
-					}
-					if resultMessage.AuthorName != wantAuthorName {
-						t.Fatalf("result[%d].AuthorName = %q, want %q", resultIndex+1, resultMessage.AuthorName, wantAuthorName)
-					}
-				}
-			}
-		})
-	}
-}
-
-func expectedSequentialDoubleEchoOutputs(numAgents int, inputText string) []string {
-	transcript := inputText
-	outputs := make([]string, 0, numAgents)
-	for agentNumber := 1; agentNumber <= numAgents; agentNumber++ {
-		agentID := fmt.Sprintf("agent%d", agentNumber)
-		outputText := agentID + transcript + transcript
-		outputs = append(outputs, outputText)
-		transcript += outputText
-	}
-	return outputs
-}
-
-// TestBuildConcurrent_SingleAgent verifies that a single-agent concurrent
-// workflow builds and emits the agent's output.
-func TestBuildConcurrent_SingleAgent(t *testing.T) {
-	a := newLabeledEchoAgent("a", "A", "from-a")
-	wf, err := workflowhosting.BuildConcurrent("single-concurrent", a)
-	if err != nil {
-		t.Fatalf("BuildConcurrent: %v", err)
-	}
-	if wf.Name() != "single-concurrent" {
-		t.Fatalf("workflow name = %q, want %q", wf.Name(), "single-concurrent")
-	}
-
-	events := runBuiltWorkflow(t, wf)
-	texts := collectOutputTexts(events)
-	if len(texts) != 1 || texts[0] != "from-a" {
-		t.Errorf("got texts %v, want [from-a]", texts)
-	}
-	resultTexts := collectMessageTexts(collectOutputMessages(events))
-	if !slices.Equal(resultTexts, []string{"from-a"}) {
-		t.Errorf("result texts = %v, want [from-a]", resultTexts)
-	}
-}
-
-// TestBuildConcurrent_MultiAgent verifies that a multi-agent concurrent
-// workflow builds and emits output from all agents.
-func TestBuildConcurrent_MultiAgent(t *testing.T) {
-	a := newLabeledEchoAgent("a", "A", "from-a")
-	b := newLabeledEchoAgent("b", "B", "from-b")
-	wf, err := workflowhosting.BuildConcurrent("", a, b)
-	if err != nil {
-		t.Fatalf("BuildConcurrent: %v", err)
-	}
-
-	events := runBuiltWorkflow(t, wf)
-	texts := collectOutputTexts(events)
-
-	want := map[string]bool{"from-a": true, "from-b": true}
-	got := map[string]bool{}
-	for _, text := range texts {
-		got[text] = true
-	}
-	for label := range want {
-		if !got[label] {
-			t.Errorf("missing output %q; got all texts: %v", label, texts)
-		}
-	}
-
-	resultTexts := collectMessageTexts(collectOutputMessages(events))
-	if len(resultTexts) != 2 {
-		t.Fatalf("result texts = %v, want two messages", resultTexts)
-	}
-	for label := range want {
-		if !slices.Contains(resultTexts, label) {
-			t.Errorf("missing result %q; got result texts: %v", label, resultTexts)
-		}
-	}
-}
-
-func TestBuildConcurrentWithAggregator_UsesCustomAggregator(t *testing.T) {
-	a := newLabeledEchoAgent("a", "A", "from-a")
-	b := newLabeledEchoAgent("b", "B", "from-b")
-	contextWasPresent := false
-	wf, err := workflowhosting.BuildConcurrentWithAggregator("", func(ctx context.Context, lists [][]*message.Message) []*message.Message {
-		contextWasPresent = ctx != nil
-		return []*message.Message{{
-			Role: message.RoleAssistant,
-			Contents: []message.Content{
-				&message.TextContent{Text: fmt.Sprintf("batches:%d", len(lists))},
-			},
-		}}
-	}, a, b)
-	if err != nil {
-		t.Fatalf("BuildConcurrentWithAggregator: %v", err)
-	}
-
-	resultTexts := collectMessageTexts(collectOutputMessages(runBuiltWorkflow(t, wf)))
-	if !slices.Equal(resultTexts, []string{"batches:2"}) {
-		t.Fatalf("result texts = %v, want [batches:2]", resultTexts)
-	}
-	if !contextWasPresent {
-		t.Fatal("expected aggregator to receive a context")
-	}
-}
-
-func TestBuildConcurrentWithAggregator_ResetsEndExecutorBetweenTurns(t *testing.T) {
-	a := newLabeledEchoAgent("a", "A", "from-a")
-	b := newLabeledEchoAgent("b", "B", "from-b")
-	callCount := 0
-	wf, err := workflowhosting.BuildConcurrentWithAggregator("", func(_ context.Context, lists [][]*message.Message) []*message.Message {
-		callCount++
-		return []*message.Message{{
-			Role: message.RoleAssistant,
-			Contents: []message.Content{
-				&message.TextContent{Text: fmt.Sprintf("turn:%d batches:%d", callCount, len(lists))},
-			},
-		}}
-	}, a, b)
-	if err != nil {
-		t.Fatalf("BuildConcurrentWithAggregator: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	stream, err := inproc.Lockstep.RunStreaming(ctx, wf, nil)
-	if err != nil {
-		t.Fatalf("RunStreaming: %v", err)
-	}
-	defer func() {
-		if err := stream.Close(ctx); err != nil {
-			t.Errorf("Close: %v", err)
-		}
-	}()
-
-	first := collectMessageTexts(collectOutputMessages(runStreamingWorkflowTurn(t, ctx, stream, "first")))
-	if !slices.Equal(first, []string{"turn:1 batches:2"}) {
-		t.Fatalf("first result texts = %v, want [turn:1 batches:2]", first)
-	}
-	second := collectMessageTexts(collectOutputMessages(runStreamingWorkflowTurn(t, ctx, stream, "second")))
-	if !slices.Equal(second, []string{"turn:2 batches:2"}) {
-		t.Fatalf("second result texts = %v, want [turn:2 batches:2]", second)
-	}
-}
-
-func TestBuildConcurrent_AgentsRunInParallel(t *testing.T) {
-	barrier := &runBarrier{}
-	wf, err := workflowhosting.BuildConcurrent("",
-		newBarrierDoubleEchoAgent("agent1", barrier),
-		newBarrierDoubleEchoAgent("agent2", barrier),
-	)
-	if err != nil {
-		t.Fatalf("BuildConcurrent: %v", err)
-	}
-
-	for range 3 {
-		barrier.reset(2)
-		events := runBuiltWorkflowWithText(t, wf, "abc")
-		updateText := strings.Join(collectOutputTexts(events), "")
-		if updateText == "" {
-			t.Fatal("expected non-empty update text")
-		}
-		if count := strings.Count(updateText, "agent1"); count != 1 {
-			t.Fatalf("agent1 update count = %d in %q, want 1", count, updateText)
-		}
-		if count := strings.Count(updateText, "agent2"); count != 1 {
-			t.Fatalf("agent2 update count = %d in %q, want 1", count, updateText)
-		}
-		if count := strings.Count(updateText, "abc"); count != 4 {
-			t.Fatalf("abc update count = %d in %q, want 4", count, updateText)
-		}
-
-		resultTexts := collectMessageTexts(collectOutputMessages(events))
-		if len(resultTexts) != 2 {
-			t.Fatalf("result texts = %v, want 2 messages", resultTexts)
-		}
-		for _, want := range []string{"agent1abcabc", "agent2abcabc"} {
-			if !slices.Contains(resultTexts, want) {
-				t.Fatalf("result texts = %v, missing %q", resultTexts, want)
-			}
-		}
-	}
+	return tags
 }

--- a/agent/hosting/workflowhosting/concurrent.go
+++ b/agent/hosting/workflowhosting/concurrent.go
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowhosting
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/message/messageworkflow"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+const (
+	aggregateTurnMessagesStateKey = "workflowhosting.AggregateTurnMessagesExecutor.State"
+	concurrentEndExecutorID       = "workflowhosting.ConcurrentEnd"
+)
+
+// MessageAggregator combines per-agent message batches into a single batch.
+type MessageAggregator func(context.Context, [][]*message.Message) []*message.Message
+
+// ConcurrentWorkflowBuilder fluently builds concurrent agent workflows.
+type ConcurrentWorkflowBuilder struct {
+	name               string
+	description        string
+	agents             []*agent.Agent
+	aggregator         MessageAggregator
+	outputDesignations outputDesignations
+	err                error
+}
+
+// NewConcurrentWorkflowBuilder creates a builder for a concurrent agent workflow.
+func NewConcurrentWorkflowBuilder(agents ...*agent.Agent) *ConcurrentWorkflowBuilder {
+	return &ConcurrentWorkflowBuilder{agents: slices.Clone(agents)}
+}
+
+// WithName sets the workflow name.
+func (b *ConcurrentWorkflowBuilder) WithName(name string) *ConcurrentWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.name = name
+	return b
+}
+
+// WithDescription sets the workflow description.
+func (b *ConcurrentWorkflowBuilder) WithDescription(description string) *ConcurrentWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.description = description
+	return b
+}
+
+// WithAggregator sets the concurrent output aggregator. Nil keeps the default aggregator.
+func (b *ConcurrentWorkflowBuilder) WithAggregator(aggregator MessageAggregator) *ConcurrentWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.aggregator = aggregator
+	return b
+}
+
+// WithOutputFrom designates agents as terminal workflow output sources.
+func (b *ConcurrentWorkflowBuilder) WithOutputFrom(agents ...*agent.Agent) *ConcurrentWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.outputDesignations, b.err = b.outputDesignations.withOutputFrom(agents...)
+	return b
+}
+
+// WithIntermediateOutputFrom designates agents as intermediate workflow output sources.
+func (b *ConcurrentWorkflowBuilder) WithIntermediateOutputFrom(agents ...*agent.Agent) *ConcurrentWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.outputDesignations, b.err = b.outputDesignations.withIntermediateOutputFrom(agents...)
+	return b
+}
+
+// Build builds the concurrent workflow.
+func (b *ConcurrentWorkflowBuilder) Build() (*workflow.Workflow, error) {
+	if b == nil {
+		return nil, fmt.Errorf("workflowhosting: ConcurrentWorkflowBuilder is nil")
+	}
+	if b.err != nil {
+		return nil, b.err
+	}
+	if err := validateBuilderAgents("ConcurrentWorkflowBuilder", b.agents); err != nil {
+		return nil, err
+	}
+
+	cfg := Config{}
+	bindings := make([]workflow.ExecutorBinding, len(b.agents))
+	bindingsByAgent := make(map[*agent.Agent]workflow.ExecutorBinding, len(b.agents))
+	for index, currentAgent := range b.agents {
+		binding := New(currentAgent, cfg)
+		bindings[index] = binding
+		bindingsByAgent[currentAgent] = binding
+	}
+
+	start := newMessageForwardingBinding("Start")
+	accumulators := make([]workflow.ExecutorBinding, len(bindings))
+	for i, binding := range bindings {
+		accumulators[i] = newAggregateTurnMessagesBinding("Batcher/" + binding.ID)
+	}
+	end := newConcurrentEndBinding(len(bindings), b.aggregator)
+
+	bld := applyBuilderMetadata(workflow.NewBuilder(start), b.name, b.description)
+	bld = bld.AddFanOutEdge(start, bindings)
+	for i, binding := range bindings {
+		bld = bld.AddEdge(binding, accumulators[i])
+	}
+	bld = bld.AddFanInBarrierEdge(accumulators, end)
+	var err error
+	bld, err = applyOutputDesignations(bld, b.outputDesignations, bindingsByAgent, "concurrent", func() {
+		intermediateOutputs := make([]workflow.ExecutorBinding, 0, len(bindings)+len(accumulators))
+		intermediateOutputs = append(intermediateOutputs, bindings...)
+		intermediateOutputs = append(intermediateOutputs, accumulators...)
+		bld = bld.WithOutputFrom(end).WithIntermediateOutputFrom(intermediateOutputs...)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return bld.Build()
+}
+
+func newMessageForwardingBinding(id string) workflow.ExecutorBinding {
+	return workflow.ExecutorBinding{
+		ID:                                id,
+		SupportsConcurrentSharedExecution: true,
+		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+			executor := workflow.Executor{ID: id}
+			messageworkflow.ConfigureForwarding(&executor, nil)
+			return &executor, nil
+		},
+	}
+}
+
+func newAggregateTurnMessagesBinding(id string) workflow.ExecutorBinding {
+	return workflow.ExecutorBinding{
+		ID:                                id,
+		SupportsConcurrentSharedExecution: true,
+		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+			executor := workflow.Executor{
+				ID: id,
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					return pb.SendsMessageType(reflect.TypeFor[[]*message.Message]()), nil
+				},
+			}
+			messageworkflow.Configure(&executor, &messageworkflow.Options{
+				StateKey:                 aggregateTurnMessagesStateKey,
+				DisableAutoSendTurnToken: true,
+				TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, messages []*message.Message) error {
+					return ctx.SendMessage("", messages)
+				},
+			})
+			return &executor, nil
+		},
+	}
+}
+
+func newConcurrentEndBinding(expectedInputs int, aggregator MessageAggregator) workflow.ExecutorBinding {
+	if aggregator == nil {
+		aggregator = defaultConcurrentMessageAggregator
+	}
+	return workflow.ExecutorBinding{
+		ID:                                concurrentEndExecutorID,
+		SupportsConcurrentSharedExecution: true,
+		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+			allResults := make([][]*message.Message, 0, expectedInputs)
+			remaining := expectedInputs
+			reset := func() {
+				allResults = make([][]*message.Message, 0, expectedInputs)
+				remaining = expectedInputs
+			}
+			return &workflow.Executor{
+				ID: concurrentEndExecutorID,
+				ResetFunc: func() error {
+					reset()
+					return nil
+				},
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.YieldsOutputType(reflect.TypeFor[[]*message.Message]())
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+						allResults = append(allResults, msg.([]*message.Message))
+						remaining--
+						if remaining == 0 {
+							results := allResults
+							reset()
+							if err := ctx.YieldOutput(aggregator(ctx, results)); err != nil {
+								return nil, err
+							}
+						}
+						return struct{}{}, nil
+					})
+					return rb, nil
+				},
+			}, nil
+		},
+	}
+}
+
+func defaultConcurrentMessageAggregator(_ context.Context, lists [][]*message.Message) []*message.Message {
+	results := make([]*message.Message, 0, len(lists))
+	for _, list := range lists {
+		if len(list) > 0 {
+			results = append(results, list[len(list)-1])
+		}
+	}
+	return results
+}

--- a/agent/hosting/workflowhosting/concurrent_test.go
+++ b/agent/hosting/workflowhosting/concurrent_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowhosting_test
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/hosting/workflowhosting"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+// TestConcurrentWorkflowBuilder_ReturnsErrorForNoAgents checks that the
+// concurrent builder rejects an empty agent list.
+func TestConcurrentWorkflowBuilder_ReturnsErrorForNoAgents(t *testing.T) {
+	_, err := workflowhosting.NewConcurrentWorkflowBuilder().Build()
+	if err == nil {
+		t.Fatal("expected error for zero agents, got nil")
+	}
+}
+
+func TestConcurrentWorkflowBuilder_ReturnsErrorForNilAgent(t *testing.T) {
+	validAgent := newLabeledEchoAgent("a", "A", "from-a")
+	for _, tt := range []struct {
+		name   string
+		agents []*agent.Agent
+	}{
+		{name: "only_nil", agents: []*agent.Agent{nil}},
+		{name: "second_nil", agents: []*agent.Agent{validAgent, nil}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := workflowhosting.NewConcurrentWorkflowBuilder(tt.agents...).Build()
+			if err == nil {
+				t.Fatal("expected error for nil agent, got nil")
+			}
+			if !strings.Contains(err.Error(), "nil") {
+				t.Fatalf("error = %q, want it to mention nil", err.Error())
+			}
+		})
+	}
+}
+
+// TestConcurrentWorkflowBuilder_SingleAgent verifies that a single-agent concurrent
+// workflow builds and emits the agent's output.
+func TestConcurrentWorkflowBuilder_SingleAgent(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	wf, err := workflowhosting.NewConcurrentWorkflowBuilder(a).WithName("single-concurrent").Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if wf.Name() != "single-concurrent" {
+		t.Fatalf("workflow name = %q, want %q", wf.Name(), "single-concurrent")
+	}
+
+	events := runBuiltWorkflow(t, wf)
+	texts := collectOutputTexts(events)
+	if len(texts) != 1 || texts[0] != "from-a" {
+		t.Errorf("got texts %v, want [from-a]", texts)
+	}
+	resultTexts := collectMessageTexts(collectOutputMessages(events))
+	if !slices.Equal(resultTexts, []string{"from-a"}) {
+		t.Errorf("result texts = %v, want [from-a]", resultTexts)
+	}
+}
+
+// TestConcurrentWorkflowBuilder_MultiAgent verifies that a multi-agent concurrent
+// workflow builds and emits output from all agents.
+func TestConcurrentWorkflowBuilder_MultiAgent(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	b := newLabeledEchoAgent("b", "B", "from-b")
+	wf, err := workflowhosting.NewConcurrentWorkflowBuilder(a, b).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	events := runBuiltWorkflow(t, wf)
+	texts := collectOutputTexts(events)
+
+	want := map[string]bool{"from-a": true, "from-b": true}
+	got := map[string]bool{}
+	for _, text := range texts {
+		got[text] = true
+	}
+	for label := range want {
+		if !got[label] {
+			t.Errorf("missing output %q; got all texts: %v", label, texts)
+		}
+	}
+
+	resultTexts := collectMessageTexts(collectOutputMessages(events))
+	if len(resultTexts) != 2 {
+		t.Fatalf("result texts = %v, want two messages", resultTexts)
+	}
+	for label := range want {
+		if !slices.Contains(resultTexts, label) {
+			t.Errorf("missing result %q; got result texts: %v", label, resultTexts)
+		}
+	}
+}
+
+func TestConcurrentWorkflowBuilder_ExplicitOutputDesignationSuppressesDefaults(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	b := newLabeledEchoAgent("b", "B", "from-b")
+	wf, err := workflowhosting.NewConcurrentWorkflowBuilder(a, b).
+		WithOutputFrom(a).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	wantOutputID := workflowhosting.New(a, workflowhosting.Config{}).ID
+	outputIDs := wf.OutputExecutorIDs()
+	slices.Sort(outputIDs)
+	if !slices.Equal(outputIDs, []string{wantOutputID}) {
+		t.Fatalf("output executor IDs = %v, want [%s]", outputIDs, wantOutputID)
+	}
+	events := runBuiltWorkflow(t, wf)
+	texts := collectOutputTexts(events)
+	if !slices.Equal(texts, []string{"from-a"}) {
+		t.Fatalf("output texts = %v, want [from-a]", texts)
+	}
+	if messages := collectOutputMessages(events); len(messages) != 0 {
+		t.Fatalf("terminal aggregator output should be suppressed, got %v", collectMessageTexts(messages))
+	}
+}
+
+func TestConcurrentWorkflowBuilder_ExplicitOutputDesignationRejectsNonParticipant(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	nonParticipant := newLabeledEchoAgent("outside", "Outside", "from-outside")
+
+	for _, testCase := range []struct {
+		name      string
+		configure func(*workflowhosting.ConcurrentWorkflowBuilder) *workflowhosting.ConcurrentWorkflowBuilder
+	}{
+		{
+			name: "terminal",
+			configure: func(builder *workflowhosting.ConcurrentWorkflowBuilder) *workflowhosting.ConcurrentWorkflowBuilder {
+				return builder.WithOutputFrom(nonParticipant)
+			},
+		},
+		{
+			name: "intermediate",
+			configure: func(builder *workflowhosting.ConcurrentWorkflowBuilder) *workflowhosting.ConcurrentWorkflowBuilder {
+				return builder.WithIntermediateOutputFrom(nonParticipant)
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := testCase.configure(workflowhosting.NewConcurrentWorkflowBuilder(a)).Build()
+			if err == nil {
+				t.Fatal("expected error for non-participant output designation, got nil")
+			}
+			if !strings.Contains(err.Error(), "not a participant") {
+				t.Fatalf("error = %q, want it to mention not a participant", err.Error())
+			}
+		})
+	}
+}
+
+func TestConcurrentWorkflowBuilder_UsesCustomAggregator(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	b := newLabeledEchoAgent("b", "B", "from-b")
+	contextWasPresent := false
+	wf, err := workflowhosting.NewConcurrentWorkflowBuilder(a, b).WithAggregator(func(ctx context.Context, lists [][]*message.Message) []*message.Message {
+		contextWasPresent = ctx != nil
+		return []*message.Message{{
+			Role: message.RoleAssistant,
+			Contents: []message.Content{
+				&message.TextContent{Text: fmt.Sprintf("batches:%d", len(lists))},
+			},
+		}}
+	}).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	resultTexts := collectMessageTexts(collectOutputMessages(runBuiltWorkflow(t, wf)))
+	if !slices.Equal(resultTexts, []string{"batches:2"}) {
+		t.Fatalf("result texts = %v, want [batches:2]", resultTexts)
+	}
+	if !contextWasPresent {
+		t.Fatal("expected aggregator to receive a context")
+	}
+}
+
+func TestConcurrentWorkflowBuilder_ResetsEndExecutorBetweenTurns(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	b := newLabeledEchoAgent("b", "B", "from-b")
+	callCount := 0
+	wf, err := workflowhosting.NewConcurrentWorkflowBuilder(a, b).WithAggregator(func(_ context.Context, lists [][]*message.Message) []*message.Message {
+		callCount++
+		return []*message.Message{{
+			Role: message.RoleAssistant,
+			Contents: []message.Content{
+				&message.TextContent{Text: fmt.Sprintf("turn:%d batches:%d", callCount, len(lists))},
+			},
+		}}
+	}).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := inproc.Lockstep.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("RunStreaming: %v", err)
+	}
+	defer func() {
+		if err := stream.Close(ctx); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	first := collectMessageTexts(collectOutputMessages(runStreamingWorkflowTurn(t, ctx, stream, "first")))
+	if !slices.Equal(first, []string{"turn:1 batches:2"}) {
+		t.Fatalf("first result texts = %v, want [turn:1 batches:2]", first)
+	}
+	second := collectMessageTexts(collectOutputMessages(runStreamingWorkflowTurn(t, ctx, stream, "second")))
+	if !slices.Equal(second, []string{"turn:2 batches:2"}) {
+		t.Fatalf("second result texts = %v, want [turn:2 batches:2]", second)
+	}
+}
+
+func TestConcurrentWorkflowBuilder_AgentsRunInParallel(t *testing.T) {
+	barrier := &runBarrier{}
+	wf, err := workflowhosting.NewConcurrentWorkflowBuilder(
+		newBarrierDoubleEchoAgent("agent1", barrier),
+		newBarrierDoubleEchoAgent("agent2", barrier),
+	).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	for range 3 {
+		barrier.reset(2)
+		events := runBuiltWorkflowWithText(t, wf, "abc")
+		updateText := strings.Join(collectOutputTexts(events), "")
+		if updateText == "" {
+			t.Fatal("expected non-empty update text")
+		}
+		if count := strings.Count(updateText, "agent1"); count != 1 {
+			t.Fatalf("agent1 update count = %d in %q, want 1", count, updateText)
+		}
+		if count := strings.Count(updateText, "agent2"); count != 1 {
+			t.Fatalf("agent2 update count = %d in %q, want 1", count, updateText)
+		}
+		if count := strings.Count(updateText, "abc"); count != 4 {
+			t.Fatalf("abc update count = %d in %q, want 4", count, updateText)
+		}
+
+		resultTexts := collectMessageTexts(collectOutputMessages(events))
+		if len(resultTexts) != 2 {
+			t.Fatalf("result texts = %v, want 2 messages", resultTexts)
+		}
+		for _, want := range []string{"agent1abcabc", "agent2abcabc"} {
+			if !slices.Contains(resultTexts, want) {
+				t.Fatalf("result texts = %v, missing %q", resultTexts, want)
+			}
+		}
+	}
+}

--- a/agent/hosting/workflowhosting/groupchat.go
+++ b/agent/hosting/workflowhosting/groupchat.go
@@ -101,7 +101,7 @@ func NewRoundRobinGroupChatManager(agents []*agent.Agent, opts RoundRobinGroupCh
 }
 
 func (manager *roundRobinGroupChatManager) maxIterationCount() int {
-	if manager == nil || manager.maximumIterationCount == 0 {
+	if manager == nil || manager.maximumIterationCount <= 0 {
 		return defaultGroupChatMaximumIterations
 	}
 	return manager.maximumIterationCount

--- a/agent/hosting/workflowhosting/groupchat.go
+++ b/agent/hosting/workflowhosting/groupchat.go
@@ -351,9 +351,12 @@ func (host *groupChatHostExecutor) handleTurn(ctx *workflow.Context, token workf
 	if err != nil {
 		return err
 	}
+	if nextAgent == nil {
+		return host.complete(ctx)
+	}
 	nextBinding, ok := host.bindingForAgent(nextAgent)
 	if !ok {
-		return host.complete(ctx)
+		return fmt.Errorf("workflowhosting: group chat manager selected non-participant agent %q", agentNameForError(nextAgent))
 	}
 
 	host.iterationCount++

--- a/agent/hosting/workflowhosting/groupchat.go
+++ b/agent/hosting/workflowhosting/groupchat.go
@@ -1,0 +1,652 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowhosting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/message/messageworkflow"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+const (
+	defaultGroupChatMaximumIterations = 40
+
+	groupChatHostExecutorID       = "workflowhosting.GroupChatHost"
+	groupChatHostBufferedStateKey = "workflowhosting.GroupChatHost.Messages"
+	groupChatHistoryStateKey      = "_history"
+	groupChatCurrentSpeakerKey    = "_currentSpeakerExecutorId"
+
+	groupChatManagerStateKey             = "GroupChatManager"
+	groupChatManagerSubclassStateKeyPref = "GroupChatManager_"
+	roundRobinGroupChatManagerStateKey   = "next_index"
+)
+
+// GroupChatManagerFactory creates the manager used by a group chat workflow run.
+// The returned manager must set [GroupChatManager.SelectNextAgent].
+type GroupChatManagerFactory func(agents []*agent.Agent) *GroupChatManager
+
+// GroupChatManager manages the flow of a group chat. SelectNextAgent is
+// required; all other functions are optional.
+type GroupChatManager struct {
+	// SelectNextAgent selects the next participant to speak. Returning nil ends
+	// the chat and yields the accumulated conversation.
+	SelectNextAgent func(ctx context.Context, history []*message.Message) (*agent.Agent, error)
+
+	// UpdateHistory filters the messages broadcast to participants for the current
+	// turn. Returning nil preserves the original messages.
+	UpdateHistory func(ctx context.Context, messages []*message.Message) ([]*message.Message, error)
+
+	// ShouldTerminate decides whether the chat should end. When nil, the host
+	// stops after 40 participant turns.
+	ShouldTerminate func(ctx context.Context, history []*message.Message, iterationCount int) (bool, error)
+
+	// Reset clears manager-owned local state when the hosting executor is reset.
+	Reset func()
+
+	// OnCheckpoint persists manager-owned state. The supplied context prefixes
+	// state keys with "GroupChatManager_" so custom manager state cannot collide
+	// with host state.
+	OnCheckpoint func(ctx *workflow.Context) error
+
+	// OnCheckpointRestored restores manager-owned state from the same prefixed
+	// state context used by OnCheckpoint.
+	OnCheckpointRestored func(ctx *workflow.Context) error
+}
+
+// RoundRobinGroupChatOptions configures [NewRoundRobinGroupChatManager].
+type RoundRobinGroupChatOptions struct {
+	// MaximumIterationCount is the maximum number of participant turns before
+	// the default termination behavior ends the chat. The zero value is 40.
+	MaximumIterationCount int
+
+	// ShouldTerminate can stop the chat before the default iteration-limit check
+	// runs.
+	ShouldTerminate func(ctx context.Context, history []*message.Message, iterationCount int) (bool, error)
+}
+
+type roundRobinGroupChatManager struct {
+	manager               GroupChatManager
+	agents                []*agent.Agent
+	shouldTerminateFunc   func(ctx context.Context, history []*message.Message, iterationCount int) (bool, error)
+	nextIndex             int
+	maximumIterationCount int
+}
+
+// NewRoundRobinGroupChatManager creates a [GroupChatManager] that selects
+// agents in a round-robin order.
+func NewRoundRobinGroupChatManager(agents []*agent.Agent, opts RoundRobinGroupChatOptions) *GroupChatManager {
+	manager := &roundRobinGroupChatManager{
+		agents:                slices.Clone(agents),
+		shouldTerminateFunc:   opts.ShouldTerminate,
+		maximumIterationCount: opts.MaximumIterationCount,
+	}
+	manager.manager = GroupChatManager{
+		SelectNextAgent:      manager.selectNextAgent,
+		ShouldTerminate:      manager.shouldTerminate,
+		Reset:                manager.reset,
+		OnCheckpoint:         manager.onCheckpoint,
+		OnCheckpointRestored: manager.onCheckpointRestored,
+	}
+	return &manager.manager
+}
+
+func (manager *roundRobinGroupChatManager) maxIterationCount() int {
+	if manager == nil || manager.maximumIterationCount == 0 {
+		return defaultGroupChatMaximumIterations
+	}
+	return manager.maximumIterationCount
+}
+
+func (manager *roundRobinGroupChatManager) selectNextAgent(context.Context, []*message.Message) (*agent.Agent, error) {
+	if manager == nil || len(manager.agents) == 0 {
+		return nil, nil
+	}
+	if manager.nextIndex < 0 || manager.nextIndex >= len(manager.agents) {
+		manager.nextIndex = 0
+	}
+	nextAgent := manager.agents[manager.nextIndex]
+	manager.nextIndex = (manager.nextIndex + 1) % len(manager.agents)
+	return nextAgent, nil
+}
+
+func (manager *roundRobinGroupChatManager) shouldTerminate(ctx context.Context, history []*message.Message, iterationCount int) (bool, error) {
+	if manager != nil && manager.shouldTerminateFunc != nil {
+		terminate, err := manager.shouldTerminateFunc(ctx, history, iterationCount)
+		if err != nil || terminate {
+			return terminate, err
+		}
+	}
+	return iterationCount >= manager.maxIterationCount(), nil
+}
+
+func (manager *roundRobinGroupChatManager) reset() {
+	if manager == nil {
+		return
+	}
+	manager.nextIndex = 0
+}
+
+func (manager *roundRobinGroupChatManager) onCheckpoint(ctx *workflow.Context) error {
+	return ctx.QueueStateUpdate(roundRobinGroupChatManagerStateKey, "", roundRobinGroupChatManagerState{NextIndex: manager.nextIndex})
+}
+
+func (manager *roundRobinGroupChatManager) onCheckpointRestored(ctx *workflow.Context) error {
+	value, err := ctx.ReadState(roundRobinGroupChatManagerStateKey, "")
+	if err != nil {
+		return err
+	}
+	state, err := roundRobinGroupChatManagerStateFromAny(value)
+	if err != nil {
+		return err
+	}
+	manager.nextIndex = 0
+	if state != nil {
+		manager.nextIndex = state.NextIndex
+	}
+	if manager.nextIndex < 0 || manager.nextIndex >= len(manager.agents) {
+		manager.nextIndex = 0
+	}
+	return nil
+}
+
+// GroupChatWorkflowBuilder fluently builds group chat workflows.
+type GroupChatWorkflowBuilder struct {
+	name               string
+	description        string
+	managerFactory     GroupChatManagerFactory
+	agents             []*agent.Agent
+	outputDesignations outputDesignations
+	err                error
+}
+
+// NewGroupChatWorkflowBuilder creates a builder for a group chat workflow.
+func NewGroupChatWorkflowBuilder(managerFactory GroupChatManagerFactory, agents ...*agent.Agent) *GroupChatWorkflowBuilder {
+	return &GroupChatWorkflowBuilder{managerFactory: managerFactory, agents: slices.Clone(agents)}
+}
+
+// WithName sets the workflow name.
+func (b *GroupChatWorkflowBuilder) WithName(name string) *GroupChatWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.name = name
+	return b
+}
+
+// WithDescription sets the workflow description.
+func (b *GroupChatWorkflowBuilder) WithDescription(description string) *GroupChatWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.description = description
+	return b
+}
+
+// WithOutputFrom designates agents as terminal workflow output sources.
+func (b *GroupChatWorkflowBuilder) WithOutputFrom(agents ...*agent.Agent) *GroupChatWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.outputDesignations, b.err = b.outputDesignations.withOutputFrom(agents...)
+	return b
+}
+
+// WithIntermediateOutputFrom designates agents as intermediate workflow output sources.
+func (b *GroupChatWorkflowBuilder) WithIntermediateOutputFrom(agents ...*agent.Agent) *GroupChatWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.outputDesignations, b.err = b.outputDesignations.withIntermediateOutputFrom(agents...)
+	return b
+}
+
+// Build builds the group chat workflow.
+func (b *GroupChatWorkflowBuilder) Build() (*workflow.Workflow, error) {
+	if b == nil {
+		return nil, fmt.Errorf("workflowhosting: GroupChatWorkflowBuilder is nil")
+	}
+	if b.err != nil {
+		return nil, b.err
+	}
+	if err := validateBuilderAgents("GroupChatWorkflowBuilder", b.agents); err != nil {
+		return nil, err
+	}
+	if b.managerFactory == nil {
+		return nil, fmt.Errorf("workflowhosting: GroupChatWorkflowBuilder manager factory is nil")
+	}
+
+	participants := b.agents
+	participantBindings := make([]workflow.ExecutorBinding, len(participants))
+	bindingsByAgent := make(map[*agent.Agent]workflow.ExecutorBinding, len(participants))
+	bindingsByAgentID := make(map[string]workflow.ExecutorBinding, len(participants))
+	participantConfig := Config{DisableForwardIncomingMessages: true}
+	for index, currentAgent := range participants {
+		binding := New(currentAgent, participantConfig)
+		participantBindings[index] = binding
+		bindingsByAgent[currentAgent] = binding
+		bindingsByAgentID[currentAgent.ID()] = binding
+	}
+
+	host := newGroupChatHostBinding(participants, participantBindings, bindingsByAgent, bindingsByAgentID, b.managerFactory)
+	builder := applyBuilderMetadata(workflow.NewBuilder(host), b.name, b.description)
+	for _, participant := range participantBindings {
+		builder = builder.AddEdge(host, participant).AddEdge(participant, host)
+	}
+	var err error
+	builder, err = applyOutputDesignations(builder, b.outputDesignations, bindingsByAgent, "group chat", func() {
+		builder = builder.WithOutputFrom(host).WithIntermediateOutputFrom(participantBindings...)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return builder.Build()
+}
+
+type groupChatHostExecutor struct {
+	id                string
+	agents            []*agent.Agent
+	participants      []workflow.ExecutorBinding
+	bindingsByAgent   map[*agent.Agent]workflow.ExecutorBinding
+	bindingsByAgentID map[string]workflow.ExecutorBinding
+	managerFactory    GroupChatManagerFactory
+
+	manager                  *GroupChatManager
+	messageState             *messageworkflow.MessageState
+	history                  []*message.Message
+	currentSpeakerExecutorID string
+	iterationCount           int
+}
+
+func newGroupChatHostBinding(
+	agents []*agent.Agent,
+	participants []workflow.ExecutorBinding,
+	bindingsByAgent map[*agent.Agent]workflow.ExecutorBinding,
+	bindingsByAgentID map[string]workflow.ExecutorBinding,
+	managerFactory GroupChatManagerFactory,
+) workflow.ExecutorBinding {
+	return workflow.ExecutorBinding{
+		ID:                                groupChatHostExecutorID,
+		ImplementationID:                  groupChatHostExecutorID,
+		SupportsConcurrentSharedExecution: true,
+		NewExecutorFunc: func(string) (*workflow.Executor, error) {
+			host := &groupChatHostExecutor{
+				id:                groupChatHostExecutorID,
+				agents:            slices.Clone(agents),
+				participants:      slices.Clone(participants),
+				bindingsByAgent:   maps.Clone(bindingsByAgent),
+				bindingsByAgentID: maps.Clone(bindingsByAgentID),
+				managerFactory:    managerFactory,
+				messageState:      messageworkflow.NewMessageState(groupChatHostBufferedStateKey, ""),
+			}
+			return host.executor(), nil
+		},
+	}
+}
+
+func (host *groupChatHostExecutor) executor() *workflow.Executor {
+	executor := workflow.Executor{
+		ID: host.id,
+		ConfigureProtocol: func(protocolBuilder *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+			return protocolBuilder.
+				SendsMessageType(reflect.TypeFor[[]*message.Message](), reflect.TypeFor[workflow.TurnToken]()).
+				YieldsOutputType(reflect.TypeFor[[]*message.Message]()), nil
+		},
+	}
+	messageworkflow.Configure(&executor, &messageworkflow.Options{
+		StateKey:                 groupChatHostBufferedStateKey,
+		TakeTurnHandler:          host.handleTurn,
+		StringMessageRole:        string(message.RoleUser),
+		DisableAutoSendTurnToken: true,
+		MessageState:             host.messageState,
+	})
+	executor.Extend(&workflow.Executor{
+		ResetFunc:                host.reset,
+		OnCheckpointFunc:         host.onCheckpoint,
+		OnCheckpointRestoredFunc: host.onCheckpointRestored,
+	})
+	return &executor
+}
+
+func (host *groupChatHostExecutor) handleTurn(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error {
+	manager, err := host.ensureManager()
+	if err != nil {
+		return err
+	}
+
+	if len(messages) > 0 {
+		host.history = append(host.history, messages...)
+	}
+
+	terminate, err := host.shouldTerminate(ctx, manager)
+	if err != nil {
+		return err
+	}
+	if terminate {
+		return host.complete(ctx)
+	}
+
+	if len(messages) > 0 {
+		broadcastMessages, err := host.updateHistory(ctx, manager, messages)
+		if err != nil {
+			return err
+		}
+		if len(broadcastMessages) > 0 {
+			if err := host.broadcast(ctx, broadcastMessages); err != nil {
+				return err
+			}
+		}
+	}
+
+	nextAgent, err := manager.SelectNextAgent(ctx, host.history)
+	if err != nil {
+		return err
+	}
+	nextBinding, ok := host.bindingForAgent(nextAgent)
+	if !ok {
+		return host.complete(ctx)
+	}
+
+	host.iterationCount++
+	host.currentSpeakerExecutorID = nextBinding.ID
+	return ctx.SendMessage(nextBinding.ID, token)
+}
+
+func (host *groupChatHostExecutor) shouldTerminate(ctx context.Context, manager *GroupChatManager) (bool, error) {
+	if manager.ShouldTerminate != nil {
+		return manager.ShouldTerminate(ctx, host.history, host.iterationCount)
+	}
+	return host.iterationCount >= defaultGroupChatMaximumIterations, nil
+}
+
+func (host *groupChatHostExecutor) updateHistory(ctx context.Context, manager *GroupChatManager, messages []*message.Message) ([]*message.Message, error) {
+	if manager.UpdateHistory == nil {
+		return messages, nil
+	}
+	updated, err := manager.UpdateHistory(ctx, messages)
+	if err != nil || updated != nil {
+		return updated, err
+	}
+	return messages, nil
+}
+
+func (host *groupChatHostExecutor) broadcast(ctx *workflow.Context, messages []*message.Message) error {
+	for _, participant := range host.participants {
+		if participant.ID == host.currentSpeakerExecutorID {
+			continue
+		}
+		if err := ctx.SendMessage(participant.ID, messages); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (host *groupChatHostExecutor) complete(ctx *workflow.Context) error {
+	output := host.history
+	host.history = nil
+	host.currentSpeakerExecutorID = ""
+	host.manager = nil
+	host.iterationCount = 0
+	if err := host.messageState.Reset(); err != nil {
+		return err
+	}
+	return ctx.YieldOutput(output)
+}
+
+func (host *groupChatHostExecutor) reset() error {
+	if host.manager != nil && host.manager.Reset != nil {
+		host.manager.Reset()
+	}
+	host.manager = nil
+	host.history = nil
+	host.currentSpeakerExecutorID = ""
+	host.iterationCount = 0
+	return nil
+}
+
+func (host *groupChatHostExecutor) ensureManager() (*GroupChatManager, error) {
+	if host.manager != nil {
+		return host.manager, nil
+	}
+	manager := host.managerFactory(slices.Clone(host.agents))
+	if manager == nil {
+		return nil, fmt.Errorf("workflowhosting: group chat manager factory returned nil")
+	}
+	if manager.SelectNextAgent == nil {
+		return nil, fmt.Errorf("workflowhosting: group chat manager SelectNextAgent is nil")
+	}
+	host.manager = manager
+	return manager, nil
+}
+
+func (host *groupChatHostExecutor) bindingForAgent(currentAgent *agent.Agent) (workflow.ExecutorBinding, bool) {
+	if currentAgent == nil {
+		return workflow.ExecutorBinding{}, false
+	}
+	if binding, ok := host.bindingsByAgent[currentAgent]; ok {
+		return binding, true
+	}
+	if binding, ok := host.bindingsByAgentID[currentAgent.ID()]; ok {
+		return binding, true
+	}
+	return workflow.ExecutorBinding{}, false
+}
+
+func (host *groupChatHostExecutor) onCheckpoint(ctx *workflow.Context) error {
+	if err := ctx.QueueStateUpdate(groupChatHistoryStateKey, "", host.history); err != nil {
+		return err
+	}
+	if err := ctx.QueueStateUpdate(groupChatCurrentSpeakerKey, "", host.currentSpeakerExecutorID); err != nil {
+		return err
+	}
+	manager, err := host.ensureManager()
+	if err != nil {
+		return err
+	}
+	return checkpointGroupChatManager(ctx, manager, host.iterationCount)
+}
+
+func (host *groupChatHostExecutor) onCheckpointRestored(ctx *workflow.Context) error {
+	history, err := readMessageSliceState(ctx, groupChatHistoryStateKey)
+	if err != nil {
+		return err
+	}
+	host.history = history
+
+	currentSpeaker, err := readStringState(ctx, groupChatCurrentSpeakerKey)
+	if err != nil {
+		return err
+	}
+	host.currentSpeakerExecutorID = currentSpeaker
+
+	manager, err := host.ensureManager()
+	if err != nil {
+		return err
+	}
+	iterationCount, err := restoreGroupChatManagerCheckpoint(ctx, manager)
+	if err != nil {
+		return err
+	}
+	host.iterationCount = iterationCount
+	return nil
+}
+
+func checkpointGroupChatManager(ctx *workflow.Context, manager *GroupChatManager, iterationCount int) error {
+	if err := ctx.QueueStateUpdate(groupChatManagerStateKey, "", groupChatManagerState{IterationCount: iterationCount}); err != nil {
+		return err
+	}
+	if manager.OnCheckpoint != nil {
+		return manager.OnCheckpoint(prefixingWorkflowContext(ctx, groupChatManagerSubclassStateKeyPref))
+	}
+	return nil
+}
+
+func restoreGroupChatManagerCheckpoint(ctx *workflow.Context, manager *GroupChatManager) (int, error) {
+	value, err := ctx.ReadState(groupChatManagerStateKey, "")
+	if err != nil {
+		return 0, err
+	}
+	state, err := groupChatManagerStateFromAny(value)
+	if err != nil {
+		return 0, err
+	}
+	if manager.OnCheckpointRestored != nil {
+		if err := manager.OnCheckpointRestored(prefixingWorkflowContext(ctx, groupChatManagerSubclassStateKeyPref)); err != nil {
+			return 0, err
+		}
+	}
+	if state == nil {
+		return 0, nil
+	}
+	return state.IterationCount, nil
+}
+
+func prefixingWorkflowContext(inner *workflow.Context, prefix string) *workflow.Context {
+	wrapped := *inner
+	wrap := func(key string) string { return prefix + key }
+
+	if inner.ReadState != nil {
+		wrapped.ReadState = func(key string, scope string) (any, error) {
+			return inner.ReadState(wrap(key), scope)
+		}
+	}
+	if inner.ReadOrInitState != nil {
+		wrapped.ReadOrInitState = func(key string, scope string, initFunc func(context.Context, string, string) (any, error)) (any, error) {
+			return inner.ReadOrInitState(wrap(key), scope, func(ctx context.Context, wrappedKey string, wrappedScope string) (any, error) {
+				if initFunc == nil {
+					return nil, nil
+				}
+				return initFunc(ctx, key, wrappedScope)
+			})
+		}
+	}
+	if inner.ReadStateKeys != nil {
+		wrapped.ReadStateKeys = func(scope string) iter.Seq2[string, error] {
+			return func(yield func(string, error) bool) {
+				for key, err := range inner.ReadStateKeys(scope) {
+					if err != nil {
+						if !yield("", err) {
+							return
+						}
+						continue
+					}
+					if strings.HasPrefix(key, prefix) {
+						if !yield(strings.TrimPrefix(key, prefix), nil) {
+							return
+						}
+					}
+				}
+			}
+		}
+	}
+	if inner.QueueStateUpdate != nil {
+		wrapped.QueueStateUpdate = func(key string, scope string, value any) error {
+			return inner.QueueStateUpdate(wrap(key), scope, value)
+		}
+	}
+	return &wrapped
+}
+
+func readMessageSliceState(ctx *workflow.Context, key string) ([]*message.Message, error) {
+	value, err := ctx.ReadState(key, "")
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return nil, nil
+	}
+	if messages, ok := value.([]*message.Message); ok {
+		return messages, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var messages []*message.Message
+	if err := json.Unmarshal(data, &messages); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+func readStringState(ctx *workflow.Context, key string) (string, error) {
+	value, err := ctx.ReadState(key, "")
+	if err != nil {
+		return "", err
+	}
+	if value == nil {
+		return "", nil
+	}
+	if text, ok := value.(string); ok {
+		return text, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return "", err
+	}
+	return text, nil
+}
+
+type groupChatManagerState struct {
+	IterationCount int
+}
+
+func groupChatManagerStateFromAny(value any) (*groupChatManagerState, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch state := value.(type) {
+	case groupChatManagerState:
+		return &state, nil
+	case *groupChatManagerState:
+		return state, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var state groupChatManagerState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+type roundRobinGroupChatManagerState struct {
+	NextIndex int
+}
+
+func roundRobinGroupChatManagerStateFromAny(value any) (*roundRobinGroupChatManagerState, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch state := value.(type) {
+	case roundRobinGroupChatManagerState:
+		return &state, nil
+	case *roundRobinGroupChatManagerState:
+		return state, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var state roundRobinGroupChatManagerState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}

--- a/agent/hosting/workflowhosting/groupchat.go
+++ b/agent/hosting/workflowhosting/groupchat.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
-	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -281,10 +280,10 @@ func newGroupChatHostBinding(
 		NewExecutorFunc: func(string) (*workflow.Executor, error) {
 			host := &groupChatHostExecutor{
 				id:                groupChatHostExecutorID,
-				agents:            slices.Clone(agents),
-				participants:      slices.Clone(participants),
-				bindingsByAgent:   maps.Clone(bindingsByAgent),
-				bindingsByAgentID: maps.Clone(bindingsByAgentID),
+				agents:            agents,
+				participants:      participants,
+				bindingsByAgent:   bindingsByAgent,
+				bindingsByAgentID: bindingsByAgentID,
 				managerFactory:    managerFactory,
 				messageState:      messageworkflow.NewMessageState(groupChatHostBufferedStateKey, ""),
 			}

--- a/agent/hosting/workflowhosting/groupchat_test.go
+++ b/agent/hosting/workflowhosting/groupchat_test.go
@@ -1,0 +1,1048 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowhosting
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/checkpoint"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+func newGroupChatWorkflow(name string, managerFactory GroupChatManagerFactory, agents ...*agent.Agent) (*workflow.Workflow, error) {
+	return NewGroupChatWorkflowBuilder(managerFactory, agents...).WithName(name).Build()
+}
+
+func TestGroupChatWorkflowBuilder_RoundRobinManagerProducesTranscript(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	agentB := newGroupChatLabelAgent("b", "B", "from-b")
+	agentC := newGroupChatLabelAgent("c", "C", "from-c")
+
+	wf, err := newGroupChatWorkflow("round-robin", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 3})
+	}, agentA, agentB, agentC)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if wf.Name() != "round-robin" {
+		t.Fatalf("workflow name = %q, want round-robin", wf.Name())
+	}
+
+	events := runGroupChatWorkflowTurn(t, wf, "hello")
+	if got := collectGroupChatUpdateTexts(events); !slices.Equal(got, []string{"from-a", "from-b", "from-c"}) {
+		t.Fatalf("update texts = %v, want [from-a from-b from-c]", got)
+	}
+	if got := collectGroupChatOutputTexts(events); !slices.Equal(got, []string{"hello", "from-a", "from-b", "from-c"}) {
+		t.Fatalf("output transcript = %v, want [hello from-a from-b from-c]", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_WithNameOnlySetsWorkflowName(t *testing.T) {
+	const workflowName = "named group chat"
+	wf, err := newGroupChatWorkflow(workflowName, func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 1})
+	}, newGroupChatLabelAgent("a", "A", "from-a"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := wf.Name(); got != workflowName {
+		t.Fatalf("workflow name = %q, want %q", got, workflowName)
+	}
+	if got := wf.Description(); got != "" {
+		t.Fatalf("workflow description = %q, want empty", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_WithoutNameDefaultsToEmptyMetadata(t *testing.T) {
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 1})
+	}, newGroupChatLabelAgent("a", "A", "from-a"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := wf.Name(); got != "" {
+		t.Fatalf("workflow name = %q, want empty", got)
+	}
+	if got := wf.Description(); got != "" {
+		t.Fatalf("workflow description = %q, want empty", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_DefaultOutputMetadataDesignatesHostAndIntermediateParticipants(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	agentB := newGroupChatLabelAgent("b", "B", "from-b")
+	agentC := newGroupChatLabelAgent("c", "C", "from-c")
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 1})
+	}, agentA, agentB, agentC)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	outputIDs := wf.OutputExecutorIDs()
+	slices.Sort(outputIDs)
+	wantIDs := []string{groupChatHostExecutorID}
+	for _, currentAgent := range []*agent.Agent{agentA, agentB, agentC} {
+		wantIDs = append(wantIDs, New(currentAgent, Config{DisableForwardIncomingMessages: true}).ID)
+	}
+	slices.Sort(wantIDs)
+	if !slices.Equal(outputIDs, wantIDs) {
+		t.Fatalf("output executor IDs = %v, want %v", outputIDs, wantIDs)
+	}
+	if !wf.HasOutputExecutor(groupChatHostExecutorID) {
+		t.Fatalf("expected %q to be an output executor", groupChatHostExecutorID)
+	}
+	if tags := outputExecutorTags(wf, groupChatHostExecutorID); len(tags) != 0 {
+		t.Fatalf("host tags = %v, want terminal output with no tags", tags)
+	}
+	for _, currentAgent := range []*agent.Agent{agentA, agentB, agentC} {
+		participantID := New(currentAgent, Config{DisableForwardIncomingMessages: true}).ID
+		if !wf.HasOutputExecutor(participantID) {
+			t.Fatalf("participant %q was not designated as an output executor", participantID)
+		}
+		if tags := outputExecutorTags(wf, participantID); len(tags) != 1 || tags[0] != workflow.OutputTagIntermediate {
+			t.Fatalf("participant %q tags = %v, want intermediate", participantID, tags)
+		}
+	}
+}
+
+func TestGroupChatWorkflowBuilder_ExplicitOutputDesignationSuppressesDefaults(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	agentB := newGroupChatLabelAgent("b", "B", "from-b")
+	wf, err := NewGroupChatWorkflowBuilder(func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 1})
+	}, agentA, agentB).
+		WithOutputFrom(agentA).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	wantOutputID := New(agentA, Config{DisableForwardIncomingMessages: true}).ID
+	outputIDs := wf.OutputExecutorIDs()
+	slices.Sort(outputIDs)
+	if !slices.Equal(outputIDs, []string{wantOutputID}) {
+		t.Fatalf("output executor IDs = %v, want [%s]", outputIDs, wantOutputID)
+	}
+	if wf.HasOutputExecutor(groupChatHostExecutorID) {
+		t.Fatalf("host output should be suppressed when explicit output designations are present")
+	}
+}
+
+func TestGroupChatWorkflowBuilder_ExplicitOutputDesignationRejectsNonParticipant(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	nonParticipant := newGroupChatLabelAgent("outside", "Outside", "from-outside")
+	managerFactory := func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 1})
+	}
+
+	for _, testCase := range []struct {
+		name      string
+		configure func(*GroupChatWorkflowBuilder) *GroupChatWorkflowBuilder
+	}{
+		{
+			name: "terminal",
+			configure: func(builder *GroupChatWorkflowBuilder) *GroupChatWorkflowBuilder {
+				return builder.WithOutputFrom(nonParticipant)
+			},
+		},
+		{
+			name: "intermediate",
+			configure: func(builder *GroupChatWorkflowBuilder) *GroupChatWorkflowBuilder {
+				return builder.WithIntermediateOutputFrom(nonParticipant)
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := testCase.configure(NewGroupChatWorkflowBuilder(managerFactory, agentA)).Build()
+			if err == nil {
+				t.Fatal("expected error for non-participant output designation, got nil")
+			}
+			if !strings.Contains(err.Error(), "not a participant") {
+				t.Fatalf("error = %q, want it to mention not a participant", err.Error())
+			}
+		})
+	}
+}
+
+func outputExecutorTags(wf *workflow.Workflow, executorID string) []workflow.OutputTag {
+	if wf == nil {
+		return nil
+	}
+	tags, ok := wf.OutputExecutors()[executorID]
+	if !ok {
+		return nil
+	}
+	return tags
+}
+
+func TestGroupChatWorkflowBuilder_RegistersParticipantRequestPorts(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	agentB := newGroupChatLabelAgent("b", "B", "from-b")
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 1})
+	}, agentA, agentB)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	for _, currentAgent := range []*agent.Agent{agentA, agentB} {
+		participantID := New(currentAgent, Config{DisableForwardIncomingMessages: true}).ID
+		approvalPort, ok := wf.RequestPort(participantID + "_UserInput")
+		if !ok {
+			t.Fatalf("missing user-input request port for participant %q", participantID)
+		}
+		if approvalPort.Request != reflect.TypeFor[*message.ToolApprovalRequestContent]() {
+			t.Fatalf("approval request type = %v, want %v", approvalPort.Request, reflect.TypeFor[*message.ToolApprovalRequestContent]())
+		}
+		if approvalPort.Response != reflect.TypeFor[*message.ToolApprovalResponseContent]() {
+			t.Fatalf("approval response type = %v, want %v", approvalPort.Response, reflect.TypeFor[*message.ToolApprovalResponseContent]())
+		}
+
+		functionPort, ok := wf.RequestPort(participantID + "_FunctionCall")
+		if !ok {
+			t.Fatalf("missing function-call request port for participant %q", participantID)
+		}
+		if functionPort.Request != reflect.TypeFor[*message.FunctionCallContent]() {
+			t.Fatalf("function-call request type = %v, want %v", functionPort.Request, reflect.TypeFor[*message.FunctionCallContent]())
+		}
+		if functionPort.Response != reflect.TypeFor[*message.FunctionResultContent]() {
+			t.Fatalf("function-call response type = %v, want %v", functionPort.Response, reflect.TypeFor[*message.FunctionResultContent]())
+		}
+	}
+}
+
+func TestGroupChatWorkflowBuilder_AgentsRunInOrder(t *testing.T) {
+	for _, maxIterations := range []int{1, 2, 3, 4, 5} {
+		t.Run(fmt.Sprintf("max_%d", maxIterations), func(t *testing.T) {
+			agents := []*agent.Agent{
+				newGroupChatDoubleEchoAgent("agent1"),
+				newGroupChatDoubleEchoAgent("agent2"),
+				newGroupChatDoubleEchoAgent("agent3"),
+			}
+			wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+				return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: maxIterations})
+			}, agents...)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+
+			events := runGroupChatWorkflowTurn(t, wf, "abc")
+			wantTranscript := expectedGroupChatDoubleEchoTranscript(maxIterations, "abc")
+			wantUpdates := wantTranscript[1:]
+			if got := collectGroupChatUpdateTexts(events); !slices.Equal(got, wantUpdates) {
+				t.Fatalf("update texts = %v, want %v", got, wantUpdates)
+			}
+			if got := collectGroupChatOutputTexts(events); !slices.Equal(got, wantTranscript) {
+				t.Fatalf("output transcript = %v, want %v", got, wantTranscript)
+			}
+		})
+	}
+}
+
+func TestGroupChatWorkflowBuilder_BroadcastsDeltaAndTargetsTurnTokenToSpeakerOnly(t *testing.T) {
+	agentA := newGroupChatRecordingAgent("agentA")
+	agentB := newGroupChatRecordingAgent("agentB")
+	agentC := newGroupChatRecordingAgent("agentC")
+
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 4})
+	}, agentA.Agent, agentB.Agent, agentC.Agent)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	events := runGroupChatWorkflowTurn(t, wf, "hello")
+	if got := collectGroupChatOutputTexts(events); !slices.Equal(got, []string{"hello", "agentA", "agentB", "agentC", "agentA"}) {
+		t.Fatalf("output transcript = %v, want [hello agentA agentB agentC agentA]", got)
+	}
+	if got := agentA.Invocations(); !equalGroupChatInvocations(got, [][]string{{"hello"}, {"agentB", "agentC"}}) {
+		t.Fatalf("agentA invocations = %v, want [[hello] [agentB agentC]]", got)
+	}
+	if got := agentB.Invocations(); !equalGroupChatInvocations(got, [][]string{{"hello", "agentA"}}) {
+		t.Fatalf("agentB invocations = %v, want [[hello agentA]]", got)
+	}
+	if got := agentC.Invocations(); !equalGroupChatInvocations(got, [][]string{{"hello", "agentA", "agentB"}}) {
+		t.Fatalf("agentC invocations = %v, want [[hello agentA agentB]]", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_UpdateHistoryFiltersBroadcastPayload(t *testing.T) {
+	agentA := newGroupChatRecordingAgent("agentA")
+	agentB := newGroupChatRecordingAgent("agentB")
+
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		manager := NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 2})
+		manager.UpdateHistory = func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
+			return prefixGroupChatMessages("[broadcast] ", messages), nil
+		}
+		return manager
+	}, agentA.Agent, agentB.Agent)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	_ = runGroupChatWorkflowTurn(t, wf, "hello")
+	if got := agentA.Invocations(); !equalGroupChatInvocations(got, [][]string{{"[broadcast] hello"}}) {
+		t.Fatalf("agentA invocations = %v, want [[broadcast hello]]", got)
+	}
+	if got := agentB.Invocations(); !equalGroupChatInvocations(got, [][]string{{"[broadcast] hello", "[broadcast] agentA"}}) {
+		t.Fatalf("agentB invocations = %v, want [[broadcast hello] [broadcast agentA]]", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_ToolApprovalCheckpointResumePreservesFunctionCallContent(t *testing.T) {
+	approvalAgent := newGroupChatApprovalAgent("approval-agent")
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 1})
+	}, approvalAgent.Agent)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx := t.Context()
+	checkpointManager := newGroupChatJSONCheckpointManager(t)
+	first, err := inproc.Default.WithCheckpointing(checkpointManager).Run(ctx, wf, []*message.Message{textMessage("go")})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	pendingRequest := firstGroupChatRequest(t, first.OutgoingEvents())
+	checkpointInfo, ok := first.LastCheckpoint()
+	if !ok {
+		t.Fatal("expected checkpoint")
+	}
+	if err := first.Close(ctx); err != nil {
+		t.Fatalf("Close first run: %v", err)
+	}
+
+	preCheckpointApproval := groupChatApprovalRequest(t, pendingRequest)
+	if _, ok := preCheckpointApproval.ToolCall.(*message.FunctionCallContent); !ok {
+		t.Fatalf("pre-checkpoint ToolCall = %T, want *message.FunctionCallContent", preCheckpointApproval.ToolCall)
+	}
+
+	resumed, err := inproc.Default.WithCheckpointing(checkpointManager).Resume(ctx, wf, checkpointInfo)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	defer func() { _ = resumed.Close(ctx) }()
+
+	replayedRequest := firstGroupChatRequest(t, resumed.NewEvents())
+	replayedApproval := groupChatApprovalRequest(t, replayedRequest)
+	if _, ok := replayedApproval.ToolCall.(*message.FunctionCallContent); !ok {
+		t.Fatalf("replayed ToolCall = %T, want *message.FunctionCallContent", replayedApproval.ToolCall)
+	}
+
+	response, err := replayedRequest.CreateResponse(replayedApproval.CreateResponse(true, ""))
+	if err != nil {
+		t.Fatalf("CreateResponse: %v", err)
+	}
+	if _, err := resumed.Resume(ctx, response); err != nil {
+		t.Fatalf("Resume with response: %v", err)
+	}
+	postResponseEvents := slices.Collect(resumed.NewEvents())
+	assertNoGroupChatErrors(t, postResponseEvents)
+	if got := collectGroupChatOutputTexts(postResponseEvents); !slices.Equal(got, []string{"go", "approved"}) {
+		t.Fatalf("output transcript = %v, want [go approved]", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_ToolApprovalDeniedResponseConversationContinues(t *testing.T) {
+	approvalAgent := newGroupChatApprovalAgent("approval-agent")
+	nextAgent := newGroupChatRecordingAgent("next-agent")
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 2})
+	}, approvalAgent.Agent, nextAgent.Agent)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx := t.Context()
+	run, err := inproc.Default.Run(ctx, wf, []*message.Message{textMessage("go")})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	defer func() { _ = run.Close(ctx) }()
+
+	pendingRequest := firstGroupChatRequest(t, run.OutgoingEvents())
+	approvalRequest := groupChatApprovalRequest(t, pendingRequest)
+	if _, ok := approvalRequest.ToolCall.(*message.FunctionCallContent); !ok {
+		t.Fatalf("ToolCall = %T, want *message.FunctionCallContent", approvalRequest.ToolCall)
+	}
+	response, err := pendingRequest.CreateResponse(approvalRequest.CreateResponse(false, "Denied"))
+	if err != nil {
+		t.Fatalf("CreateResponse: %v", err)
+	}
+	if _, err := run.Resume(ctx, response); err != nil {
+		t.Fatalf("Resume with denial: %v", err)
+	}
+	postResponseEvents := slices.Collect(run.NewEvents())
+	assertNoGroupChatErrors(t, postResponseEvents)
+	if got := collectGroupChatOutputTexts(postResponseEvents); !slices.Equal(got, []string{"go", "denied", "next-agent"}) {
+		t.Fatalf("output transcript = %v, want [go denied next-agent]", got)
+	}
+	if got := nextAgent.Invocations(); !equalGroupChatInvocations(got, [][]string{{"go", "denied"}}) {
+		t.Fatalf("next-agent invocations = %v, want [[go denied]]", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_FunctionCallExternallyResolvedConversationContinues(t *testing.T) {
+	functionAgent := newGroupChatFunctionCallAgent("function-agent")
+	nextAgent := newGroupChatRecordingAgent("next-agent")
+	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {
+		return NewRoundRobinGroupChatManager(agents, RoundRobinGroupChatOptions{MaximumIterationCount: 2})
+	}, functionAgent.Agent, nextAgent.Agent)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx := t.Context()
+	run, err := inproc.Default.Run(ctx, wf, []*message.Message{textMessage("go")})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	defer func() { _ = run.Close(ctx) }()
+
+	pendingRequest := firstGroupChatRequest(t, run.OutgoingEvents())
+	functionCall := groupChatFunctionCall(t, pendingRequest)
+	if functionCall.Name != "FetchExternalData" {
+		t.Fatalf("function name = %q, want FetchExternalData", functionCall.Name)
+	}
+	response, err := pendingRequest.CreateResponse(&message.FunctionResultContent{CallID: functionCall.CallID, Result: "external-data"})
+	if err != nil {
+		t.Fatalf("CreateResponse: %v", err)
+	}
+	if _, err := run.Resume(ctx, response); err != nil {
+		t.Fatalf("Resume with response: %v", err)
+	}
+	postResponseEvents := slices.Collect(run.NewEvents())
+	assertNoGroupChatErrors(t, postResponseEvents)
+	if got := collectGroupChatOutputTexts(postResponseEvents); !slices.Equal(got, []string{"go", "got:external-data", "next-agent"}) {
+		t.Fatalf("output transcript = %v, want [go got:external-data next-agent]", got)
+	}
+	if got := nextAgent.Invocations(); !equalGroupChatInvocations(got, [][]string{{"go", "got:external-data"}}) {
+		t.Fatalf("next-agent invocations = %v, want [[go got:external-data]]", got)
+	}
+}
+
+func TestGroupChatWorkflowBuilder_ReturnsErrorsForInvalidInputs(t *testing.T) {
+	_, err := newGroupChatWorkflow("", func([]*agent.Agent) *GroupChatManager { return nil })
+	if err == nil {
+		t.Fatal("expected error for zero agents, got nil")
+	}
+
+	validAgent := newGroupChatLabelAgent("a", "A", "from-a")
+	_, err = newGroupChatWorkflow("", nil, validAgent)
+	if err == nil {
+		t.Fatal("expected error for nil manager factory, got nil")
+	}
+
+	_, err = newGroupChatWorkflow("", func([]*agent.Agent) *GroupChatManager { return nil }, validAgent, nil)
+	if err == nil {
+		t.Fatal("expected error for nil agent, got nil")
+	}
+}
+
+func TestRoundRobinGroupChatManager_CheckpointRestoresCursor(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	agentB := newGroupChatLabelAgent("b", "B", "from-b")
+	manager := NewRoundRobinGroupChatManager([]*agent.Agent{agentA, agentB}, RoundRobinGroupChatOptions{})
+	if _, err := manager.SelectNextAgent(t.Context(), nil); err != nil {
+		t.Fatalf("SelectNextAgent: %v", err)
+	}
+
+	const iterationCount = 4
+	state := make(map[string]any)
+	ctx := newGroupChatStateContext(t.Context(), state)
+	if err := checkpointGroupChatManager(ctx, manager, iterationCount); err != nil {
+		t.Fatalf("checkpointGroupChatManager: %v", err)
+	}
+	if _, ok := state[groupChatManagerStateKey]; !ok {
+		t.Fatalf("missing manager state key %q", groupChatManagerStateKey)
+	}
+	if _, ok := state[groupChatManagerSubclassStateKeyPref+roundRobinGroupChatManagerStateKey]; !ok {
+		t.Fatalf("missing prefixed round robin state key")
+	}
+	if _, ok := state[roundRobinGroupChatManagerStateKey]; ok {
+		t.Fatalf("round robin state was written without prefix")
+	}
+
+	restored := NewRoundRobinGroupChatManager([]*agent.Agent{agentA, agentB}, RoundRobinGroupChatOptions{})
+	restoredIterationCount, err := restoreGroupChatManagerCheckpoint(newGroupChatStateContext(t.Context(), state), restored)
+	if err != nil {
+		t.Fatalf("restoreGroupChatManagerCheckpoint: %v", err)
+	}
+	if got := restoredIterationCount; got != iterationCount {
+		t.Fatalf("iteration count = %d, want 4", got)
+	}
+	nextAgent, err := restored.SelectNextAgent(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("SelectNextAgent restored: %v", err)
+	}
+	if nextAgent != agentB {
+		t.Fatalf("restored next agent = %s, want B", nextAgent.ID())
+	}
+}
+
+func TestRoundRobinGroupChatManager_SelectNextAgentCyclesAndWraps(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	agentB := newGroupChatLabelAgent("b", "B", "from-b")
+	agentC := newGroupChatLabelAgent("c", "C", "from-c")
+	manager := NewRoundRobinGroupChatManager([]*agent.Agent{agentA, agentB, agentC}, RoundRobinGroupChatOptions{})
+
+	var got []*agent.Agent
+	for range 4 {
+		next, err := manager.SelectNextAgent(t.Context(), nil)
+		if err != nil {
+			t.Fatalf("SelectNextAgent: %v", err)
+		}
+		got = append(got, next)
+	}
+	want := []*agent.Agent{agentA, agentB, agentC, agentA}
+	if !slices.Equal(got, want) {
+		t.Fatalf("selected agents = %v, want %v", agentIDs(got), agentIDs(want))
+	}
+}
+
+func TestRoundRobinGroupChatManager_ShouldTerminate(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	manager := NewRoundRobinGroupChatManager([]*agent.Agent{agentA}, RoundRobinGroupChatOptions{MaximumIterationCount: 3})
+
+	terminate, err := manager.ShouldTerminate(t.Context(), nil, 2)
+	if err != nil {
+		t.Fatalf("ShouldTerminate before max: %v", err)
+	}
+	if terminate {
+		t.Fatal("ShouldTerminate before max = true, want false")
+	}
+	terminate, err = manager.ShouldTerminate(t.Context(), nil, 3)
+	if err != nil {
+		t.Fatalf("ShouldTerminate at max: %v", err)
+	}
+	if !terminate {
+		t.Fatal("ShouldTerminate at max = false, want true")
+	}
+
+	custom := NewRoundRobinGroupChatManager([]*agent.Agent{agentA}, RoundRobinGroupChatOptions{
+		MaximumIterationCount: 100,
+		ShouldTerminate: func(_ context.Context, history []*message.Message, _ int) (bool, error) {
+			return slices.Contains(collectGroupChatMessageTexts(history), "done"), nil
+		},
+	})
+	terminate, err = custom.ShouldTerminate(t.Context(), []*message.Message{textMessage("continue")}, 0)
+	if err != nil {
+		t.Fatalf("custom ShouldTerminate continue: %v", err)
+	}
+	if terminate {
+		t.Fatal("custom ShouldTerminate without marker = true, want false")
+	}
+	terminate, err = custom.ShouldTerminate(t.Context(), []*message.Message{textMessage("done")}, 0)
+	if err != nil {
+		t.Fatalf("custom ShouldTerminate done: %v", err)
+	}
+	if !terminate {
+		t.Fatal("custom ShouldTerminate with marker = false, want true")
+	}
+}
+
+func TestNewRoundRobinGroupChatManager_DoesNotValidateInputs(t *testing.T) {
+	validAgent := newGroupChatLabelAgent("a", "A", "from-a")
+	for _, testCase := range []struct {
+		name   string
+		agents []*agent.Agent
+		opts   RoundRobinGroupChatOptions
+		want   *agent.Agent
+	}{
+		{name: "no agents"},
+		{name: "nil agent", agents: []*agent.Agent{nil}},
+		{name: "negative max", agents: []*agent.Agent{validAgent}, opts: RoundRobinGroupChatOptions{MaximumIterationCount: -1}, want: validAgent},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			manager := NewRoundRobinGroupChatManager(testCase.agents, testCase.opts)
+			if manager == nil {
+				t.Fatal("manager = nil, want non-nil")
+			}
+			got, err := manager.SelectNextAgent(t.Context(), nil)
+			if err != nil {
+				t.Fatalf("SelectNextAgent: %v", err)
+			}
+			if got != testCase.want {
+				t.Fatalf("selected agent = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestRoundRobinGroupChatManager_RestoreWithoutCheckpointDefaultsToZeroState(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	agentB := newGroupChatLabelAgent("b", "B", "from-b")
+	manager := NewRoundRobinGroupChatManager([]*agent.Agent{agentA, agentB}, RoundRobinGroupChatOptions{})
+	if _, err := manager.SelectNextAgent(t.Context(), nil); err != nil {
+		t.Fatalf("SelectNextAgent: %v", err)
+	}
+
+	iterationCount, err := restoreGroupChatManagerCheckpoint(newGroupChatStateContext(t.Context(), map[string]any{}), manager)
+	if err != nil {
+		t.Fatalf("restoreGroupChatManagerCheckpoint: %v", err)
+	}
+	if iterationCount != 0 {
+		t.Fatalf("iterationCount = %d, want 0", iterationCount)
+	}
+	next, err := manager.SelectNextAgent(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("SelectNextAgent after restore: %v", err)
+	}
+	if next != agentA {
+		t.Fatalf("next after empty restore = %s, want agentA", next.ID())
+	}
+}
+
+func newGroupChatLabelAgent(id string, name string, label string) *agent.Agent {
+	run := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				Role:       message.RoleAssistant,
+				AgentID:    id,
+				AuthorName: name,
+				Contents:   []message.Content{&message.TextContent{Text: label}},
+			}, nil)
+		}
+	}
+	return agent.New(
+		agent.ProviderConfig{ProviderName: "group-chat-label", Run: run},
+		agent.Config{ID: id, Name: name, DisableFuncAutoCall: true},
+	)
+}
+
+func newGroupChatDoubleEchoAgent(id string) *agent.Agent {
+	run := func(_ context.Context, messages []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			inputText := ""
+			for _, msg := range messages {
+				inputText += msg.String()
+			}
+			yield(&agent.ResponseUpdate{
+				Role:       message.RoleAssistant,
+				AgentID:    id,
+				AuthorName: id,
+				Contents: []message.Content{
+					&message.TextContent{Text: id + inputText + inputText},
+				},
+			}, nil)
+		}
+	}
+	return agent.New(
+		agent.ProviderConfig{ProviderName: "group-chat-double-echo", Run: run},
+		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"}},
+	)
+}
+
+func expectedGroupChatDoubleEchoTranscript(maxIterations int, userInput string) []string {
+	agentIDs := []string{"agent1", "agent2", "agent3"}
+	buffers := make([][]string, len(agentIDs))
+	for index := range buffers {
+		buffers[index] = []string{userInput}
+	}
+	transcript := []string{userInput}
+	for turn := range maxIterations {
+		speakerIndex := turn % len(agentIDs)
+		inputText := ""
+		for _, text := range buffers[speakerIndex] {
+			inputText += text
+		}
+		outputText := agentIDs[speakerIndex] + inputText + inputText
+		transcript = append(transcript, outputText)
+		buffers[speakerIndex] = nil
+		for index := range buffers {
+			if index != speakerIndex {
+				buffers[index] = append(buffers[index], outputText)
+			}
+		}
+	}
+	return transcript
+}
+
+type groupChatRecordingAgent struct {
+	Agent *agent.Agent
+	name  string
+
+	mu          sync.Mutex
+	invocations [][]string
+}
+
+type groupChatApprovalAgent struct {
+	Agent *agent.Agent
+
+	mu   sync.Mutex
+	step int
+}
+
+func newGroupChatApprovalAgent(id string) *groupChatApprovalAgent {
+	agentState := &groupChatApprovalAgent{}
+	run := func(_ context.Context, messages []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			agentState.mu.Lock()
+			step := agentState.step
+			agentState.step++
+			agentState.mu.Unlock()
+
+			if step == 0 {
+				yield(&agent.ResponseUpdate{
+					Role: message.RoleAssistant,
+					Contents: []message.Content{&message.ToolApprovalRequestContent{
+						RequestID: "approval-call-1",
+						ToolCall: &message.FunctionCallContent{
+							CallID: "approval-call-1",
+							Name:   "DoPrivilegedThing",
+						},
+					}},
+				}, nil)
+				return
+			}
+
+			approvalText := "no-approval"
+			for _, msg := range messages {
+				for _, content := range msg.Contents {
+					approval, ok := content.(*message.ToolApprovalResponseContent)
+					if !ok {
+						continue
+					}
+					if approval.Approved {
+						approvalText = "approved"
+					} else {
+						approvalText = "denied"
+					}
+				}
+			}
+			yield(&agent.ResponseUpdate{
+				Role:       message.RoleAssistant,
+				AgentID:    id,
+				AuthorName: id,
+				Contents:   []message.Content{&message.TextContent{Text: approvalText}},
+			}, nil)
+		}
+	}
+	agentState.Agent = agent.New(
+		agent.ProviderConfig{ProviderName: "group-chat-approval", Run: run},
+		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"}},
+	)
+	return agentState
+}
+
+type groupChatFunctionCallAgent struct {
+	Agent *agent.Agent
+
+	mu   sync.Mutex
+	step int
+}
+
+func newGroupChatFunctionCallAgent(id string) *groupChatFunctionCallAgent {
+	agentState := &groupChatFunctionCallAgent{}
+	run := func(_ context.Context, messages []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			agentState.mu.Lock()
+			step := agentState.step
+			agentState.step++
+			agentState.mu.Unlock()
+
+			if step == 0 {
+				yield(&agent.ResponseUpdate{
+					Role: message.RoleAssistant,
+					Contents: []message.Content{&message.FunctionCallContent{
+						CallID: "function-call-1",
+						Name:   "FetchExternalData",
+					}},
+				}, nil)
+				return
+			}
+
+			text := "no-result"
+			for _, msg := range messages {
+				for _, content := range msg.Contents {
+					result, ok := content.(*message.FunctionResultContent)
+					if !ok {
+						continue
+					}
+					if resultText, ok := result.Result.(string); ok {
+						text = "got:" + resultText
+					}
+				}
+			}
+			yield(&agent.ResponseUpdate{
+				Role:       message.RoleAssistant,
+				AgentID:    id,
+				AuthorName: id,
+				Contents:   []message.Content{&message.TextContent{Text: text}},
+			}, nil)
+		}
+	}
+	agentState.Agent = agent.New(
+		agent.ProviderConfig{ProviderName: "group-chat-function-call", Run: run},
+		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"}},
+	)
+	return agentState
+}
+
+func newGroupChatRecordingAgent(name string) *groupChatRecordingAgent {
+	recorder := &groupChatRecordingAgent{name: name}
+	run := func(_ context.Context, messages []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			recorder.mu.Lock()
+			recorder.invocations = append(recorder.invocations, collectGroupChatMessageTexts(messages))
+			recorder.mu.Unlock()
+
+			yield(&agent.ResponseUpdate{
+				Role:       message.RoleAssistant,
+				AgentID:    name,
+				AuthorName: name,
+				Contents:   []message.Content{&message.TextContent{Text: name}},
+			}, nil)
+		}
+	}
+	recorder.Agent = agent.New(
+		agent.ProviderConfig{ProviderName: "group-chat-recording", Run: run},
+		agent.Config{
+			ID:              name,
+			Name:            name,
+			HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"},
+		},
+	)
+	return recorder
+}
+
+func (recorder *groupChatRecordingAgent) Invocations() [][]string {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	invocations := make([][]string, len(recorder.invocations))
+	for index, invocation := range recorder.invocations {
+		invocations[index] = slices.Clone(invocation)
+	}
+	return invocations
+}
+
+func equalGroupChatInvocations(left, right [][]string) bool {
+	return slices.EqualFunc(left, right, func(leftInvocation []string, rightInvocation []string) bool {
+		return slices.Equal(leftInvocation, rightInvocation)
+	})
+}
+
+func prefixGroupChatMessages(prefix string, messages []*message.Message) []*message.Message {
+	prefixed := make([]*message.Message, 0, len(messages))
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		prefixed = append(prefixed, &message.Message{
+			Role:       msg.Role,
+			AuthorName: msg.AuthorName,
+			Contents: []message.Content{
+				&message.TextContent{Text: prefix + msg.String()},
+			},
+		})
+	}
+	return prefixed
+}
+
+func collectGroupChatMessageTexts(messages []*message.Message) []string {
+	texts := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		if msg != nil && msg.String() != "" {
+			texts = append(texts, msg.String())
+		}
+	}
+	return texts
+}
+
+func textMessage(text string) *message.Message {
+	return &message.Message{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: text}},
+	}
+}
+
+func agentIDs(agents []*agent.Agent) []string {
+	ids := make([]string, 0, len(agents))
+	for _, currentAgent := range agents {
+		ids = append(ids, currentAgent.ID())
+	}
+	return ids
+}
+
+func firstGroupChatRequest(t *testing.T, events iter.Seq[workflow.Event]) *workflow.ExternalRequest {
+	t.Helper()
+	for event := range events {
+		if requestEvent, ok := event.(workflow.RequestInfoEvent); ok {
+			return requestEvent.Request
+		}
+	}
+	t.Fatal("expected RequestInfoEvent")
+	return nil
+}
+
+func groupChatApprovalRequest(t *testing.T, request *workflow.ExternalRequest) *message.ToolApprovalRequestContent {
+	t.Helper()
+	approval, ok := workflow.PortableValueAs[*message.ToolApprovalRequestContent](request.Data)
+	if !ok {
+		t.Fatalf("request data = %T, want *message.ToolApprovalRequestContent", request.Data.Any())
+	}
+	return approval
+}
+
+func groupChatFunctionCall(t *testing.T, request *workflow.ExternalRequest) *message.FunctionCallContent {
+	t.Helper()
+	functionCall, ok := workflow.PortableValueAs[*message.FunctionCallContent](request.Data)
+	if !ok {
+		t.Fatalf("request data = %T, want *message.FunctionCallContent", request.Data.Any())
+	}
+	return functionCall
+}
+
+func assertNoGroupChatErrors(t *testing.T, events []workflow.Event) {
+	t.Helper()
+	for _, event := range events {
+		switch event := event.(type) {
+		case workflow.ErrorEvent:
+			t.Fatalf("unexpected workflow error: %v", event.Error)
+		case workflow.ExecutorFailedEvent:
+			t.Fatalf("unexpected executor failure from %q: %v", event.ExecutorID, event.Error)
+		}
+	}
+}
+
+func newGroupChatJSONCheckpointManager(t *testing.T) checkpoint.Manager {
+	t.Helper()
+	store, err := checkpoint.NewFileSystemJSONStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileSystemJSONStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close checkpoint store: %v", err)
+		}
+	})
+	return checkpoint.NewJSONManager(store)
+}
+
+func runGroupChatWorkflowTurn(t *testing.T, wf *workflow.Workflow, inputText string) []workflow.Event {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	stream, err := inproc.Lockstep.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("RunStreaming: %v", err)
+	}
+	defer func() {
+		if err := stream.Close(ctx); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	if err := stream.SendMessage(ctx, []*message.Message{{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: inputText}},
+	}}); err != nil {
+		t.Fatalf("SendMessage input: %v", err)
+	}
+	emitEvents := true
+	if err := stream.SendMessage(ctx, workflow.TurnToken{EmitEvents: &emitEvents}); err != nil {
+		t.Fatalf("SendMessage turn token: %v", err)
+	}
+
+	var events []workflow.Event
+	for event, err := range stream.WatchStream(ctx) {
+		if err != nil {
+			t.Fatalf("WatchStream: %v", err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func collectGroupChatUpdateTexts(events []workflow.Event) []string {
+	var texts []string
+	for _, event := range events {
+		output, ok := event.(workflow.OutputEvent)
+		if !ok {
+			continue
+		}
+		update, ok := output.Output.(*agent.ResponseUpdate)
+		if !ok {
+			continue
+		}
+		for _, content := range update.Contents {
+			if textContent, ok := content.(*message.TextContent); ok {
+				texts = append(texts, textContent.Text)
+			}
+		}
+	}
+	return texts
+}
+
+func collectGroupChatOutputTexts(events []workflow.Event) []string {
+	var texts []string
+	for _, event := range events {
+		output, ok := event.(workflow.OutputEvent)
+		if !ok {
+			continue
+		}
+		messages, ok := output.Output.([]*message.Message)
+		if !ok {
+			continue
+		}
+		for _, currentMessage := range messages {
+			for _, content := range currentMessage.Contents {
+				if textContent, ok := content.(*message.TextContent); ok {
+					texts = append(texts, textContent.Text)
+				}
+			}
+		}
+	}
+	return texts
+}
+
+func newGroupChatStateContext(ctx context.Context, state map[string]any) *workflow.Context {
+	return &workflow.Context{
+		Context: ctx,
+		ReadState: func(key string, scope string) (any, error) {
+			return state[key], nil
+		},
+		ReadOrInitState: func(key string, scope string, initFunc func(context.Context, string, string) (any, error)) (any, error) {
+			if value, ok := state[key]; ok {
+				return value, nil
+			}
+			value, err := initFunc(ctx, key, scope)
+			if err != nil {
+				return nil, err
+			}
+			state[key] = value
+			return value, nil
+		},
+		ReadStateKeys: func(string) iter.Seq2[string, error] {
+			return func(yield func(string, error) bool) {
+				for key := range state {
+					if !yield(key, nil) {
+						return
+					}
+				}
+			}
+		},
+		QueueStateUpdate: func(key string, scope string, value any) error {
+			if value == nil {
+				delete(state, key)
+				return nil
+			}
+			state[key] = value
+			return nil
+		},
+	}
+}

--- a/agent/hosting/workflowhosting/groupchat_test.go
+++ b/agent/hosting/workflowhosting/groupchat_test.go
@@ -579,6 +579,15 @@ func TestNewRoundRobinGroupChatManager_DoesNotValidateInputs(t *testing.T) {
 			if got != testCase.want {
 				t.Fatalf("selected agent = %v, want %v", got, testCase.want)
 			}
+			if testCase.opts.MaximumIterationCount < 0 {
+				terminate, err := manager.ShouldTerminate(t.Context(), nil, 0)
+				if err != nil {
+					t.Fatalf("ShouldTerminate: %v", err)
+				}
+				if terminate {
+					t.Fatal("ShouldTerminate at iteration 0 with negative max = true, want false")
+				}
+			}
 		})
 	}
 }

--- a/agent/hosting/workflowhosting/inprocess_execution_test.go
+++ b/agent/hosting/workflowhosting/inprocess_execution_test.go
@@ -106,7 +106,7 @@ func TestRunAsync_ExecutesWorkflow(t *testing.T) {
 	}
 }
 
-func TestWorkflowBuilderWithHostedAgentsEmitsOutputEventWithoutWithOutputFrom(t *testing.T) {
+func TestWorkflowBuilderWithHostedAgentsFiltersOutputEventWithoutWithOutputFrom(t *testing.T) {
 	agent1 := workflowhosting.New(newEchoAgent("agent-1"), workflowhosting.Config{})
 	agent2 := workflowhosting.New(newEchoAgent("agent-2"), workflowhosting.Config{})
 	wf, err := workflow.NewBuilder(agent1).
@@ -116,30 +116,36 @@ func TestWorkflowBuilderWithHostedAgentsEmitsOutputEventWithoutWithOutputFrom(t 
 		t.Fatalf("Build: %v", err)
 	}
 
-	ctx := context.Background()
-	stream, err := inproc.Default.RunStreaming(ctx, wf, nil)
+	events := runHostedAgentWorkflow(t, wf)
+	if containsOutputPayloadType[*agent.ResponseUpdate](events) {
+		t.Fatalf("expected hosted agent response updates to be filtered without WithOutputFrom")
+	}
+}
+
+func TestWorkflowBuilderWithHostedAgentsTagsIntermediateOutputs(t *testing.T) {
+	binding := workflowhosting.New(newEchoAgent("agent-1"), workflowhosting.Config{
+		EmitResponseEvents: true,
+	})
+	wf, err := workflow.NewBuilder(binding).
+		WithIntermediateOutputFrom(binding).
+		Build()
 	if err != nil {
-		t.Fatalf("Stream: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
-	defer func() { _ = stream.CancelRun() }()
 
-	sendStreamMessage(t, stream, ctx, []*message.Message{{
-		Role:     message.RoleUser,
-		Contents: []message.Content{&message.TextContent{Text: "Hello"}},
-	}})
-	emit := true
-	sendStreamMessage(t, stream, ctx, workflow.TurnToken{EmitEvents: &emit})
-
-	var events []workflow.Event
-	for evt, err := range stream.WatchStream(ctx) {
-		if err != nil {
-			t.Fatalf("watch: %v", err)
+	events := runHostedAgentWorkflow(t, wf)
+	updates := outputEventsWithPayloadType[*agent.ResponseUpdate](events)
+	if len(updates) == 0 {
+		t.Fatal("expected at least one OutputEvent carrying *agent.ResponseUpdate")
+	}
+	responses := outputEventsWithPayloadType[*agent.Response](events)
+	if len(responses) == 0 {
+		t.Fatal("expected at least one OutputEvent carrying *agent.Response")
+	}
+	for _, output := range append(updates, responses...) {
+		if !output.IsIntermediate() {
+			t.Fatalf("OutputEvent tags = %v, want intermediate", output.Tags)
 		}
-		events = append(events, evt)
-	}
-
-	if !containsOutputPayloadType[*agent.ResponseUpdate](events) {
-		t.Fatalf("expected at least one OutputEvent carrying *agent.ResponseUpdate")
 	}
 }
 
@@ -182,6 +188,32 @@ func TestStreamAsync_ExecutesWorkflowWithTurnToken(t *testing.T) {
 	if !containsOutputPayloadType[*agent.Response](events) {
 		t.Errorf("expected at least one OutputEvent carrying *agent.Response")
 	}
+}
+
+func runHostedAgentWorkflow(t *testing.T, wf *workflow.Workflow) []workflow.Event {
+	t.Helper()
+	ctx := context.Background()
+	stream, err := inproc.Default.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.CancelRun() }()
+
+	sendStreamMessage(t, stream, ctx, []*message.Message{{
+		Role:     message.RoleUser,
+		Contents: []message.Content{&message.TextContent{Text: "Hello"}},
+	}})
+	emit := true
+	sendStreamMessage(t, stream, ctx, workflow.TurnToken{EmitEvents: &emit})
+
+	var events []workflow.Event
+	for evt, err := range stream.WatchStream(ctx) {
+		if err != nil {
+			t.Fatalf("watch: %v", err)
+		}
+		events = append(events, evt)
+	}
+	return events
 }
 
 func TestRunAsyncAndStreamAsync_ProduceSimilarResults(t *testing.T) {
@@ -301,4 +333,18 @@ func countOutputPayloadType[T any](events []workflow.Event) int {
 		}
 	}
 	return n
+}
+
+func outputEventsWithPayloadType[T any](events []workflow.Event) []workflow.OutputEvent {
+	var outputs []workflow.OutputEvent
+	for _, e := range events {
+		out, ok := e.(workflow.OutputEvent)
+		if !ok {
+			continue
+		}
+		if _, ok := out.Output.(T); ok {
+			outputs = append(outputs, out)
+		}
+	}
+	return outputs
 }

--- a/agent/hosting/workflowhosting/sequential.go
+++ b/agent/hosting/workflowhosting/sequential.go
@@ -20,11 +20,12 @@ const (
 
 // SequentialWorkflowBuilder fluently builds sequential agent workflows.
 type SequentialWorkflowBuilder struct {
-	name               string
-	description        string
-	agents             []*agent.Agent
-	outputDesignations outputDesignations
-	err                error
+	name                    string
+	description             string
+	agents                  []*agent.Agent
+	chainOnlyAgentResponses bool
+	outputDesignations      outputDesignations
+	err                     error
 }
 
 // NewSequentialWorkflowBuilder creates a builder for a sequential agent workflow.
@@ -47,6 +48,17 @@ func (b *SequentialWorkflowBuilder) WithDescription(description string) *Sequent
 		return b
 	}
 	b.description = description
+	return b
+}
+
+// WithChainOnlyAgentResponses controls whether each agent only forwards its own
+// response to the next agent, instead of forwarding the full accumulated
+// conversation. The default is false.
+func (b *SequentialWorkflowBuilder) WithChainOnlyAgentResponses(enabled bool) *SequentialWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.chainOnlyAgentResponses = enabled
 	return b
 }
 
@@ -80,7 +92,7 @@ func (b *SequentialWorkflowBuilder) Build() (*workflow.Workflow, error) {
 		return nil, err
 	}
 
-	cfg := Config{}
+	cfg := Config{DisableForwardIncomingMessages: b.chainOnlyAgentResponses}
 	bindings := make([]workflow.ExecutorBinding, len(b.agents))
 	bindingsByAgent := make(map[*agent.Agent]workflow.ExecutorBinding, len(b.agents))
 	for index, currentAgent := range b.agents {

--- a/agent/hosting/workflowhosting/sequential.go
+++ b/agent/hosting/workflowhosting/sequential.go
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowhosting
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/message/messageworkflow"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+const (
+	outputMessagesExecutorID = "workflowhosting.OutputMessages"
+	outputMessagesStateKey   = "workflowhosting.OutputMessagesExecutor.State"
+)
+
+// SequentialWorkflowBuilder fluently builds sequential agent workflows.
+type SequentialWorkflowBuilder struct {
+	name               string
+	description        string
+	agents             []*agent.Agent
+	outputDesignations outputDesignations
+	err                error
+}
+
+// NewSequentialWorkflowBuilder creates a builder for a sequential agent workflow.
+func NewSequentialWorkflowBuilder(agents ...*agent.Agent) *SequentialWorkflowBuilder {
+	return &SequentialWorkflowBuilder{agents: slices.Clone(agents)}
+}
+
+// WithName sets the workflow name.
+func (b *SequentialWorkflowBuilder) WithName(name string) *SequentialWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.name = name
+	return b
+}
+
+// WithDescription sets the workflow description.
+func (b *SequentialWorkflowBuilder) WithDescription(description string) *SequentialWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.description = description
+	return b
+}
+
+// WithOutputFrom designates agents as terminal workflow output sources.
+func (b *SequentialWorkflowBuilder) WithOutputFrom(agents ...*agent.Agent) *SequentialWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.outputDesignations, b.err = b.outputDesignations.withOutputFrom(agents...)
+	return b
+}
+
+// WithIntermediateOutputFrom designates agents as intermediate workflow output sources.
+func (b *SequentialWorkflowBuilder) WithIntermediateOutputFrom(agents ...*agent.Agent) *SequentialWorkflowBuilder {
+	if b == nil || b.err != nil {
+		return b
+	}
+	b.outputDesignations, b.err = b.outputDesignations.withIntermediateOutputFrom(agents...)
+	return b
+}
+
+// Build builds the sequential workflow.
+func (b *SequentialWorkflowBuilder) Build() (*workflow.Workflow, error) {
+	if b == nil {
+		return nil, fmt.Errorf("workflowhosting: SequentialWorkflowBuilder is nil")
+	}
+	if b.err != nil {
+		return nil, b.err
+	}
+	if err := validateBuilderAgents("SequentialWorkflowBuilder", b.agents); err != nil {
+		return nil, err
+	}
+
+	cfg := Config{}
+	bindings := make([]workflow.ExecutorBinding, len(b.agents))
+	bindingsByAgent := make(map[*agent.Agent]workflow.ExecutorBinding, len(b.agents))
+	for index, currentAgent := range b.agents {
+		binding := New(currentAgent, cfg)
+		bindings[index] = binding
+		bindingsByAgent[currentAgent] = binding
+	}
+
+	bld := applyBuilderMetadata(workflow.NewBuilder(bindings[0]), b.name, b.description)
+	previous := bindings[0]
+	for _, next := range bindings[1:] {
+		bld = bld.AddEdge(previous, next)
+		previous = next
+	}
+	outputMessages := newOutputMessagesBinding()
+	bld = bld.AddEdge(previous, outputMessages)
+	var err error
+	bld, err = applyOutputDesignations(bld, b.outputDesignations, bindingsByAgent, "sequential", func() {
+		bld = bld.WithOutputFrom(outputMessages).WithIntermediateOutputFrom(bindings...)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return bld.Build()
+}
+
+func newOutputMessagesBinding() workflow.ExecutorBinding {
+	return workflow.ExecutorBinding{
+		ID:                                outputMessagesExecutorID,
+		SupportsConcurrentSharedExecution: true,
+		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+			executor := workflow.Executor{
+				ID: outputMessagesExecutorID,
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					return pb.YieldsOutputType(reflect.TypeFor[[]*message.Message]()), nil
+				},
+			}
+			messageworkflow.Configure(&executor, &messageworkflow.Options{
+				StateKey:                 outputMessagesStateKey,
+				DisableAutoSendTurnToken: true,
+				TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, messages []*message.Message) error {
+					return ctx.YieldOutput(messages)
+				},
+			})
+			return &executor, nil
+		},
+	}
+}

--- a/agent/hosting/workflowhosting/sequential_test.go
+++ b/agent/hosting/workflowhosting/sequential_test.go
@@ -221,6 +221,40 @@ func TestSequentialWorkflowBuilder_AgentsRunInOrder(t *testing.T) {
 	}
 }
 
+func TestSequentialWorkflowBuilder_ChainOnlyAgentResponses(t *testing.T) {
+	agents := []*agent.Agent{
+		newDoubleEchoAgent("agent1"),
+		newDoubleEchoAgent("agent2"),
+		newDoubleEchoAgent("agent3"),
+	}
+	wf, err := workflowhosting.NewSequentialWorkflowBuilder(agents...).WithChainOnlyAgentResponses(true).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	const inputText = "abc"
+	events := runBuiltWorkflowWithText(t, wf, inputText)
+	texts := collectOutputTexts(events)
+	want := expectedSequentialChainOnlyDoubleEchoOutputs(len(agents), inputText)
+	if !slices.Equal(texts, want) {
+		t.Fatalf("output texts = %v, want %v", texts, want)
+	}
+
+	resultMessages := collectOutputMessages(events)
+	if gotResultTexts := collectMessageTexts(resultMessages); !slices.Equal(gotResultTexts, []string{want[len(want)-1]}) {
+		t.Fatalf("result texts = %v, want [%s]", gotResultTexts, want[len(want)-1])
+	}
+	if len(resultMessages) != 1 {
+		t.Fatalf("result count = %d, want 1", len(resultMessages))
+	}
+	if resultMessages[0].Role != message.RoleAssistant {
+		t.Fatalf("result[0].Role = %q, want %q", resultMessages[0].Role, message.RoleAssistant)
+	}
+	if resultMessages[0].AuthorName != "agent3" {
+		t.Fatalf("result[0].AuthorName = %q, want agent3", resultMessages[0].AuthorName)
+	}
+}
+
 func expectedSequentialDoubleEchoOutputs(numAgents int, inputText string) []string {
 	transcript := inputText
 	outputs := make([]string, 0, numAgents)
@@ -229,6 +263,18 @@ func expectedSequentialDoubleEchoOutputs(numAgents int, inputText string) []stri
 		outputText := agentID + transcript + transcript
 		outputs = append(outputs, outputText)
 		transcript += outputText
+	}
+	return outputs
+}
+
+func expectedSequentialChainOnlyDoubleEchoOutputs(numAgents int, inputText string) []string {
+	previous := inputText
+	outputs := make([]string, 0, numAgents)
+	for agentNumber := 1; agentNumber <= numAgents; agentNumber++ {
+		agentID := fmt.Sprintf("agent%d", agentNumber)
+		outputText := agentID + previous + previous
+		outputs = append(outputs, outputText)
+		previous = outputText
 	}
 	return outputs
 }

--- a/agent/hosting/workflowhosting/sequential_test.go
+++ b/agent/hosting/workflowhosting/sequential_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowhosting_test
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/hosting/workflowhosting"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+// TestSequentialWorkflowBuilder_ReturnsErrorForNoAgents checks that the
+// sequential builder rejects an empty agent list.
+func TestSequentialWorkflowBuilder_ReturnsErrorForNoAgents(t *testing.T) {
+	_, err := workflowhosting.NewSequentialWorkflowBuilder().Build()
+	if err == nil {
+		t.Fatal("expected error for zero agents, got nil")
+	}
+}
+
+func TestSequentialWorkflowBuilder_ReturnsErrorForNilAgent(t *testing.T) {
+	validAgent := newLabeledEchoAgent("a", "A", "from-a")
+	for _, tt := range []struct {
+		name   string
+		agents []*agent.Agent
+	}{
+		{name: "only_nil", agents: []*agent.Agent{nil}},
+		{name: "second_nil", agents: []*agent.Agent{validAgent, nil}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := workflowhosting.NewSequentialWorkflowBuilder(tt.agents...).Build()
+			if err == nil {
+				t.Fatal("expected error for nil agent, got nil")
+			}
+			if !strings.Contains(err.Error(), "nil") {
+				t.Fatalf("error = %q, want it to mention nil", err.Error())
+			}
+		})
+	}
+}
+
+// TestSequentialWorkflowBuilder_SingleAgent verifies that a single-agent sequential
+// workflow builds successfully and emits the agent's output.
+func TestSequentialWorkflowBuilder_SingleAgent(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	wf, err := workflowhosting.NewSequentialWorkflowBuilder(a).WithName("single-agent").Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if wf.Name() != "single-agent" {
+		t.Fatalf("workflow name = %q, want %q", wf.Name(), "single-agent")
+	}
+
+	texts := collectOutputTexts(runBuiltWorkflow(t, wf))
+	if len(texts) != 1 || texts[0] != "from-a" {
+		t.Errorf("got texts %v, want [from-a]", texts)
+	}
+}
+
+// TestSequentialWorkflowBuilder_MultiAgent verifies that a multi-agent sequential
+// workflow builds successfully and that the last agent's output is emitted.
+func TestSequentialWorkflowBuilder_MultiAgent(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	b := newLabeledEchoAgent("b", "B", "from-b")
+	c := newLabeledEchoAgent("c", "C", "from-c")
+	wf, err := workflowhosting.NewSequentialWorkflowBuilder(a, b, c).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if wf.Name() != "" {
+		t.Fatalf("workflow name = %q, want empty", wf.Name())
+	}
+
+	texts := collectOutputTexts(runBuiltWorkflow(t, wf))
+	// Only the last agent (c) is the output node, so we expect "from-c".
+	if len(texts) == 0 {
+		t.Fatal("expected at least one output text")
+	}
+	last := texts[len(texts)-1]
+	if last != "from-c" {
+		t.Errorf("last output text = %q, want %q", last, "from-c")
+	}
+}
+
+func TestSequentialWorkflowBuilder_ExplicitOutputDesignationSuppressesDefaults(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	b := newLabeledEchoAgent("b", "B", "from-b")
+	wf, err := workflowhosting.NewSequentialWorkflowBuilder(a, b).
+		WithOutputFrom(b).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	wantOutputID := workflowhosting.New(b, workflowhosting.Config{}).ID
+	outputIDs := wf.OutputExecutorIDs()
+	slices.Sort(outputIDs)
+	if !slices.Equal(outputIDs, []string{wantOutputID}) {
+		t.Fatalf("output executor IDs = %v, want [%s]", outputIDs, wantOutputID)
+	}
+
+	events := runBuiltWorkflow(t, wf)
+	texts := collectOutputTexts(events)
+	if !slices.Equal(texts, []string{"from-b"}) {
+		t.Fatalf("output texts = %v, want [from-b]", texts)
+	}
+	if messages := collectOutputMessages(events); len(messages) != 0 {
+		t.Fatalf("terminal aggregator output should be suppressed, got %v", collectMessageTexts(messages))
+	}
+}
+
+func TestSequentialWorkflowBuilder_ExplicitIntermediateDesignationSuppressesDefaults(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	b := newLabeledEchoAgent("b", "B", "from-b")
+	wf, err := workflowhosting.NewSequentialWorkflowBuilder(a, b).
+		WithIntermediateOutputFrom(a).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	wantOutputID := workflowhosting.New(a, workflowhosting.Config{}).ID
+	outputIDs := wf.OutputExecutorIDs()
+	slices.Sort(outputIDs)
+	if !slices.Equal(outputIDs, []string{wantOutputID}) {
+		t.Fatalf("output executor IDs = %v, want [%s]", outputIDs, wantOutputID)
+	}
+	if tags := outputExecutorTags(wf, wantOutputID); len(tags) != 1 || tags[0] != workflow.OutputTagIntermediate {
+		t.Fatalf("tags = %v, want intermediate", tags)
+	}
+	texts := collectOutputTexts(runBuiltWorkflow(t, wf))
+	if !slices.Equal(texts, []string{"from-a"}) {
+		t.Fatalf("output texts = %v, want [from-a]", texts)
+	}
+}
+
+func TestSequentialWorkflowBuilder_ExplicitOutputDesignationRejectsNonParticipant(t *testing.T) {
+	a := newLabeledEchoAgent("a", "A", "from-a")
+	nonParticipant := newLabeledEchoAgent("outside", "Outside", "from-outside")
+
+	for _, testCase := range []struct {
+		name      string
+		configure func(*workflowhosting.SequentialWorkflowBuilder) *workflowhosting.SequentialWorkflowBuilder
+	}{
+		{
+			name: "terminal",
+			configure: func(builder *workflowhosting.SequentialWorkflowBuilder) *workflowhosting.SequentialWorkflowBuilder {
+				return builder.WithOutputFrom(nonParticipant)
+			},
+		},
+		{
+			name: "intermediate",
+			configure: func(builder *workflowhosting.SequentialWorkflowBuilder) *workflowhosting.SequentialWorkflowBuilder {
+				return builder.WithIntermediateOutputFrom(nonParticipant)
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := testCase.configure(workflowhosting.NewSequentialWorkflowBuilder(a)).Build()
+			if err == nil {
+				t.Fatal("expected error for non-participant output designation, got nil")
+			}
+			if !strings.Contains(err.Error(), "not a participant") {
+				t.Fatalf("error = %q, want it to mention not a participant", err.Error())
+			}
+		})
+	}
+}
+
+// TestSequentialWorkflowBuilder_AgentsRunInOrder verifies that each agent receives the
+// accumulated conversation produced by the agents before it.
+func TestSequentialWorkflowBuilder_AgentsRunInOrder(t *testing.T) {
+	for _, numAgents := range []int{1, 2, 3, 4, 5} {
+		t.Run(fmt.Sprintf("%d_agents", numAgents), func(t *testing.T) {
+			agents := make([]*agent.Agent, 0, numAgents)
+			for agentNumber := 1; agentNumber <= numAgents; agentNumber++ {
+				agents = append(agents, newDoubleEchoAgent(fmt.Sprintf("agent%d", agentNumber)))
+			}
+
+			wf, err := workflowhosting.NewSequentialWorkflowBuilder(agents...).Build()
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+
+			for range 3 {
+				const inputText = "abc"
+				events := runBuiltWorkflowWithText(t, wf, inputText)
+				texts := collectOutputTexts(events)
+				want := expectedSequentialDoubleEchoOutputs(numAgents, inputText)
+				if !slices.Equal(texts, want) {
+					t.Fatalf("output texts = %v, want %v", texts, want)
+				}
+
+				resultMessages := collectOutputMessages(events)
+				wantResultTexts := append([]string{inputText}, want...)
+				if gotResultTexts := collectMessageTexts(resultMessages); !slices.Equal(gotResultTexts, wantResultTexts) {
+					t.Fatalf("result texts = %v, want %v", gotResultTexts, wantResultTexts)
+				}
+				if len(resultMessages) != numAgents+1 {
+					t.Fatalf("result count = %d, want %d", len(resultMessages), numAgents+1)
+				}
+				if resultMessages[0].Role != message.RoleUser {
+					t.Fatalf("result[0].Role = %q, want %q", resultMessages[0].Role, message.RoleUser)
+				}
+				for resultIndex, resultMessage := range resultMessages[1:] {
+					wantAuthorName := fmt.Sprintf("agent%d", resultIndex+1)
+					if resultMessage.Role != message.RoleAssistant {
+						t.Fatalf("result[%d].Role = %q, want %q", resultIndex+1, resultMessage.Role, message.RoleAssistant)
+					}
+					if resultMessage.AuthorName != wantAuthorName {
+						t.Fatalf("result[%d].AuthorName = %q, want %q", resultIndex+1, resultMessage.AuthorName, wantAuthorName)
+					}
+				}
+			}
+		})
+	}
+}
+
+func expectedSequentialDoubleEchoOutputs(numAgents int, inputText string) []string {
+	transcript := inputText
+	outputs := make([]string, 0, numAgents)
+	for agentNumber := 1; agentNumber <= numAgents; agentNumber++ {
+		agentID := fmt.Sprintf("agent%d", agentNumber)
+		outputText := agentID + transcript + transcript
+		outputs = append(outputs, outputText)
+		transcript += outputText
+	}
+	return outputs
+}

--- a/agent/hosting/workflowhosting/workflow.go
+++ b/agent/hosting/workflowhosting/workflow.go
@@ -400,7 +400,7 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context, messages []*m
 			return err
 		}
 		if emitUpdates {
-			if err := wctx.AddEvent(workflow.OutputEvent{ExecutorID: h.id, Output: update}); err != nil {
+			if err := wctx.YieldOutput(update); err != nil {
 				return err
 			}
 		}
@@ -418,7 +418,7 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context, messages []*m
 	}
 
 	if h.cfg.EmitResponseEvents {
-		if err := wctx.AddEvent(workflow.OutputEvent{ExecutorID: h.id, Output: &resp}); err != nil {
+		if err := wctx.YieldOutput(&resp); err != nil {
 			return err
 		}
 	}

--- a/agent/hosting/workflowhosting/workflow_test.go
+++ b/agent/hosting/workflowhosting/workflow_test.go
@@ -312,7 +312,7 @@ func collectForwardedResponseMessages(t *testing.T, a *agent.Agent, cfg workflow
 func runHostedAgent(t *testing.T, a *agent.Agent, cfg workflowhosting.Config, token workflow.TurnToken, msgs []*message.Message) []workflow.Event {
 	t.Helper()
 	binding := workflowhosting.New(a, cfg)
-	wf, err := workflow.NewBuilder(binding).Build()
+	wf, err := workflow.NewBuilder(binding).WithOutputFrom(binding).Build()
 	if err != nil {
 		t.Fatalf("build workflow: %v", err)
 	}
@@ -1172,6 +1172,7 @@ func TestHostedAgent_InterceptUserInputRequests(t *testing.T) {
 	wf, err := workflow.NewBuilder(host).
 		AddEdge(host, app).
 		AddEdge(app, host).
+		WithOutputFrom(host).
 		Build()
 	if err != nil {
 		t.Fatalf("build: %v", err)
@@ -1221,6 +1222,7 @@ func TestHostedAgent_InterceptUnterminatedFunctionCalls(t *testing.T) {
 	wf, err := workflow.NewBuilder(host).
 		AddEdge(host, exec).
 		AddEdge(exec, host).
+		WithOutputFrom(host).
 		Build()
 	if err != nil {
 		t.Fatalf("build: %v", err)
@@ -1442,7 +1444,7 @@ func TestHostedAgent_ResetSignal_StartsNewSession(t *testing.T) {
 		agent.Config{ID: testAgentID, Name: testAgentName, DisableFuncAutoCall: true},
 	)
 	host := workflowhosting.New(a, workflowhosting.Config{})
-	wf, err := workflow.NewBuilder(host).Build()
+	wf, err := workflow.NewBuilder(host).WithOutputFrom(host).Build()
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -1496,7 +1498,7 @@ func TestHostedAgent_InterceptDisabled_ResumesWithExternalResponse(t *testing.T)
 		EmitResponseEvents: true,
 	})
 
-	wf, err := workflow.NewBuilder(host).Build()
+	wf, err := workflow.NewBuilder(host).WithOutputFrom(host).Build()
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -1635,7 +1637,7 @@ func TestHostedAgent_InterceptsOnlyUnpairedFunctionCalls_PortMode(t *testing.T) 
 	host := workflowhosting.New(newRequestAgent(unpaired, paired), workflowhosting.Config{
 		EmitResponseEvents: true,
 	})
-	wf, err := workflow.NewBuilder(host).Build()
+	wf, err := workflow.NewBuilder(host).WithOutputFrom(host).Build()
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}

--- a/agent/provider/workflowprovider/workflow_test.go
+++ b/agent/provider/workflowprovider/workflow_test.go
@@ -285,6 +285,79 @@ func TestNew_IncludeOutputsInResponse(t *testing.T) {
 	}
 }
 
+func TestNew_DoesNotIncludeGenericMessageOutputsByDefault(t *testing.T) {
+	binding := workflow.ExecutorBinding{
+		ID:               "message-yielder",
+		ImplementationID: "*workflow.Executor",
+		RawValue:         struct{}{},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return newMessageExecutor(binding.ID, &messageworkflow.Options{
+			StateKey: "message_yielder_msgs",
+			TakeTurnHandler: func(ctx *workflow.Context, _ workflow.TurnToken, _ []*message.Message) error {
+				return ctx.YieldOutput(&message.Message{
+					Role:     message.RoleAssistant,
+					Contents: message.Contents{&message.TextContent{Text: "generic-output"}},
+				})
+			},
+		}), nil
+	}
+	wf, err := workflow.NewBuilder(binding).
+		WithOutputFrom(binding).
+		Build()
+	if err != nil {
+		t.Fatalf("build workflow: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := ag.RunText(t.Context(), "ping").Collect()
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if strings.Contains(resp.String(), "generic-output") {
+		t.Fatalf("generic message output surfaced with IncludeOutputsInResponse=false: %+v", resp)
+	}
+}
+
+func TestNew_ForwardsHostedAgentResponseOutputsByDefault(t *testing.T) {
+	run := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: message.Contents{&message.TextContent{Text: "hosted-response"}},
+			}, nil)
+		}
+	}
+	host := workflowhosting.New(
+		agent.New(
+			agent.ProviderConfig{ProviderName: "hosted-response", Run: run},
+			agent.Config{ID: "hosted-id", Name: "hosted-name", DisableFuncAutoCall: true},
+		),
+		workflowhosting.Config{EmitResponseEvents: true},
+	)
+	wf, err := workflow.NewBuilder(host).
+		WithOutputFrom(host).
+		Build()
+	if err != nil {
+		t.Fatalf("build workflow: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := ag.RunText(t.Context(), "ping").Collect()
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if !strings.Contains(resp.String(), "hosted-response") {
+		t.Fatalf("hosted agent response output was not forwarded by default: %+v", resp)
+	}
+}
+
 func TestNew_ConvertsResponseOutputWithResponseMetadata(t *testing.T) {
 	createdAt := time.Date(2024, 11, 10, 9, 20, 0, 0, time.UTC)
 	binding := workflow.ExecutorBinding{
@@ -1663,7 +1736,7 @@ func TestNew_MatchingResponse_DoesNotCauseExtraTurn(t *testing.T) {
 		requestEmittingAgent("matching-response-call-id", "matchingResponseFunction"),
 		workflowhosting.Config{EmitUpdateEvents: true},
 	)
-	wf, err := workflow.NewBuilder(host).Build()
+	wf, err := workflow.NewBuilder(host).WithOutputFrom(host).Build()
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1731,7 +1804,7 @@ func TestNew_UnmatchedResponse_TriggersTurnAndKeepsProgressing(t *testing.T) {
 		requestEmittingAgent("unmatched-response-call-id", "unmatchedResponseFunction"),
 		workflowhosting.Config{EmitUpdateEvents: true},
 	)
-	wf, err := workflow.NewBuilder(host).Build()
+	wf, err := workflow.NewBuilder(host).WithOutputFrom(host).Build()
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1795,7 +1868,9 @@ func TestNew_MixedResponseAndRegularMessage_CrossExecutorStartExecutorIsReawaken
 		resumeRegularText,
 		resumeProcessed,
 	)
-	wf, err := addCrossExecutorEdges(workflow.NewBuilder(start), start, downstream).Build()
+	wf, err := addCrossExecutorEdges(workflow.NewBuilder(start), start, downstream).
+		WithOutputFrom(downstream).
+		Build()
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1851,7 +1926,9 @@ func TestNew_ResponseOnlyToNonStartExecutor_StartExecutorIsStillActivated(t *tes
 		workflowhosting.Config{EmitUpdateEvents: true},
 	)
 	start := turnTrackingStartExecutorBinding(startExecutorID, downstream.ID, activatedMarker)
-	wf, err := addCrossExecutorEdges(workflow.NewBuilder(start), start, downstream).Build()
+	wf, err := addCrossExecutorEdges(workflow.NewBuilder(start), start, downstream).
+		WithOutputFrom(downstream).
+		Build()
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}

--- a/docs/dotnet-go-sdk-feature-comparison.md
+++ b/docs/dotnet-go-sdk-feature-comparison.md
@@ -72,7 +72,7 @@ Within overlapping features, the main misalignments are API shape and ecosystem 
 | RAG | Basic text RAG, custom vector store RAG, custom data source RAG, Foundry service RAG, Neo4j graph RAG samples. | No RAG package or sample found. | .NET only | Go has data/file/vector content types but no RAG workflow package or samples. |
 | Purview | `Microsoft.Agents.AI.Purview` models and end-to-end sample. | No equivalent package. | .NET only | No Go governance/Purview integration. |
 | Cosmos DB storage | Cosmos chat history provider and workflow checkpoint store. | No built-in Cosmos package. | .NET only | Go only exposes in-memory workflow checkpointing publicly. |
-| Agent workflow builders | Sequential, concurrent, handoff, group chat builders. | `workflowhosting.BuildSequential`, `workflowhosting.BuildConcurrent`; manual builder plus `AddChain`, `AddSwitch`, direct/fan-out/fan-in edges; workflow-as-agent and agents-in-workflows examples. | Partial | Go now has first-class sequential and concurrent builders matching .NET's `AgentWorkflowBuilder.BuildSequential`/`BuildConcurrent`. Handoff and group chat builders are not yet implemented. |
+| Agent workflow builders | Sequential, concurrent, handoff, group chat builders. | `workflowhosting.NewSequentialWorkflowBuilder`, `workflowhosting.NewConcurrentWorkflowBuilder`, `workflowhosting.NewGroupChatWorkflowBuilder`; manual builder plus `AddChain`, `AddSwitch`, direct/fan-out/fan-in edges; workflow-as-agent, group chat, and agents-in-workflows examples. | Partial | Go now has first-class sequential, concurrent, and group chat builders with explicit output designation support. Handoff and Magentic builders are not yet implemented. |
 | Workflow graph builder | `WorkflowBuilder`, direct edges, fan-out, fan-in barrier, labels, conditions, switch/case samples. | `workflow.Builder`, `AddEdge`, `AddDirectEdge`, `AddFanOutEdge`, `AddFanInBarrierEdge`, `WithEdgeLabel`, `WithEdgeAssigner`, `AddSwitch`. | Aligned | .NET has more overloads/extension methods; Go uses simpler methods and option functions. |
 | Workflow executor model | Generic `Executor<TInput>` and `Executor<TInput,TOutput>`, function executors, aggregating executor, protocol builder. | `Executor`, `NewExecutor`, `Executor.Bind`, `Executor.Extend`, `RouteBuilder`, `StatefulExecutorCache`. | Partial | .NET has more overloads and an explicit `AggregatingExecutor`; Go mirrors .NET's executor-level cross-run declaration and binding-level concurrent-run gate, while route configuration and lifecycle hooks live on `Executor`. |
 | Workflow protocol description | Accepts/yields/sends/catch-all protocol descriptor and chat protocol helpers. | `ProtocolDescriptor` exposes accepted, yielded, and sent types plus catch-all acceptance; `messageworkflow.Configure` contributes chat-message protocol metadata. | Aligned | Go now exposes the same protocol shape while keeping chat helpers in the Go-specific message workflow adapter. |
@@ -85,7 +85,7 @@ Within overlapping features, the main misalignments are API shape and ecosystem 
 | Workflow as agent | Workflow host agent / `AsAIAgent`, sample. | `agent/provider/workflowprovider.New`. | Aligned | Go chooses in-process environment based on concurrency; .NET is integrated with `AIAgent` extensions. |
 | Subworkflows | `ConfigureSubWorkflow`, `BindAsExecutor`, subworkflow sample. | `inproc.BindSubworkflowAsExecutor` plus in-process subworkflow execution. | Aligned | Go exposes subworkflow binding from the in-process execution package. |
 | Handoff orchestration | Handoff workflow builder with handoff instructions, tool-call filtering, return-to-previous, response/update events. | No first-class handoff builder. | .NET only | Could be modeled manually with tools/workflows, but no SDK feature. |
-| Group chat orchestration | Group chat manager and group chat workflow builder. | No first-class group chat builder. | .NET only | Go has workflow primitives but not the managed group chat abstraction. |
+| Group chat orchestration | Group chat manager and group chat workflow builder. | `workflowhosting.GroupChatManager`, `workflowhosting.NewRoundRobinGroupChatManager`, `workflowhosting.NewGroupChatWorkflowBuilder`. | Aligned | API shape differs, but Go now has a managed group chat abstraction with manager callbacks and workflow hosting. |
 | Declarative agents | YAML prompt/declarative agent packages, factories, PowerFx helpers. | No equivalent package. | .NET only | Go skills are prompt-like, but not declarative agents. |
 | Declarative workflows | Declarative workflow packages, Foundry/MCP declarative integrations, samples for confirm input, HTTP, code, MCP, function tools, marketing, student/teacher, etc. | No equivalent package. | .NET only | Go workflows are code-first. |
 | Workflow source generators | `Microsoft.Agents.AI.Workflows.Generators`. | No equivalent package. | .NET only | Go relies on generics/reflection without generator tooling. |
@@ -118,7 +118,7 @@ Within overlapping features, the main misalignments are API shape and ecosystem 
 ### Workflows
 
 - Core graph primitives are close: direct, fan-out, fan-in barrier, edge labels, conditions/assigners, output executors, run events, run status, checkpointing, state, and human-in-the-loop request ports.
-- .NET has more convenience builders: sequential/concurrent agent workflows, handoff workflows, group chat workflows, and declarative workflows. Go has first-class sequential/concurrent helpers and subworkflow binding via `workflow/inproc`, while handoff/group-chat/declarative workflows are not first-class public features.
+- .NET has more convenience builders: sequential/concurrent agent workflows, handoff workflows, group chat workflows, and declarative workflows. Go has first-class sequential/concurrent/group chat helpers and subworkflow binding via `workflow/inproc`, while handoff/declarative workflows are not first-class public features.
 - .NET workflow protocol metadata exposes accepted, yielded, sent, and catch-all aspects. Go's public `ProtocolDescriptor` currently exposes accepted input types; output types exist for runtime validation but are not reflected through the same public descriptor.
 - .NET checkpointing supports in-memory, JSON stores, and Cosmos DB. Go supports in-memory checkpointing and resume/restore, but the checkpoint manager interface lives under an internal package, so external custom checkpoint stores are not currently ergonomic as a public SDK feature.
 - .NET Durable Task is a separate durable execution model. Go has no durable equivalent.
@@ -208,7 +208,7 @@ The following Go packages and sample groups were present and accounted for in th
 | `workflow/inproc` | In-process run/streaming/resume/checkpoint execution environments. |
 | `examples/01-get-started` | Hello agent, tools, multi-turn, memory, first workflow. |
 | `examples/02-agents` | Running agents, tools, approvals, structured output, persisted conversation, third-party history, observability, DI-style construction, agent as MCP/tool, images, context providers, compaction, shell environment context, A2A, AGUI, providers, MCP server, skills. |
-| `examples/03-workflows` | Streaming, agents in workflows, patterns, subworkflows, nested subworkflows, checkpoint/resume, concurrent, conditional edges, HITL, loop, shared state. |
+| `examples/03-workflows` | Streaming, agents in workflows, sequential/concurrent/group chat patterns, group chat tool approval, subworkflows, nested subworkflows, checkpoint/resume, concurrent, conditional edges, HITL, loop, shared state. |
 | `examples/05-end-to-end` | A2A client/server. |
 | `examples/demos/chat_cli` | Chat CLI demo. |
 
@@ -218,6 +218,6 @@ The following Go packages and sample groups were present and accounted for in th
 2. Add DevUI or at least workflow visualization/export support that consumes existing reflection metadata.
 3. Add evaluation primitives and samples, starting with local function checks and expected-output/tool-call assertions.
 4. Add declarative agent/workflow support only if Go wants parity with .NET's YAML/PowerFx model; otherwise document the intentional code-first stance.
-5. Add first-class handoff and group chat builders, or document recommended manual workflow patterns.
+5. Add first-class handoff builder support, or document recommended manual workflow patterns.
 6. Expand provider integrations for Foundry, Azure AI Persistent Agents, Copilot Studio, GitHub Copilot, Mem0, Cosmos DB, and Purview if Go intends to match .NET's product surface.
 7. Add OpenAI-compatible, Azure Functions, and richer web hosting adapters if Go should match .NET hosting scenarios.

--- a/examples/03-workflows/01-start-here/03_agent_workflow_patterns/main.go
+++ b/examples/03-workflows/01-start-here/03_agent_workflow_patterns/main.go
@@ -18,7 +18,7 @@ import (
 
 var logger = demo.NewLogger(
 	"Agent Workflow Patterns",
-	"This sample switches between sequential and concurrent agent workflow patterns.",
+	"This sample switches between sequential, concurrent, and group chat agent workflow patterns.",
 	"Model", demo.Deployment,
 )
 
@@ -84,11 +84,18 @@ func buildPattern(pattern string) (*workflow.Workflow, error) {
 
 	switch pattern {
 	case "sequential":
-		return workflowhosting.BuildSequential("", agents...)
+		return workflowhosting.NewSequentialWorkflowBuilder(agents...).Build()
 	case "concurrent":
-		return workflowhosting.BuildConcurrent("", agents...)
+		return workflowhosting.NewConcurrentWorkflowBuilder(agents...).Build()
+	case "groupchat":
+		return workflowhosting.NewGroupChatWorkflowBuilder(func(agents []*agent.Agent) *workflowhosting.GroupChatManager {
+			return workflowhosting.NewRoundRobinGroupChatManager(agents, workflowhosting.RoundRobinGroupChatOptions{MaximumIterationCount: 5})
+		}, agents...).
+			WithName("Translation Round Robin Workflow").
+			WithDescription("A workflow where three translation agents take turns responding in a round-robin fashion.").
+			Build()
 	default:
-		return nil, fmt.Errorf("unknown WORKFLOW_PATTERN %q; use sequential or concurrent", pattern)
+		return nil, fmt.Errorf("unknown WORKFLOW_PATTERN %q; use sequential, concurrent, or groupchat", pattern)
 	}
 }
 

--- a/examples/03-workflows/01-start-here/04_multi_model_service/main.go
+++ b/examples/03-workflows/01-start-here/04_multi_model_service/main.go
@@ -20,11 +20,12 @@ var logger = demo.NewLogger(
 )
 
 func main() {
-	wf, err := workflowhosting.BuildSequential("multi-service-workflow", []*agent.Agent{
+	agents := []*agent.Agent{
 		demo.NewAzureChatAgent("researcher", "Write a concise three-paragraph overview of the user's topic. Include one claim that should be fact checked.", logger),
 		demo.NewAzureChatAgent("fact_checker", "Review the prior essay. Identify supported, questionable, and false claims in concise bullets.", logger),
 		demo.NewAzureChatAgent("reporter", "Write a final single-paragraph summary using only claims that survived the fact check.", logger),
-	}...)
+	}
+	wf, err := workflowhosting.NewSequentialWorkflowBuilder(agents...).WithName("multi-service-workflow").Build()
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/examples/03-workflows/agents/group_chat_tool_approval/main.go
+++ b/examples/03-workflows/agents/group_chat_tool_approval/main.go
@@ -1,0 +1,257 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/hosting/workflowhosting"
+	"github.com/microsoft/agent-framework-go/agent/provider/openaiagent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/tool"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+var logger = demo.NewLogger(
+	"Group Chat Tool Approval",
+	"This sample runs a QA and DevOps group chat where production deployment requires approval.",
+	"Model", demo.Deployment,
+)
+
+type runTestsInput struct {
+	TestSuite string `json:"testSuite"`
+}
+
+type createRollbackPlanInput struct {
+	Version string `json:"version"`
+}
+
+type deployToProductionInput struct {
+	Version    string `json:"version"`
+	Components string `json:"components"`
+}
+
+var runTestsTool = functool.MustNew(functool.Config{
+	Name:        "RunTests",
+	Description: "Run automated tests for the application.",
+}, func(_ context.Context, input runTestsInput) (string, error) {
+	return fmt.Sprintf("Test suite %q completed: 47 passed, 0 failed, 0 skipped", input.TestSuite), nil
+})
+
+var checkStagingStatusTool = functool.MustNew(functool.Config{
+	Name:        "CheckStagingStatus",
+	Description: "Check the current status of the staging environment.",
+}, func(context.Context, struct{}) (string, error) {
+	return "Staging environment: Healthy, Version 2.3.0 deployed, All services running", nil
+})
+
+var createRollbackPlanTool = functool.MustNew(functool.Config{
+	Name:        "CreateRollbackPlan",
+	Description: "Create a rollback plan for the deployment.",
+}, func(_ context.Context, input createRollbackPlanInput) (string, error) {
+	return fmt.Sprintf("Rollback plan created for version %s: Automated rollback to v2.2.0 if health checks fail within 5 minutes", input.Version), nil
+})
+
+var deployToProductionTool = functool.MustNew(functool.Config{
+	Name:        "DeployToProduction",
+	Description: "Deploy specified components to production. Requires human approval.",
+}, func(_ context.Context, input deployToProductionInput) (string, error) {
+	return fmt.Sprintf("Production deployment complete: Version %s, Components: %s", input.Version, input.Components), nil
+})
+
+func main() {
+	qaEngineer := newDeploymentAgent(
+		"QAEngineer",
+		"You are a QA engineer responsible for running tests before deployment. Use RunTests for the release test suite and report the result clearly.",
+		runTestsTool,
+	)
+	devopsEngineer := newDeploymentAgent(
+		"DevOpsEngineer",
+		"You are a DevOps engineer responsible for deployments. Check staging status, create a rollback plan for version 2.4.0, then deploy version 2.4.0 to production. Use the provided tools and report each step.",
+		checkStagingStatusTool,
+		createRollbackPlanTool,
+		tool.ApprovalRequiredFunc(deployToProductionTool),
+	)
+
+	wf, err := workflowhosting.NewGroupChatWorkflowBuilder(newDeploymentGroupChatManager, qaEngineer, devopsEngineer).
+		WithName("Software Deployment Group Chat").
+		Build()
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	demo.Assistant("Starting group chat workflow for software deployment...")
+	demo.Assistantf("Agents: [%s, %s]", qaEngineer.Name(), devopsEngineer.Name())
+
+	ctx := context.Background()
+	run, err := inproc.Default.RunStreaming(ctx, wf, []*message.Message{
+		message.NewText("We need to deploy version 2.4.0 to production. Please coordinate the deployment."),
+	})
+	if err != nil {
+		demo.Panic(err)
+	}
+	defer func() { _ = run.Close(ctx) }()
+
+	emitEvents := true
+	if err := run.SendMessage(ctx, workflow.TurnToken{EmitEvents: &emitEvents}); err != nil {
+		demo.Panic(err)
+	}
+
+	if err := watchDeploymentWorkflow(ctx, run); err != nil {
+		demo.Panic(err)
+	}
+	demo.Assistant("Deployment workflow completed successfully.")
+}
+
+func newDeploymentAgent(name string, instructions string, tools ...tool.Tool) *agent.Agent {
+	return openaiagent.NewChatCompletions(
+		demo.NewAzureOpenAIClient(),
+		openaiagent.Config{
+			Model:        demo.Deployment,
+			Instructions: instructions,
+			Config: agent.Config{
+				Name:        name,
+				Middlewares: []agent.Middleware{logger},
+				Tools:       tools,
+			},
+		},
+	)
+}
+
+func newDeploymentGroupChatManager(agents []*agent.Agent) *workflowhosting.GroupChatManager {
+	manager := &deploymentGroupChatManager{agents: agents}
+	return &workflowhosting.GroupChatManager{
+		SelectNextAgent: manager.selectNextAgent,
+		ShouldTerminate: func(_ context.Context, _ []*message.Message, iterationCount int) (bool, error) {
+			return iterationCount >= 4, nil
+		},
+	}
+}
+
+type deploymentGroupChatManager struct {
+	agents []*agent.Agent
+}
+
+func (m *deploymentGroupChatManager) selectNextAgent(_ context.Context, history []*message.Message) (*agent.Agent, error) {
+	if len(history) == 0 {
+		return nil, fmt.Errorf("conversation is empty; cannot select next speaker")
+	}
+	if !hasAssistantMessage(history) {
+		return m.agentByName("QAEngineer")
+	}
+	return m.agentByName("DevOpsEngineer")
+}
+
+func (m *deploymentGroupChatManager) agentByName(name string) (*agent.Agent, error) {
+	for _, currentAgent := range m.agents {
+		if currentAgent.Name() == name {
+			return currentAgent, nil
+		}
+	}
+	return nil, fmt.Errorf("agent %q is not part of the deployment group chat", name)
+}
+
+func hasAssistantMessage(messages []*message.Message) bool {
+	for _, msg := range messages {
+		if msg.Role == message.RoleAssistant {
+			return true
+		}
+	}
+	return false
+}
+
+func watchDeploymentWorkflow(ctx context.Context, run *inproc.StreamingRun) error {
+	lastExecutorID := ""
+	for evt, err := range run.WatchStream(ctx) {
+		if err != nil {
+			return err
+		}
+		switch e := evt.(type) {
+		case workflow.RequestInfoEvent:
+			if err := approveToolRequest(ctx, run, e.Request); err != nil {
+				return err
+			}
+		case workflow.OutputEvent:
+			if update, ok := e.Output.(*agent.ResponseUpdate); ok {
+				printAgentUpdate(e.ExecutorID, update, &lastExecutorID)
+				continue
+			}
+			if transcript, ok := e.Output.([]*message.Message); ok {
+				printTranscript(transcript)
+			}
+		case workflow.ErrorEvent:
+			return e.Error
+		case workflow.ExecutorFailedEvent:
+			return fmt.Errorf("executor %q failed: %v", e.ExecutorID, e.Error)
+		}
+	}
+	return nil
+}
+
+func approveToolRequest(ctx context.Context, run *inproc.StreamingRun, request *workflow.ExternalRequest) error {
+	approvalRequest, ok := workflow.PortableValueAs[*message.ToolApprovalRequestContent](request.Data)
+	if !ok {
+		return fmt.Errorf("request %q is %T, want *message.ToolApprovalRequestContent", request.RequestID, request.Data.Any())
+	}
+	toolName, arguments := approvalToolCallDetails(approvalRequest.ToolCall)
+	demo.Assistantf("Approval required from %s", request.PortInfo.PortID)
+	demo.Assistantf("Tool: %s", toolName)
+	demo.Assistantf("Arguments: %s", arguments)
+	demo.Assistantf("Tool %s approved", toolName)
+
+	response, err := request.CreateResponse(approvalRequest.CreateResponse(true, "Approved for sample deployment."))
+	if err != nil {
+		return err
+	}
+	return run.SendResponse(ctx, response)
+}
+
+func approvalToolCallDetails(toolCall message.ToolCallContent) (string, string) {
+	switch toolCall := toolCall.(type) {
+	case *message.FunctionCallContent:
+		if toolCall != nil {
+			return toolCall.Name, toolCall.Arguments
+		}
+	case *message.MCPServerToolCallContent:
+		if toolCall != nil {
+			return toolCall.Name, toolCall.Arguments
+		}
+	}
+	return "unknown", ""
+}
+
+func printAgentUpdate(executorID string, update *agent.ResponseUpdate, lastExecutorID *string) {
+	if update == nil {
+		return
+	}
+	if executorID != *lastExecutorID {
+		if *lastExecutorID != "" {
+			fmt.Println()
+		}
+		demo.Assistantf("%s", executorID)
+		*lastExecutorID = executorID
+	}
+	if text := update.String(); strings.TrimSpace(text) != "" {
+		demo.Assistantf("%s", text)
+	}
+}
+
+func printTranscript(messages []*message.Message) {
+	if len(messages) == 0 {
+		return
+	}
+	demo.Assistant("Final transcript:")
+	for _, msg := range messages {
+		name := msg.AuthorName
+		if name == "" {
+			name = string(msg.Role)
+		}
+		demo.Assistantf("%s: %s", name, msg.String())
+	}
+}

--- a/examples/03-workflows/agents/workflow_as_an_agent/main.go
+++ b/examples/03-workflows/agents/workflow_as_an_agent/main.go
@@ -19,7 +19,7 @@ func main() {
 	french := demo.NewAzureChatAgent("French", "Respond in French. Keep the answer concise.", logger)
 	english := demo.NewAzureChatAgent("English", "Respond in English. Keep the answer concise.", logger)
 
-	wf, err := workflowhosting.BuildConcurrent("bilingual-workflow", french, english)
+	wf, err := workflowhosting.NewConcurrentWorkflowBuilder(french, english).WithName("bilingual-workflow").Build()
 	if err != nil {
 		demo.Panic(err)
 	}

--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -28,7 +28,7 @@ type Builder struct {
 	edges                    map[string][]Edge
 	conditionlessConnections []EdgeConnection
 	inputPorts               map[string]RequestPort
-	outputExecutors          map[string]struct{}
+	outputExecutors          map[string]map[OutputTag]struct{}
 	telemetry                *internalobservability.Context
 }
 
@@ -70,6 +70,16 @@ func (wb *Builder) WithTelemetry(tracer workflowobservability.Tracer, options Te
 }
 
 func (wb *Builder) WithOutputFrom(bindings ...ExecutorBinding) *Builder {
+	return wb.withOutputFrom(nil, bindings...)
+}
+
+// WithIntermediateOutputFrom registers bindings as workflow output sources
+// carrying [OutputTagIntermediate].
+func (wb *Builder) WithIntermediateOutputFrom(bindings ...ExecutorBinding) *Builder {
+	return wb.withOutputFrom([]OutputTag{OutputTagIntermediate}, bindings...)
+}
+
+func (wb *Builder) withOutputFrom(tags []OutputTag, bindings ...ExecutorBinding) *Builder {
 	if wb.err != nil {
 		return wb
 	}
@@ -78,9 +88,16 @@ func (wb *Builder) WithOutputFrom(bindings ...ExecutorBinding) *Builder {
 			return wb
 		}
 		if wb.outputExecutors == nil {
-			wb.outputExecutors = make(map[string]struct{})
+			wb.outputExecutors = make(map[string]map[OutputTag]struct{})
 		}
-		wb.outputExecutors[binding.ID] = struct{}{}
+		registeredTags, ok := wb.outputExecutors[binding.ID]
+		if !ok {
+			registeredTags = make(map[OutputTag]struct{})
+			wb.outputExecutors[binding.ID] = registeredTags
+		}
+		for _, tag := range tags {
+			registeredTags[tag] = struct{}{}
+		}
 	}
 	return wb
 }
@@ -224,7 +241,7 @@ func (wb *Builder) build(validateOrphans bool) (*Workflow, error) {
 		edges:            cloneEdges(wb.edges),
 		ports:            maps.Clone(wb.inputPorts),
 		executorBindings: maps.Clone(wb.executorsBindings),
-		outputExecutors:  maps.Clone(wb.outputExecutors),
+		outputExecutors:  cloneOutputExecutors(wb.outputExecutors),
 		telemetry:        telemetry,
 	}
 	internalobservability.SetBuildWorkflowAttributes(activity, observabilityMetadata(wf, ""), workflowTelemetryDefinitionFrom(wf))

--- a/workflow/builder_test.go
+++ b/workflow/builder_test.go
@@ -485,6 +485,62 @@ func TestBuilder_Validation_OutputExecutorNotBound(t *testing.T) {
 	}
 }
 
+func TestBuilder_WithIntermediateOutputFromRegistersTags(t *testing.T) {
+	start := newNoOpExecutor("start")
+	leaf := newNoOpExecutor("leaf")
+
+	wf, err := workflow.NewBuilder(start).
+		AddEdge(start, leaf).
+		WithIntermediateOutputFrom(leaf).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if !wf.HasOutputExecutor("leaf") {
+		t.Fatal("leaf should be registered as an output executor")
+	}
+	tags := outputExecutorTags(wf, "leaf")
+	if len(tags) != 1 || tags[0] != workflow.OutputTagIntermediate {
+		t.Fatalf("tags = %v, want intermediate", tags)
+	}
+	outputEvent := workflow.OutputEvent{ExecutorID: "leaf", Output: "value", Tags: tags}
+	if !outputEvent.HasTag(workflow.OutputTagIntermediate) || !outputEvent.IsIntermediate() {
+		t.Fatalf("OutputEvent did not report intermediate tag: %v", outputEvent.Tags)
+	}
+}
+
+func TestBuilder_OutputTagsAccumulateWithoutDuplicates(t *testing.T) {
+	start := newNoOpExecutor("start")
+	leaf := newNoOpExecutor("leaf")
+
+	wf, err := workflow.NewBuilder(start).
+		AddEdge(start, leaf).
+		WithOutputFrom(leaf).
+		WithIntermediateOutputFrom(leaf).
+		WithIntermediateOutputFrom(leaf).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	tags := outputExecutorTags(wf, "leaf")
+	if len(tags) != 1 || tags[0] != workflow.OutputTagIntermediate {
+		t.Fatalf("tags = %v, want intermediate", tags)
+	}
+}
+
+func outputExecutorTags(wf *workflow.Workflow, executorID string) []workflow.OutputTag {
+	if wf == nil {
+		return nil
+	}
+	tags, ok := wf.OutputExecutors()[executorID]
+	if !ok {
+		return nil
+	}
+	return tags
+}
+
 func TestBuilder_Validation_SelfLoopWarning(t *testing.T) {
 	// A self-loop (executor → itself) is allowed but should log a warning.
 	// We verify it does not produce a build error.

--- a/workflow/event.go
+++ b/workflow/event.go
@@ -2,6 +2,8 @@
 
 package workflow
 
+import "slices"
+
 type Event interface {
 	Data() any
 }
@@ -122,10 +124,21 @@ type OutputEvent struct {
 	// ExecutorID is the unique identifier of the executor that yielded this output.
 	ExecutorID string
 	Output     any
+	Tags       []OutputTag
 }
 
 func (e OutputEvent) Data() any {
 	return e.Output
+}
+
+// HasTag reports whether e carries tag.
+func (e OutputEvent) HasTag(tag OutputTag) bool {
+	return slices.Contains(e.Tags, tag)
+}
+
+// IsIntermediate reports whether e carries [OutputTagIntermediate].
+func (e OutputEvent) IsIntermediate() bool {
+	return e.HasTag(OutputTagIntermediate)
 }
 
 var _ Event = RequestHaltEvent{}

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 
 	"github.com/google/uuid"
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/workflow"
 	"github.com/microsoft/agent-framework-go/workflow/internal/checkpoint"
 	"github.com/microsoft/agent-framework-go/workflow/internal/execution"
@@ -25,8 +26,9 @@ type runnerContext struct {
 	sessionID string
 	tracer    *stepTracer
 
-	edgeMap  *execution.EdgeRunner
-	nextStep atomic.Pointer[execution.StepContext]
+	edgeMap      *execution.EdgeRunner
+	outputFilter *outputFilter
+	nextStep     atomic.Pointer[execution.StepContext]
 
 	executors   map[string]*workflow.Executor
 	executorsMu sync.RWMutex
@@ -79,6 +81,7 @@ func newInProcessRunnerContext(
 	ctx.nextStep.Store(new(execution.StepContext))
 
 	ctx.edgeMap = execution.NewEdgeRunner(wf, tracer, ctx.EnsureExecutor)
+	ctx.outputFilter = newOutputFilter(wf)
 	if enableConcurrentRuns {
 		if !wf.CheckOwnership(existingOwnerSignoff) {
 			return nil, fmt.Errorf("existing ownership does not match check value")
@@ -511,16 +514,7 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 		},
 
 		YieldOutput: func(output any) error {
-			if err := proc.validateOutputType(executorID, output); err != nil {
-				return err
-			}
-			if proc.wf.HasOutputExecutor(executorID) {
-				return proc.AddEvent(boundCtx, workflow.OutputEvent{
-					ExecutorID: executorID,
-					Output:     output,
-				})
-			}
-			return nil
+			return proc.yieldOutput(boundCtx, executorID, output)
 		},
 
 		RequestHalt: func() error {
@@ -593,6 +587,40 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 		},
 
 		ConcurrentRunsEnabled: proc.concurrentRunsEnabled,
+	}
+}
+
+func (proc *runnerContext) yieldOutput(ctx context.Context, executorID string, output any) error {
+	if output == nil {
+		return fmt.Errorf("executor %q cannot output nil", executorID)
+	}
+
+	isAgentResponseShaped := isAgentResponseOutput(output)
+	if isAgentResponseShaped {
+		if _, err := proc.EnsureExecutor(ctx, executorID, nil); err != nil {
+			return err
+		}
+	} else if err := proc.validateOutputType(executorID, output); err != nil {
+		return err
+	}
+
+	tags, ok := proc.outputFilter.tryGetTags(executorID)
+	if !ok {
+		return nil
+	}
+	return proc.AddEvent(ctx, workflow.OutputEvent{
+		ExecutorID: executorID,
+		Output:     output,
+		Tags:       tags,
+	})
+}
+
+func isAgentResponseOutput(output any) bool {
+	switch output.(type) {
+	case *agent.Response, agent.Response, *agent.ResponseUpdate, agent.ResponseUpdate:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/workflow/inproc/outputfilter.go
+++ b/workflow/inproc/outputfilter.go
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package inproc
+
+import (
+	"slices"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+type outputFilter struct {
+	tagsByExecutor map[string][]workflow.OutputTag
+}
+
+func newOutputFilter(wf *workflow.Workflow) *outputFilter {
+	if wf == nil {
+		return &outputFilter{}
+	}
+	return &outputFilter{tagsByExecutor: wf.OutputExecutors()}
+}
+
+func (f *outputFilter) tryGetTags(executorID string) ([]workflow.OutputTag, bool) {
+	if f == nil {
+		return nil, false
+	}
+	tags, ok := f.tagsByExecutor[executorID]
+	if !ok {
+		return nil, false
+	}
+	return slices.Clone(tags), true
+}

--- a/workflow/inproc/routing_test.go
+++ b/workflow/inproc/routing_test.go
@@ -495,6 +495,15 @@ func runWorkflowAndCollect(t *testing.T, wf *workflow.Workflow, input any) []wor
 	return outs
 }
 
+func runWorkflowAndCollectOne(t *testing.T, wf *workflow.Workflow, input any) workflow.OutputEvent {
+	t.Helper()
+	outs := runWorkflowAndCollect(t, wf, input)
+	if len(outs) != 1 {
+		t.Fatalf("expected 1 OutputEvent, got %d: %+v", len(outs), outs)
+	}
+	return outs[0]
+}
+
 func TestOutputFilter_AllowsRegisteredExecutor(t *testing.T) {
 	start := outputFilterExecutor("start")
 	end := outputFilterExecutor("end")
@@ -507,15 +516,33 @@ func TestOutputFilter_AllowsRegisteredExecutor(t *testing.T) {
 		t.Fatalf("build: %v", err)
 	}
 
-	outs := runWorkflowAndCollect(t, wf, "hello")
-	if len(outs) != 1 {
-		t.Fatalf("expected 1 OutputEvent from registered executor, got %d", len(outs))
+	out := runWorkflowAndCollectOne(t, wf, "hello")
+	if out.ExecutorID != "end" {
+		t.Errorf("ExecutorID = %q, want %q", out.ExecutorID, "end")
 	}
-	if outs[0].ExecutorID != "end" {
-		t.Errorf("ExecutorID = %q, want %q", outs[0].ExecutorID, "end")
-	}
-	if got, want := outs[0].Output, any("out:end:hello"); got != want {
+	if got, want := out.Output, any("out:end:hello"); got != want {
 		t.Errorf("Output = %v, want %v", got, want)
+	}
+	if len(out.Tags) != 0 {
+		t.Fatalf("terminal output tags = %v, want none", out.Tags)
+	}
+}
+
+func TestOutputFilter_TagsIntermediateOutput(t *testing.T) {
+	start := outputFilterExecutor("start")
+	end := outputFilterExecutor("end")
+
+	wf, err := workflow.NewBuilder(start).
+		AddEdge(start, end).
+		WithIntermediateOutputFrom(end).
+		Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	out := runWorkflowAndCollectOne(t, wf, "hello")
+	if !out.IsIntermediate() {
+		t.Fatalf("OutputEvent tags = %v, want intermediate", out.Tags)
 	}
 }
 

--- a/workflow/inproc/subworkflow.go
+++ b/workflow/inproc/subworkflow.go
@@ -283,13 +283,7 @@ func (h *subworkflowHostExecutor) forwardWorkflowEvent(ctx *workflow.Context, ev
 }
 
 func (h *subworkflowHostExecutor) yieldOutput(ctx context.Context, output any) error {
-	if err := h.joinContext.validateOutputType(h.id, output); err != nil {
-		return err
-	}
-	if h.joinContext.wf.HasOutputExecutor(h.id) {
-		return h.joinContext.AddEvent(ctx, workflow.OutputEvent{ExecutorID: h.id, Output: output})
-	}
-	return nil
+	return h.joinContext.yieldOutput(ctx, h.id, output)
 }
 
 func (h *subworkflowHostExecutor) qualifyRequestPortID(request *workflow.ExternalRequest) *workflow.ExternalRequest {

--- a/workflow/internal/checkpoint/info.go
+++ b/workflow/internal/checkpoint/info.go
@@ -14,11 +14,11 @@ func (e *executorInfo) matchBinding(executor workflow.ExecutorBinding) bool {
 }
 
 type WorkflowInfo struct {
-	Executors         map[string]executorInfo
-	Edges             map[string][]workflow.EdgeInfo
-	RequestPorts      map[string]workflow.RequestPortInfo
-	StartExecutorID   string
-	OutputExecutorIDs map[string]struct{}
+	Executors       map[string]executorInfo
+	Edges           map[string][]workflow.EdgeInfo
+	RequestPorts    map[string]workflow.RequestPortInfo
+	StartExecutorID string
+	OutputExecutors map[string][]workflow.OutputTag
 }
 
 func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
@@ -40,18 +40,12 @@ func NewWorkflowInfo(wf *workflow.Workflow) WorkflowInfo {
 		requestPorts[info.PortID] = info
 	}
 
-	outputIDs := wf.OutputExecutorIDs()
-	outputs := make(map[string]struct{}, len(outputIDs))
-	for _, id := range outputIDs {
-		outputs[id] = struct{}{}
-	}
-
 	return WorkflowInfo{
-		Executors:         executors,
-		Edges:             edges,
-		RequestPorts:      requestPorts,
-		StartExecutorID:   wf.StartExecutorID(),
-		OutputExecutorIDs: outputs,
+		Executors:       executors,
+		Edges:           edges,
+		RequestPorts:    requestPorts,
+		StartExecutorID: wf.StartExecutorID(),
+		OutputExecutors: wf.OutputExecutors(),
 	}
 }
 
@@ -105,13 +99,30 @@ func (w *WorkflowInfo) Match(wf *workflow.Workflow) bool {
 		}
 	}
 
-	// Validate the outputs
-	outputIDs := wf.OutputExecutorIDs()
-	if len(outputIDs) != len(w.OutputExecutorIDs) {
+	otherOutputs := wf.OutputExecutors()
+	if len(otherOutputs) != len(w.OutputExecutors) {
 		return false
 	}
-	for outputID := range w.OutputExecutorIDs {
-		if !wf.HasOutputExecutor(outputID) {
+	for id, tags := range w.OutputExecutors {
+		otherTags, ok := otherOutputs[id]
+		if !ok || !outputTagsEqual(tags, otherTags) {
+			return false
+		}
+	}
+	return true
+}
+
+func outputTagsEqual(left, right []workflow.OutputTag) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	counts := make(map[workflow.OutputTag]int, len(left))
+	for _, tag := range left {
+		counts[tag]++
+	}
+	for _, tag := range right {
+		counts[tag]--
+		if counts[tag] < 0 {
 			return false
 		}
 	}

--- a/workflow/internal/checkpoint/info_test.go
+++ b/workflow/internal/checkpoint/info_test.go
@@ -3,6 +3,8 @@
 package checkpoint
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/workflow"
@@ -60,5 +62,64 @@ func TestWorkflowInfoMatch_UsesInferredImplementationID(t *testing.T) {
 	}
 	if got := info.Executors["a"].ImplementationID; got != "a" {
 		t.Fatalf("ImplementationID = %q, want a", got)
+	}
+}
+
+func TestWorkflowInfoMatch_RequiresOutputTagsToMatch(t *testing.T) {
+	start := testBinding("a", "test")
+	terminal, err := workflow.NewBuilder(start).
+		WithOutputFrom(start).
+		Build()
+	if err != nil {
+		t.Fatalf("Build terminal: %v", err)
+	}
+	intermediate, err := workflow.NewBuilder(start).
+		WithIntermediateOutputFrom(start).
+		Build()
+	if err != nil {
+		t.Fatalf("Build intermediate: %v", err)
+	}
+
+	info := NewWorkflowInfo(intermediate)
+	if !info.Match(intermediate) {
+		t.Fatal("expected tagged workflow info to match original workflow")
+	}
+	if info.Match(terminal) {
+		t.Fatal("expected tagged workflow info not to match terminal-only workflow")
+	}
+}
+
+func TestWorkflowInfoJSON_RoundTripsTaggedOutputExecutors(t *testing.T) {
+	start := testBinding("a", "test")
+	wf, err := workflow.NewBuilder(start).
+		WithIntermediateOutputFrom(start).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	data, err := json.Marshal(NewWorkflowInfo(wf))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "OutputExecutorIDs") {
+		t.Fatalf("WorkflowInfo JSON should not include OutputExecutorIDs: %s", data)
+	}
+	var raw struct {
+		OutputExecutors map[string][]workflow.OutputTag
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw: %v", err)
+	}
+	if tags := raw.OutputExecutors["a"]; len(tags) != 1 || tags[0] != workflow.OutputTagIntermediate {
+		t.Fatalf("OutputExecutors[a] = %v, want [intermediate]", tags)
+	}
+
+	var got WorkflowInfo
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal WorkflowInfo: %v", err)
+	}
+	if !got.Match(wf) {
+		t.Fatal("expected JSON round-tripped WorkflowInfo to match workflow")
 	}
 }

--- a/workflow/outputtag.go
+++ b/workflow/outputtag.go
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// OutputTag identifies the kind of output represented by an [OutputEvent].
+// Terminal outputs are untagged; intermediate outputs carry [OutputTagIntermediate].
+type OutputTag string
+
+// OutputTagIntermediate marks an output as intermediate rather than terminal.
+const OutputTagIntermediate OutputTag = "intermediate"
+
+// Value returns the string identifier of the tag.
+func (t OutputTag) Value() string {
+	return string(t)
+}
+
+func (t OutputTag) String() string {
+	return string(t)
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (t OutputTag) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(t))
+}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (t *OutputTag) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	if value == "" {
+		return fmt.Errorf("workflow: output tag value cannot be empty")
+	}
+	*t = OutputTag(value)
+	return nil
+}
+
+func cloneOutputExecutors(in map[string]map[OutputTag]struct{}) map[string]map[OutputTag]struct{} {
+	out := make(map[string]map[OutputTag]struct{}, len(in))
+	for id, tags := range in {
+		out[id] = maps.Clone(tags)
+	}
+	return out
+}
+
+func outputTagsFromSet(tags map[OutputTag]struct{}) []OutputTag {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := slices.Collect(maps.Keys(tags))
+	slices.Sort(out)
+	return out
+}

--- a/workflow/telemetry.go
+++ b/workflow/telemetry.go
@@ -35,11 +35,11 @@ func (o TelemetryOptions) observabilityOptions(tracer workflowobservability.Trac
 }
 
 type workflowTelemetryDefinition struct {
-	Executors         map[string]string     `json:"executors"`
-	Edges             map[string][]EdgeInfo `json:"edges"`
-	RequestPorts      []RequestPortInfo     `json:"requestPorts"`
-	StartExecutorID   string                `json:"startExecutorId"`
-	OutputExecutorIDs []string              `json:"outputExecutorIds,omitempty"`
+	Executors       map[string]string      `json:"executors"`
+	Edges           map[string][]EdgeInfo  `json:"edges"`
+	RequestPorts    []RequestPortInfo      `json:"requestPorts"`
+	StartExecutorID string                 `json:"startExecutorId"`
+	OutputExecutors map[string][]OutputTag `json:"outputExecutors,omitempty"`
 }
 
 func workflowTelemetryDefinitionFrom(wf *Workflow) workflowTelemetryDefinition {
@@ -63,17 +63,16 @@ func workflowTelemetryDefinitionFrom(wf *Workflow) workflowTelemetryDefinition {
 		}
 		return 0
 	})
-	outputs := make([]string, 0, len(wf.outputExecutors))
-	for id := range wf.outputExecutors {
-		outputs = append(outputs, id)
+	outputExecutors := make(map[string][]OutputTag, len(wf.outputExecutors))
+	for id, tags := range wf.outputExecutors {
+		outputExecutors[id] = outputTagsFromSet(tags)
 	}
-	slices.Sort(outputs)
 	return workflowTelemetryDefinition{
-		Executors:         executors,
-		Edges:             wf.ReflectEdges(),
-		RequestPorts:      ports,
-		StartExecutorID:   wf.startExecutorID,
-		OutputExecutorIDs: outputs,
+		Executors:       executors,
+		Edges:           wf.ReflectEdges(),
+		RequestPorts:    ports,
+		StartExecutorID: wf.startExecutorID,
+		OutputExecutors: outputExecutors,
 	}
 }
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -139,7 +139,7 @@ type Workflow struct {
 
 	executorBindings map[string]ExecutorBinding
 	edges            map[string][]Edge
-	outputExecutors  map[string]struct{}
+	outputExecutors  map[string]map[OutputTag]struct{}
 	ports            map[string]RequestPort
 
 	needsReset atomic.Bool
@@ -250,6 +250,18 @@ func (w *Workflow) OutputExecutorIDs() []string {
 		return nil
 	}
 	return slices.Collect(maps.Keys(w.outputExecutors))
+}
+
+// OutputExecutors returns workflow output sources with their tag metadata.
+func (w *Workflow) OutputExecutors() map[string][]OutputTag {
+	if w == nil {
+		return nil
+	}
+	out := make(map[string][]OutputTag, len(w.outputExecutors))
+	for id, tags := range w.outputExecutors {
+		out[id] = outputTagsFromSet(tags)
+	}
+	return out
 }
 
 // RequestPort returns the workflow request port with id.


### PR DESCRIPTION
## Summary

Ports microsoft/agent-framework#6045.

- Add tagged workflow output metadata with `OutputTag`, `OutputEvent.Tags`, `WithIntermediateOutputFrom`, and `Workflow.OutputExecutors`, and carry tagged output executors through checkpoint metadata and telemetry.
- Route in-process `YieldOutput` through a cached workflow output filter by default, while still allowing agent response-shaped outputs to bypass declared output type validation; subworkflow output forwarding uses the same path.
- Replace the removed `BuildSequential` / `BuildConcurrent` helpers with fluent sequential and concurrent workflow builders, and add first-class group chat workflow hosting with `GroupChatManager`, `NewRoundRobinGroupChatManager`, and `NewGroupChatWorkflowBuilder`.
- Update hosted-agent workflow output behavior, workflow-as-agent response handling tests, builder tests, checkpoint/output filter tests, docs, and workflow examples, including a group chat workflow pattern and group chat tool approval sample.

## Tests

- `go test ./workflow/... ./agent/hosting/workflowhosting ./agent/provider/workflowprovider`
- `go test ./examples/03-workflows/...`
- `go test ./...`