### PR TITLE
Align workflow runner parity with .NET

### DIFF
--- a/agent/hosting/workflowhosting/builders.go
+++ b/agent/hosting/workflowhosting/builders.go
@@ -4,6 +4,7 @@ package workflowhosting
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/workflow"
@@ -89,10 +90,10 @@ func agentNameForError(a *agent.Agent) string {
 }
 
 func applyBuilderMetadata(bld *workflow.Builder, name string, description string) *workflow.Builder {
-	if name != "" {
+	if strings.TrimSpace(name) != "" {
 		bld = bld.WithName(name)
 	}
-	if description != "" {
+	if strings.TrimSpace(description) != "" {
 		bld = bld.WithDescription(description)
 	}
 	return bld

--- a/agent/hosting/workflowhosting/groupchat.go
+++ b/agent/hosting/workflowhosting/groupchat.go
@@ -556,6 +556,19 @@ func prefixingWorkflowContext(inner *workflow.Context, prefix string) *workflow.
 			return inner.QueueStateUpdate(wrap(key), scope, value)
 		}
 	}
+	if inner.QueueClearScope != nil && inner.ReadStateKeys != nil && inner.QueueStateUpdate != nil {
+		wrapped.QueueClearScope = func(scope string) error {
+			for key, err := range wrapped.ReadStateKeys(scope) {
+				if err != nil {
+					return err
+				}
+				if err := wrapped.QueueStateUpdate(key, scope, nil); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
 	return &wrapped
 }
 

--- a/agent/provider/workflowprovider/message_merger.go
+++ b/agent/provider/workflowprovider/message_merger.go
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package workflowprovider
+
+import (
+	"cmp"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+type messageMerger struct {
+	states        map[string]*responseMergeState
+	stateOrder    []string
+	danglingState responseMergeState
+}
+
+func newMessageMerger() *messageMerger {
+	return &messageMerger{
+		states: make(map[string]*responseMergeState),
+	}
+}
+
+func (m *messageMerger) AddUpdate(update *agent.ResponseUpdate) {
+	if update == nil {
+		return
+	}
+	if update.ResponseID == "" {
+		m.danglingState.addDangling(update)
+		return
+	}
+	state, ok := m.states[update.ResponseID]
+	if !ok {
+		state = &responseMergeState{responseID: update.ResponseID}
+		m.states[update.ResponseID] = state
+		m.stateOrder = append(m.stateOrder, update.ResponseID)
+	}
+	state.addUpdate(update)
+}
+
+func (m *messageMerger) ComputeMerged(primaryResponseID string, primaryAgentID string, primaryAgentName string) *agent.Response {
+	var messages []*message.Message
+	agentIDs := make(map[string]struct{})
+	finishReasons := make(map[string]struct{})
+	var additionalProperties map[string]any
+
+	for _, responseID := range m.stateOrder {
+		state := m.states[responseID]
+		responses := state.computeResponses()
+		slices.SortFunc(responses, compareResponsesByCreatedAt)
+		merged := mergeResponseList(responses)
+		if merged == nil {
+			continue
+		}
+		if merged.AgentID != "" {
+			agentIDs[merged.AgentID] = struct{}{}
+		}
+		if merged.FinishReason != "" {
+			finishReasons[merged.FinishReason] = struct{}{}
+		}
+		additionalProperties = mergeProperties(additionalProperties, merged.AdditionalProperties)
+		messages = append(messages, messagesWithCreatedAt(merged)...)
+	}
+
+	messages = append(messages, m.danglingState.computeFlattened()...)
+	messages = cleanupMergedMessages(messages)
+
+	response := &agent.Response{
+		ID:                   primaryResponseID,
+		CreatedAt:            time.Now(),
+		Messages:             messages,
+		AdditionalProperties: additionalProperties,
+	}
+	if primaryAgentID != "" {
+		response.AgentID = primaryAgentID
+	} else if primaryAgentName != "" {
+		response.AgentID = primaryAgentName
+	} else if len(agentIDs) == 1 {
+		response.AgentID = slices.Collect(maps.Keys(agentIDs))[0]
+	}
+	if len(finishReasons) == 1 {
+		response.FinishReason = slices.Collect(maps.Keys(finishReasons))[0]
+	}
+	return response
+}
+
+type responseMergeState struct {
+	responseID         string
+	updatesByMessageID map[string][]*agent.ResponseUpdate
+	messageOrder       []string
+	danglingUpdates    []*agent.ResponseUpdate
+}
+
+func (s *responseMergeState) addUpdate(update *agent.ResponseUpdate) {
+	if update.MessageID == "" {
+		s.addDangling(update)
+		return
+	}
+	if s.updatesByMessageID == nil {
+		s.updatesByMessageID = make(map[string][]*agent.ResponseUpdate)
+	}
+	if _, ok := s.updatesByMessageID[update.MessageID]; !ok {
+		s.messageOrder = append(s.messageOrder, update.MessageID)
+	}
+	s.updatesByMessageID[update.MessageID] = append(s.updatesByMessageID[update.MessageID], update)
+}
+
+func (s *responseMergeState) addDangling(update *agent.ResponseUpdate) {
+	s.danglingUpdates = append(s.danglingUpdates, update)
+}
+
+func (s *responseMergeState) computeResponses() []*agent.Response {
+	responses := make([]*agent.Response, 0, len(s.messageOrder)+1)
+	for _, messageID := range s.messageOrder {
+		responses = append(responses, responseFromUpdates(s.updatesByMessageID[messageID]))
+	}
+	if len(s.danglingUpdates) > 0 {
+		responses = append(responses, responseFromUpdates(s.danglingUpdates))
+	}
+	return responses
+}
+
+func (s *responseMergeState) computeFlattened() []*message.Message {
+	var messages []*message.Message
+	for _, response := range s.computeResponses() {
+		messages = append(messages, response.Messages...)
+	}
+	return messages
+}
+
+func responseFromUpdates(updates []*agent.ResponseUpdate) *agent.Response {
+	response := &agent.Response{}
+	for _, update := range updates {
+		response.Update(update)
+	}
+	response.Coalesce()
+	return response
+}
+
+func compareResponsesByCreatedAt(left, right *agent.Response) int {
+	leftZero := left == nil || left.CreatedAt.IsZero()
+	rightZero := right == nil || right.CreatedAt.IsZero()
+	switch {
+	case leftZero && rightZero:
+		return 0
+	case leftZero:
+		return 1
+	case rightZero:
+		return -1
+	default:
+		return left.CreatedAt.Compare(right.CreatedAt)
+	}
+}
+
+func mergeResponseList(responses []*agent.Response) *agent.Response {
+	var current *agent.Response
+	for _, incoming := range responses {
+		if incoming == nil {
+			continue
+		}
+		if current == nil {
+			clone := *incoming
+			clone.AdditionalProperties = maps.Clone(incoming.AdditionalProperties)
+			clone.Messages = slices.Clone(incoming.Messages)
+			current = &clone
+			continue
+		}
+		current.AgentID = cmp.Or(incoming.AgentID, current.AgentID)
+		current.AdditionalProperties = mergeProperties(current.AdditionalProperties, incoming.AdditionalProperties)
+		if !incoming.CreatedAt.IsZero() {
+			current.CreatedAt = incoming.CreatedAt
+		}
+		current.FinishReason = cmp.Or(incoming.FinishReason, current.FinishReason)
+		current.Messages = append(current.Messages, incoming.Messages...)
+		current.ID = cmp.Or(current.ID, incoming.ID)
+	}
+	return current
+}
+
+func messagesWithCreatedAt(response *agent.Response) []*message.Message {
+	if response == nil {
+		return nil
+	}
+	messages := make([]*message.Message, 0, len(response.Messages))
+	for _, msg := range response.Messages {
+		clone := msg.Clone()
+		if clone != nil && !response.CreatedAt.IsZero() {
+			clone.CreatedAt = response.CreatedAt
+		}
+		messages = append(messages, clone)
+	}
+	return messages
+}
+
+func mergeProperties(current, incoming map[string]any) map[string]any {
+	if current == nil {
+		return maps.Clone(incoming)
+	}
+	if incoming == nil {
+		return current
+	}
+	merged := maps.Clone(current)
+	maps.Copy(merged, incoming)
+	return merged
+}
+
+func cleanupMergedMessages(messages []*message.Message) []*message.Message {
+	keptMessages := messages[:0]
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		keptContents := msg.Contents[:0]
+		for _, content := range msg.Contents {
+			if text, ok := content.(*message.TextContent); ok && strings.TrimSpace(text.Text) == "" {
+				continue
+			}
+			keptContents = append(keptContents, content)
+		}
+		clear(msg.Contents[len(keptContents):])
+		msg.Contents = keptContents
+		if len(msg.Contents) == 0 {
+			continue
+		}
+		keptMessages = append(keptMessages, msg)
+	}
+	clear(messages[len(keptMessages):])
+	return keptMessages
+}

--- a/agent/provider/workflowprovider/workflow.go
+++ b/agent/provider/workflowprovider/workflow.go
@@ -44,9 +44,9 @@ type Config struct {
 
 	// IncludeOutputsInResponse, if true, surfaces [workflow.OutputEvent]
 	// payloads in the agent response stream when the payload is a
-	// [*message.Message] or [[]*message.Message]. By default outputs are
-	// observed only when they contain [*agent.ResponseUpdate] or [*agent.Response]
-	// payloads emitted by hosted agents inside the workflow.
+	// [*message.Message], [[]*message.Message], or [*agent.Response]. By
+	// default, only [*agent.ResponseUpdate] payloads emitted by hosted agents
+	// inside the workflow are surfaced as response content.
 	IncludeOutputsInResponse bool
 
 	// IncludeErrorDetails, if true, surfaces the full error message from
@@ -66,6 +66,12 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 	if wf == nil {
 		return nil, errors.New("workflow cannot be nil")
 	}
+	if cfg.ID == "" {
+		cfg.ID = uuid.NewString()
+	}
+	agentID := cfg.ID
+	agentName := cfg.Name
+
 	descriptor, err := wf.DescribeProtocol()
 	if err != nil {
 		return nil, fmt.Errorf("workflow start executor protocol could not be determined: %w", err)
@@ -87,6 +93,18 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 	runFn := func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
 			responseID := uuid.NewString()
+			stream, _ := agent.GetOption(options, agent.Stream)
+			merger := newMessageMerger()
+			emitUpdate := func(update *agent.ResponseUpdate) bool {
+				if update == nil {
+					return true
+				}
+				merger.AddUpdate(update)
+				if !stream {
+					return true
+				}
+				return yield(update, nil)
+			}
 
 			sess, _ := agent.GetOption(options, agent.WithSession)
 			if sess != nil && sess.ServiceID() == "" {
@@ -151,21 +169,24 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 					if e.CompletionInfo != nil && e.CompletionInfo.CheckpointInfo != nil {
 						state.lastCheckpoint = e.CompletionInfo.CheckpointInfo
 					}
-					if !yield(newUpdate(responseID, e), nil) {
+					if !emitUpdate(newUpdate(responseID, e)) {
 						return
 					}
 				case workflow.OutputEvent:
 					switch out := e.Output.(type) {
 					case *agent.ResponseUpdate:
-						if !yield(stampUpdate(out, responseID, e), nil) {
+						if !emitUpdate(stampUpdate(out, responseID, e)) {
 							return
 						}
 					case *agent.Response:
+						if !cfg.IncludeOutputsInResponse {
+							continue
+						}
 						if out == nil {
 							continue
 						}
-						for _, update := range out.ToUpdates() {
-							if !yield(stampUpdate(update, responseID, e), nil) {
+						for _, msg := range out.Messages {
+							if !emitUpdate(messageToUpdate(msg, responseID, e)) {
 								return
 							}
 						}
@@ -173,7 +194,7 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 						if !cfg.IncludeOutputsInResponse {
 							continue
 						}
-						if !yield(messageToUpdate(out, responseID, e), nil) {
+						if !emitUpdate(messageToUpdate(out, responseID, e)) {
 							return
 						}
 					case []*message.Message:
@@ -181,7 +202,7 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 							continue
 						}
 						for _, msg := range out {
-							if !yield(messageToUpdate(msg, responseID, e), nil) {
+							if !emitUpdate(messageToUpdate(msg, responseID, e)) {
 								return
 							}
 						}
@@ -190,33 +211,40 @@ func New(wf *workflow.Workflow, cfg Config) (*agent.Agent, error) {
 					update, contentID, pending, ok, err := requestToUpdate(e.Request, responseID, e)
 					if err != nil {
 						update := newUpdate(responseID, e, workflowErrorContent(err, cfg.IncludeErrorDetails))
-						if !yield(update, nil) {
+						if !emitUpdate(update) {
 							return
 						}
 						continue
 					}
 					if !ok {
-						if !yield(newUpdate(responseID, e), nil) {
+						if !emitUpdate(newUpdate(responseID, e)) {
 							return
 						}
 						continue
 					}
 					state.pending[contentID] = pending
-					if !yield(update, nil) {
+					if !emitUpdate(update) {
 						return
 					}
 				case workflow.ErrorEvent:
 					update := newUpdate(responseID, e, workflowErrorContent(e.Error, cfg.IncludeErrorDetails))
-					if !yield(update, nil) {
+					if !emitUpdate(update) {
 						return
 					}
 				case workflow.ExecutorFailedEvent:
 					update := newUpdate(responseID, e, workflowErrorContent(e.Error, cfg.IncludeErrorDetails))
-					if !yield(update, nil) {
+					if !emitUpdate(update) {
 						return
 					}
 				default:
-					if !yield(newUpdate(responseID, e), nil) {
+					if !emitUpdate(newUpdate(responseID, e)) {
+						return
+					}
+				}
+			}
+			if !stream {
+				for _, update := range merger.ComputeMerged(responseID, agentID, agentName).ToUpdates() {
+					if !yield(update, nil) {
 						return
 					}
 				}
@@ -463,11 +491,10 @@ func messageToUpdate(m *message.Message, responseID string, raw any) *agent.Resp
 		return newUpdate(responseID, raw)
 	}
 	return stampUpdate(&agent.ResponseUpdate{
-		Role:       m.Role,
-		Contents:   m.Contents,
-		AuthorName: m.AuthorName,
-		MessageID:  m.ID,
-		CreatedAt:  m.CreatedAt,
+		Role:      m.Role,
+		Contents:  m.Contents,
+		MessageID: m.ID,
+		CreatedAt: m.CreatedAt,
 	}, responseID, raw)
 }
 

--- a/agent/provider/workflowprovider/workflow_test.go
+++ b/agent/provider/workflowprovider/workflow_test.go
@@ -192,7 +192,7 @@ func TestNew_SerializedSessionResumesFromCheckpoint(t *testing.T) {
 	}
 }
 
-func TestNew_EmitsDefaultUpdatesForUnhandledWorkflowEvents(t *testing.T) {
+func TestNew_StreamsUpdatesForUnhandledWorkflowEvents(t *testing.T) {
 	binding := echoExecutorBinding("echo")
 	wf, err := workflow.NewBuilder(binding).Build()
 	if err != nil {
@@ -204,7 +204,7 @@ func TestNew_EmitsDefaultUpdatesForUnhandledWorkflowEvents(t *testing.T) {
 	}
 
 	var sawUnhandled bool
-	for update, err := range ag.RunText(t.Context(), "ping") {
+	for update, err := range ag.RunText(t.Context(), "ping", agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("RunText: %v", err)
 		}
@@ -220,6 +220,28 @@ func TestNew_EmitsDefaultUpdatesForUnhandledWorkflowEvents(t *testing.T) {
 	}
 	if !sawUnhandled {
 		t.Fatalf("expected a raw-only update for an unhandled workflow event")
+	}
+}
+
+func TestNew_CollectDropsRawOnlyWorkflowEventMessages(t *testing.T) {
+	binding := echoExecutorBinding("echo")
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("build workflow: %v", err)
+	}
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := ag.RunText(t.Context(), "ping").Collect()
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	for index, msg := range resp.Messages {
+		if len(msg.Contents) == 0 {
+			t.Fatalf("message %d has no contents after collect: %+v", index, msg)
+		}
 	}
 }
 
@@ -322,7 +344,7 @@ func TestNew_DoesNotIncludeGenericMessageOutputsByDefault(t *testing.T) {
 	}
 }
 
-func TestNew_ForwardsHostedAgentResponseOutputsByDefault(t *testing.T) {
+func TestNew_GatesHostedAgentResponseOutputsByDefault(t *testing.T) {
 	run := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
 			yield(&agent.ResponseUpdate{
@@ -349,16 +371,38 @@ func TestNew_ForwardsHostedAgentResponseOutputsByDefault(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	resp, err := ag.RunText(t.Context(), "ping").Collect()
-	if err != nil {
-		t.Fatalf("RunText: %v", err)
+	for update, err := range ag.RunText(t.Context(), "ping") {
+		if err != nil {
+			t.Fatalf("RunText: %v", err)
+		}
+		if raw, ok := update.RawRepresentation.(workflow.OutputEvent); ok {
+			if _, isResponse := raw.Output.(*agent.Response); isResponse {
+				t.Fatalf("aggregated hosted agent response output was forwarded by default: %+v", update)
+			}
+		}
 	}
-	if !strings.Contains(resp.String(), "hosted-response") {
-		t.Fatalf("hosted agent response output was not forwarded by default: %+v", resp)
+
+	included, err := workflowprovider.New(wf, workflowprovider.Config{IncludeOutputsInResponse: true})
+	if err != nil {
+		t.Fatalf("New included: %v", err)
+	}
+	var sawResponseOutput bool
+	for update, err := range included.RunText(t.Context(), "ping") {
+		if err != nil {
+			t.Fatalf("RunText included: %v", err)
+		}
+		if raw, ok := update.RawRepresentation.(workflow.OutputEvent); ok {
+			if _, isResponse := raw.Output.(*agent.Response); isResponse {
+				sawResponseOutput = true
+			}
+		}
+	}
+	if !sawResponseOutput {
+		t.Fatalf("aggregated hosted agent response output was not forwarded when included")
 	}
 }
 
-func TestNew_ConvertsResponseOutputWithResponseMetadata(t *testing.T) {
+func TestNew_ConvertsResponseOutputAsMessageUpdates(t *testing.T) {
 	createdAt := time.Date(2024, 11, 10, 9, 20, 0, 0, time.UTC)
 	binding := workflow.ExecutorBinding{
 		ID:               "response-yielder",
@@ -394,50 +438,43 @@ func TestNew_ConvertsResponseOutputWithResponseMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build workflow: %v", err)
 	}
-	ag, err := workflowprovider.New(wf, workflowprovider.Config{})
+	ag, err := workflowprovider.New(wf, workflowprovider.Config{
+		Config:                   agent.Config{ID: "workflow-agent", Name: "Workflow Agent"},
+		IncludeOutputsInResponse: true,
+	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 
 	var sawMessage bool
-	var sawMetadata bool
 	for update, err := range ag.RunText(t.Context(), "ping") {
 		if err != nil {
 			t.Fatalf("RunText: %v", err)
 		}
 		if update.String() == "from-response" {
 			sawMessage = true
-			if update.AgentID != "inner-agent" {
-				t.Errorf("expected AgentID inner-agent, got %q", update.AgentID)
+			if update.AgentID != "workflow-agent" {
+				t.Errorf("expected workflow agent ID, got %q", update.AgentID)
 			}
-			if update.ResponseID != "inner-response" {
-				t.Errorf("expected ResponseID inner-response, got %q", update.ResponseID)
+			if update.ResponseID == "" || update.ResponseID == "inner-response" {
+				t.Errorf("expected workflow response ID, got %q", update.ResponseID)
 			}
 			if update.MessageID != "inner-message" {
 				t.Errorf("expected MessageID inner-message, got %q", update.MessageID)
 			}
-			if update.AuthorName != "inner-author" {
-				t.Errorf("expected AuthorName inner-author, got %q", update.AuthorName)
+			if update.AuthorName != "Workflow Agent" {
+				t.Errorf("expected workflow agent AuthorName, got %q", update.AuthorName)
 			}
-			if !update.CreatedAt.Equal(createdAt) {
-				t.Errorf("expected CreatedAt %v, got %v", createdAt, update.CreatedAt)
+			if update.CreatedAt.IsZero() || update.CreatedAt.Equal(createdAt) {
+				t.Errorf("expected workflow-created timestamp, got %v", update.CreatedAt)
 			}
-		}
-		if update.AdditionalProperties["trace"] == "kept" {
-			sawMetadata = true
-			if update.AgentID != "inner-agent" {
-				t.Errorf("expected metadata AgentID inner-agent, got %q", update.AgentID)
-			}
-			if update.ResponseID != "inner-response" {
-				t.Errorf("expected metadata ResponseID inner-response, got %q", update.ResponseID)
+			if update.AdditionalProperties != nil {
+				t.Errorf("expected no response-level additional properties, got %v", update.AdditionalProperties)
 			}
 		}
 	}
 	if !sawMessage {
 		t.Fatalf("expected response message update")
-	}
-	if !sawMetadata {
-		t.Fatalf("expected response metadata update")
 	}
 }
 

--- a/agent/response.go
+++ b/agent/response.go
@@ -97,6 +97,7 @@ func (resp *Response) Usage() message.UsageDetails {
 	return usage
 }
 
+// Coalesce merges adjacent compatible content items within each message.
 func (resp *Response) Coalesce() {
 	for _, msg := range resp.Messages {
 		msg.Contents = message.CoalesceContents(msg.Contents)

--- a/agent/response_test.go
+++ b/agent/response_test.go
@@ -453,6 +453,46 @@ func TestResponse_Update_RawRepresentation(t *testing.T) {
 	}
 }
 
+func TestResponse_Coalesce_PreservesEmptyMessagesAndWhitespaceText(t *testing.T) {
+	resp := &agent.Response{}
+	resp.Update(&agent.ResponseUpdate{
+		MessageID:         "metadata-only",
+		RawRepresentation: "raw",
+	})
+	resp.Update(&agent.ResponseUpdate{
+		MessageID: "whitespace",
+		Contents:  message.Contents{&message.TextContent{Text: "  \t\n"}},
+	})
+	resp.Update(&agent.ResponseUpdate{
+		MessageID: "content",
+		Contents:  message.Contents{&message.TextContent{Text: "kept"}},
+	})
+
+	resp.Coalesce()
+
+	if len(resp.Messages) != 3 {
+		t.Fatalf("message count = %d, want 3", len(resp.Messages))
+	}
+	if got := resp.Messages[0].ID; got != "metadata-only" {
+		t.Fatalf("message 0 ID = %q, want metadata-only", got)
+	}
+	if len(resp.Messages[0].Contents) != 0 {
+		t.Fatalf("message 0 contents count = %d, want 0", len(resp.Messages[0].Contents))
+	}
+	if got := resp.Messages[1].ID; got != "whitespace" {
+		t.Fatalf("message 1 ID = %q, want whitespace", got)
+	}
+	if got := resp.Messages[1].Contents.Text(); got != "  \t\n" {
+		t.Fatalf("message 1 text = %q, want whitespace", got)
+	}
+	if got := resp.Messages[2].ID; got != "content" {
+		t.Fatalf("message 2 ID = %q, want content", got)
+	}
+	if got := resp.Messages[2].Contents.Text(); got != "kept" {
+		t.Fatalf("message 2 text = %q, want kept", got)
+	}
+}
+
 func TestResponse_Update_PreferLatestValues(t *testing.T) {
 	resp := &agent.Response{}
 

--- a/workflow/inproc/binding_test.go
+++ b/workflow/inproc/binding_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/workflow"
 	"github.com/microsoft/agent-framework-go/workflow/inproc"
 )
@@ -587,6 +589,65 @@ func TestWorkflowOutput_RejectsValueNotAssignableToDeclaredOutputType(t *testing
 	}
 	if outputs := outputEvents(events); len(outputs) != 0 {
 		t.Fatalf("output count = %d, want 0; outputs: %#v", len(outputs), outputs)
+	}
+}
+
+func TestWorkflowOutput_AgentResponseUsesOutputFilter(t *testing.T) {
+	binding := workflow.ExecutorBinding{
+		ID:               "agent-output",
+		ImplementationID: "*workflow.Executor",
+		RawValue:         struct{}{},
+	}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: binding.ID,
+
+			DisableAutoSendMessageHandlerResultObject: true,
+			DisableAutoYieldOutputHandlerResultObject: true,
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(wctx *workflow.Context, _ any) (any, error) {
+					return nil, wctx.YieldOutput(&agent.Response{
+						Messages: []*message.Message{{
+							Role:     message.RoleAssistant,
+							Contents: message.Contents{&message.TextContent{Text: "agent output"}},
+						}},
+					})
+				})
+				return rb, nil
+			},
+		}, nil
+	}
+
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	events := runAndCollectEvents(t, wf, "input")
+	if errors := errorEvents(events); len(errors) != 0 {
+		t.Fatalf("unexpected error events: %#v", errors)
+	}
+	if outputs := outputEvents(events); len(outputs) != 0 {
+		t.Fatalf("output count = %d, want 0 without output designation; outputs: %#v", len(outputs), outputs)
+	}
+
+	wf, err = workflow.NewBuilder(binding).WithIntermediateOutputFrom(binding).Build()
+	if err != nil {
+		t.Fatalf("Build with output: %v", err)
+	}
+	events = runAndCollectEvents(t, wf, "input")
+	if errors := errorEvents(events); len(errors) != 0 {
+		t.Fatalf("unexpected error events with output: %#v", errors)
+	}
+	outputs := outputEvents(events)
+	if len(outputs) != 1 {
+		t.Fatalf("output count = %d, want 1 with output designation; outputs: %#v", len(outputs), outputs)
+	}
+	if _, ok := outputs[0].Output.(*agent.Response); !ok {
+		t.Fatalf("OutputEvent.Output = %T, want *agent.Response", outputs[0].Output)
+	}
+	if !outputs[0].IsIntermediate() {
+		t.Fatalf("OutputEvent tags = %v, want intermediate", outputs[0].Tags)
 	}
 }
 

--- a/workflow/inproc/checkpoint_test.go
+++ b/workflow/inproc/checkpoint_test.go
@@ -377,10 +377,24 @@ func TestCheckpoint_RestoreClearsQueuedExternalResponsesBeforeImport(t *testing.
 	}
 }
 
-func TestCheckpoint_RestoreClearsExecutorInstancesBeforeImport(t *testing.T) {
+func TestCheckpoint_RestorePreservesExecutorInstancesDuringImport(t *testing.T) {
 	ctx := context.Background()
 	manager := checkpoint.NewInMemoryManager()
 	var nextInstanceID int64
+	type counterOutput struct {
+		InstanceID int64
+		Count      int
+	}
+	lastCounterOutput := func(events func(func(workflow.Event) bool)) counterOutput {
+		t.Helper()
+		var got counterOutput
+		for evt := range events {
+			if out, ok := evt.(workflow.OutputEvent); ok {
+				got = out.Output.(counterOutput)
+			}
+		}
+		return got
+	}
 	binding := workflow.ExecutorBinding{
 		ID:               "counter",
 		ImplementationID: "*workflow.Executor",
@@ -391,16 +405,10 @@ func TestCheckpoint_RestoreClearsExecutorInstancesBeforeImport(t *testing.T) {
 				ID: "counter",
 
 				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
-					rb.YieldsOutputType(reflect.TypeFor[struct {
-						InstanceID int64
-						Count      int
-					}]())
+					rb.YieldsOutputType(reflect.TypeFor[counterOutput]())
 					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
 						count++
-						return nil, ctx.YieldOutput(struct {
-							InstanceID int64
-							Count      int
-						}{InstanceID: instanceID, Count: count})
+						return nil, ctx.YieldOutput(counterOutput{InstanceID: instanceID, Count: count})
 					})
 					return rb, nil
 				},
@@ -420,10 +428,20 @@ func TestCheckpoint_RestoreClearsExecutorInstancesBeforeImport(t *testing.T) {
 	if !ok {
 		t.Fatal("expected checkpoint")
 	}
+	first := lastCounterOutput(run.NewEvents())
+	if first.Count != 1 {
+		t.Fatalf("first count = %d, want 1", first.Count)
+	}
+
 	if _, err := run.Resume(ctx, "second"); err != nil {
 		t.Fatalf("Resume second: %v", err)
 	}
-	for range run.NewEvents() {
+	second := lastCounterOutput(run.NewEvents())
+	if second.InstanceID != first.InstanceID {
+		t.Fatalf("second instance = %d, want first instance %d", second.InstanceID, first.InstanceID)
+	}
+	if second.Count != 2 {
+		t.Fatalf("second count = %d, want 2", second.Count)
 	}
 
 	if err := run.RestoreCheckpoint(ctx, checkpointInfo); err != nil {
@@ -433,23 +451,12 @@ func TestCheckpoint_RestoreClearsExecutorInstancesBeforeImport(t *testing.T) {
 		t.Fatalf("Resume third: %v", err)
 	}
 
-	var got struct {
-		InstanceID int64
-		Count      int
+	third := lastCounterOutput(run.NewEvents())
+	if third.InstanceID != second.InstanceID {
+		t.Fatalf("restored instance = %d, want preserved instance %d", third.InstanceID, second.InstanceID)
 	}
-	for evt := range run.NewEvents() {
-		if out, ok := evt.(workflow.OutputEvent); ok {
-			got = out.Output.(struct {
-				InstanceID int64
-				Count      int
-			})
-		}
-	}
-	if got.InstanceID == 1 {
-		t.Fatalf("restored run reused stale executor instance: %+v", got)
-	}
-	if got.Count != 1 {
-		t.Fatalf("restored executor count = %d, want 1", got.Count)
+	if third.Count != 3 {
+		t.Fatalf("restored executor count = %d, want 3", third.Count)
 	}
 }
 

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -7,13 +7,15 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"reflect"
 	"slices"
-	"sync"
+	"strings"
 	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/internal/concurrent"
 	"github.com/microsoft/agent-framework-go/workflow"
 	"github.com/microsoft/agent-framework-go/workflow/internal/checkpoint"
 	"github.com/microsoft/agent-framework-go/workflow/internal/execution"
@@ -30,19 +32,15 @@ type runnerContext struct {
 	outputFilter *outputFilter
 	nextStep     atomic.Pointer[execution.StepContext]
 
-	executors   map[string]*workflow.Executor
-	executorsMu sync.RWMutex
+	executors concurrent.Map[string, *executorEntry]
 
-	queuedExternalDeliveries []func(context.Context) error
-	externalDeliveriesMu     sync.Mutex
+	queuedExternalDeliveries concurrent.Queue[func(context.Context) error]
 
-	joinedSubworkflowRunners map[string]execution.SuperStepRunner
-	joinedRunnersMu          sync.RWMutex
+	joinedSubworkflowRunners concurrent.Map[string, execution.SuperStepRunner]
 
-	externalRequests   map[string]*workflow.ExternalRequest
-	requestOwners      map[string]string // requestID -> ownerExecutorID
-	responsePortOwners map[string]string // portID -> ownerExecutorID
-	requestsMu         sync.RWMutex
+	externalRequests   concurrent.Map[string, *workflow.ExternalRequest]
+	requestOwners      concurrent.Map[string, string] // requestID -> ownerExecutorID
+	responsePortOwners concurrent.Map[string, string] // portID -> ownerExecutorID
 
 	stateManager   execution.StateManager
 	outgoingEvents execution.EventSink
@@ -51,6 +49,21 @@ type runnerContext struct {
 	concurrentRunsEnabled bool
 	previousOwnership     any
 	runEnded              atomic.Bool
+}
+
+type executorEntry struct {
+	ready    chan struct{}
+	executor *workflow.Executor
+	err      error
+}
+
+func newExecutorEntry() *executorEntry {
+	return &executorEntry{ready: make(chan struct{})}
+}
+
+func (e *executorEntry) wait() (*workflow.Executor, error) {
+	<-e.ready
+	return e.executor, e.err
 }
 
 // newInProcessRunnerContext creates a new InProcessRunnerContext.
@@ -64,23 +77,17 @@ func newInProcessRunnerContext(
 	enableConcurrentRuns bool,
 ) (*runnerContext, error) {
 	ctx := &runnerContext{
-		wf:                       wf,
-		sessionID:                sessionID,
-		tracer:                   tracer,
-		executors:                make(map[string]*workflow.Executor),
-		queuedExternalDeliveries: make([]func(context.Context) error, 0),
-		joinedSubworkflowRunners: make(map[string]execution.SuperStepRunner),
-		externalRequests:         make(map[string]*workflow.ExternalRequest),
-		requestOwners:            make(map[string]string),
-		responsePortOwners:       make(map[string]string),
-		outgoingEvents:           outgoingEvents,
-		withCheckpointing:        withCheckpointing,
-		concurrentRunsEnabled:    enableConcurrentRuns,
-		stateManager:             execution.NewStateManager(),
+		wf:                    wf,
+		sessionID:             sessionID,
+		tracer:                tracer,
+		outgoingEvents:        outgoingEvents,
+		withCheckpointing:     withCheckpointing,
+		concurrentRunsEnabled: enableConcurrentRuns,
+		stateManager:          execution.NewStateManager(),
 	}
 	ctx.nextStep.Store(new(execution.StepContext))
 
-	ctx.edgeMap = execution.NewEdgeRunner(wf, tracer, ctx.EnsureExecutor)
+	ctx.edgeMap = execution.NewEdgeRunner(wf, tracer, ctx.ensureExecutor)
 	ctx.outputFilter = newOutputFilter(wf)
 	if enableConcurrentRuns {
 		if !wf.CheckOwnership(existingOwnerSignoff) {
@@ -112,42 +119,57 @@ func (proc *runnerContext) checkEnded() error {
 	return nil
 }
 
-// EnsureExecutor ensures an executor is instantiated and initialized.
-func (proc *runnerContext) EnsureExecutor(ctx context.Context, executorID string, tracer execution.StepTracer) (*workflow.Executor, error) {
+func (proc *runnerContext) executorSnapshot() ([]*workflow.Executor, error) {
+	executors := make([]*workflow.Executor, 0)
+	var snapshotErr error
+	for _, entry := range proc.executors.All() {
+		executor, err := entry.wait()
+		if err != nil {
+			snapshotErr = errors.Join(snapshotErr, err)
+		} else if executor != nil {
+			executors = append(executors, executor)
+		}
+	}
+	return executors, snapshotErr
+}
+
+// ensureExecutor ensures an executor is instantiated and initialized.
+func (proc *runnerContext) ensureExecutor(ctx context.Context, executorID string, tracer execution.StepTracer) (*workflow.Executor, error) {
 	if err := proc.checkEnded(); err != nil {
 		return nil, err
 	}
 
-	proc.executorsMu.RLock()
-	if executor, ok := proc.executors[executorID]; ok {
-		proc.executorsMu.RUnlock()
-		return executor, nil
+	if entry, ok := proc.executors.Load(executorID); ok {
+		return entry.wait()
 	}
-	proc.executorsMu.RUnlock()
-
-	// Need to create the executor
-	proc.executorsMu.Lock()
-	defer proc.executorsMu.Unlock()
-
-	// Double-check after acquiring write lock
-	if executor, ok := proc.executors[executorID]; ok {
-		return executor, nil
+	entry := newExecutorEntry()
+	actual, loaded := proc.executors.LoadOrStore(executorID, entry)
+	if loaded {
+		return actual.wait()
 	}
+	defer close(entry.ready)
+	// Mirrors .NET's ConcurrentDictionary<string, Task<Executor>>: the stored
+	// entry represents in-flight or completed initialization, so concurrent
+	// callers wait on the same result instead of initializing twice.
 
 	registration, ok := proc.wf.ExecutorBinding(executorID)
 	if !ok {
-		return nil, fmt.Errorf("executor with ID '%s' is not registered", executorID)
+		entry.err = fmt.Errorf("executor with ID '%s' is not registered", executorID)
+		return nil, entry.err
 	}
 
 	executor, err := registration.CreateInstance(proc.sessionID)
 	if err != nil {
+		entry.err = err
 		return nil, err
 	}
 
 	if err := executor.AttachRuntime(proc); err != nil {
+		entry.err = err
 		return nil, err
 	}
-	if err := executor.Initialize(proc.Bind(ctx, executorID, nil)); err != nil {
+	if err := executor.Initialize(proc.bind(ctx, executorID, nil)); err != nil {
+		entry.err = err
 		return nil, err
 	}
 
@@ -155,73 +177,57 @@ func (proc *runnerContext) EnsureExecutor(ctx context.Context, executorID string
 		tracer.TraceInstantiated(executorID)
 	}
 
-	proc.executors[executorID] = executor
+	entry.executor = executor
 
 	return executor, nil
 }
 
-func (proc *runnerContext) PrepareForCheckpoint(ctx context.Context) error {
+func (proc *runnerContext) prepareForCheckpoint(ctx context.Context) error {
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
 
-	proc.executorsMu.RLock()
-	executors := make([]*workflow.Executor, 0, len(proc.executors))
-	for _, executor := range proc.executors {
-		executors = append(executors, executor)
+	executors, err := proc.executorSnapshot()
+	if err != nil {
+		return err
 	}
-	proc.executorsMu.RUnlock()
-
 	for _, executor := range executors {
-		if err := executor.OnCheckpoint(proc.Bind(ctx, executor.ID, nil)); err != nil {
+		if err := executor.OnCheckpoint(proc.bind(ctx, executor.ID, nil)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (proc *runnerContext) NotifyCheckpointLoaded(ctx context.Context) error {
+func (proc *runnerContext) notifyCheckpointLoaded(ctx context.Context) error {
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
 
-	proc.executorsMu.RLock()
-	executors := make([]*workflow.Executor, 0, len(proc.executors))
-	for _, executor := range proc.executors {
-		executors = append(executors, executor)
+	executors, err := proc.executorSnapshot()
+	if err != nil {
+		return err
 	}
-	proc.executorsMu.RUnlock()
-
 	for _, executor := range executors {
-		if err := executor.OnCheckpointRestored(proc.Bind(ctx, executor.ID, nil)); err != nil {
+		if err := executor.OnCheckpointRestored(proc.bind(ctx, executor.ID, nil)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (proc *runnerContext) ExportState() checkpoint.RunnerStateData {
-	proc.executorsMu.RLock()
-	instantiated := make(map[string]struct{}, len(proc.executors))
-	for id := range proc.executors {
+func (proc *runnerContext) exportState() checkpoint.RunnerStateData {
+	instantiated := make(map[string]struct{})
+	for id := range proc.executors.All() {
 		instantiated[id] = struct{}{}
 	}
-	proc.executorsMu.RUnlock()
 
-	proc.requestsMu.RLock()
-	outstanding := make([]*workflow.ExternalRequest, 0, len(proc.externalRequests))
-	for _, request := range proc.externalRequests {
+	outstanding := make([]*workflow.ExternalRequest, 0)
+	for _, request := range proc.externalRequests.All() {
 		outstanding = append(outstanding, request)
 	}
-	requestOwners := make(map[string]string, len(proc.requestOwners))
-	for requestID, ownerID := range proc.requestOwners {
-		requestOwners[requestID] = ownerID
-	}
-	responsePortOwners := make(map[string]string, len(proc.responsePortOwners))
-	for portID, ownerID := range proc.responsePortOwners {
-		responsePortOwners[portID] = ownerID
-	}
-	proc.requestsMu.RUnlock()
+	requestOwners := maps.Collect(proc.requestOwners.All())
+	responsePortOwners := maps.Collect(proc.responsePortOwners.All())
 
 	return checkpoint.RunnerStateData{
 		InstantiatedExecutors: instantiated,
@@ -232,7 +238,7 @@ func (proc *runnerContext) ExportState() checkpoint.RunnerStateData {
 	}
 }
 
-func (proc *runnerContext) ImportState(ctx context.Context, cp *checkpoint.Checkpoint) error {
+func (proc *runnerContext) importState(ctx context.Context, cp *checkpoint.Checkpoint) error {
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
@@ -240,58 +246,53 @@ func (proc *runnerContext) ImportState(ctx context.Context, cp *checkpoint.Check
 		return errors.New("checkpoint cannot be nil")
 	}
 
-	proc.executorsMu.Lock()
-	proc.executors = make(map[string]*workflow.Executor, len(cp.RunnerData.InstantiatedExecutors))
-	proc.executorsMu.Unlock()
-
-	proc.joinedRunnersMu.Lock()
-	proc.joinedSubworkflowRunners = make(map[string]execution.SuperStepRunner)
-	proc.joinedRunnersMu.Unlock()
-
 	for executorID := range cp.RunnerData.InstantiatedExecutors {
-		if _, err := proc.EnsureExecutor(ctx, executorID, nil); err != nil {
-			return err
+		if _, ok := proc.executors.Load(executorID); !ok {
+			if _, err := proc.ensureExecutor(ctx, executorID, nil); err != nil {
+				return err
+			}
 		}
 	}
 
-	proc.externalDeliveriesMu.Lock()
-	proc.queuedExternalDeliveries = make([]func(context.Context) error, 0)
-	proc.externalDeliveriesMu.Unlock()
+	for {
+		if _, ok := proc.queuedExternalDeliveries.Dequeue(); !ok {
+			break
+		}
+	}
 
 	nextStep := new(execution.StepContext)
 	nextStep.ImportMessages(cp.RunnerData.QueuedMessages)
 	proc.nextStep.Store(nextStep)
 
-	proc.requestsMu.Lock()
-	proc.externalRequests = make(map[string]*workflow.ExternalRequest, len(cp.RunnerData.OutstandingRequests))
-	proc.requestOwners = make(map[string]string, len(cp.RunnerData.RequestOwners))
-	proc.responsePortOwners = make(map[string]string, len(cp.RunnerData.ResponsePortOwners))
+	proc.externalRequests.Clear()
+	proc.requestOwners.Clear()
+	proc.responsePortOwners.Clear()
 	for requestID, ownerID := range cp.RunnerData.RequestOwners {
-		proc.requestOwners[requestID] = ownerID
+		proc.requestOwners.Store(requestID, ownerID)
 	}
 	for portID, ownerID := range cp.RunnerData.ResponsePortOwners {
-		proc.responsePortOwners[portID] = ownerID
+		proc.responsePortOwners.Store(portID, ownerID)
 	}
 	for _, request := range cp.RunnerData.OutstandingRequests {
-		proc.externalRequests[request.RequestID] = request
-		if ownerID := proc.requestOwners[request.RequestID]; ownerID == "" {
-			ownerID = proc.responsePortOwners[request.PortInfo.PortID]
+		proc.externalRequests.Store(request.RequestID, request)
+		if ownerID, _ := proc.requestOwners.Load(request.RequestID); ownerID == "" {
+			ownerID, _ = proc.responsePortOwners.Load(request.PortInfo.PortID)
 			if ownerID == "" {
 				ownerID = request.PortInfo.PortID
 			}
-			proc.requestOwners[request.RequestID] = ownerID
+			proc.requestOwners.Store(request.RequestID, ownerID)
 		}
-		if _, ok := proc.responsePortOwners[request.PortInfo.PortID]; !ok {
-			proc.responsePortOwners[request.PortInfo.PortID] = proc.requestOwners[request.RequestID]
+		if _, ok := proc.responsePortOwners.Load(request.PortInfo.PortID); !ok {
+			ownerID, _ := proc.requestOwners.Load(request.RequestID)
+			proc.responsePortOwners.Store(request.PortInfo.PortID, ownerID)
 		}
 	}
-	proc.requestsMu.Unlock()
 
 	return nil
 }
 
-// AddExternalMessage queues an external message for delivery.
-func (proc *runnerContext) AddExternalMessage(ctx context.Context, message any, declaredType reflect.Type) error {
+// addExternalMessage queues an external message for delivery.
+func (proc *runnerContext) addExternalMessage(message any, declaredType reflect.Type) error {
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
@@ -299,9 +300,7 @@ func (proc *runnerContext) AddExternalMessage(ctx context.Context, message any, 
 		return errors.New("message cannot be nil")
 	}
 
-	proc.externalDeliveriesMu.Lock()
-	defer proc.externalDeliveriesMu.Unlock()
-	proc.queuedExternalDeliveries = append(proc.queuedExternalDeliveries, func(ctx context.Context) error {
+	proc.queuedExternalDeliveries.Enqueue(func(ctx context.Context) error {
 		envelope, err := execution.NewMessageEnvelope(message, declaredType, "", "")
 		if err != nil {
 			return err
@@ -319,16 +318,29 @@ func (proc *runnerContext) AddExternalMessage(ctx context.Context, message any, 
 	return nil
 }
 
-// AddExternalResponse queues an external response for delivery.
-func (proc *runnerContext) AddExternalResponse(ctx context.Context, response *workflow.ExternalResponse) error {
+// addExternalResponse queues an external response for delivery.
+func (proc *runnerContext) addExternalResponse(response *workflow.ExternalResponse) error {
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
+	if response == nil {
+		return errors.New("response cannot be nil")
+	}
 
-	proc.externalDeliveriesMu.Lock()
-	defer proc.externalDeliveriesMu.Unlock()
-	proc.queuedExternalDeliveries = append(proc.queuedExternalDeliveries, func(ctx context.Context) error {
-		ownerID, existed := proc.CompleteRequest(response.RequestID)
+	proc.queuedExternalDeliveries.Enqueue(func(ctx context.Context) error {
+		pending, existed := proc.externalRequests.Load(response.RequestID)
+		if !existed {
+			return fmt.Errorf("no pending request with ID %s found in the workflow context", response.RequestID)
+		}
+
+		// Reject responses whose PortInfo.PortID does not match the originating request's port to
+		// prevent forged routing into unrelated port-specific execution paths.
+		if pending != nil && pending.PortInfo.PortID != response.PortInfo.PortID {
+			return fmt.Errorf("response port id %q does not match the originating port id for request %s", response.PortInfo.PortID, response.RequestID)
+		}
+
+		// Consume only after validation so a rejected response leaves the legitimate one able to complete.
+		ownerID, existed := proc.completeRequest(response.RequestID)
 		if !existed {
 			return fmt.Errorf("no pending request with ID %s found in the workflow context", response.RequestID)
 		}
@@ -346,19 +358,14 @@ func (proc *runnerContext) AddExternalResponse(ctx context.Context, response *wo
 	return nil
 }
 
-// HasQueuedExternalDeliveries returns true if there are queued external deliveries.
-func (proc *runnerContext) HasQueuedExternalDeliveries() bool {
-	proc.externalDeliveriesMu.Lock()
-	defer proc.externalDeliveriesMu.Unlock()
-	return len(proc.queuedExternalDeliveries) > 0
+// hasQueuedExternalDeliveries returns true if there are queued external deliveries.
+func (proc *runnerContext) hasQueuedExternalDeliveries() bool {
+	return !proc.queuedExternalDeliveries.IsEmpty()
 }
 
-// JoinedRunnersHaveActions returns true if any joined subworkflow has actions.
-func (proc *runnerContext) JoinedRunnersHaveActions() bool {
-	proc.joinedRunnersMu.RLock()
-	defer proc.joinedRunnersMu.RUnlock()
-
-	for _, runner := range proc.joinedSubworkflowRunners {
+// joinedRunnersHaveActions returns true if any joined subworkflow has actions.
+func (proc *runnerContext) joinedRunnersHaveActions() bool {
+	for runner := range proc.joinedSubworkflowRunners.Values() {
 		if runner.HasUnprocessedMessages() {
 			return true
 		}
@@ -366,25 +373,18 @@ func (proc *runnerContext) JoinedRunnersHaveActions() bool {
 	return false
 }
 
-// NextStepHasActions returns true if the next step has actions to process.
-func (proc *runnerContext) NextStepHasActions() bool {
-	return proc.currentStep().HasMessages() || proc.HasQueuedExternalDeliveries() || proc.JoinedRunnersHaveActions()
+// nextStepHasActions returns true if the next step has actions to process.
+func (proc *runnerContext) nextStepHasActions() bool {
+	return proc.currentStep().HasMessages() || proc.hasQueuedExternalDeliveries() || proc.joinedRunnersHaveActions()
 }
 
-// HasUnservicedRequests returns true if there are unserviced external requests.
-func (proc *runnerContext) HasUnservicedRequests() bool {
-	proc.requestsMu.RLock()
-	hasLocal := len(proc.externalRequests) > 0
-	proc.requestsMu.RUnlock()
-
-	if hasLocal {
+// hasUnservicedRequests returns true if there are unserviced external requests.
+func (proc *runnerContext) hasUnservicedRequests() bool {
+	for range proc.externalRequests.All() {
 		return true
 	}
 
-	proc.joinedRunnersMu.RLock()
-	defer proc.joinedRunnersMu.RUnlock()
-
-	for _, runner := range proc.joinedSubworkflowRunners {
+	for runner := range proc.joinedSubworkflowRunners.Values() {
 		if runner.HasUnservicedRequests() {
 			return true
 		}
@@ -394,21 +394,21 @@ func (proc *runnerContext) HasUnservicedRequests() bool {
 
 // RepublishUnservicedRequests re-emits outstanding external requests after an
 // event stream has subscribed, matching checkpoint-resume behavior.
-func (proc *runnerContext) RepublishUnservicedRequests(ctx context.Context) error {
-	proc.requestsMu.RLock()
-	requestIDs := make([]string, 0, len(proc.externalRequests))
-	for requestID := range proc.externalRequests {
+func (proc *runnerContext) republishUnservicedRequests(ctx context.Context) error {
+	requestIDs := make([]string, 0)
+	requestsByID := make(map[string]*workflow.ExternalRequest)
+	for requestID, request := range proc.externalRequests.All() {
 		requestIDs = append(requestIDs, requestID)
+		requestsByID[requestID] = request
 	}
 	slices.Sort(requestIDs)
 	requests := make([]*workflow.ExternalRequest, 0, len(requestIDs))
 	for _, requestID := range requestIDs {
-		requests = append(requests, proc.externalRequests[requestID])
+		requests = append(requests, requestsByID[requestID])
 	}
-	proc.requestsMu.RUnlock()
 
 	for _, request := range requests {
-		if err := proc.AddEvent(ctx, workflow.RequestInfoEvent{Request: request}); err != nil {
+		if err := proc.addEvent(ctx, workflow.RequestInfoEvent{Request: request}); err != nil {
 			return err
 		}
 	}
@@ -416,18 +416,18 @@ func (proc *runnerContext) RepublishUnservicedRequests(ctx context.Context) erro
 }
 
 // Advance advances to the next step, processing all queued external deliveries.
-func (proc *runnerContext) Advance(ctx context.Context) (*execution.StepContext, error) {
+func (proc *runnerContext) advance(ctx context.Context) (*execution.StepContext, error) {
 	if err := proc.checkEnded(); err != nil {
 		return nil, err
 	}
 
-	// Process all queued external deliveries
-	proc.externalDeliveriesMu.Lock()
-	deliveries := proc.queuedExternalDeliveries
-	proc.queuedExternalDeliveries = make([]func(context.Context) error, 0)
-	proc.externalDeliveriesMu.Unlock()
+	for {
+		delivery, ok := proc.queuedExternalDeliveries.Dequeue()
+		if !ok {
+			break
+		}
 
-	for _, delivery := range deliveries {
+		// Deliveries may mutate shared edge state, matching .NET's sequential TryDequeue loop.
 		if err := delivery(ctx); err != nil {
 			return nil, err
 		}
@@ -438,7 +438,7 @@ func (proc *runnerContext) Advance(ctx context.Context) (*execution.StepContext,
 }
 
 // AddEvent adds a workflow event to the outgoing event stream.
-func (proc *runnerContext) AddEvent(ctx context.Context, event workflow.Event) error {
+func (proc *runnerContext) addEvent(ctx context.Context, event workflow.Event) error {
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
@@ -446,7 +446,7 @@ func (proc *runnerContext) AddEvent(ctx context.Context, event workflow.Event) e
 }
 
 // SendMessage sends a message from one executor to another through the workflow edges.
-func (proc *runnerContext) SendMessage(ctx context.Context, sourceID, targetID string, message any) error {
+func (proc *runnerContext) sendMessage(ctx context.Context, sourceID, targetID string, message any) error {
 	telemetry := observability.FromContext(ctx)
 	ctx, span := telemetry.StartMessageSend(ctx, sourceID, targetID, message)
 	defer span.End()
@@ -461,7 +461,7 @@ func (proc *runnerContext) SendMessage(ctx context.Context, sourceID, targetID s
 		span.CaptureError(err)
 		return err
 	}
-	sourceExecutor, err := proc.EnsureExecutor(ctx, sourceID, nil)
+	sourceExecutor, err := proc.ensureExecutor(ctx, sourceID, nil)
 	if err != nil {
 		span.CaptureError(err)
 		return err
@@ -497,7 +497,7 @@ func (proc *runnerContext) SendMessage(ctx context.Context, sourceID, targetID s
 }
 
 // Bind creates a bound workflow context for a specific executor.
-func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceContext map[string]string) *workflow.Context {
+func (proc *runnerContext) bind(ctx context.Context, executorID string, traceContext map[string]string) *workflow.Context {
 	boundCtx := ctx
 	telemetry := observability.FromContext(ctx)
 	boundCtx = observability.ContextWithTelemetry(boundCtx, telemetry)
@@ -506,11 +506,11 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 		Context: boundCtx,
 
 		AddEvent: func(event workflow.Event) error {
-			return proc.AddEvent(boundCtx, event)
+			return proc.addEvent(boundCtx, event)
 		},
 
 		SendMessage: func(targetID string, message any) error {
-			return proc.SendMessage(boundCtx, executorID, targetID, message)
+			return proc.sendMessage(boundCtx, executorID, targetID, message)
 		},
 
 		YieldOutput: func(output any) error {
@@ -518,11 +518,11 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 		},
 
 		RequestHalt: func() error {
-			return proc.AddEvent(boundCtx, workflow.RequestHaltEvent{})
+			return proc.addEvent(boundCtx, workflow.RequestHaltEvent{})
 		},
 
 		PostRequest: func(request *workflow.ExternalRequest) error {
-			return proc.Post(boundCtx, executorID, request)
+			return proc.post(boundCtx, executorID, request)
 		},
 
 		ReadState: func(key string, scope string) (any, error) {
@@ -574,6 +574,10 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 			return proc.stateManager.WriteState(executorID, scope, key, value)
 		},
 
+		QueueClearScope: func(scope string) error {
+			return proc.stateManager.ClearState(executorID, scope)
+		},
+
 		TraceContext: func() map[string]any {
 			if traceContext == nil {
 				return nil
@@ -591,24 +595,32 @@ func (proc *runnerContext) Bind(ctx context.Context, executorID string, traceCon
 }
 
 func (proc *runnerContext) yieldOutput(ctx context.Context, executorID string, output any) error {
+	if err := proc.checkEnded(); err != nil {
+		return err
+	}
 	if output == nil {
 		return fmt.Errorf("executor %q cannot output nil", executorID)
 	}
 
-	isAgentResponseShaped := isAgentResponseOutput(output)
-	if isAgentResponseShaped {
-		if _, err := proc.EnsureExecutor(ctx, executorID, nil); err != nil {
-			return err
-		}
-	} else if err := proc.validateOutputType(executorID, output); err != nil {
+	sourceExecutor, err := proc.ensureExecutor(ctx, executorID, nil)
+	if err != nil {
 		return err
+	}
+	isAgentResponseShaped := isAgentResponseOutput(output)
+	if !isAgentResponseShaped && !execution.CanOutputType(sourceExecutor, reflect.TypeOf(output)) {
+		expectedTypes := make([]string, 0, len(sourceExecutor.DescribeProtocol().Yields))
+		for _, typ := range sourceExecutor.DescribeProtocol().Yields {
+			expectedTypes = append(expectedTypes, typ.String())
+		}
+		slices.Sort(expectedTypes)
+		return fmt.Errorf("executor %q cannot output object of type %s; expected one of %v", executorID, reflect.TypeOf(output), expectedTypes)
 	}
 
 	tags, ok := proc.outputFilter.tryGetTags(executorID)
 	if !ok {
 		return nil
 	}
-	return proc.AddEvent(ctx, workflow.OutputEvent{
+	return proc.addEvent(ctx, workflow.OutputEvent{
 		ExecutorID: executorID,
 		Output:     output,
 		Tags:       tags,
@@ -624,146 +636,92 @@ func isAgentResponseOutput(output any) bool {
 	}
 }
 
-func (proc *runnerContext) validateOutputType(executorID string, output any) error {
-	if output == nil {
-		return fmt.Errorf("executor %q cannot output nil", executorID)
-	}
-
-	proc.executorsMu.RLock()
-	executor, ok := proc.executors[executorID]
-	proc.executorsMu.RUnlock()
-	if !ok {
-		return fmt.Errorf("executor %q is not instantiated", executorID)
-	}
-
-	declaredTypes := executor.DescribeProtocol().Yields
-	outputType := reflect.TypeOf(output)
-	if execution.CanOutputType(executor, outputType) {
-		return nil
-	}
-	return fmt.Errorf("executor %q cannot output object of type %s; expected one of %v", executorID, outputType, sortedTypeNames(declaredTypes))
-}
-
-func sortedTypeNames(types []reflect.Type) []string {
-	names := make([]string, 0, len(types))
-	for _, typ := range types {
-		names = append(names, typ.String())
-	}
-	slices.Sort(names)
-	return names
-}
-
 // Post raises an external request originating from the executor identified
 // by ownerID. The matching response (delivered later via [AddExternalResponse])
 // will be routed back to that executor as a regular message.
-func (proc *runnerContext) Post(ctx context.Context, ownerID string, request *workflow.ExternalRequest) error {
+func (proc *runnerContext) post(ctx context.Context, ownerID string, request *workflow.ExternalRequest) error {
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
 	if ownerID == "" {
 		return errors.New("ownerID is required when posting an external request")
 	}
+	if request == nil {
+		return errors.New("request cannot be nil")
+	}
 
-	proc.requestsMu.Lock()
-	if _, exists := proc.externalRequests[request.RequestID]; exists {
-		proc.requestsMu.Unlock()
+	if _, exists := proc.externalRequests.LoadOrStore(request.RequestID, request); exists {
 		return fmt.Errorf("pending request with id '%s' already exists", request.RequestID)
 	}
-	proc.externalRequests[request.RequestID] = request
-	proc.requestOwners[request.RequestID] = ownerID
-	proc.responsePortOwners[request.PortInfo.PortID] = ownerID
-	proc.requestsMu.Unlock()
+	proc.requestOwners.Store(request.RequestID, ownerID)
+	proc.responsePortOwners.Store(request.PortInfo.PortID, ownerID)
 
-	return proc.AddEvent(ctx, workflow.RequestInfoEvent{Request: request})
+	return proc.addEvent(ctx, workflow.RequestInfoEvent{Request: request})
 }
 
-// CompleteRequest marks a request as completed and returns the executor that
+// completeRequest marks a request as completed and returns the executor that
 // posted it.
-func (proc *runnerContext) CompleteRequest(requestID string) (string, bool) {
+func (proc *runnerContext) completeRequest(requestID string) (string, bool) {
 	if err := proc.checkEnded(); err != nil {
 		return "", false
 	}
 
-	proc.requestsMu.Lock()
-	defer proc.requestsMu.Unlock()
-
-	_, existed := proc.externalRequests[requestID]
-	delete(proc.externalRequests, requestID)
-	owner := proc.requestOwners[requestID]
-	delete(proc.requestOwners, requestID)
+	_, existed := proc.externalRequests.LoadAndDelete(requestID)
+	owner, _ := proc.requestOwners.LoadAndDelete(requestID)
 	return owner, existed
 }
 
 // ResponsePortExecutorID returns the executor that handles responses on the
 // given port, or ("", false) if no such port is registered. Mirrors .NET's
 // [EdgeMap.TryGetResponsePortExecutorId].
-func (proc *runnerContext) ResponsePortExecutorID(portID string) (string, bool) {
-	proc.requestsMu.Lock()
-	defer proc.requestsMu.Unlock()
-	owner, ok := proc.responsePortOwners[portID]
-	return owner, ok
+func (proc *runnerContext) responsePortExecutorID(portID string) (string, bool) {
+	return proc.responsePortOwners.Load(portID)
 }
 
-// JoinedSubworkflowRunners returns all joined subworkflow runners.
-func (proc *runnerContext) JoinedSubworkflowRunners() []execution.SuperStepRunner {
-	proc.joinedRunnersMu.RLock()
-	defer proc.joinedRunnersMu.RUnlock()
-
-	runners := make([]execution.SuperStepRunner, 0, len(proc.joinedSubworkflowRunners))
-	for _, runner := range proc.joinedSubworkflowRunners {
+// joinedSubworkflowRunnerSnapshot returns all joined subworkflow runners.
+func (proc *runnerContext) joinedSubworkflowRunnerSnapshot() []execution.SuperStepRunner {
+	runners := make([]execution.SuperStepRunner, 0)
+	for runner := range proc.joinedSubworkflowRunners.Values() {
 		runners = append(runners, runner)
 	}
 	return runners
 }
 
-// AttachSuperstep attaches a subworkflow runner.
-func (proc *runnerContext) AttachSuperstep(ctx context.Context, runner execution.SuperStepRunner) (string, error) {
-	proc.joinedRunnersMu.Lock()
-	defer proc.joinedRunnersMu.Unlock()
-
-	// Generate a unique join ID
-	joinID := uuid.NewString()
-	proc.joinedSubworkflowRunners[joinID] = runner
-	return joinID, nil
+// attachSuperstep attaches a subworkflow runner.
+func (proc *runnerContext) attachSuperstep(runner execution.SuperStepRunner) (string, error) {
+	for {
+		joinID := strings.ReplaceAll(uuid.NewString(), "-", "")
+		if _, exists := proc.joinedSubworkflowRunners.LoadOrStore(joinID, runner); !exists {
+			return joinID, nil
+		}
+	}
 }
 
-// DetachSuperstep detaches a subworkflow runner.
-func (proc *runnerContext) DetachSuperstep(joinID string) bool {
-	proc.joinedRunnersMu.Lock()
-	defer proc.joinedRunnersMu.Unlock()
-
-	_, existed := proc.joinedSubworkflowRunners[joinID]
-	delete(proc.joinedSubworkflowRunners, joinID)
+// detachSuperstep detaches a subworkflow runner.
+func (proc *runnerContext) detachSuperstep(joinID string) bool {
+	_, existed := proc.joinedSubworkflowRunners.LoadAndDelete(joinID)
 	return existed
 }
 
-// EndRun marks the run as ended and cleans up resources.
-func (proc *runnerContext) EndRun(ctx context.Context) error {
+// endRun marks the run as ended and cleans up resources.
+func (proc *runnerContext) endRun(ctx context.Context) error {
 	if proc.runEnded.Swap(true) {
 		return nil // Already ended
 	}
 	var runErr error
 
-	proc.executorsMu.RLock()
-	executors := make([]*workflow.Executor, 0, len(proc.executors))
-	for _, executor := range proc.executors {
-		executors = append(executors, executor)
+	executors, err := proc.executorSnapshot()
+	if err != nil {
+		runErr = errors.Join(runErr, err)
 	}
-	proc.executorsMu.RUnlock()
-
 	for _, executor := range executors {
 		if err := executor.Close(ctx); err != nil {
 			runErr = errors.Join(runErr, err)
 		}
 	}
 
-	proc.joinedRunnersMu.Lock()
-	joinedRunners := make([]execution.SuperStepRunner, 0, len(proc.joinedSubworkflowRunners))
-	for _, runner := range proc.joinedSubworkflowRunners {
-		joinedRunners = append(joinedRunners, runner)
-	}
-	proc.joinedSubworkflowRunners = make(map[string]execution.SuperStepRunner)
-	proc.joinedRunnersMu.Unlock()
+	joinedRunners := slices.Collect(proc.joinedSubworkflowRunners.Values())
+	proc.joinedSubworkflowRunners.Clear()
 
 	for _, runner := range joinedRunners {
 		if err := runner.RequestEndRun(ctx); err != nil {

--- a/workflow/inproc/events_test.go
+++ b/workflow/inproc/events_test.go
@@ -128,6 +128,34 @@ func TestStartedEvent_NotEmittedWhenNoWork(t *testing.T) {
 	}
 }
 
+func TestStartedEvent_EmittedInLockstepWithoutWork(t *testing.T) {
+	ex := minimalEchoBinding("ex")
+	wf, err := workflow.NewBuilder(ex).WithOutputFrom(ex).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx := context.Background()
+	stream, err := inproc.Lockstep.RunStreaming(ctx, wf, nil)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.CancelRun() }()
+
+	var sawStarted bool
+	for evt, err := range stream.WatchUntilHalt(ctx) {
+		if err != nil {
+			t.Fatalf("watch: %v", err)
+		}
+		if _, ok := evt.(workflow.StartedEvent); ok {
+			sawStarted = true
+		}
+	}
+	if !sawStarted {
+		t.Fatal("expected StartedEvent even when lockstep has no queued work")
+	}
+}
+
 func TestStreamingRun_WaitToTakeStreamDoesNotBlockOffThread(t *testing.T) {
 	ex := minimalEchoBinding("ex")
 	wf, err := workflow.NewBuilder(ex).WithOutputFrom(ex).Build()

--- a/workflow/inproc/external_request_test.go
+++ b/workflow/inproc/external_request_test.go
@@ -18,6 +18,62 @@ func (s requestPortStringer) String() string { return string(s) }
 
 type requestNilPayload struct{}
 
+func TestPostRequest_NilRejected(t *testing.T) {
+	binding := workflow.ExecutorBinding{
+		ID:               "poster",
+		ImplementationID: "*workflow.Executor",
+		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+			return &workflow.Executor{
+				ID: "poster",
+
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+						return nil, ctx.PostRequest(nil)
+					})
+					return rb, nil
+				},
+			}, nil
+		},
+	}
+
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	run, err := inproc.Default.Run(t.Context(), wf, "start")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var gotErr error
+	for evt := range run.OutgoingEvents() {
+		if errEvt, ok := evt.(workflow.ErrorEvent); ok {
+			gotErr = errEvt.Error
+			break
+		}
+	}
+	if gotErr == nil || !strings.Contains(gotErr.Error(), "request cannot be nil") {
+		t.Fatalf("PostRequest(nil) error = %v, want request cannot be nil", gotErr)
+	}
+}
+
+func TestExternalResponse_NilRejectedBeforeRunAdvance(t *testing.T) {
+	binding := workflow.NewExecutor("echo", func(message string) string { return message }).Bind()
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	run, err := inproc.Default.Run(t.Context(), wf, "start")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := run.Resume(t.Context(), (*workflow.ExternalResponse)(nil)); err == nil || !strings.Contains(err.Error(), "response cannot be nil") {
+		t.Fatalf("Resume(nil ExternalResponse) error = %v, want response cannot be nil", err)
+	}
+}
+
 // TestPostRequestFromExecutor verifies that an executor can raise an
 // ExternalRequest via Context.PostRequest, that the matching ExternalResponse
 // is routed back to that executor (not to the start executor), and that the
@@ -262,6 +318,88 @@ func TestExternalResponse_UnsolicitedResponseErrors(t *testing.T) {
 	}
 	if !sawErr {
 		t.Errorf("expected an ErrorEvent referencing 'no pending request', got none")
+	}
+}
+
+func TestExternalResponse_RejectsForgedPortIDWithoutConsumingRequest(t *testing.T) {
+	portA := workflow.RequestPort{ID: "portA", Request: reflect.TypeFor[string](), Response: reflect.TypeFor[int]()}
+	portB := workflow.RequestPort{ID: "portB", Request: reflect.TypeFor[string](), Response: reflect.TypeFor[int]()}
+
+	id := "asker"
+	binding := workflow.ExecutorBinding{ID: id, ImplementationID: "*workflow.Executor"}
+	binding.NewExecutorFunc = func(_ string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: id,
+
+			DisableAutoSendMessageHandlerResultObject: true,
+			DisableAutoYieldOutputHandlerResultObject: true,
+			ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				rb.YieldsOutputType(reflect.TypeFor[int]())
+				rb.RouteBuilder.
+					AddHandlerRaw(reflect.TypeFor[string](), nil, func(wctx *workflow.Context, _ any) (any, error) {
+						req, err := workflow.NewExternalRequest("request-1", portA, "data")
+						if err != nil {
+							return nil, err
+						}
+						return nil, wctx.PostRequest(req)
+					}).
+					AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(wctx *workflow.Context, msg any) (any, error) {
+						resp := msg.(*workflow.ExternalResponse)
+						data, _ := resp.Data.As(portA.Response)
+						return nil, wctx.YieldOutput(data)
+					})
+				return rb, nil
+			},
+		}, nil
+	}
+
+	wf, err := workflow.NewBuilder(binding).WithOutputFrom(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx := context.Background()
+	run, err := inproc.Lockstep.Run(ctx, wf, "kick")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var pending *workflow.ExternalRequest
+	for evt := range run.OutgoingEvents() {
+		if requestInfo, ok := evt.(workflow.RequestInfoEvent); ok {
+			pending = requestInfo.Request
+			break
+		}
+	}
+	if pending == nil {
+		t.Fatal("expected pending external request")
+	}
+
+	forged := &workflow.ExternalResponse{
+		PortInfo:  workflow.NewRequestPortInfo(portB),
+		RequestID: pending.RequestID,
+		Data:      workflow.AnyPortableValue(42),
+	}
+	if _, err := run.Resume(ctx, forged); err == nil || !strings.Contains(err.Error(), "response port id") {
+		t.Fatalf("forged response error = %v, want port mismatch", err)
+	}
+
+	legitimate, err := pending.CreateResponse(42)
+	if err != nil {
+		t.Fatalf("CreateResponse: %v", err)
+	}
+	if _, err := run.Resume(ctx, legitimate); err != nil {
+		t.Fatalf("legitimate response after rejected forged response: %v", err)
+	}
+
+	var gotOutput any
+	for evt := range run.NewEvents() {
+		if out, ok := evt.(workflow.OutputEvent); ok {
+			gotOutput = out.Output
+		}
+	}
+	if gotOutput != 42 {
+		t.Fatalf("output = %v, want 42", gotOutput)
 	}
 }
 

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -114,7 +114,7 @@ func newInProcessRunner(
 		return nil, err
 	}
 
-	edgeMap := execution.NewEdgeRunner(wf, stepTracer, runContext.EnsureExecutor)
+	edgeMap := execution.NewEdgeRunner(wf, stepTracer, runContext.ensureExecutor)
 
 	runner := &runner{
 		sessionID:            sessionID,
@@ -157,23 +157,23 @@ func (r *runner) OutgoingEvents() *execution.ConcurrentEventSink {
 
 // HasUnservicedRequests returns true if there are unserviced external requests.
 func (r *runner) HasUnservicedRequests() bool {
-	return r.runContext.HasUnservicedRequests()
+	return r.runContext.hasUnservicedRequests()
 }
 
 // ResponsePortExecutorID returns the executor that handles responses on the
 // given port, or ("", false) if no such port is registered.
 func (r *runner) ResponsePortExecutorID(portID string) (string, bool) {
-	return r.runContext.ResponsePortExecutorID(portID)
+	return r.runContext.responsePortExecutorID(portID)
 }
 
 // HasUnprocessedMessages returns true if the next step has actions to process.
 func (r *runner) HasUnprocessedMessages() bool {
-	return r.runContext.NextStepHasActions()
+	return r.runContext.nextStepHasActions()
 }
 
 func (r *runner) RepublishPendingEvents(ctx context.Context) error {
 	if r.needsRepublish.Swap(false) {
-		return r.runContext.RepublishUnservicedRequests(ctx)
+		return r.runContext.republishUnservicedRequests(ctx)
 	}
 	return nil
 }
@@ -184,7 +184,7 @@ func (r *runner) IsValidInputType(ctx context.Context, messageType reflect.Type)
 		return true
 	}
 
-	startingExecutor, err := r.runContext.EnsureExecutor(ctx, r.startExecutorID, nil)
+	startingExecutor, err := r.runContext.ensureExecutor(ctx, r.startExecutorID, nil)
 	if err != nil {
 		return false
 	}
@@ -230,7 +230,7 @@ func (r *runner) EnqueueMessage(ctx context.Context, message any) error {
 	}
 
 	if response, ok := message.(*workflow.ExternalResponse); ok {
-		return r.runContext.AddExternalResponse(ctx, response)
+		return r.runContext.addExternalResponse(response)
 	}
 
 	messageType := reflect.TypeOf(message)
@@ -238,12 +238,12 @@ func (r *runner) EnqueueMessage(ctx context.Context, message any) error {
 		return fmt.Errorf("message type %v is not a valid input type for this workflow: %w", messageType, workflow.ErrInvalidInputType)
 	}
 
-	return r.runContext.AddExternalMessage(ctx, message, messageType)
+	return r.runContext.addExternalMessage(message, messageType)
 }
 
 // EnqueueResponse enqueues an external response to the workflow.
 func (r *runner) EnqueueResponse(ctx context.Context, response *workflow.ExternalResponse) error {
-	return r.runContext.AddExternalResponse(ctx, response)
+	return r.runContext.addExternalResponse(response)
 }
 
 // RunSuperStep executes a single super step of the workflow.
@@ -256,14 +256,14 @@ func (r *runner) RunSuperStep(ctx context.Context) (bool, error) {
 		return false, ctx.Err()
 	}
 
-	currentStep, err := r.runContext.Advance(ctx)
+	currentStep, err := r.runContext.advance(ctx)
 	if err != nil {
 		return false, err
 	}
 
 	if currentStep.HasMessages() ||
-		r.runContext.HasQueuedExternalDeliveries() ||
-		r.runContext.JoinedRunnersHaveActions() {
+		r.runContext.hasQueuedExternalDeliveries() ||
+		r.runContext.joinedRunnersHaveActions() {
 
 		if err := r.runSuperstep(ctx, currentStep); err != nil {
 			if !errors.Is(err, context.Canceled) {
@@ -279,7 +279,7 @@ func (r *runner) RunSuperStep(ctx context.Context) (bool, error) {
 
 // RequestEndRun requests the workflow run to end.
 func (r *runner) RequestEndRun(ctx context.Context) error {
-	return r.runContext.EndRun(ctx)
+	return r.runContext.endRun(ctx)
 }
 
 // Checkpoints returns the list of created checkpoints.
@@ -307,7 +307,7 @@ func (r *runner) RestoreCheckpoint(ctx context.Context, checkpointInfo workflow.
 	if err := r.restoreCheckpointCore(ctx, checkpointInfo); err != nil {
 		return err
 	}
-	return r.runContext.RepublishUnservicedRequests(ctx)
+	return r.runContext.republishUnservicedRequests(ctx)
 }
 
 func (r *runner) restoreCheckpointCore(ctx context.Context, checkpointInfo workflow.CheckpointInfo) error {
@@ -332,10 +332,10 @@ func (r *runner) restoreCheckpointCore(ctx context.Context, checkpointInfo workf
 	if err := r.runContext.stateManager.ImportState(cp); err != nil {
 		return err
 	}
-	if err := r.runContext.ImportState(ctx, cp); err != nil {
+	if err := r.runContext.importState(ctx, cp); err != nil {
 		return err
 	}
-	if err := r.runContext.NotifyCheckpointLoaded(ctx); err != nil {
+	if err := r.runContext.notifyCheckpointLoaded(ctx); err != nil {
 		return err
 	}
 	if err := r.edgeMap.ImportState(cp); err != nil {
@@ -374,7 +374,7 @@ func (r *runner) runSuperstep(ctx context.Context, currentStep *execution.StepCo
 	}
 
 	// Process subworkflows
-	for _, subRunner := range r.runContext.JoinedSubworkflowRunners() {
+	for _, subRunner := range r.runContext.joinedSubworkflowRunnerSnapshot() {
 		if _, err := subRunner.RunSuperStep(ctx); err != nil {
 			return err
 		}
@@ -386,12 +386,12 @@ func (r *runner) runSuperstep(ctx context.Context, currentStep *execution.StepCo
 	}
 
 	// Raise superstep completed event
-	completeEvt := r.stepTracer.Complete(r.runContext.NextStepHasActions(), r.runContext.HasUnservicedRequests())
+	completeEvt := r.stepTracer.Complete(r.runContext.nextStepHasActions(), r.runContext.hasUnservicedRequests())
 	return r.outgoingEvents.Enqueue(ctx, completeEvt)
 }
 
 func (r *runner) deliverMessages(ctx context.Context, receiverID string, envelopes *concurrent.Queue[*execution.MessageEnvelope]) (err error) {
-	executor, err := r.runContext.EnsureExecutor(ctx, receiverID, r.stepTracer)
+	executor, err := r.runContext.ensureExecutor(ctx, receiverID, r.stepTracer)
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,7 @@ func (r *runner) deliverMessages(ctx context.Context, receiverID string, envelop
 	r.stepTracer.TraceActivated(receiverID)
 
 	// Bind a context with no per-message trace context for delivery-level callbacks.
-	tracelessCtx := r.runContext.Bind(ctx, receiverID, nil)
+	tracelessCtx := r.runContext.bind(ctx, receiverID, nil)
 	if err := executor.OnMessageDeliveryStarting(tracelessCtx); err != nil {
 		return err
 	}
@@ -416,7 +416,7 @@ func (r *runner) deliverMessages(ctx context.Context, receiverID string, envelop
 		if !ok {
 			break
 		}
-		boundCtx := r.runContext.Bind(ctx, receiverID, envelope.TraceContext)
+		boundCtx := r.runContext.bind(ctx, receiverID, envelope.TraceContext)
 		if _, execErr := executor.Execute(boundCtx, envelope.Message); execErr != nil {
 			return execErr
 		}
@@ -434,7 +434,7 @@ func (r *runner) checkpoint(ctx context.Context) error {
 		return r.runContext.stateManager.PublishUpdates(r.stepTracer)
 	}
 
-	if err := r.runContext.PrepareForCheckpoint(ctx); err != nil {
+	if err := r.runContext.prepareForCheckpoint(ctx); err != nil {
 		return err
 	}
 
@@ -461,7 +461,7 @@ func (r *runner) checkpoint(ctx context.Context) error {
 	cp := &checkpoint.Checkpoint{
 		StepNumber:    r.stepTracer.StepNumber(),
 		WorkflowInfo:  workflowInfo,
-		RunnerData:    r.runContext.ExportState(),
+		RunnerData:    r.runContext.exportState(),
 		StateData:     *stateData,
 		EdgeStateData: edgeData,
 		Parent:        cloneCheckpointInfoPtr(r.lastCheckpointInfo),

--- a/workflow/inproc/state_test.go
+++ b/workflow/inproc/state_test.go
@@ -444,6 +444,62 @@ func readWorkflowStateKeys(ctx *workflow.Context, scope string) ([]string, error
 	return keys, nil
 }
 
+func TestInProcessRun_QueueClearScopeRemovesVisibleKeys(t *testing.T) {
+	const scope = "clear-scope"
+	observed := make(map[string][]string)
+
+	binding := workflow.ExecutorBinding{
+		ID:               "stateful",
+		ImplementationID: "*workflow.Executor",
+		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+			return &workflow.Executor{
+				ID: "stateful",
+
+				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, message any) (any, error) {
+						switch message.(string) {
+						case "seed":
+							if err := ctx.QueueStateUpdate("first", scope, "value"); err != nil {
+								return nil, err
+							}
+							if err := ctx.QueueStateUpdate("second", scope, "value"); err != nil {
+								return nil, err
+							}
+							return nil, ctx.SendMessage("", "clear")
+						case "clear":
+							if err := ctx.QueueClearScope(scope); err != nil {
+								return nil, err
+							}
+							keys, err := readWorkflowStateKeys(ctx, scope)
+							if err != nil {
+								return nil, err
+							}
+							observed["after-clear"] = keys
+						}
+						return nil, nil
+					})
+					return rb, nil
+				},
+			}, nil
+		},
+	}
+
+	wf, err := workflow.NewBuilder(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	run, err := inproc.Default.Run(t.Context(), wf, "seed")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for range run.NewEvents() {
+	}
+
+	if got := observed["after-clear"]; len(got) != 0 {
+		t.Fatalf("keys after clear = %v, want empty", got)
+	}
+}
+
 func TestInProcessRun_StateShouldError_TwoExecutors(t *testing.T) {
 	forward := workflow.NewExecutor("ForwardMessageExecutor", func(t TestTurnToken) TestTurnToken {
 		return t

--- a/workflow/inproc/subworkflow.go
+++ b/workflow/inproc/subworkflow.go
@@ -178,7 +178,7 @@ func (h *subworkflowHostExecutor) ensureRunSendMessage(ctx *workflow.Context, in
 		}
 	}
 
-	joinID, err := h.joinContext.AttachSuperstep(ctx, runner)
+	joinID, err := h.joinContext.attachSuperstep(runner)
 	if err != nil {
 		_ = run.Close(ctx)
 		_ = runner.RequestEndRun(ctx)
@@ -234,7 +234,7 @@ func (h *subworkflowHostExecutor) forwardWorkflowEvent(ctx *workflow.Context, ev
 		}
 		if err != nil {
 			if h.joinContext != nil {
-				_ = h.joinContext.AddEvent(ctx, workflow.ErrorEvent{Error: err, SubWorkflowID: h.id})
+				_ = h.joinContext.addEvent(ctx, workflow.ErrorEvent{Error: err, SubWorkflowID: h.id})
 			}
 			err = nil
 		}
@@ -249,13 +249,13 @@ func (h *subworkflowHostExecutor) forwardWorkflowEvent(ctx *workflow.Context, ev
 			return nil
 		}
 		if h.joinContext != nil {
-			return h.joinContext.SendMessage(ctx, h.id, "", request)
+			return h.joinContext.sendMessage(ctx, h.id, "", request)
 		}
 		return nil
 	case workflow.ErrorEvent:
 		event.SubWorkflowID = h.id
 		if h.joinContext != nil {
-			return h.joinContext.AddEvent(ctx, event)
+			return h.joinContext.addEvent(ctx, event)
 		}
 		return nil
 	case workflow.OutputEvent:
@@ -263,7 +263,7 @@ func (h *subworkflowHostExecutor) forwardWorkflowEvent(ctx *workflow.Context, ev
 			return nil
 		}
 		if h.joinContext != nil {
-			if err := h.joinContext.SendMessage(ctx, h.id, "", event.Output); err != nil {
+			if err := h.joinContext.sendMessage(ctx, h.id, "", event.Output); err != nil {
 				return err
 			}
 			return h.yieldOutput(ctx, event.Output)
@@ -271,12 +271,12 @@ func (h *subworkflowHostExecutor) forwardWorkflowEvent(ctx *workflow.Context, ev
 		return nil
 	case workflow.RequestHaltEvent:
 		if h.joinContext != nil {
-			return h.joinContext.AddEvent(ctx, workflow.RequestHaltEvent{})
+			return h.joinContext.addEvent(ctx, workflow.RequestHaltEvent{})
 		}
 		return nil
 	default:
 		if h.joinContext != nil {
-			return h.joinContext.AddEvent(ctx, evt)
+			return h.joinContext.addEvent(ctx, evt)
 		}
 		return nil
 	}
@@ -378,7 +378,7 @@ func (h *subworkflowHostExecutor) reset(ctx context.Context) error {
 	}
 
 	if h.joinContext != nil && h.joinID != "" {
-		h.joinContext.DetachSuperstep(h.joinID)
+		h.joinContext.detachSuperstep(h.joinID)
 		h.joinID = ""
 	}
 	return runErr

--- a/workflow/internal/execution/eventstream.go
+++ b/workflow/internal/execution/eventstream.go
@@ -505,15 +505,6 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 			return !hadRequestHaltEvent && linkedCtx.Err() == nil
 		}
 
-		if err := l.stepRunner.RepublishPendingEvents(linkedCtx); err != nil {
-			sessionErr = err
-			yield(nil, err)
-			return
-		}
-		if !drainEvents() {
-			return
-		}
-
 		l.setStatus(RunStatusRunning)
 
 		var runActivity *observability.Activity
@@ -524,9 +515,15 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 		}
 
 		startRunActivity()
-		// Emit StartedEvent only when there's actual work to process.
-		if l.stepRunner.HasUnprocessedMessages() {
-			l.eventQueue.Enqueue(workflow.StartedEvent{})
+		l.eventQueue.Enqueue(workflow.StartedEvent{})
+
+		if err := l.stepRunner.RepublishPendingEvents(linkedCtx); err != nil {
+			sessionErr = err
+			yield(nil, err)
+			return
+		}
+		if !drainEvents() {
+			return
 		}
 
 		for {
@@ -574,9 +571,6 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 					return
 				}
 				startRunActivity()
-				if l.stepRunner.HasUnprocessedMessages() {
-					l.eventQueue.Enqueue(workflow.StartedEvent{})
-				}
 			} else {
 				// No more work to do
 				return

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -553,6 +553,10 @@ type Context struct {
 	// If no scope is provided, the executor's default scope is used.
 	QueueStateUpdate func(key string, scope string, value any) error
 
+	// QueueClearScope clears all state entries within the specified scope.
+	// If no scope is provided, the executor's default scope is used.
+	QueueClearScope func(scope string) error
+
 	// TraceContext returns the trace context associated with the current message about to be processed by the executor, if any.
 	TraceContext func() map[string]any
 


### PR DESCRIPTION
## Summary
- Align in-process runner context behavior and structure with the .NET InProcessRunnerContext
- Add workflow-as-agent response merging parity and preserve generic Response.Coalesce behavior
- Tighten external response validation, checkpoint import, queued delivery processing, output filtering, and state scope clearing parity

## Validation
- go test ./workflow/inproc ./workflow/internal/execution ./agent/hosting/workflowhosting ./agent/provider/workflowprovider ./agent