### PR TITLE
[dotnet-port] Align fsskills nested discovery with .NET

### DIFF
--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -192,6 +192,7 @@ func searchForSkills(filesystem fs.FS, dir string, results *[]discoveredSkillDir
 		if err == nil {
 			*results = append(*results, discoveredSkillDir{fsys: sub, path: dir})
 		}
+		return
 	}
 	if currentDepth >= defaultSearchDepth {
 		return

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -188,11 +188,14 @@ func discoverSkillDirectories(filesystems []fs.FS) []discoveredSkillDir {
 func searchForSkills(filesystem fs.FS, dir string, results *[]discoveredSkillDir, currentDepth int) {
 	skillPath := path.Join(dir, skillFileName)
 	if _, err := fs.Stat(filesystem, skillPath); err == nil {
-		sub, err := fs.Sub(filesystem, dir)
+		sub := filesystem
+		if dir != "." {
+			sub, err = fs.Sub(filesystem, dir)
+		}
 		if err == nil {
 			*results = append(*results, discoveredSkillDir{fsys: sub, path: dir})
+			return
 		}
-		return
 	}
 	if currentDepth >= defaultSearchDepth {
 		return

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -189,10 +189,11 @@ func searchForSkills(filesystem fs.FS, dir string, results *[]discoveredSkillDir
 	skillPath := path.Join(dir, skillFileName)
 	if _, err := fs.Stat(filesystem, skillPath); err == nil {
 		sub := filesystem
+		var subErr error
 		if dir != "." {
-			sub, err = fs.Sub(filesystem, dir)
+			sub, subErr = fs.Sub(filesystem, dir)
 		}
-		if err == nil {
+		if subErr == nil {
 			*results = append(*results, discoveredSkillDir{fsys: sub, path: dir})
 			return
 		}

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -70,6 +70,30 @@ func TestFileSource_NestedSkillDirectory_DiscoveredWithinDepthLimit(t *testing.T
 	}
 }
 
+func TestFileSource_NestedSkillFileUnderSkillRoot_NotDiscoveredAsIndependentSkill(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "parent-skill", "Parent", "Parent body.")
+	childDir := filepath.Join(root, "parent-skill", "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "SKILL.md"), []byte("---\nname: child\ndescription: Child\n---\nChild body."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := fsskills.NewSource(os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(loaded))
+	}
+	if loaded[0].Frontmatter.Name != "parent-skill" {
+		t.Fatalf("expected parent-skill, got %q", loaded[0].Frontmatter.Name)
+	}
+}
+
 func TestFileSource_SkillBeyondMaxDepth_NotDiscovered(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, filepath.Join(root, "l1", "l2", "l3"), "deep-skill", "Too deep", "Body.")

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -70,6 +70,32 @@ func TestFileSource_NestedSkillDirectory_DiscoveredWithinDepthLimit(t *testing.T
 	}
 }
 
+func TestFileSource_RootSkillFileWithNestedSkillFile_DoesNotAbortDiscovery(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte("---\nname: root-skill\ndescription: Root\n---\nRoot body."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	childDir := filepath.Join(root, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "SKILL.md"), []byte("---\nname: child\ndescription: Child\n---\nChild body."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := fsskills.NewSource(os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(loaded))
+	}
+	if loaded[0].Frontmatter.Name != "root-skill" {
+		t.Fatalf("expected root-skill, got %q", loaded[0].Frontmatter.Name)
+	}
+}
+
 func TestFileSource_NestedSkillFileUnderSkillRoot_NotDiscoveredAsIndependentSkill(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "parent-skill", "Parent", "Parent body.")


### PR DESCRIPTION
Stop recursive skill root discovery once a SKILL.md is found so nested files remain part of the parent skill instead of becoming independent skill roots.