### PR TITLE
[dotnet-port] Align external response port correlation with .NET

### DIFF
--- a/workflow/inproc/binding_test.go
+++ b/workflow/inproc/binding_test.go
@@ -1009,9 +1009,30 @@ func TestRequestPortBind_RejectsResponseForOtherPort(t *testing.T) {
 		Data:      workflow.AnyPortableValue(int(7)),
 	}
 	if _, err := run.Resume(ctx, resp); err != nil {
-		t.Fatalf("Resume: %v", err)
+		t.Fatalf("Resume with mismatched response port: %v", err)
 	}
-	for range run.OutgoingEvents() {
+	errorsAfterMismatch := errorEvents(slices.Collect(run.OutgoingEvents()))
+	var sawPortMismatch bool
+	for _, errEvt := range errorsAfterMismatch {
+		if errEvt.Error != nil &&
+			strings.Contains(errEvt.Error.Error(), `response port ID "other"`) &&
+			strings.Contains(errEvt.Error.Error(), req.RequestID) {
+			sawPortMismatch = true
+		}
+	}
+	if !sawPortMismatch {
+		t.Fatal("expected an ErrorEvent for the mismatched response port")
+	}
+
+	legitimate, err := req.CreateResponse(int(7))
+	if err != nil {
+		t.Fatalf("CreateResponse: %v", err)
+	}
+	if _, err := run.Resume(ctx, legitimate); err != nil {
+		t.Fatalf("Resume with legitimate response after rejected mismatch: %v", err)
+	}
+	if got := len(errorEvents(slices.Collect(run.OutgoingEvents()))); got != len(errorsAfterMismatch) {
+		t.Fatalf("legitimate response after rejected mismatch added an error event; got %d errors, want %d", got, len(errorsAfterMismatch))
 	}
 }
 

--- a/workflow/inproc/binding_test.go
+++ b/workflow/inproc/binding_test.go
@@ -1023,6 +1023,13 @@ func TestRequestPortBind_RejectsResponseForOtherPort(t *testing.T) {
 	if !sawPortMismatch {
 		t.Fatal("expected an ErrorEvent for the mismatched response port")
 	}
+	status, err := run.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus after mismatched response: %v", err)
+	}
+	if status == inproc.RunStatusEnded {
+		t.Fatal("run ended after rejected mismatched response")
+	}
 
 	legitimate, err := req.CreateResponse(int(7))
 	if err != nil {

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -333,6 +333,9 @@ func (proc *runnerContext) AddExternalResponse(ctx context.Context, response *wo
 	proc.queuedExternalDeliveries = append(proc.queuedExternalDeliveries, func(ctx context.Context) error {
 		ownerID, err := proc.completeResponse(response)
 		if err != nil {
+			if proc.runEnded.Load() {
+				return err
+			}
 			return proc.outgoingEvents.EnqueueNonFatal(ctx, workflow.ErrorEvent{Error: err})
 		}
 

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -324,13 +324,16 @@ func (proc *runnerContext) AddExternalResponse(ctx context.Context, response *wo
 	if err := proc.checkEnded(); err != nil {
 		return err
 	}
+	if response == nil {
+		return errors.New("response cannot be nil")
+	}
 
 	proc.externalDeliveriesMu.Lock()
 	defer proc.externalDeliveriesMu.Unlock()
 	proc.queuedExternalDeliveries = append(proc.queuedExternalDeliveries, func(ctx context.Context) error {
 		ownerID, err := proc.completeResponse(response)
 		if err != nil {
-			return err
+			return proc.outgoingEvents.EnqueueNonFatal(ctx, workflow.ErrorEvent{Error: err})
 		}
 
 		mapping, err := proc.edgeMap.PrepareDeliveryForResponse(ctx, response, ownerID)
@@ -683,6 +686,9 @@ func (proc *runnerContext) completeResponse(response *workflow.ExternalResponse)
 	if err := proc.checkEnded(); err != nil {
 		return "", err
 	}
+	if response == nil {
+		return "", errors.New("response cannot be nil")
+	}
 
 	proc.requestsMu.Lock()
 	defer proc.requestsMu.Unlock()
@@ -692,7 +698,7 @@ func (proc *runnerContext) completeResponse(response *workflow.ExternalResponse)
 		return "", fmt.Errorf("no pending request with ID %s found in the workflow context", response.RequestID)
 	}
 	if pendingRequest.PortInfo.PortID != response.PortInfo.PortID {
-		return "", fmt.Errorf("response port ID %q does not match the originating port ID for request %s", response.PortInfo.PortID, response.RequestID)
+		return "", fmt.Errorf("response port ID %q does not match originating port ID %q for request %s", response.PortInfo.PortID, pendingRequest.PortInfo.PortID, response.RequestID)
 	}
 
 	delete(proc.externalRequests, response.RequestID)

--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -328,9 +328,9 @@ func (proc *runnerContext) AddExternalResponse(ctx context.Context, response *wo
 	proc.externalDeliveriesMu.Lock()
 	defer proc.externalDeliveriesMu.Unlock()
 	proc.queuedExternalDeliveries = append(proc.queuedExternalDeliveries, func(ctx context.Context) error {
-		ownerID, existed := proc.CompleteRequest(response.RequestID)
-		if !existed {
-			return fmt.Errorf("no pending request with ID %s found in the workflow context", response.RequestID)
+		ownerID, err := proc.completeResponse(response)
+		if err != nil {
+			return err
 		}
 
 		mapping, err := proc.edgeMap.PrepareDeliveryForResponse(ctx, response, ownerID)
@@ -677,21 +677,28 @@ func (proc *runnerContext) Post(ctx context.Context, ownerID string, request *wo
 	return proc.AddEvent(ctx, workflow.RequestInfoEvent{Request: request})
 }
 
-// CompleteRequest marks a request as completed and returns the executor that
-// posted it.
-func (proc *runnerContext) CompleteRequest(requestID string) (string, bool) {
+// completeResponse validates and consumes the matching pending request, then
+// returns the executor that posted it.
+func (proc *runnerContext) completeResponse(response *workflow.ExternalResponse) (string, error) {
 	if err := proc.checkEnded(); err != nil {
-		return "", false
+		return "", err
 	}
 
 	proc.requestsMu.Lock()
 	defer proc.requestsMu.Unlock()
 
-	_, existed := proc.externalRequests[requestID]
-	delete(proc.externalRequests, requestID)
-	owner := proc.requestOwners[requestID]
-	delete(proc.requestOwners, requestID)
-	return owner, existed
+	pendingRequest, existed := proc.externalRequests[response.RequestID]
+	if !existed {
+		return "", fmt.Errorf("no pending request with ID %s found in the workflow context", response.RequestID)
+	}
+	if pendingRequest.PortInfo.PortID != response.PortInfo.PortID {
+		return "", fmt.Errorf("response port ID %q does not match the originating port ID for request %s", response.PortInfo.PortID, response.RequestID)
+	}
+
+	delete(proc.externalRequests, response.RequestID)
+	owner := proc.requestOwners[response.RequestID]
+	delete(proc.requestOwners, response.RequestID)
+	return owner, nil
 }
 
 // ResponsePortExecutorID returns the executor that handles responses on the

--- a/workflow/internal/execution/eventstream.go
+++ b/workflow/internal/execution/eventstream.go
@@ -247,7 +247,9 @@ func (s *streamingRunEventStream) onEventRaised(ctx context.Context, sender any,
 		return err
 	}
 	if _, ok := evt.(workflow.ErrorEvent); ok {
-		s.runLoopCancel()
+		if _, nonFatal := sender.(nonFatalEventSender); !nonFatal {
+			s.runLoopCancel()
+		}
 		return nil
 	}
 	return s.runLoopCtx.Err()

--- a/workflow/internal/execution/eventstream.go
+++ b/workflow/internal/execution/eventstream.go
@@ -247,7 +247,7 @@ func (s *streamingRunEventStream) onEventRaised(ctx context.Context, sender any,
 		return err
 	}
 	if _, ok := evt.(workflow.ErrorEvent); ok {
-		if _, nonFatal := sender.(nonFatalEventSender); !nonFatal {
+		if _, isNonFatal := sender.(nonFatalEventSender); !isNonFatal {
 			s.runLoopCancel()
 		}
 		return nil

--- a/workflow/internal/execution/execution.go
+++ b/workflow/internal/execution/execution.go
@@ -20,6 +20,7 @@ const (
 
 type EventSink interface {
 	Enqueue(context.Context, workflow.Event) error
+	EnqueueNonFatal(context.Context, workflow.Event) error
 }
 
 var _ EventSink = (*ConcurrentEventSink)(nil)
@@ -28,6 +29,8 @@ type ConcurrentEventSink struct {
 	mu          sync.RWMutex
 	EventRaised []func(context.Context, any, workflow.Event) error
 }
+
+type nonFatalEventSender struct{}
 
 func (s *ConcurrentEventSink) AddHandler(handler func(context.Context, any, workflow.Event) error) {
 	if handler == nil {
@@ -60,12 +63,20 @@ func (s *ConcurrentEventSink) HandlerCount() int {
 }
 
 func (s *ConcurrentEventSink) Enqueue(ctx context.Context, evt workflow.Event) error {
+	return s.enqueue(ctx, nil, evt)
+}
+
+func (s *ConcurrentEventSink) EnqueueNonFatal(ctx context.Context, evt workflow.Event) error {
+	return s.enqueue(ctx, nonFatalEventSender{}, evt)
+}
+
+func (s *ConcurrentEventSink) enqueue(ctx context.Context, sender any, evt workflow.Event) error {
 	s.mu.RLock()
 	handlers := append([]func(context.Context, any, workflow.Event) error(nil), s.EventRaised...)
 	s.mu.RUnlock()
 
 	for _, handler := range handlers {
-		if err := handler(ctx, nil, evt); err != nil {
+		if err := handler(ctx, sender, evt); err != nil {
 			return err
 		}
 	}

--- a/workflow/internal/execution/execution.go
+++ b/workflow/internal/execution/execution.go
@@ -30,6 +30,8 @@ type ConcurrentEventSink struct {
 	EventRaised []func(context.Context, any, workflow.Event) error
 }
 
+// nonFatalEventSender marks events that should be delivered without cancelling
+// the off-thread run loop.
 type nonFatalEventSender struct{}
 
 func (s *ConcurrentEventSink) AddHandler(handler func(context.Context, any, workflow.Event) error) {

--- a/workflow/internal/execution/execution.go
+++ b/workflow/internal/execution/execution.go
@@ -30,8 +30,8 @@ type ConcurrentEventSink struct {
 	EventRaised []func(context.Context, any, workflow.Event) error
 }
 
-// nonFatalEventSender marks events that should be delivered without cancelling
-// the off-thread run loop.
+// nonFatalEventSender marks validation ErrorEvents that should reach consumers
+// without cancelling the off-thread run loop.
 type nonFatalEventSender struct{}
 
 func (s *ConcurrentEventSink) AddHandler(handler func(context.Context, any, workflow.Event) error) {


### PR DESCRIPTION
This pull request strengthens the validation logic for handling external responses in the workflow engine. It ensures that responses are only accepted if they match the expected request and port, and improves test coverage to verify this behavior. The main changes are grouped below.

**Validation and Error Handling Improvements:**

* Replaced the previous `CompleteRequest` method with a new `completeResponse` method in `runnerContext`, which validates that an incoming response matches both the expected request ID and port ID before marking it as complete. If the response does not match, an error is returned. (`workflow/inproc/context.go`)
* Updated `AddExternalResponse` to use the new `completeResponse` method, so that mismatched responses are correctly rejected with an error. (`workflow/inproc/context.go`)

**Testing Enhancements:**

* Improved the test `TestRequestPortBind_RejectsResponseForOtherPort` to explicitly check for error events when a response is received for a mismatched port, and to verify that a legitimate response after the error is handled correctly without producing additional errors. (`workflow/inproc/binding_test.go`)