### PR TITLE
[dotnet-code] Extract skill deduplication helper

### DIFF
--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -308,18 +308,22 @@ func (p *providerState) loadSkills(ctx context.Context) ([]*Skill, error) {
 	if p.options.DisableSourceDeduplication {
 		return loaded, nil
 	}
-	seen := make(map[string]struct{}, len(loaded))
-	deduplicated := loaded[:0]
-	for _, skill := range loaded {
+	return deduplicateSkillsByName(loaded, p.logger), nil
+}
+
+func deduplicateSkillsByName(skills []*Skill, logger *slog.Logger) []*Skill {
+	seen := make(map[string]struct{}, len(skills))
+	deduplicated := skills[:0]
+	for _, skill := range skills {
 		resolvedKey := strings.ToLower(skill.Frontmatter.Name)
 		if _, ok := seen[resolvedKey]; ok {
-			p.logger.Warn("Duplicate skill name: subsequent skill skipped in favor of first occurrence", "skillName", skill.Frontmatter.Name)
+			logger.Warn("Duplicate skill name: subsequent skill skipped in favor of first occurrence", "skillName", skill.Frontmatter.Name)
 			continue
 		}
 		seen[resolvedKey] = struct{}{}
 		deduplicated = append(deduplicated, skill)
 	}
-	return deduplicated, nil
+	return deduplicated
 }
 
 func indexSkills(skills []*Skill) providedSkillSet {


### PR DESCRIPTION
This pull request refactors the skill deduplication logic in `provider.go` to improve code organization and reusability. The deduplication code is extracted into a new helper function, making the main function cleaner and separating concerns.

**Code organization and refactoring:**

* Extracted the skill deduplication logic from `loadSkills` into a new helper function `deduplicateSkillsByName`, improving readability and reusability. (`agent/skills/provider.go`, [agent/skills/provider.goL311-R326](diffhunk://#diff-290d2c4c5e492387385994a6e69dc70ab7fc3bab525ad7dd999a2f12c36968a6L311-R326))
* Updated the deduplication process to use the new helper function, passing in the logger as a parameter instead of referencing it directly. (`agent/skills/provider.go`, [agent/skills/provider.goL311-R326](diffhunk://#diff-290d2c4c5e492387385994a6e69dc70ab7fc3bab525ad7dd999a2f12c36968a6L311-R326))