### PR TITLE
[dotnet-code] Consolidate workflow edge registration

### DIFF
--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -127,7 +127,7 @@ func (wb *Builder) AddDirectEdge(source ExecutorBinding, target ExecutorBinding,
 		Index:      wb.edgeIdx(),
 	}
 	applyEdgeOptions(&edge, opts)
-	wb.edges[source.ID] = append(wb.edges[source.ID], edge)
+	wb.addEdgeForSource(source.ID, edge)
 	wb.conditionlessConnections = append(wb.conditionlessConnections, conn)
 	return wb
 }
@@ -159,7 +159,7 @@ func (wb *Builder) AddFanOutEdge(source ExecutorBinding, targets []ExecutorBindi
 		Index:      wb.edgeIdx(),
 	}
 	applyEdgeOptions(&edge, opts)
-	wb.edges[source.ID] = append(wb.edges[source.ID], edge)
+	wb.addEdgeForSource(source.ID, edge)
 	return wb
 }
 
@@ -188,7 +188,7 @@ func (wb *Builder) AddFanInBarrierEdge(sources []ExecutorBinding, target Executo
 	}
 	applyEdgeOptions(&edge, opts)
 	for _, id := range sourceIDs {
-		wb.edges[id] = append(wb.edges[id], edge)
+		wb.addEdgeForSource(id, edge)
 	}
 	return wb
 }
@@ -335,6 +335,10 @@ func (wb *Builder) validate(validateOrphans bool) bool {
 func (wb *Builder) edgeIdx() int {
 	wb.edgeCount++
 	return wb.edgeCount
+}
+
+func (wb *Builder) addEdgeForSource(sourceID string, edge Edge) {
+	wb.edges[sourceID] = append(wb.edges[sourceID], edge)
 }
 
 // validateTypeCompatibility checks that sent message types of source executors


### PR DESCRIPTION
Centralize workflow builder edge insertion behind an unexported helper so direct, fan-out, and fan-in edge paths share the same internal registration shape.