### PR TITLE
Add merge queue triggers to CI workflows

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - "main"
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Add `merge_group` triggers to the Tests workflow so merge queue commits produce the required `conclusion` check.
- Add the same trigger to golangci-lint so merge queue validation runs lint checks too.

## Validation
- `git diff --check`
- VS Code diagnostics for the edited workflow files

This should unblock merge queue entries that are stuck in `AWAITING_CHECKS` because GitHub Actions workflows are not starting for `gh-readonly-queue` commits.