### PR TITLE
Add Agent Framework user agent telemetry

### DIFF
--- a/agent/provider/openaiagent/chat.go
+++ b/agent/provider/openaiagent/chat.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"net/http"
 	"reflect"
 	"slices"
 	"strings"
@@ -16,12 +17,19 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/format/jsonformat"
 	"github.com/microsoft/agent-framework-go/agent/harness/toolautocall"
+	"github.com/microsoft/agent-framework-go/internal/telemetry"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/hostedtool"
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
 )
+
+var telemetryRequestOption = option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+	telemetry.PrependAgentFrameworkToHTTPHeader(req.Header)
+	return next(req)
+})
 
 type chatClient struct {
 	client openai.Client
@@ -94,7 +102,7 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 		}
 	}
 	if stream, _ := agent.GetOption(options, agent.Stream); !stream {
-		resp, err := a.client.Chat.Completions.New(ctx, body)
+		resp, err := a.client.Chat.Completions.New(ctx, body, telemetryRequestOption)
 		if err != nil {
 			return func(yield func(*agent.ResponseUpdate, error) bool) {
 				yield(nil, err)
@@ -133,7 +141,7 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 		}
 	}
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
-		stream := a.client.Chat.Completions.NewStreaming(ctx, body)
+		stream := a.client.Chat.Completions.NewStreaming(ctx, body, telemetryRequestOption)
 		defer func() { _ = stream.Close() }()
 		var acc openai.ChatCompletionAccumulator
 		for stream.Next() {

--- a/agent/provider/openaiagent/chat.go
+++ b/agent/provider/openaiagent/chat.go
@@ -27,7 +27,7 @@ import (
 )
 
 var telemetryRequestOption = option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-	telemetry.PrependAgentFrameworkToHTTPHeader(req.Header)
+	req.Header = telemetry.PrependAgentFrameworkToHTTPHeader(req.Header)
 	return next(req)
 })
 

--- a/agent/provider/openaiagent/chat_test.go
+++ b/agent/provider/openaiagent/chat_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,6 +70,32 @@ func newTestClient(server *httptest.Server) *agent.Agent {
 			Config: agent.Config{DisableFuncAutoCall: true},
 		},
 	)
+}
+
+func TestChatRequestIncludesAgentFrameworkUserAgent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		if !strings.HasPrefix(userAgent, "agent-framework-go/") {
+			t.Fatalf("User-Agent = %q, want agent-framework-go prefix", userAgent)
+		}
+		if !strings.Contains(userAgent, "OpenAI/Go") {
+			t.Fatalf("User-Agent = %q, want OpenAI SDK token", userAgent)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":1727888631,
+			"model":"gpt-4o-mini",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer server.Close()
+
+	a := newTestClient(server)
+	if _, err := a.RunText(t.Context(), "hello").Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
 }
 
 func TestChatConfigInstructions_NonStreaming(t *testing.T) {

--- a/agent/provider/openaiagent/responses.go
+++ b/agent/provider/openaiagent/responses.go
@@ -118,7 +118,7 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 				// Get streaming response
 				streamResp := a.client.Responses.GetStreaming(ctx, ct.ResponseID, responses.ResponseGetParams{
 					StartingAfter: openai.Int(ct.SequenceNumber),
-				})
+				}, telemetryRequestOption)
 				// Update conversation ID when resuming
 				updateConversationID(ct.ResponseID)
 				for streamResp.Next() {
@@ -138,7 +138,7 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 				}
 			} else {
 				// Get complete response
-				resp, err := a.client.Responses.Get(ctx, ct.ResponseID, responses.ResponseGetParams{})
+				resp, err := a.client.Responses.Get(ctx, ct.ResponseID, responses.ResponseGetParams{}, telemetryRequestOption)
 				if err != nil {
 					yield(nil, err)
 					return
@@ -159,7 +159,7 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 
 		if stream {
 			// Create streaming response
-			streamResp := a.client.Responses.NewStreaming(ctx, body)
+			streamResp := a.client.Responses.NewStreaming(ctx, body, telemetryRequestOption)
 			responseID := ""
 			createdAt := time.Time{}
 			isBackground, _ := agent.GetOption(options, agent.AllowBackgroundResponses)
@@ -196,7 +196,7 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 			}
 		} else {
 			// Create complete response
-			resp, err := a.client.Responses.New(ctx, body)
+			resp, err := a.client.Responses.New(ctx, body, telemetryRequestOption)
 			if err != nil {
 				yield(nil, err)
 				return

--- a/agent/provider/openaiagent/responses_test.go
+++ b/agent/provider/openaiagent/responses_test.go
@@ -74,6 +74,35 @@ func newTestResponsesClient(server *httptest.Server, model string) *agent.Agent 
 	)
 }
 
+func TestResponsesRequestIncludesAgentFrameworkUserAgent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		if !strings.HasPrefix(userAgent, "agent-framework-go/") {
+			t.Fatalf("User-Agent = %q, want agent-framework-go prefix", userAgent)
+		}
+		if !strings.Contains(userAgent, "OpenAI/Go") {
+			t.Fatalf("User-Agent = %q, want OpenAI SDK token", userAgent)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"resp_test",
+			"object":"response",
+			"created_at":1741891428,
+			"status":"completed",
+			"error":null,
+			"incomplete_details":null,
+			"model":"gpt-4o-mini",
+			"output":[{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"hello","annotations":[]}]}]
+		}`)
+	}))
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	if _, err := a.RunText(t.Context(), "hello").Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestResponsesConfigInstructions_NonStreaming(t *testing.T) {
 	const input = `
 						{

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package telemetry
+
+import (
+	"net/http"
+	"os"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"sync"
+)
+
+const (
+	modulePath                       = "github.com/microsoft/agent-framework-go"
+	userAgentTelemetryDisabledEnvVar = "AGENT_FRAMEWORK_USER_AGENT_DISABLED"
+	userAgentKey                     = "User-Agent"
+	httpUserAgent                    = "agent-framework-go"
+	foundryHostingEnvVar             = "FOUNDRY_HOSTING_ENVIRONMENT"
+	hostedUserAgentPrefix            = "foundry-hosting"
+)
+
+var (
+	version                 = detectVersion()
+	agentFrameworkUserAgent = httpUserAgent + "/" + version
+	userAgentPrefixes       = map[string]struct{}{}
+)
+
+var userAgentTelemetryEnabled = sync.OnceValue(func() bool {
+	switch strings.ToLower(os.Getenv(userAgentTelemetryDisabledEnvVar)) {
+	case "true", "1":
+		return false
+	default:
+		return true
+	}
+})
+
+var userAgent = sync.OnceValue(func() string {
+	if os.Getenv(foundryHostingEnvVar) != "" {
+		if hostedUserAgentPrefix != "" {
+			userAgentPrefixes[hostedUserAgentPrefix] = struct{}{}
+		}
+	}
+	prefixes := userAgentPrefixList()
+	if len(prefixes) == 0 {
+		return agentFrameworkUserAgent
+	}
+	return strings.Join(prefixes, "/") + "/" + agentFrameworkUserAgent
+})
+
+// AppInfo returns Agent Framework application metadata for telemetry, or nil when telemetry is disabled.
+func AppInfo() map[string]string {
+	if !userAgentTelemetryEnabled() {
+		return nil
+	}
+	return map[string]string{"agent-framework-version": "go/" + version}
+}
+
+// UserAgent returns the full Agent Framework user-agent string including registered prefixes.
+func UserAgent() string {
+	return userAgent()
+}
+
+// PrependAgentFrameworkToUserAgent prepends the Agent Framework user-agent value to headers.
+func PrependAgentFrameworkToUserAgent(headers map[string]string) map[string]string {
+	if !userAgentTelemetryEnabled() {
+		return headers
+	}
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	userAgent := UserAgent()
+	if existing := headers[userAgentKey]; existing != "" {
+		headers[userAgentKey] = userAgent + " " + existing
+	} else {
+		headers[userAgentKey] = userAgent
+	}
+	return headers
+}
+
+// PrependAgentFrameworkToHTTPHeader prepends the Agent Framework user-agent value to an http.Header.
+func PrependAgentFrameworkToHTTPHeader(headers http.Header) http.Header {
+	if !userAgentTelemetryEnabled() {
+		return headers
+	}
+	if headers == nil {
+		headers = http.Header{}
+	}
+	userAgent := UserAgent()
+	if existing := headers.Get(userAgentKey); existing != "" {
+		headers.Set(userAgentKey, userAgent+" "+existing)
+	} else {
+		headers.Set(userAgentKey, userAgent)
+	}
+	return headers
+}
+
+func userAgentPrefixList() []string {
+	prefixes := make([]string, 0, len(userAgentPrefixes))
+	for prefix := range userAgentPrefixes {
+		prefixes = append(prefixes, prefix)
+	}
+	slices.Sort(prefixes)
+	return prefixes
+}
+
+func detectVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "v0.0.0"
+	}
+	if info.Main.Path == modulePath && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == modulePath && dep.Version != "" && dep.Version != "(devel)" {
+			return dep.Version
+		}
+	}
+	return "v0.0.0"
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -48,19 +48,6 @@ var userAgent = sync.OnceValue(func() string {
 	return strings.Join(prefixes, "/") + "/" + agentFrameworkUserAgent
 })
 
-// AppInfo returns Agent Framework application metadata for telemetry, or nil when telemetry is disabled.
-func AppInfo() map[string]string {
-	if !userAgentTelemetryEnabled() {
-		return nil
-	}
-	return map[string]string{"agent-framework-version": "go/" + version}
-}
-
-// UserAgent returns the full Agent Framework user-agent string including registered prefixes.
-func UserAgent() string {
-	return userAgent()
-}
-
 // PrependAgentFrameworkToUserAgent prepends the Agent Framework user-agent value to headers.
 func PrependAgentFrameworkToUserAgent(headers map[string]string) map[string]string {
 	if !userAgentTelemetryEnabled() {
@@ -69,7 +56,7 @@ func PrependAgentFrameworkToUserAgent(headers map[string]string) map[string]stri
 	if headers == nil {
 		headers = map[string]string{}
 	}
-	userAgent := UserAgent()
+	userAgent := userAgent()
 	if existing := headers[userAgentKey]; existing != "" {
 		headers[userAgentKey] = userAgent + " " + existing
 	} else {
@@ -86,7 +73,7 @@ func PrependAgentFrameworkToHTTPHeader(headers http.Header) http.Header {
 	if headers == nil {
 		headers = http.Header{}
 	}
-	userAgent := UserAgent()
+	userAgent := userAgent()
 	if existing := headers.Get(userAgentKey); existing != "" {
 		headers.Set(userAgentKey, userAgent+" "+existing)
 	} else {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package telemetry_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/internal/telemetry"
+)
+
+const helperProcessEnv = "AGENT_FRAMEWORK_TELEMETRY_TEST_HELPER"
+
+const (
+	foundryHostingEnvVar             = "FOUNDRY_HOSTING_ENVIRONMENT"
+	userAgentKey                     = "User-Agent"
+	userAgentTelemetryDisabledEnvVar = "AGENT_FRAMEWORK_USER_AGENT_DISABLED"
+)
+
+func TestVersionHasLeadingV(t *testing.T) {
+	got := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
+	if !strings.HasPrefix(got, "agent-framework-go/v") {
+		t.Fatalf("UserAgent() = %q, want agent-framework-go/v...", got)
+	}
+}
+
+func TestAppInfo(t *testing.T) {
+	got := runHelper(t, "app-info", userAgentTelemetryDisabledEnvVar+"=")
+	base := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
+	want := "go/" + strings.TrimPrefix(base, "agent-framework-go/")
+	if got != want {
+		t.Fatalf("AppInfo()[agent-framework-version] = %q, want %q", got, want)
+	}
+}
+
+func TestAppInfoDisabled(t *testing.T) {
+	if got := runHelper(t, "app-info-disabled", userAgentTelemetryDisabledEnvVar+"=true"); got != "nil" {
+		t.Fatalf("AppInfo() = %q, want nil", got)
+	}
+}
+
+func TestPrependAgentFrameworkToUserAgent(t *testing.T) {
+	got := runHelper(t, "prepend-map", userAgentTelemetryDisabledEnvVar+"=")
+	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=") + " my-app/1.0"
+	if got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestPrependAgentFrameworkToUserAgentWithNilHeaders(t *testing.T) {
+	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
+	if got := runHelper(t, "prepend-nil", userAgentTelemetryDisabledEnvVar+"="); got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestPrependAgentFrameworkToUserAgentDisabled(t *testing.T) {
+	got := runHelper(t, "prepend-disabled", userAgentTelemetryDisabledEnvVar+"=1")
+	want := "my-app/1.0\ntrue\ntrue"
+	if got != want {
+		t.Fatalf("helper output = %q, want %q", got, want)
+	}
+}
+
+func TestPrependAgentFrameworkToHTTPHeader(t *testing.T) {
+	got := runHelper(t, "prepend-http", userAgentTelemetryDisabledEnvVar+"=")
+	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=") + " my-app/1.0"
+	if got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestIsUserAgentTelemetryEnabledCached(t *testing.T) {
+	got := runHelper(t, "telemetry-enabled-cached", userAgentTelemetryDisabledEnvVar+"=")
+	if got != "true\ntrue" {
+		t.Fatalf("helper output = %q, want true true", got)
+	}
+}
+
+func TestUserAgentHostedEnvironmentPrefix(t *testing.T) {
+	got := runHelper(t, "hosted-prefix", foundryHostingEnvVar+"=1", userAgentTelemetryDisabledEnvVar+"=")
+	want := "foundry-hosting/" + runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
+	if got != want {
+		t.Fatalf("UserAgent() = %q, want %q", got, want)
+	}
+}
+
+func TestUserAgentHostedEnvironmentDetectionCached(t *testing.T) {
+	got := runHelper(t, "hosted-cached", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
+	base := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
+	want := base + "\n" + base
+	if got != want {
+		t.Fatalf("helper output = %q, want %q", got, want)
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv(helperProcessEnv) != "1" {
+		return
+	}
+	_, helperName, ok := strings.Cut(strings.Join(os.Args, "\x00"), "\x00--\x00")
+	if !ok {
+		fmt.Fprint(os.Stderr, "missing helper name")
+		os.Exit(2)
+	}
+	switch strings.Trim(helperName, "\x00") {
+	case "user-agent":
+		fmt.Print(telemetry.UserAgent())
+	case "app-info":
+		fmt.Print(telemetry.AppInfo()["agent-framework-version"])
+	case "app-info-disabled":
+		if telemetry.AppInfo() == nil {
+			fmt.Print("nil")
+			break
+		}
+		fmt.Print("not nil")
+	case "prepend-map":
+		headers := telemetry.PrependAgentFrameworkToUserAgent(map[string]string{"User-Agent": "my-app/1.0"})
+		fmt.Print(headers[userAgentKey])
+	case "prepend-nil":
+		headers := telemetry.PrependAgentFrameworkToUserAgent(nil)
+		fmt.Print(headers[userAgentKey])
+	case "prepend-disabled":
+		headers := telemetry.PrependAgentFrameworkToUserAgent(map[string]string{"User-Agent": "my-app/1.0"})
+		fmt.Println(headers[userAgentKey])
+		fmt.Println(telemetry.PrependAgentFrameworkToUserAgent(nil) == nil)
+		fmt.Print(telemetry.PrependAgentFrameworkToHTTPHeader(nil) == nil)
+	case "prepend-http":
+		headers := telemetry.PrependAgentFrameworkToHTTPHeader(http.Header{"User-Agent": []string{"my-app/1.0"}})
+		fmt.Print(headers.Get(userAgentKey))
+	case "telemetry-enabled-cached":
+		fmt.Println(telemetry.AppInfo() != nil)
+		_ = os.Setenv(userAgentTelemetryDisabledEnvVar, "true")
+		fmt.Print(telemetry.AppInfo() != nil)
+	case "hosted-prefix":
+		fmt.Print(telemetry.UserAgent())
+	case "hosted-cached":
+		fmt.Println(telemetry.UserAgent())
+		_ = os.Setenv(foundryHostingEnvVar, "1")
+		fmt.Print(telemetry.UserAgent())
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper %q", helperName)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func runHelper(t *testing.T, name string, env ...string) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() failed: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=^TestHelperProcess$", "--", name)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(cmd.Env, helperProcessEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper %q failed: %v\n%s", name, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -24,22 +24,7 @@ const (
 func TestVersionHasLeadingV(t *testing.T) {
 	got := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
 	if !strings.HasPrefix(got, "agent-framework-go/v") {
-		t.Fatalf("UserAgent() = %q, want agent-framework-go/v...", got)
-	}
-}
-
-func TestAppInfo(t *testing.T) {
-	got := runHelper(t, "app-info", userAgentTelemetryDisabledEnvVar+"=")
-	base := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
-	want := "go/" + strings.TrimPrefix(base, "agent-framework-go/")
-	if got != want {
-		t.Fatalf("AppInfo()[agent-framework-version] = %q, want %q", got, want)
-	}
-}
-
-func TestAppInfoDisabled(t *testing.T) {
-	if got := runHelper(t, "app-info-disabled", userAgentTelemetryDisabledEnvVar+"=true"); got != "nil" {
-		t.Fatalf("AppInfo() = %q, want nil", got)
+		t.Fatalf("User-Agent = %q, want agent-framework-go/v...", got)
 	}
 }
 
@@ -85,7 +70,7 @@ func TestUserAgentHostedEnvironmentPrefix(t *testing.T) {
 	got := runHelper(t, "hosted-prefix", foundryHostingEnvVar+"=1", userAgentTelemetryDisabledEnvVar+"=")
 	want := "foundry-hosting/" + runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
 	if got != want {
-		t.Fatalf("UserAgent() = %q, want %q", got, want)
+		t.Fatalf("User-Agent = %q, want %q", got, want)
 	}
 }
 
@@ -109,15 +94,8 @@ func TestHelperProcess(t *testing.T) {
 	}
 	switch strings.Trim(helperName, "\x00") {
 	case "user-agent":
-		fmt.Print(telemetry.UserAgent())
-	case "app-info":
-		fmt.Print(telemetry.AppInfo()["agent-framework-version"])
-	case "app-info-disabled":
-		if telemetry.AppInfo() == nil {
-			fmt.Print("nil")
-			break
-		}
-		fmt.Print("not nil")
+		headers := telemetry.PrependAgentFrameworkToUserAgent(nil)
+		fmt.Print(headers[userAgentKey])
 	case "prepend-map":
 		headers := telemetry.PrependAgentFrameworkToUserAgent(map[string]string{"User-Agent": "my-app/1.0"})
 		fmt.Print(headers[userAgentKey])
@@ -133,15 +111,18 @@ func TestHelperProcess(t *testing.T) {
 		headers := telemetry.PrependAgentFrameworkToHTTPHeader(http.Header{"User-Agent": []string{"my-app/1.0"}})
 		fmt.Print(headers.Get(userAgentKey))
 	case "telemetry-enabled-cached":
-		fmt.Println(telemetry.AppInfo() != nil)
+		fmt.Println(telemetry.PrependAgentFrameworkToUserAgent(nil) != nil)
 		_ = os.Setenv(userAgentTelemetryDisabledEnvVar, "true")
-		fmt.Print(telemetry.AppInfo() != nil)
+		fmt.Print(telemetry.PrependAgentFrameworkToUserAgent(nil) != nil)
 	case "hosted-prefix":
-		fmt.Print(telemetry.UserAgent())
+		headers := telemetry.PrependAgentFrameworkToUserAgent(nil)
+		fmt.Print(headers[userAgentKey])
 	case "hosted-cached":
-		fmt.Println(telemetry.UserAgent())
+		headers := telemetry.PrependAgentFrameworkToUserAgent(nil)
+		fmt.Println(headers[userAgentKey])
 		_ = os.Setenv(foundryHostingEnvVar, "1")
-		fmt.Print(telemetry.UserAgent())
+		headers = telemetry.PrependAgentFrameworkToUserAgent(nil)
+		fmt.Print(headers[userAgentKey])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown helper %q", helperName)
 		os.Exit(2)


### PR DESCRIPTION
## Summary
- add internal Agent Framework user-agent telemetry helpers
- prepend the Agent Framework user-agent to OpenAI provider requests
- add focused tests for telemetry behavior and OpenAI request headers

## Tests
- go test ./agent/provider/openaiagent ./internal/telemetry