### PR TITLE
Align context and history providers with .NET

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -57,7 +57,7 @@ type Config struct {
 
 	// HistoryProvider injects and persists conversation history around each agent run.
 	// When nil, New uses a default in-memory history provider for local sessions.
-	HistoryProvider *HistoryProvider
+	HistoryProvider HistoryProvider
 
 	// AllowHistoryProviderConflict prevents returning an error when a configured
 	// HistoryProvider conflicts with service-managed history.
@@ -72,7 +72,7 @@ type Config struct {
 	KeepHistoryProviderOnConflict bool
 
 	// ContextProviders inject and persist context around each agent run.
-	ContextProviders []*ContextProvider
+	ContextProviders []ContextProvider
 
 	// DisableFuncAutoCall tells provider constructors not to add automatic function-tool calling middleware.
 	DisableFuncAutoCall bool
@@ -123,7 +123,7 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 			unmarshal: prov.Unmarshal,
 		})
 	}
-	contextProviders := make([]*ContextProvider, 0, len(cfg.ContextProviders))
+	contextProviders := make([]ContextProvider, 0, len(cfg.ContextProviders))
 	for _, provider := range cfg.ContextProviders {
 		if provider != nil {
 			contextProviders = append(contextProviders, provider)
@@ -132,7 +132,7 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 	historyProvider := cfg.HistoryProvider
 	var hasDefaultHistoryProvider bool
 	if historyProvider == nil {
-		historyProvider = NewInMemoryHistoryProvider("")
+		historyProvider = NewInMemoryHistoryProvider(InMemoryHistoryProviderConfig{})
 		hasDefaultHistoryProvider = true
 	}
 	prov.Middlewares = append(prov.Middlewares, authorMiddleware(cfg.ID, cfg.Name))
@@ -166,7 +166,7 @@ type Agent struct {
 	runOptions  []Option
 	logger      *slog.Logger
 
-	historyProvider      *HistoryProvider
+	historyProvider      HistoryProvider
 	hasConfiguredHistory bool
 	// hasDefaultHistoryProvider is true when New synthesized the in-memory
 	// history provider because Config.HistoryProvider was nil. The synthesized
@@ -177,7 +177,7 @@ type Agent struct {
 	suppressHistoryWarning       bool
 	keepHistoryOnConflict        bool
 	providerDoesNotManageHistory bool
-	contextProviders             []*ContextProvider
+	contextProviders             []ContextProvider
 }
 
 // ID returns the agent's unique identifier.
@@ -272,7 +272,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 		runContextProviders := continuationToken == "" && len(a.contextProviders) > 0
 		if historyProvider != nil {
 			var err error
-			messages, err = historyProvider.BeforeRun(ctx, messages, lifecycleOptions...)
+			messages, err = historyProvider.Invoking(ctx, InvokingContext{Messages: messages, Options: lifecycleOptions})
 			if err != nil {
 				yield(nil, err)
 				return
@@ -283,7 +283,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 			options = slices.Clone(lifecycleOptions)
 			for _, provider := range a.contextProviders {
 				var err error
-				messages, options, err = provider.BeforeRun(ctx, messages, options...)
+				messages, options, err = provider.Invoking(ctx, InvokingContext{Messages: messages, Options: options})
 				if err != nil {
 					yield(nil, err)
 					return
@@ -343,20 +343,25 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 			storeResponseMessages = continuationResponse.Messages
 		}
 
-		if runErr == nil && historyStoreProvider != nil {
-			storeHistory, err := a.handleHistoryProviderConflict(ctx, historyStoreProvider, session)
-			if err != nil {
-				if !stopped {
-					yield(nil, err)
+		if historyStoreProvider != nil {
+			storeHistory := a.shouldStoreHistoryProvider(historyStoreProvider, session)
+			if runErr == nil {
+				var err error
+				storeHistory, err = a.handleHistoryProviderConflict(ctx, historyStoreProvider, session)
+				if err != nil {
+					if !stopped {
+						yield(nil, err)
+					}
+					return
 				}
-				return
+				storeHistory = storeHistory && a.shouldStoreHistoryProvider(historyStoreProvider, session)
 			}
-			if storeHistory && a.shouldStoreHistoryProvider(historyStoreProvider, session) {
+			if storeHistory {
 				if continuationToken == "" {
 					historyResponse.Coalesce()
 					storeResponseMessages = historyResponse.Messages
 				}
-				if err := historyStoreProvider.AfterRun(ctx, slices.Clone(storeRequestMessages), slices.Clone(storeResponseMessages), withoutContinuationToken(options)...); err != nil {
+				if err := historyStoreProvider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(storeRequestMessages), ResponseMessages: slices.Clone(storeResponseMessages), Options: withoutContinuationToken(options), Err: runErr}); err != nil {
 					if !stopped {
 						yield(nil, err)
 					}
@@ -365,7 +370,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 			}
 		}
 
-		if runErr == nil && (runContextProviders || continuationToken != "" && len(a.contextProviders) > 0) {
+		if runContextProviders || continuationToken != "" && len(a.contextProviders) > 0 {
 			var contextStoreResponseMessages []*message.Message
 			if continuationToken != "" {
 				continuationResponse := responseFromUpdates(continuationUpdates)
@@ -375,7 +380,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 				contextStoreResponseMessages = contextResponse.Messages
 			}
 			for _, provider := range a.contextProviders {
-				if err := provider.AfterRun(ctx, slices.Clone(storeRequestMessages), slices.Clone(contextStoreResponseMessages), withoutContinuationToken(options)...); err != nil {
+				if err := provider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(storeRequestMessages), ResponseMessages: slices.Clone(contextStoreResponseMessages), Options: withoutContinuationToken(options), Err: runErr}); err != nil {
 					if !stopped {
 						yield(nil, err)
 					}
@@ -399,18 +404,18 @@ func withoutContinuationToken(options []Option) []Option {
 	})
 }
 
-func (a *Agent) historyProviderForRun(session *Session, continuationToken string, noSession bool) *HistoryProvider {
+func (a *Agent) historyProviderForRun(session *Session, continuationToken string, noSession bool) HistoryProvider {
 	if continuationToken != "" {
 		return nil
 	}
 	return a.historyProviderForSession(session, noSession)
 }
 
-func (a *Agent) historyProviderForContinuationStore(session *Session, noSession bool) *HistoryProvider {
+func (a *Agent) historyProviderForContinuationStore(session *Session, noSession bool) HistoryProvider {
 	return a.historyProviderForSession(session, noSession)
 }
 
-func (a *Agent) historyProviderForSession(session *Session, noSession bool) *HistoryProvider {
+func (a *Agent) historyProviderForSession(session *Session, noSession bool) HistoryProvider {
 	if a.historyProvider == nil || session == nil {
 		return nil
 	}
@@ -432,7 +437,7 @@ func (a *Agent) historyProviderForSession(session *Session, noSession bool) *His
 	return a.historyProvider
 }
 
-func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session *Session) bool {
+func (a *Agent) shouldStoreHistoryProvider(provider HistoryProvider, session *Session) bool {
 	if provider == nil {
 		return false
 	}
@@ -449,7 +454,7 @@ func (a *Agent) shouldStoreHistoryProvider(provider *HistoryProvider, session *S
 	return session != nil && session.ServiceID() == ""
 }
 
-func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider *HistoryProvider, session *Session) (bool, error) {
+func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider HistoryProvider, session *Session) (bool, error) {
 	if provider == nil || !a.hasConfiguredHistory || session == nil || session.ServiceID() == "" || a.providerDoesNotManageHistory {
 		return true, nil
 	}
@@ -461,9 +466,7 @@ func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider *His
 		return false, errors.New("only Session.ServiceID or HistoryProvider may be used, but not both; the service returned an ID indicating service-managed history while the agent has a HistoryProvider configured")
 	}
 	if !a.keepHistoryOnConflict {
-		if a.historyProvider == provider {
-			a.historyProvider = nil
-		}
+		a.historyProvider = nil
 		return false, nil
 	}
 	return true, nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -365,7 +365,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 			}
 		}
 
-		if runContextProviders || continuationToken != "" && len(a.contextProviders) > 0 {
+		if runErr == nil && (runContextProviders || continuationToken != "" && len(a.contextProviders) > 0) {
 			var contextStoreResponseMessages []*message.Message
 			if continuationToken != "" {
 				continuationResponse := responseFromUpdates(continuationUpdates)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -651,7 +651,7 @@ func TestAgent_Run_ContextMiddlewareReceivesSession(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ContextMiddlewareCanFailBeforeRun(t *testing.T) {
+func TestAgent_Run_ContextMiddlewareCanFailBeforeInvokingNext(t *testing.T) {
 	middlewareErr := errors.New("middleware failed")
 	runFn := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -828,22 +828,22 @@ func TestRun_All_WithError(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionHasServiceID(t *testing.T) {
+func TestAgent_Run_ContextProvider_RunsWithServiceManagedSession(t *testing.T) {
 	provideCalled := false
 	var capturedMessages []*message.Message
 	var storedResponseMessages []*message.Message
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			provideCalled = true
-			return append(messages, message.NewText("history")), options, nil
+			return []*message.Message{message.NewText("history")}, nil, nil
 		},
-		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, _ ...agent.Option) error {
-			storedResponseMessages = responseMessages
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			storedResponseMessages = invoked.ResponseMessages
 			return nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		capturedMessages = msgs
@@ -854,7 +854,7 @@ func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionHasServiceID(t *te
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	session := agenttest.CreateSession()
@@ -882,13 +882,13 @@ func TestAgent_Run_ContextProviders_SkipWithContinuationToken(t *testing.T) {
 	provideCalled := false
 	runCalled := false
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			provideCalled = true
-			return messages, options, nil
+			return nil, nil, nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		runCalled = true
@@ -902,7 +902,7 @@ func TestAgent_Run_ContextProviders_SkipWithContinuationToken(t *testing.T) {
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	token := agenttest.NewContinuationToken(t, "ct-1")
@@ -997,22 +997,22 @@ func TestAgent_Run_ContinuationToken_PersistsSavedResponseUpdates(t *testing.T) 
 	var contextResponseMessages []*message.Message
 	var historyStoreSawContinuationToken bool
 	var contextStoreSawContinuationToken bool
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, options ...agent.Option) error {
-			historyResponseMessages = responseMessages
-			_, historyStoreSawContinuationToken = agent.GetOption(options, agent.WithContinuationToken)
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			historyResponseMessages = invoked.ResponseMessages
+			_, historyStoreSawContinuationToken = agent.GetOption(invoked.Options, agent.WithContinuationToken)
 			return nil
 		},
-	}
-	contextProvider := &agent.ContextProvider{
+	})
+	contextProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, options ...agent.Option) error {
-			contextResponseMessages = responseMessages
-			_, contextStoreSawContinuationToken = agent.GetOption(options, agent.WithContinuationToken)
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			contextResponseMessages = invoked.ResponseMessages
+			_, contextStoreSawContinuationToken = agent.GetOption(invoked.Options, agent.WithContinuationToken)
 			return nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		if len(messages) != 0 {
 			t.Fatalf("resume messages = %v, want none", messageStrings(messages))
@@ -1034,7 +1034,7 @@ func TestAgent_Run_ContinuationToken_PersistsSavedResponseUpdates(t *testing.T) 
 		ID:               "test-agent",
 		Name:             "test-agent",
 		HistoryProvider:  historyProvider,
-		ContextProviders: []*agent.ContextProvider{contextProvider},
+		ContextProviders: []agent.ContextProvider{contextProvider},
 	})
 	token := agenttest.EncodeContinuationToken(t, agenttest.ContinuationToken{
 		Type:       agenttest.ContinuationTokenType,
@@ -1065,20 +1065,20 @@ func TestAgent_Run_ContinuationToken_PersistsSavedResponseUpdates(t *testing.T) 
 func TestAgent_Run_ContinuationToken_PersistsSavedInputMessages(t *testing.T) {
 	var historyRequestMessages []*message.Message
 	var contextRequestMessages []*message.Message
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
-			historyRequestMessages = requestMessages
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			historyRequestMessages = invoked.RequestMessages
 			return nil
 		},
-	}
-	contextProvider := &agent.ContextProvider{
+	})
+	contextProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
-			contextRequestMessages = requestMessages
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			contextRequestMessages = invoked.RequestMessages
 			return nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		if len(messages) != 0 {
 			t.Fatalf("resume messages = %v, want none", messageStrings(messages))
@@ -1092,7 +1092,7 @@ func TestAgent_Run_ContinuationToken_PersistsSavedInputMessages(t *testing.T) {
 		ID:               "test-agent",
 		Name:             "test-agent",
 		HistoryProvider:  historyProvider,
-		ContextProviders: []*agent.ContextProvider{contextProvider},
+		ContextProviders: []agent.ContextProvider{contextProvider},
 	})
 	token := agenttest.EncodeContinuationToken(t, agenttest.ContinuationToken{
 		Type:          agenttest.ContinuationTokenType,
@@ -1116,13 +1116,13 @@ func TestAgent_Run_UsesConfigContextProvider(t *testing.T) {
 	provideCalled := false
 	runCalled := false
 
-	contextProvider := &agent.ContextProvider{
+	contextProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx-provider",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			provideCalled = true
-			return messages, options, nil
+			return nil, nil, nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		runCalled = true
@@ -1133,7 +1133,7 @@ func TestAgent_Run_UsesConfigContextProvider(t *testing.T) {
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{contextProvider},
+		ContextProviders: []agent.ContextProvider{contextProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -1285,12 +1285,12 @@ func TestAgent_Run_DefaultHistoryProvider_UsesExplicitLocalSession(t *testing.T)
 }
 
 func TestAgent_Run_DefaultHistoryProvider_RunsWithContextProviders(t *testing.T) {
-	contextProvider := &agent.ContextProvider{
+	contextProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return append(messages, message.NewText("context")), options, nil
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{message.NewText("context")}, nil, nil
 		},
-	}
+	})
 	runner := &agenttest.Runner{
 		Responses: []agenttest.Turn{
 			{
@@ -1318,7 +1318,7 @@ func TestAgent_Run_DefaultHistoryProvider_RunsWithContextProviders(t *testing.T)
 	a := agent.New(agent.ProviderConfig{Run: runner.Run}, agent.Config{
 		ID:               "test-agent",
 		Name:             "test-agent",
-		ContextProviders: []*agent.ContextProvider{contextProvider},
+		ContextProviders: []agent.ContextProvider{contextProvider},
 	})
 	session := agenttest.CreateSession()
 
@@ -1361,7 +1361,7 @@ func TestAgent_Run_UsesConfigHistoryProvider(t *testing.T) {
 	a := agent.New(agent.ProviderConfig{Run: runner.Run}, agent.Config{
 		ID:              "test-agent",
 		Name:            "test-agent",
-		HistoryProvider: agent.NewInMemoryHistoryProvider(""),
+		HistoryProvider: agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{}),
 	})
 	session := agenttest.CreateSession()
 
@@ -1377,17 +1377,17 @@ func TestAgent_Run_HistoryProvider_SkipsWhenSessionHasServiceID(t *testing.T) {
 	provideCalled := false
 	storeCalled := false
 	var capturedMessages []*message.Message
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
 			provideCalled = true
-			return append([]*message.Message{message.NewText("history")}, messages...), nil
+			return []*message.Message{message.NewText("history")}, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			storeCalled = true
 			return nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		capturedMessages = msgs
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -1413,17 +1413,17 @@ func TestAgent_Run_HistoryProvider_SkipsWhenSessionHasServiceID(t *testing.T) {
 func TestAgent_Run_HistoryProvider_ThrowsWhenServiceIDReturnedByDefault(t *testing.T) {
 	provideCalled := false
 	storeCalled := false
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
 			provideCalled = true
-			return messages, nil
+			return nil, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			storeCalled = true
 			return nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		session, _ := agent.GetOption(options, agent.WithSession)
 		session.SetServiceID("server-managed")
@@ -1451,17 +1451,17 @@ func TestAgent_Run_HistoryProvider_ThrowsWhenServiceIDReturnedByDefault(t *testi
 func TestAgent_Run_HistoryProvider_ClearsWhenThrowDisabledAndClearEnabled(t *testing.T) {
 	provideCalls := 0
 	storeCalled := false
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
 			provideCalls++
-			return messages, nil
+			return nil, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			storeCalled = true
 			return nil
 		},
-	}
+	})
 	runCalls := 0
 	runFn := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		runCalls++
@@ -1500,17 +1500,17 @@ func TestAgent_Run_HistoryProvider_ClearsWhenThrowDisabledAndClearEnabled(t *tes
 func TestAgent_Run_HistoryProvider_KeepsWhenThrowAndClearDisabled(t *testing.T) {
 	provideCalls := 0
 	storeCalls := 0
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
 			provideCalls++
-			return messages, nil
+			return nil, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			storeCalls++
 			return nil
 		},
-	}
+	})
 	runCalls := 0
 	runFn := func(_ context.Context, _ []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		runCalls++
@@ -1548,13 +1548,13 @@ func TestAgent_Run_HistoryProvider_KeepsWhenThrowAndClearDisabled(t *testing.T) 
 func TestAgent_Run_HistoryProvider_SkipsWithContinuationToken(t *testing.T) {
 	provideCalled := false
 	runCalled := false
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
 			provideCalled = true
-			return messages, nil
+			return nil, nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		runCalled = true
 		if len(msgs) != 0 {
@@ -1582,29 +1582,29 @@ func TestAgent_Run_HistoryProvider_SkipsWithContinuationToken(t *testing.T) {
 func TestAgent_Run_UsesHistoryBeforeContextProviders(t *testing.T) {
 	sequence := make([]string, 0, 5)
 	var storedRequestMessages []*message.Message
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
 			sequence = append(sequence, "history-before")
-			return append([]*message.Message{message.NewText("history")}, messages...), nil
+			return []*message.Message{message.NewText("history")}, nil
 		},
-		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
 			sequence = append(sequence, "history-after")
-			storedRequestMessages = requestMessages
+			storedRequestMessages = invoked.RequestMessages
 			return nil
 		},
-	}
-	contextProvider := &agent.ContextProvider{
+	})
+	contextProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			sequence = append(sequence, "context-before")
-			return append(messages, message.NewText("context")), options, nil
+			return []*message.Message{message.NewText("context")}, nil, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			sequence = append(sequence, "context-after")
 			return nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		sequence = append(sequence, "run")
 		if got := messageStrings(msgs); !slices.Equal(got, []string{"history", "input", "context"}) {
@@ -1621,7 +1621,7 @@ func TestAgent_Run_UsesHistoryBeforeContextProviders(t *testing.T) {
 		ID:               "test-agent",
 		Name:             "test-agent",
 		HistoryProvider:  historyProvider,
-		ContextProviders: []*agent.ContextProvider{contextProvider},
+		ContextProviders: []agent.ContextProvider{contextProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -1640,13 +1640,13 @@ func TestAgent_Run_UsesHistoryBeforeContextProviders(t *testing.T) {
 func TestAgent_Run_HistoryProvider_DoesNotStoreInstructions(t *testing.T) {
 	var storedRequestMessages []*message.Message
 	var capturedInstructions []string
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Store: func(_ context.Context, requestMessages []*message.Message, _ []*message.Message, _ ...agent.Option) error {
-			storedRequestMessages = requestMessages
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			storedRequestMessages = invoked.RequestMessages
 			return nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, msgs []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		capturedInstructions = slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
 		if got := messageStrings(msgs); !slices.Equal(got, []string{"input"}) {
@@ -1675,19 +1675,19 @@ func TestAgent_Run_HistoryProvider_DoesNotStoreInstructions(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_HistoryProvider_SkipsStoreAfterRunError(t *testing.T) {
+func TestAgent_Run_HistoryProvider_SkipsStoreOnRunError(t *testing.T) {
 	expected := errors.New("run failed")
 	storeCalled := false
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
-			return messages, nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
+			return nil, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			storeCalled = true
 			return nil
 		},
-	}
+	})
 	runFn := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
 			yield(nil, expected)
@@ -1708,16 +1708,16 @@ func TestAgent_Run_HistoryProvider_SkipsStoreAfterRunError(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_PropagatesInvokingError(t *testing.T) {
+func TestAgent_Run_ContextProvider_PropagatesInvokingError(t *testing.T) {
 	expected := errors.New("invoking failed")
 	runCalled := false
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Provide: func(context.Context, []*message.Message, ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(context.Context, agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			return nil, nil, expected
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		runCalled = true
@@ -1726,7 +1726,7 @@ func TestAgent_Run_ProviderMiddleware_PropagatesInvokingError(t *testing.T) {
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -1738,17 +1738,17 @@ func TestAgent_Run_ProviderMiddleware_PropagatesInvokingError(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionAutoCreated(t *testing.T) {
+func TestAgent_Run_ContextProvider_RunsWithAutoCreatedSession(t *testing.T) {
 	provideCalled := false
 	runCalled := false
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			provideCalled = true
-			return messages, options, nil
+			return nil, nil, nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		runCalled = true
@@ -1759,7 +1759,7 @@ func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionAutoCreated(t *tes
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input").Collect()
@@ -1774,7 +1774,7 @@ func TestAgent_Run_ProviderMiddleware_RunsProvidersWhenSessionAutoCreated(t *tes
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_PersistsHistoryAfterSuccessfulRun(t *testing.T) {
+func TestAgent_Run_ContextProvider_PersistsAfterSuccessfulRun(t *testing.T) {
 	historyMessage := message.NewText("history")
 	requestMessage := message.NewText("input")
 
@@ -1783,18 +1783,18 @@ func TestAgent_Run_ProviderMiddleware_PersistsHistoryAfterSuccessfulRun(t *testi
 	var storedResponse []*message.Message
 	storeCalled := false
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return append(messages, historyMessage), options, nil
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{historyMessage}, nil, nil
 		},
-		Store: func(_ context.Context, requestMessages, responseMessages []*message.Message, _ ...agent.Option) error {
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
 			storeCalled = true
-			storedRequest = requestMessages
-			storedResponse = responseMessages
+			storedRequest = invoked.RequestMessages
+			storedResponse = invoked.ResponseMessages
 			return nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		capturedMessages = msgs
@@ -1808,7 +1808,7 @@ func TestAgent_Run_ProviderMiddleware_PersistsHistoryAfterSuccessfulRun(t *testi
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	_, err := a.RunMessage(t.Context(), requestMessage, agent.WithSession(agenttest.CreateSession())).Collect()
@@ -1830,18 +1830,18 @@ func TestAgent_Run_ProviderMiddleware_PersistsHistoryAfterSuccessfulRun(t *testi
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_PersistsWithoutResponseMessages(t *testing.T) {
+func TestAgent_Run_ContextProvider_PersistsWithoutResponseMessages(t *testing.T) {
 	storeCalled := false
 	storedResponseCount := -1
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, _ ...agent.Option) error {
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
 			storeCalled = true
-			storedResponseCount = len(responseMessages)
+			storedResponseCount = len(invoked.ResponseMessages)
 			return nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -1851,7 +1851,7 @@ func TestAgent_Run_ProviderMiddleware_PersistsWithoutResponseMessages(t *testing
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -1867,15 +1867,15 @@ func TestAgent_Run_ProviderMiddleware_PersistsWithoutResponseMessages(t *testing
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_PropagatesStoreError(t *testing.T) {
+func TestAgent_Run_ContextProvider_PropagatesStoreError(t *testing.T) {
 	expected := errors.New("store failed")
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			return expected
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -1885,7 +1885,7 @@ func TestAgent_Run_ProviderMiddleware_PropagatesStoreError(t *testing.T) {
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -1894,17 +1894,17 @@ func TestAgent_Run_ProviderMiddleware_PropagatesStoreError(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_SkipsStoreAfterRunError(t *testing.T) {
+func TestAgent_Run_ContextProvider_SkipsDefaultStoreOnRunError(t *testing.T) {
 	runErr := errors.New("run failed")
 	storeCalled := false
 
-	historyProvider := &agent.ContextProvider{
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "history",
-		Store: func(_ context.Context, _ []*message.Message, _ []*message.Message, _ ...agent.Option) error {
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
 			storeCalled = true
 			return nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -1917,7 +1917,7 @@ func TestAgent_Run_ProviderMiddleware_SkipsStoreAfterRunError(t *testing.T) {
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -1929,16 +1929,46 @@ func TestAgent_Run_ProviderMiddleware_SkipsStoreAfterRunError(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_EarlyStopWithoutErrorStillStores(t *testing.T) {
-	storeCalled := false
-
-	historyProvider := &agent.ContextProvider{
-		SourceID: "history",
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
-			storeCalled = true
+func TestAgent_Run_ContextProvider_InvokedReceivesRunError(t *testing.T) {
+	runErr := errors.New("run failed")
+	var invokedErr error
+	contextProvider := contextProviderFunc{
+		invoked: func(_ context.Context, invoked agent.InvokedContext) error {
+			invokedErr = invoked.Err
 			return nil
 		},
 	}
+
+	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(nil, runErr)
+		}
+	}
+
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID: "test-agent", Name: "test-agent",
+		ContextProviders: []agent.ContextProvider{contextProvider},
+	})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if !errors.Is(err, runErr) {
+		t.Fatalf("expected %v, got %v", runErr, err)
+	}
+	if !errors.Is(invokedErr, runErr) {
+		t.Fatalf("expected invoked error %v, got %v", runErr, invokedErr)
+	}
+}
+
+func TestAgent_Run_ContextProvider_EarlyStopWithoutErrorStillStores(t *testing.T) {
+	storeCalled := false
+
+	historyProvider := agent.NewContextProvider(agent.ContextProviderConfig{
+		SourceID: "history",
+		Store: func(context.Context, agent.InvokedContext) error {
+			storeCalled = true
+			return nil
+		},
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -1951,7 +1981,7 @@ func TestAgent_Run_ProviderMiddleware_EarlyStopWithoutErrorStillStores(t *testin
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{historyProvider},
+		ContextProviders: []agent.ContextProvider{historyProvider},
 	})
 
 	for _, err := range a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession()), agent.Stream(true)) {
@@ -1968,28 +1998,28 @@ func TestAgent_Run_ProviderMiddleware_EarlyStopWithoutErrorStillStores(t *testin
 
 func TestAgent_Run_UsesContextProvidersInOrder(t *testing.T) {
 	sequence := make([]string, 0, 4)
-	providerA := &agent.ContextProvider{
+	providerA := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "provider-a",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			sequence = append(sequence, "before-a")
-			return append(messages, message.NewText("a")), options, nil
+			return []*message.Message{message.NewText("a")}, nil, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			sequence = append(sequence, "after-a")
 			return nil
 		},
-	}
-	providerB := &agent.ContextProvider{
+	})
+	providerB := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "provider-b",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			sequence = append(sequence, "before-b")
-			return append(messages, message.NewText("b")), options, nil
+			return []*message.Message{message.NewText("b")}, nil, nil
 		},
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			sequence = append(sequence, "after-b")
 			return nil
 		},
-	}
+	})
 
 	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		if len(msgs) != 3 {
@@ -2005,7 +2035,7 @@ func TestAgent_Run_UsesContextProvidersInOrder(t *testing.T) {
 
 	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
 		ID: "test-agent", Name: "test-agent",
-		ContextProviders: []*agent.ContextProvider{providerA, providerB},
+		ContextProviders: []agent.ContextProvider{providerA, providerB},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -2035,24 +2065,22 @@ func TestAgent_Run_PipelineOrder_AgentHistoryContextProviderMiddlewareRun(t *tes
 		messages = append(slices.Clone(messages), message.NewText("agent"))
 		return next(ctx, messages, options...)
 	})
-	historyProvider := &agent.HistoryProvider{
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "history",
-		Provide: func(_ context.Context, messages []*message.Message, _ ...agent.Option) ([]*message.Message, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
 			sequence = append(sequence, "history")
-			historyMessages = messageStrings(messages)
-			return append(slices.Clone(messages), message.NewText("history")), nil
+			historyMessages = messageStrings(invoking.Messages)
+			return []*message.Message{message.NewText("history")}, nil
 		},
-	}
-	contextProvider := &agent.ContextProvider{
+	})
+	contextProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "context",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			sequence = append(sequence, "context")
-			contextMessages = messageStrings(messages)
-			messages = append(slices.Clone(messages), message.NewText("context"))
-			options = append(slices.Clone(options), agent.WithTool(contextTool))
-			return messages, options, nil
+			contextMessages = messageStrings(invoking.Messages)
+			return []*message.Message{message.NewText("context")}, []agent.Option{agent.WithTool(contextTool)}, nil
 		},
-	}
+	})
 	providerMiddleware := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		sequence = append(sequence, "provider")
 		providerMessages = messageStrings(messages)
@@ -2075,7 +2103,7 @@ func TestAgent_Run_PipelineOrder_AgentHistoryContextProviderMiddlewareRun(t *tes
 		Name:             "test-agent",
 		Middlewares:      []agent.Middleware{agentMiddleware},
 		HistoryProvider:  historyProvider,
-		ContextProviders: []*agent.ContextProvider{contextProvider},
+		ContextProviders: []agent.ContextProvider{contextProvider},
 	})
 
 	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
@@ -2096,13 +2124,13 @@ func TestAgent_Run_PipelineOrder_AgentHistoryContextProviderMiddlewareRun(t *tes
 	if got, want := historyMessages, []string{"input", "agent"}; !slices.Equal(got, want) {
 		t.Fatalf("expected history messages %v, got %v", want, got)
 	}
-	if got, want := contextMessages, []string{"input", "agent", "history"}; !slices.Equal(got, want) {
+	if got, want := contextMessages, []string{"input"}; !slices.Equal(got, want) {
 		t.Fatalf("expected context messages %v, got %v", want, got)
 	}
-	if got, want := providerMessages, []string{"input", "agent", "history", "context"}; !slices.Equal(got, want) {
+	if got, want := providerMessages, []string{"history", "input", "agent", "context"}; !slices.Equal(got, want) {
 		t.Fatalf("expected provider middleware messages %v, got %v", want, got)
 	}
-	if got, want := runMessages, []string{"input", "agent", "history", "context"}; !slices.Equal(got, want) {
+	if got, want := runMessages, []string{"history", "input", "agent", "context"}; !slices.Equal(got, want) {
 		t.Fatalf("expected run messages %v, got %v", want, got)
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -564,6 +564,72 @@ func TestAgent_Run_InvokesSingleContextMiddleware(t *testing.T) {
 	}
 }
 
+func TestAgent_Run_MarksMiddlewareAddedMessagesWithSource(t *testing.T) {
+	added := message.NewText("middleware")
+	mw := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		messages = append(slices.Clone(messages), added)
+		return next(ctx, messages, opts...)
+	})
+
+	var capturedMessages []*message.Message
+	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		capturedMessages = msgs
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "response"}}}, nil)
+		}
+	}
+	a := newGenericTestAgent(runFn, []agent.Middleware{mw})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(capturedMessages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(capturedMessages))
+	}
+	if capturedMessages[1] == added {
+		t.Fatal("expected middleware message to be cloned before source stamping")
+	}
+	if capturedMessages[1].Source != (message.Source{Type: agent.SourceTypeMiddleware}) {
+		t.Fatalf("middleware message source = %#v, want middleware source", capturedMessages[1].Source)
+	}
+}
+
+func TestAgent_Run_PreservesMiddlewareAddedMessagesWithSource(t *testing.T) {
+	source := message.Source{Type: agent.SourceTypeContextProvider, ID: "ctx"}
+	added := message.NewText("context")
+	added.Source = source
+	mw := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		messages = append(slices.Clone(messages), added)
+		return next(ctx, messages, opts...)
+	})
+
+	var capturedMessages []*message.Message
+	runFn := func(_ context.Context, msgs []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		capturedMessages = msgs
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "response"}}}, nil)
+		}
+	}
+	a := newGenericTestAgent(runFn, []agent.Middleware{mw})
+
+	_, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(capturedMessages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(capturedMessages))
+	}
+	if capturedMessages[1] != added {
+		t.Fatal("expected middleware message with existing source to be preserved")
+	}
+	if capturedMessages[1].Source != source {
+		t.Fatalf("middleware message source = %#v, want %#v", capturedMessages[1].Source, source)
+	}
+}
+
 func TestAgent_Run_ContextMiddlewareReceivesSession(t *testing.T) {
 	mw := &prependMiddleware{}
 	runFn := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
@@ -1283,8 +1349,8 @@ func TestAgent_Run_UsesConfigHistoryProvider(t *testing.T) {
 						if got := messageStrings(messages); !slices.Equal(got, []string{"first", "one", "second"}) {
 							t.Fatalf("second turn messages = %v, want [first one second]", got)
 						}
-						if messages[0].SourceID != "in-memory" || messages[1].SourceID != "in-memory" || messages[2].SourceID != "" {
-							t.Fatalf("unexpected source IDs: [%q %q %q]", messages[0].SourceID, messages[1].SourceID, messages[2].SourceID)
+						if messages[0].Source.ID != "in-memory" || messages[1].Source.ID != "in-memory" || messages[2].Source.ID != "" {
+							t.Fatalf("unexpected source IDs: [%q %q %q]", messages[0].Source.ID, messages[1].Source.ID, messages[2].Source.ID)
 						}
 					},
 				},
@@ -1544,8 +1610,8 @@ func TestAgent_Run_UsesHistoryBeforeContextProviders(t *testing.T) {
 		if got := messageStrings(msgs); !slices.Equal(got, []string{"history", "input", "context"}) {
 			t.Fatalf("messages = %v, want [history input context]", got)
 		}
-		if msgs[0].SourceID != "history" || msgs[1].SourceID != "" || msgs[2].SourceID != "ctx" {
-			t.Fatalf("unexpected source IDs: [%q %q %q]", msgs[0].SourceID, msgs[1].SourceID, msgs[2].SourceID)
+		if msgs[0].Source.ID != "history" || msgs[1].Source.ID != "" || msgs[2].Source.ID != "ctx" {
+			t.Fatalf("unexpected source IDs: [%q %q %q]", msgs[0].Source.ID, msgs[1].Source.ID, msgs[2].Source.ID)
 		}
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
 			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
@@ -1828,7 +1894,7 @@ func TestAgent_Run_ProviderMiddleware_PropagatesStoreError(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ProviderMiddleware_EarlyStopOnErrorStillStores(t *testing.T) {
+func TestAgent_Run_ProviderMiddleware_SkipsStoreAfterRunError(t *testing.T) {
 	runErr := errors.New("run failed")
 	storeCalled := false
 
@@ -1858,8 +1924,8 @@ func TestAgent_Run_ProviderMiddleware_EarlyStopOnErrorStillStores(t *testing.T) 
 	if !errors.Is(err, runErr) {
 		t.Fatalf("expected %v, got %v", runErr, err)
 	}
-	if !storeCalled {
-		t.Fatal("expected store to be called when run stops on error")
+	if storeCalled {
+		t.Fatal("expected store to be skipped when run stops on error")
 	}
 }
 

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
+func invokeProvider(provider agent.ContextProvider, ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
+}
+
 func TestMessageIndex_GroupsToolCallsAtomically(t *testing.T) {
 	messages := []*message.Message{
 		textMessage(message.RoleSystem, "system"),
@@ -414,7 +418,7 @@ func TestNewProvider_CompactsAndPersistsIndex(t *testing.T) {
 		SourceID: "compaction-test",
 	})
 
-	compactedMessages, _, err := provider.BeforeRun(t.Context(), turnMessages(3), agent.WithSession(session))
+	compactedMessages, _, err := invokeProvider(provider, t.Context(), turnMessages(3), agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -441,6 +445,31 @@ func TestNewProvider_CompactsAndPersistsIndex(t *testing.T) {
 	}
 }
 
+func TestNewProvider_SourceStampsGeneratedMessages(t *testing.T) {
+	provider := compaction.NewContextProvider(compaction.ContextProviderConfig{
+		Strategy: &compaction.SummarizationStrategy{
+			Trigger:                compaction.GroupsExceed(2),
+			Summarizer:             compaction.SummarizerFunc(func(context.Context, []*message.Message) (string, error) { return "older context", nil }),
+			MinimumPreservedGroups: 2,
+		},
+		SourceID: "compaction-test",
+	})
+
+	compactedMessages, _, err := invokeProvider(provider, t.Context(), turnMessages(3))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := messageTexts(compactedMessages), []string{"[Summary]\nolder context", "u3", "a3"}; !slices.Equal(got, want) {
+		t.Fatalf("unexpected compacted messages: got %v want %v", got, want)
+	}
+	if got, want := compactedMessages[0].Source, (message.Source{Type: agent.SourceTypeContextProvider, ID: "compaction-test"}); got != want {
+		t.Fatalf("summary source = %#v, want %#v", got, want)
+	}
+	if compactedMessages[1].Source != (message.Source{}) || compactedMessages[2].Source != (message.Source{}) {
+		t.Fatalf("expected preserved messages to keep original sources, got %#v and %#v", compactedMessages[1].Source, compactedMessages[2].Source)
+	}
+}
+
 func TestNewProvider_CompactsWithoutSession(t *testing.T) {
 	provider := compaction.NewContextProvider(compaction.ContextProviderConfig{
 		Strategy: &compaction.TruncationStrategy{
@@ -449,7 +478,7 @@ func TestNewProvider_CompactsWithoutSession(t *testing.T) {
 		},
 	})
 
-	compactedMessages, _, err := provider.BeforeRun(t.Context(), turnMessages(3))
+	compactedMessages, _, err := invokeProvider(provider, t.Context(), turnMessages(3))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/agent/compaction/provider.go
+++ b/agent/compaction/provider.go
@@ -38,69 +38,112 @@ type providerState struct {
 	MessageGroups []*MessageGroup `json:"messagegroups,omitempty"`
 }
 
+type contextProvider struct {
+	strategy     Strategy
+	sourceID     string
+	stateKey     string
+	tokenCounter TokenCounter
+	logger       *slog.Logger
+}
+
 // NewContextProvider creates a context provider that applies compaction before each agent run.
 //
 // When a local session is available, the provider stores message-group state so subsequent runs can
 // incrementally update the index. Without a session, it still performs stateless compaction over the
 // current message list. Service-managed sessions are skipped because the service owns history.
-func NewContextProvider(cfg ContextProviderConfig) *agent.ContextProvider {
+func NewContextProvider(cfg ContextProviderConfig) agent.ContextProvider {
 	if cfg.Strategy == nil {
 		panic("Strategy is required")
 	}
 	cfg.SourceID = cmp.Or(cfg.SourceID, defaultProviderSourceID)
 	cfg.StateKey = cmp.Or(cfg.StateKey, cfg.SourceID)
-	return &agent.ContextProvider{
-		SourceID: cfg.SourceID,
-		Provide: func(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			session, _ := agent.GetOption(options, agent.WithSession)
-			if len(messages) == 0 {
-				if cfg.Logger != nil {
-					cfg.Logger.DebugContext(ctx, "compaction provider skipped", slog.String("reason", "no messages"))
-				}
-				return messages, options, nil
-			}
-			if session == nil {
-				index := CreateMessageIndex(messages, cfg.TokenCounter)
-				if _, err := cfg.Strategy.Compact(ctx, index); err != nil {
-					return nil, nil, err
-				}
-				return index.IncludedMessages(), options, nil
-			}
-			if session.ServiceID() != "" {
-				if cfg.Logger != nil {
-					cfg.Logger.DebugContext(ctx, "compaction provider skipped", slog.String("reason", "session managed by remote service"))
-				}
-				return messages, options, nil
-			}
-
-			var state providerState
-			if _, err := session.Get(cfg.StateKey, &state); err != nil {
-				return nil, nil, err
-			}
-
-			var index *MessageIndex
-			if len(state.MessageGroups) > 0 {
-				index = NewMessageIndex(state.MessageGroups, cfg.TokenCounter)
-				index.Update(messages)
-			} else {
-				index = CreateMessageIndex(messages, cfg.TokenCounter)
-			}
-
-			beforeMessages := index.IncludedMessageCount()
-			if cfg.Logger != nil {
-				cfg.Logger.DebugContext(ctx, "applying compaction", slog.Int("messages", beforeMessages))
-			}
-			if _, err := cfg.Strategy.Compact(ctx, index); err != nil {
-				return nil, nil, err
-			}
-			afterMessages := index.IncludedMessageCount()
-			if cfg.Logger != nil && afterMessages < beforeMessages {
-				cfg.Logger.DebugContext(ctx, "compaction applied", slog.Int("before_messages", beforeMessages), slog.Int("after_messages", afterMessages))
-			}
-
-			state.MessageGroups = index.Groups
-			session.Set(cfg.StateKey, state)
-			return index.IncludedMessages(), options, nil
-		},
+	return &contextProvider{
+		strategy:     cfg.Strategy,
+		sourceID:     cfg.SourceID,
+		stateKey:     cfg.StateKey,
+		tokenCounter: cfg.TokenCounter,
+		logger:       cfg.Logger,
 	}
+}
+
+func (p *contextProvider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	messages := invoking.Messages
+	options := invoking.Options
+	session, _ := agent.GetOption(options, agent.WithSession)
+	if len(messages) == 0 {
+		if p.logger != nil {
+			p.logger.DebugContext(ctx, "compaction provider skipped", slog.String("reason", "no messages"))
+		}
+		return messages, options, nil
+	}
+	inputMessages := append([]*message.Message(nil), messages...)
+	if session == nil {
+		index := CreateMessageIndex(messages, p.tokenCounter)
+		if _, err := p.strategy.Compact(ctx, index); err != nil {
+			return nil, nil, err
+		}
+		return p.markGeneratedMessages(index.IncludedMessages(), inputMessages), options, nil
+	}
+	if session.ServiceID() != "" {
+		if p.logger != nil {
+			p.logger.DebugContext(ctx, "compaction provider skipped", slog.String("reason", "session managed by remote service"))
+		}
+		return messages, options, nil
+	}
+
+	var state providerState
+	if _, err := session.Get(p.stateKey, &state); err != nil {
+		return nil, nil, err
+	}
+
+	var index *MessageIndex
+	if len(state.MessageGroups) > 0 {
+		index = NewMessageIndex(state.MessageGroups, p.tokenCounter)
+		index.Update(messages)
+	} else {
+		index = CreateMessageIndex(messages, p.tokenCounter)
+	}
+
+	beforeMessages := index.IncludedMessageCount()
+	if p.logger != nil {
+		p.logger.DebugContext(ctx, "applying compaction", slog.Int("messages", beforeMessages))
+	}
+	if _, err := p.strategy.Compact(ctx, index); err != nil {
+		return nil, nil, err
+	}
+	afterMessages := index.IncludedMessageCount()
+	if p.logger != nil && afterMessages < beforeMessages {
+		p.logger.DebugContext(ctx, "compaction applied", slog.Int("before_messages", beforeMessages), slog.Int("after_messages", afterMessages))
+	}
+
+	state.MessageGroups = index.Groups
+	session.Set(p.stateKey, state)
+	return p.markGeneratedMessages(index.IncludedMessages(), inputMessages), options, nil
+}
+
+func (p *contextProvider) Invoked(context.Context, agent.InvokedContext) error {
+	return nil
+}
+
+func (p *contextProvider) markGeneratedMessages(messages, inputMessages []*message.Message) []*message.Message {
+	if len(messages) == 0 {
+		return messages
+	}
+	originals := make(map[*message.Message]struct{}, len(inputMessages))
+	for _, msg := range inputMessages {
+		originals[msg] = struct{}{}
+	}
+	source := message.Source{Type: agent.SourceTypeContextProvider, ID: p.sourceID}
+	for i, msg := range messages {
+		if _, ok := originals[msg]; ok {
+			continue
+		}
+		if msg == nil || msg.Source == source {
+			continue
+		}
+		marked := msg.Clone()
+		marked.Source = source
+		messages[i] = marked
+	}
+	return messages
 }

--- a/agent/context.go
+++ b/agent/context.go
@@ -14,42 +14,180 @@ import (
 // SourceTypeContextProvider represents a message that originated from a context provider.
 const SourceTypeContextProvider message.SourceType = "context-provider"
 
-// ContextProvider provides a structured subset of middleware behavior for
-// injecting and persisting additional context around an agent invocation.
+// ContextProvider participates in an agent invocation lifecycle by supplying
+// additional context before a run and processing context after a run completes.
 //
-// A provider can add, replace, or annotate request messages, add run options,
-// and persist filtered request and response messages after the run completes.
-// It does not wrap the provider [RunFunc] directly, so it cannot intercept
-// individual streamed updates, emit replacement updates, retry or replace the
-// provider invocation, or transform provider errors as they occur.
-// Use [Middleware] for those lower-level run-pipeline behaviors.
-type ContextProvider struct {
+// Context providers can retrieve relevant information, add instructions, inject
+// contextual messages, provide tools for the current invocation, and persist or
+// learn from request and response messages after successful runs.
+//
+// Prefer creating providers with [NewContextProvider]. Implement [ContextProvider]
+// directly when a provider needs custom filtering, merging, source attribution,
+// failure handling, or non-additive behavior such as compaction or truncation.
+//
+// # Security considerations
+//
+// Context providers may inject messages with any role, including system, which has
+// the highest trust level and directly shapes LLM behavior. Developers must ensure
+// that all providers attached to an agent are trusted. Agent Framework does not
+// validate or filter the data returned by providers — it is accepted as-is and
+// merged into the request context. If a provider retrieves data from an external
+// source (e.g., a vector database or memory service), be aware that a compromised
+// data source could introduce adversarial content designed to manipulate LLM behavior
+// via indirect prompt injection. Implementers should validate and sanitize data
+// retrieved from external sources before returning it.
+type ContextProvider interface {
+	// Invoking returns the input messages and options with provider-specific additions applied.
+	Invoking(context.Context, InvokingContext) ([]*message.Message, []Option, error)
+
+	// Invoked persists context-related state after an agent invocation finishes.
+	Invoked(context.Context, InvokedContext) error
+}
+
+// InvokingContext contains the agent invocation context available to a
+// [ContextProvider] before the provider run starts.
+type InvokingContext struct {
+	// Messages are the request messages currently being prepared for the invocation.
+	Messages []*message.Message
+
+	// Options are the run options currently being prepared for the invocation.
+	Options []Option
+}
+
+// InvokedContext contains the agent invocation context available to a
+// [ContextProvider] after a provider run completes.
+type InvokedContext struct {
+	// RequestMessages are the messages used for the invocation.
+	RequestMessages []*message.Message
+
+	// ResponseMessages are the messages produced by the invocation.
+	ResponseMessages []*message.Message
+
+	// Options are the run options used for the invocation.
+	Options []Option
+
+	// Err is the error returned by the invocation, if any.
+	Err error
+}
+
+// ContextProviderConfig configures the provider created by [NewContextProvider].
+type ContextProviderConfig struct {
 	// Unique identifier for this provider instance (required).
 	SourceID string
 
+	// Optional filter applied to request messages before Provide.
+	// Defaults to [messagefilter.ExternalOnly].
+	ProvideInputMessageFilter messagefilter.Filter
+
 	// Optional filter applied to request messages before Store.
 	// Defaults to [messagefilter.ExternalOnly].
-	StoreRequestFilter messagefilter.Filter
+	StoreInputRequestMessageFilter messagefilter.Filter
 
 	// Optional filter applied to response messages before Store.
 	// Defaults to passing all response messages through.
-	StoreResponseFilter messagefilter.Filter
+	StoreInputResponseMessageFilter messagefilter.Filter
 
-	// Optional retrieval hook that returns updated provider context messages and run options.
-	// Messages that are not pointer-identical to the messages passed to Provide are marked with this provider's source.
-	// If unset, the original messages and options are returned unchanged.
-	// If set, returned options are used as-is; returned messages are source-stamped as described above.
-	Provide func(context.Context, []*message.Message, ...Option) ([]*message.Message, []Option, error)
+	// Optional retrieval hook that returns additional provider context messages and run options.
+	Provide func(context.Context, InvokingContext) ([]*message.Message, []Option, error)
 
 	// Optional storage hook. Defaults to no-op.
-	Store func(context.Context, []*message.Message, []*message.Message, ...Option) error
+	Store func(context.Context, InvokedContext) error
 }
 
-// Middleware adapts this context provider into middleware for callers that
-// explicitly need middleware composition. Agents configured with
+type defaultContextProvider struct {
+	config ContextProviderConfig
+}
+
+// NewContextProvider creates the default additive context provider.
+//
+// The provider filters input messages before invoking Provide, treats Provide
+// results as additive, source-stamps provided messages, appends provided
+// messages and options to the original invocation context, filters stored
+// request and response messages, and skips Store when the run fails.
+func NewContextProvider(config ContextProviderConfig) ContextProvider {
+	return &defaultContextProvider{config: config}
+}
+
+// Invoking returns the input messages and options with this provider's additions applied.
+func (p *defaultContextProvider) Invoking(ctx context.Context, invoking InvokingContext) ([]*message.Message, []Option, error) {
+	if p.config.SourceID == "" {
+		panic("SourceID is required")
+	}
+	if p.config.Provide == nil {
+		return invoking.Messages, invoking.Options, nil
+	}
+
+	provideFilter := p.config.ProvideInputMessageFilter
+	if provideFilter == nil {
+		provideFilter = messagefilter.ExternalOnly
+	}
+	provideMessages, err := provideFilter(ctx, slices.Clone(invoking.Messages))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	providedMessages, providedOptions, err := p.config.Provide(ctx, InvokingContext{Messages: provideMessages, Options: invoking.Options})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	outMessages := invoking.Messages
+	if len(providedMessages) > 0 {
+		source := message.Source{Type: SourceTypeContextProvider, ID: p.config.SourceID}
+		for i, msg := range providedMessages {
+			if msg == nil || msg.Source == source {
+				continue
+			}
+			marked := msg.Clone()
+			marked.Source = source
+			providedMessages[i] = marked
+		}
+		outMessages = append(outMessages, providedMessages...)
+	}
+
+	outOptions := invoking.Options
+	if len(providedOptions) > 0 {
+		outOptions = append(outOptions, providedOptions...)
+	}
+
+	return outMessages, outOptions, nil
+}
+
+// Invoked persists context-related state after an agent invocation finishes.
+func (p *defaultContextProvider) Invoked(ctx context.Context, invoked InvokedContext) error {
+	if p.config.SourceID == "" {
+		panic("SourceID is required")
+	}
+	if invoked.Err != nil {
+		return nil
+	}
+	if p.config.Store == nil {
+		return nil
+	}
+	requestFilter := p.config.StoreInputRequestMessageFilter
+	if requestFilter == nil {
+		requestFilter = messagefilter.ExternalOnly
+	}
+	responseFilter := p.config.StoreInputResponseMessageFilter
+	if responseFilter == nil {
+		responseFilter = messagefilter.PassThrough
+	}
+	filteredReq, err := requestFilter(ctx, invoked.RequestMessages)
+	if err != nil {
+		return err
+	}
+	filteredResp, err := responseFilter(ctx, invoked.ResponseMessages)
+	if err != nil {
+		return err
+	}
+	return p.config.Store(ctx, InvokedContext{RequestMessages: filteredReq, ResponseMessages: filteredResp, Options: invoked.Options, Err: invoked.Err})
+}
+
+// ContextProviderMiddleware adapts a context provider into middleware for
+// callers that explicitly need middleware composition. Agents configured with
 // Config.ContextProviders run providers through the agent lifecycle rather than
 // through this adapter.
-func (p *ContextProvider) Middleware() Middleware {
+func ContextProviderMiddleware(p ContextProvider) Middleware {
 	if p == nil {
 		panic("context provider is required")
 	}
@@ -57,14 +195,14 @@ func (p *ContextProvider) Middleware() Middleware {
 }
 
 type contextProviderMiddleware struct {
-	provider *ContextProvider
+	provider ContextProvider
 }
 
 func (r *contextProviderMiddleware) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
 	return func(yield func(*ResponseUpdate, error) bool) {
 		options = slices.Clone(options)
 		var err error
-		messages, options, err = r.provider.BeforeRun(ctx, messages, options...)
+		messages, options, err = r.provider.Invoking(ctx, InvokingContext{Messages: messages, Options: options})
 		if err != nil {
 			yield(nil, err)
 			return
@@ -72,113 +210,23 @@ func (r *contextProviderMiddleware) Run(next RunFunc, ctx context.Context, messa
 
 		requestMessages := slices.Clone(messages)
 		var resp Response
-		var runErr error
+		var invokeErr error
 		for update, err := range next(ctx, messages, options...) {
 			if update != nil {
 				resp.Update(update)
 			}
 			if err != nil {
-				runErr = err
+				invokeErr = err
 			}
 			if !yield(update, err) {
 				break
 			}
 		}
 		resp.Coalesce()
-		if runErr != nil {
-			return
-		}
 
-		if err := r.provider.AfterRun(ctx, requestMessages, resp.Messages, options...); err != nil {
+		if err := r.provider.Invoked(ctx, InvokedContext{RequestMessages: requestMessages, ResponseMessages: resp.Messages, Options: options, Err: invokeErr}); err != nil {
 			yield(nil, err)
 			return
 		}
 	}
-}
-
-// BeforeRun returns the input messages and options with this provider's additions applied.
-func (p *ContextProvider) BeforeRun(ctx context.Context, messages []*message.Message, options ...Option) ([]*message.Message, []Option, error) {
-	if p.SourceID == "" {
-		panic("SourceID is required")
-	}
-	if p.Provide == nil {
-		return messages, options, nil
-	}
-
-	inputMessages := slices.Clone(messages)
-	messages, options, err := p.Provide(ctx, messages, options...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	markNewMessagesWithSource(messages, inputMessages, message.Source{Type: SourceTypeContextProvider, ID: p.SourceID}, true)
-	return messages, options, nil
-}
-
-// AfterRun persists context-related state after an agent invocation finishes.
-func (p *ContextProvider) AfterRun(ctx context.Context, requestMessages, responseMessages []*message.Message, options ...Option) error {
-	if p.SourceID == "" {
-		panic("SourceID is required")
-	}
-	requestFilter := p.StoreRequestFilter
-	if requestFilter == nil {
-		requestFilter = messagefilter.ExternalOnly
-	}
-	return runStoreHook(ctx, p.Store, requestFilter, p.StoreResponseFilter, requestMessages, responseMessages, options)
-}
-
-// markNewMessagesWithSource marks messages in outMessages that are not pointer-identical
-// to messages in inMessages with source. Marked messages are cloned before source is set.
-// When overwrite is false, messages that already have any source are preserved as-is.
-// Messages that are nil, already have source, or are present in inMessages are skipped.
-func markNewMessagesWithSource(outMessages, inMessages []*message.Message, source message.Source, overwrite bool) {
-	originals := make(map[*message.Message]struct{}, len(inMessages))
-	for _, msg := range inMessages {
-		originals[msg] = struct{}{}
-	}
-	if len(outMessages) == 0 {
-		return
-	}
-	for i, msg := range outMessages {
-		if _, ok := originals[msg]; ok {
-			continue
-		}
-		if msg == nil || msg.Source == source || !overwrite && msg.Source != (message.Source{}) {
-			continue
-		}
-		marked := msg.Clone()
-		marked.Source = source
-		outMessages[i] = marked
-	}
-}
-
-// runStoreHook applies request and response filters then calls store.
-// When store is nil, it is a no-op. A nil requestFilter defaults to
-// messagefilter.PassThrough; a nil responseFilter defaults to
-// messagefilter.PassThrough.
-func runStoreHook(
-	ctx context.Context,
-	store func(context.Context, []*message.Message, []*message.Message, ...Option) error,
-	requestFilter, responseFilter messagefilter.Filter,
-	requestMessages, responseMessages []*message.Message,
-	options []Option,
-) error {
-	if store == nil {
-		return nil
-	}
-	if requestFilter == nil {
-		requestFilter = messagefilter.PassThrough
-	}
-	if responseFilter == nil {
-		responseFilter = messagefilter.PassThrough
-	}
-	filteredReq, err := requestFilter(ctx, requestMessages)
-	if err != nil {
-		return err
-	}
-	filteredResp, err := responseFilter(ctx, responseMessages)
-	if err != nil {
-		return err
-	}
-	return store(ctx, filteredReq, filteredResp, options...)
 }

--- a/agent/context.go
+++ b/agent/context.go
@@ -11,6 +11,9 @@ import (
 	"github.com/microsoft/agent-framework-go/message/messagefilter"
 )
 
+// SourceTypeContextProvider represents a message that originated from a context provider.
+const SourceTypeContextProvider message.SourceType = "context-provider"
+
 // ContextProvider provides a structured subset of middleware behavior for
 // injecting and persisting additional context around an agent invocation.
 //
@@ -25,7 +28,7 @@ type ContextProvider struct {
 	SourceID string
 
 	// Optional filter applied to request messages before Store.
-	// Defaults to excluding messages from the same provider SourceID.
+	// Defaults to [messagefilter.ExternalOnly].
 	StoreRequestFilter messagefilter.Filter
 
 	// Optional filter applied to response messages before Store.
@@ -33,8 +36,9 @@ type ContextProvider struct {
 	StoreResponseFilter messagefilter.Filter
 
 	// Optional retrieval hook that returns updated provider context messages and run options.
-	// Messages that are not pointer-identical to the original input messages are marked with SourceID.
-	// Defaults to returning the original messages and options unchanged.
+	// Messages that are not pointer-identical to the messages passed to Provide are marked with this provider's source.
+	// If unset, the original messages and options are returned unchanged.
+	// If set, the returned messages and options are used as-is.
 	Provide func(context.Context, []*message.Message, ...Option) ([]*message.Message, []Option, error)
 
 	// Optional storage hook. Defaults to no-op.
@@ -68,15 +72,22 @@ func (r *contextProviderMiddleware) Run(next RunFunc, ctx context.Context, messa
 
 		requestMessages := slices.Clone(messages)
 		var resp Response
+		var runErr error
 		for update, err := range next(ctx, messages, options...) {
 			if update != nil {
 				resp.Update(update)
+			}
+			if err != nil {
+				runErr = err
 			}
 			if !yield(update, err) {
 				break
 			}
 		}
 		resp.Coalesce()
+		if runErr != nil {
+			return
+		}
 
 		if err := r.provider.AfterRun(ctx, requestMessages, resp.Messages, options...); err != nil {
 			yield(nil, err)
@@ -94,21 +105,14 @@ func (p *ContextProvider) BeforeRun(ctx context.Context, messages []*message.Mes
 		return messages, options, nil
 	}
 
-	outMessages, outOptions, err := p.Provide(ctx, messages, options...)
+	inputMessages := slices.Clone(messages)
+	messages, options, err := p.Provide(ctx, messages, options...)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if outMessages == nil {
-		outMessages = messages
-	}
-	outMessages = p.withProviderSource(outMessages, messages)
-
-	if outOptions == nil {
-		outOptions = options
-	}
-
-	return outMessages, outOptions, nil
+	markNewMessagesWithSource(messages, inputMessages, message.Source{Type: SourceTypeContextProvider, ID: p.SourceID}, true)
+	return messages, options, nil
 }
 
 // AfterRun persists context-related state after an agent invocation finishes.
@@ -116,52 +120,44 @@ func (p *ContextProvider) AfterRun(ctx context.Context, requestMessages, respons
 	if p.SourceID == "" {
 		panic("SourceID is required")
 	}
-	return runStoreHook(ctx, p.SourceID, p.Store, p.StoreRequestFilter, p.StoreResponseFilter, requestMessages, responseMessages, options)
-}
-
-func (p *ContextProvider) withProviderSource(outMessages, inMessages []*message.Message) []*message.Message {
-	return markNewMessages(outMessages, inMessages, p.SourceID)
-}
-
-// markNewMessages marks messages not present in inMessages with sourceID,
-// lazy-cloning the slice the first time a message needs to be updated.
-// Messages already carrying sourceID or present in inMessages are skipped.
-func markNewMessages(outMessages, inMessages []*message.Message, sourceID string) []*message.Message {
-	if len(outMessages) == 0 {
-		return outMessages
+	requestFilter := p.StoreRequestFilter
+	if requestFilter == nil {
+		requestFilter = messagefilter.ExternalOnly
 	}
+	return runStoreHook(ctx, p.Store, requestFilter, p.StoreResponseFilter, requestMessages, responseMessages, options)
+}
+
+// markNewMessagesWithSource marks messages in outMessages that are not pointer-identical
+// to messages in inMessages with source. Marked messages are cloned before source is set.
+// When overwrite is false, messages that already have any source are preserved as-is.
+// Messages that are nil, already have source, or are present in inMessages are skipped.
+func markNewMessagesWithSource(outMessages, inMessages []*message.Message, source message.Source, overwrite bool) {
 	originals := make(map[*message.Message]struct{}, len(inMessages))
 	for _, msg := range inMessages {
 		originals[msg] = struct{}{}
 	}
-	var cloned []*message.Message
+	if len(outMessages) == 0 {
+		return
+	}
 	for i, msg := range outMessages {
 		if _, ok := originals[msg]; ok {
 			continue
 		}
-		if msg == nil || msg.SourceID == sourceID {
+		if msg == nil || msg.Source == source || !overwrite && msg.Source != (message.Source{}) {
 			continue
 		}
-		if cloned == nil {
-			cloned = slices.Clone(outMessages)
-		}
 		marked := msg.Clone()
-		marked.SourceID = sourceID
-		cloned[i] = marked
+		marked.Source = source
+		outMessages[i] = marked
 	}
-	if cloned != nil {
-		return cloned
-	}
-	return outMessages
 }
 
 // runStoreHook applies request and response filters then calls store.
 // When store is nil, it is a no-op. A nil requestFilter defaults to
-// messagefilter.NotSources(sourceID); a nil responseFilter defaults to
+// messagefilter.PassThrough; a nil responseFilter defaults to
 // messagefilter.PassThrough.
 func runStoreHook(
 	ctx context.Context,
-	sourceID string,
 	store func(context.Context, []*message.Message, []*message.Message, ...Option) error,
 	requestFilter, responseFilter messagefilter.Filter,
 	requestMessages, responseMessages []*message.Message,
@@ -171,7 +167,7 @@ func runStoreHook(
 		return nil
 	}
 	if requestFilter == nil {
-		requestFilter = messagefilter.NotSources(sourceID)
+		requestFilter = messagefilter.PassThrough
 	}
 	if responseFilter == nil {
 		responseFilter = messagefilter.PassThrough

--- a/agent/context.go
+++ b/agent/context.go
@@ -38,7 +38,7 @@ type ContextProvider struct {
 	// Optional retrieval hook that returns updated provider context messages and run options.
 	// Messages that are not pointer-identical to the messages passed to Provide are marked with this provider's source.
 	// If unset, the original messages and options are returned unchanged.
-	// If set, the returned messages and options are used as-is.
+	// If set, returned options are used as-is; returned messages are source-stamped as described above.
 	Provide func(context.Context, []*message.Message, ...Option) ([]*message.Message, []Option, error)
 
 	// Optional storage hook. Defaults to no-op.

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -168,6 +168,35 @@ func TestContextProviderMiddleware_Run_PassesResponseMessagesWithServiceManagedS
 	}
 }
 
+func TestContextProviderMiddleware_Run_SkipsStoreAfterRunError(t *testing.T) {
+	expected := errors.New("run failed")
+	storeCalled := false
+	provider := &agent.ContextProvider{
+		SourceID: "provider-a",
+		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+			storeCalled = true
+			return nil
+		},
+	}
+
+	_, err := collectContextProviderMiddlewareResponse(provider.Middleware().Run(
+		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(nil, expected)
+			}
+		},
+		context.Background(),
+		[]*message.Message{message.NewText("hello")},
+		agent.WithSession(agenttest.CreateSession()),
+	))
+	if !errors.Is(err, expected) {
+		t.Fatalf("expected %v, got %v", expected, err)
+	}
+	if storeCalled {
+		t.Fatal("expected store to be skipped after run error")
+	}
+}
+
 func contextProviderMiddlewareSingleUpdate(text string) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: text}}}, nil)
@@ -196,26 +225,48 @@ func TestContextProvider_Invoking_PanicsWithoutSourceID(t *testing.T) {
 	_, _, _ = provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 }
 
-func TestContextProvider_Invoking_PassesAllMessagesToProvide(t *testing.T) {
-	external := message.NewText("external")
-	history := message.NewText("history")
-	history.SourceID = "other"
-
-	var captured []*message.Message
+func TestContextProvider_Invoking_MarksMessagesReplacedByProvide(t *testing.T) {
+	replacement := message.NewText("replacement")
 	provider := &agent.ContextProvider{
 		SourceID: "ctx",
 		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			captured = messages
+			messages[0] = replacement
 			return messages, options, nil
 		},
 	}
 
-	_, _, err := provider.BeforeRun(t.Context(), []*message.Message{external, history}, agent.WithSession(agenttest.CreateSession()))
+	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{message.NewText("request")}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(captured) != 2 || captured[0] != external || captured[1] != history {
-		t.Fatal("expected Provide to receive all input messages by default")
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	if messages[0] == replacement {
+		t.Fatal("expected replaced message to be cloned")
+	}
+	if messages[0].Source != (message.Source{Type: agent.SourceTypeContextProvider, ID: "ctx"}) {
+		t.Fatalf("replaced message source = %#v, want context provider source", messages[0].Source)
+	}
+}
+
+func TestContextProvider_Invoking_HonorsNilProvideOutputs(t *testing.T) {
+	provider := &agent.ContextProvider{
+		SourceID: "ctx",
+		Provide: func(context.Context, []*message.Message, ...agent.Option) ([]*message.Message, []agent.Option, error) {
+			return nil, nil, nil
+		},
+	}
+
+	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{message.NewText("r1")}, agent.WithSession(agenttest.CreateSession()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if messages != nil {
+		t.Fatalf("expected nil messages returned by Provide to be honored, got %v", messageStrings(messages))
+	}
+	if options != nil {
+		t.Fatalf("expected nil options returned by Provide to be honored, got %d", len(options))
 	}
 }
 
@@ -258,8 +309,8 @@ func TestContextProvider_Invoking_ReturnsProvidedMessagesAndSetsSourceID(t *test
 	if messages[1] == provided {
 		t.Fatal("expected provided message to be cloned")
 	}
-	if messages[1].SourceID != "ctx" {
-		t.Fatalf("expected SourceID=ctx, got %q", messages[1].SourceID)
+	if messages[1].Source.ID != "ctx" {
+		t.Fatalf("expected SourceID=ctx, got %q", messages[1].Source.ID)
 	}
 }
 
@@ -287,8 +338,8 @@ func TestContextProvider_Invoking_SetsSourceIDOnPrependedMessages(t *testing.T) 
 	if messages[0] == provided {
 		t.Fatal("expected prepended message to be cloned")
 	}
-	if messages[0].SourceID != "ctx" {
-		t.Fatalf("expected SourceID=ctx, got %q", messages[0].SourceID)
+	if messages[0].Source.ID != "ctx" {
+		t.Fatalf("expected SourceID=ctx, got %q", messages[0].Source.ID)
 	}
 	if messages[1] != request {
 		t.Fatal("expected original message to be preserved")
@@ -310,8 +361,8 @@ func TestContextProvider_Invoking_UsesCustomSourceID(t *testing.T) {
 	if len(messages) != 1 {
 		t.Fatalf("expected 1 provided message, got %d", len(messages))
 	}
-	if messages[0].SourceID != "CustomContextSource" {
-		t.Fatalf("expected custom source ID, got %q", messages[0].SourceID)
+	if messages[0].Source.ID != "CustomContextSource" {
+		t.Fatalf("expected custom source ID, got %q", messages[0].Source.ID)
 	}
 }
 
@@ -325,10 +376,13 @@ func TestContextProvider_Invoked_PanicsWithoutSourceID(t *testing.T) {
 	_ = provider.AfterRun(t.Context(), nil, nil, agent.WithSession(agenttest.CreateSession()))
 }
 
-func TestContextProvider_Invoked_CallsStoreAndExcludesSameProviderRequestMessagesByDefault(t *testing.T) {
+func TestContextProvider_Invoked_CallsStoreAndIncludesExternalRequestMessagesByDefault(t *testing.T) {
 	req1 := message.NewText("request1")
+	req1.Source.ID = "ctx"
 	req2 := message.NewText("request2")
-	req2.SourceID = "ctx"
+	req2.Source = message.Source{Type: agent.SourceTypeContextProvider, ID: "ctx"}
+	req3 := message.NewText("request3")
+	req3.Source = message.Source{Type: agent.SourceTypeHistoryProvider, ID: "history"}
 	resp := message.NewText("response")
 
 	called := false
@@ -345,7 +399,7 @@ func TestContextProvider_Invoked_CallsStoreAndExcludesSameProviderRequestMessage
 		},
 	}
 
-	err := provider.AfterRun(t.Context(), []*message.Message{req1, req2}, []*message.Message{resp}, agent.WithSession(agenttest.CreateSession()))
+	err := provider.AfterRun(t.Context(), []*message.Message{req1, req2, req3}, []*message.Message{resp}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -353,7 +407,7 @@ func TestContextProvider_Invoked_CallsStoreAndExcludesSameProviderRequestMessage
 		t.Fatal("expected Store to be called")
 	}
 	if len(storedRequest) != 1 || storedRequest[0] != req1 {
-		t.Fatal("expected default request filter to exclude same-provider messages")
+		t.Fatal("expected default request filter to keep only external messages")
 	}
 	if len(storedResponse) != 1 || storedResponse[0] != resp {
 		t.Fatal("expected response messages to pass through unchanged")
@@ -405,7 +459,7 @@ func TestContextProvider_InvokingContext_ReturnsProvidedFields(t *testing.T) {
 	if messages[1].String() != "provided" {
 		t.Fatal("expected provided message to be appended")
 	}
-	if messages[1].SourceID != "ctx" {
+	if messages[1].Source.ID != "ctx" {
 		t.Fatal("expected provided message to be source-stamped with provider SourceID")
 	}
 	tools := slices.Collect(agent.AllOptions(options, agent.WithTool))

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -12,15 +12,16 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/message/messagefilter"
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
 func TestContextProvider_Invoking_WithoutProvide_ReturnsNoAdditions(t *testing.T) {
 	request := message.NewText("r1")
-	provider := &agent.ContextProvider{SourceID: "ctx"}
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{SourceID: "ctx"})
 
-	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
+	messages, options, err := invokeContextProvider(provider, t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -39,22 +40,22 @@ func TestContextProvider_Middleware_PanicsWithNilProvider(t *testing.T) {
 		}
 	}()
 
-	var provider *agent.ContextProvider
-	_ = provider.Middleware()
+	var provider agent.ContextProvider
+	_ = agent.ContextProviderMiddleware(provider)
 }
 
 func TestContextProviderMiddleware_Run_ProviderOptionsEnrichTools(t *testing.T) {
 	baselineTool := stubTool{name: "baseline"}
 	providerTool := stubTool{name: "provider"}
 	var capturedTools []tool.Tool
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "provider-a",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return messages, append(options, agent.WithTool(providerTool)), nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return nil, []agent.Option{agent.WithTool(providerTool)}, nil
 		},
-	}
+	})
 
-	_, err := collectContextProviderMiddlewareResponse(provider.Middleware().Run(
+	_, err := collectContextProviderMiddlewareResponse(agent.ContextProviderMiddleware(provider).Run(
 		func(_ context.Context, _ []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 			capturedTools = slices.Collect(agent.AllOptions(opts, agent.WithTool))
 			return contextProviderMiddlewareSingleUpdate("ok")
@@ -75,19 +76,19 @@ func TestContextProviderMiddleware_Run_ProviderOptionsEnrichTools(t *testing.T) 
 
 func TestContextProviderMiddleware_Run_SharedOptions_ProviderToolsDoNotAccumulateAcrossCalls(t *testing.T) {
 	toolCounts := make([]int, 0, 3)
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "provider-a",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return messages, append(options, agent.WithTool(stubTool{name: "provider"})), nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return nil, []agent.Option{agent.WithTool(stubTool{name: "provider"})}, nil
 		},
-	}
+	})
 	sharedOptions := []agent.Option{
 		agent.WithSession(agenttest.CreateSession()),
 		agent.WithTool(stubTool{name: "baseline"}),
 	}
 
 	for range 3 {
-		_, err := collectContextProviderMiddlewareResponse(provider.Middleware().Run(
+		_, err := collectContextProviderMiddlewareResponse(agent.ContextProviderMiddleware(provider).Run(
 			func(_ context.Context, _ []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 				toolCounts = append(toolCounts, len(slices.Collect(agent.AllOptions(opts, agent.WithTool))))
 				return contextProviderMiddlewareSingleUpdate("ok")
@@ -108,18 +109,18 @@ func TestContextProviderMiddleware_Run_SharedOptions_ProviderToolsDoNotAccumulat
 
 func TestContextProviderMiddleware_Run_SharedOptions_OriginalToolsNotMutated(t *testing.T) {
 	baselineTool := stubTool{name: "baseline"}
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "provider-a",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return messages, append(options, agent.WithTool(stubTool{name: "provider"})), nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return nil, []agent.Option{agent.WithTool(stubTool{name: "provider"})}, nil
 		},
-	}
+	})
 	sharedOptions := []agent.Option{
 		agent.WithSession(agenttest.CreateSession()),
 		agent.WithTool(baselineTool),
 	}
 
-	_, err := collectContextProviderMiddlewareResponse(provider.Middleware().Run(
+	_, err := collectContextProviderMiddlewareResponse(agent.ContextProviderMiddleware(provider).Run(
 		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 			return contextProviderMiddlewareSingleUpdate("ok")
 		},
@@ -144,15 +145,15 @@ func TestContextProviderMiddleware_Run_PassesResponseMessagesWithServiceManagedS
 	session := agenttest.CreateSession()
 	session.SetServiceID("server-managed")
 	var storedResponseMessages []*message.Message
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "provider-a",
-		Store: func(_ context.Context, _ []*message.Message, responseMessages []*message.Message, _ ...agent.Option) error {
-			storedResponseMessages = responseMessages
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			storedResponseMessages = invoked.ResponseMessages
 			return nil
 		},
-	}
+	})
 
-	_, err := collectContextProviderMiddlewareResponse(provider.Middleware().Run(
+	_, err := collectContextProviderMiddlewareResponse(agent.ContextProviderMiddleware(provider).Run(
 		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 			return contextProviderMiddlewareSingleUpdate("ok")
 		},
@@ -168,18 +169,18 @@ func TestContextProviderMiddleware_Run_PassesResponseMessagesWithServiceManagedS
 	}
 }
 
-func TestContextProviderMiddleware_Run_SkipsStoreAfterRunError(t *testing.T) {
+func TestContextProviderMiddleware_Run_SkipsDefaultStoreOnRunError(t *testing.T) {
 	expected := errors.New("run failed")
 	storeCalled := false
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "provider-a",
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			storeCalled = true
 			return nil
 		},
-	}
+	})
 
-	_, err := collectContextProviderMiddlewareResponse(provider.Middleware().Run(
+	_, err := collectContextProviderMiddlewareResponse(agent.ContextProviderMiddleware(provider).Run(
 		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 			return func(yield func(*agent.ResponseUpdate, error) bool) {
 				yield(nil, expected)
@@ -194,6 +195,37 @@ func TestContextProviderMiddleware_Run_SkipsStoreAfterRunError(t *testing.T) {
 	}
 	if storeCalled {
 		t.Fatal("expected store to be skipped after run error")
+	}
+}
+
+func TestContextProviderMiddleware_Run_PassesRunErrorToCustomProvider(t *testing.T) {
+	expected := errors.New("run failed")
+	var invokedErr error
+	provider := contextProviderFunc{
+		invoking: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return invoking.Messages, invoking.Options, nil
+		},
+		invoked: func(_ context.Context, invoked agent.InvokedContext) error {
+			invokedErr = invoked.Err
+			return nil
+		},
+	}
+
+	_, err := collectContextProviderMiddlewareResponse(agent.ContextProviderMiddleware(provider).Run(
+		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(nil, expected)
+			}
+		},
+		context.Background(),
+		[]*message.Message{message.NewText("hello")},
+		agent.WithSession(agenttest.CreateSession()),
+	))
+	if !errors.Is(err, expected) {
+		t.Fatalf("expected %v, got %v", expected, err)
+	}
+	if !errors.Is(invokedErr, expected) {
+		t.Fatalf("expected invoked error %v, got %v", expected, invokedErr)
 	}
 }
 
@@ -215,73 +247,151 @@ func collectContextProviderMiddlewareResponse(seq iter.Seq2[*agent.ResponseUpdat
 	return &resp, nil
 }
 
+func invokeContextProvider(provider agent.ContextProvider, ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
+}
+
+func invokeContextProviderInvoked(provider agent.ContextProvider, ctx context.Context, requestMessages, responseMessages []*message.Message, options ...agent.Option) error {
+	return provider.Invoked(ctx, agent.InvokedContext{RequestMessages: requestMessages, ResponseMessages: responseMessages, Options: options})
+}
+
+type contextProviderFunc struct {
+	invoking func(context.Context, agent.InvokingContext) ([]*message.Message, []agent.Option, error)
+	invoked  func(context.Context, agent.InvokedContext) error
+}
+
+func (p contextProviderFunc) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	if p.invoking == nil {
+		return invoking.Messages, invoking.Options, nil
+	}
+	return p.invoking(ctx, invoking)
+}
+
+func (p contextProviderFunc) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
+	if p.invoked == nil {
+		return nil
+	}
+	return p.invoked(ctx, invoked)
+}
+
 func TestContextProvider_Invoking_PanicsWithoutSourceID(t *testing.T) {
-	provider := &agent.ContextProvider{}
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{})
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected panic")
 		}
 	}()
-	_, _, _ = provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
+	_, _, _ = invokeContextProvider(provider, t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 }
 
-func TestContextProvider_Invoking_MarksMessagesReplacedByProvide(t *testing.T) {
-	replacement := message.NewText("replacement")
-	provider := &agent.ContextProvider{
+func TestContextProvider_Invoking_SourceStampsProvidedMessages(t *testing.T) {
+	provided := message.NewText("provided")
+	request := message.NewText("request")
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			messages[0] = replacement
-			return messages, options, nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{provided}, nil, nil
 		},
-	}
+	})
 
-	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{message.NewText("request")}, agent.WithSession(agenttest.CreateSession()))
+	messages, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(messages))
+	if len(messages) != 2 {
+		t.Fatalf("expected original and provided messages, got %d", len(messages))
 	}
-	if messages[0] == replacement {
-		t.Fatal("expected replaced message to be cloned")
+	if messages[0] != request {
+		t.Fatal("expected original request message to be preserved")
 	}
-	if messages[0].Source != (message.Source{Type: agent.SourceTypeContextProvider, ID: "ctx"}) {
-		t.Fatalf("replaced message source = %#v, want context provider source", messages[0].Source)
+	if messages[1] == provided {
+		t.Fatal("expected provided message to be cloned")
+	}
+	if messages[1].Source != (message.Source{Type: agent.SourceTypeContextProvider, ID: "ctx"}) {
+		t.Fatalf("provided message source = %#v, want context provider source", messages[1].Source)
 	}
 }
 
 func TestContextProvider_Invoking_HonorsNilProvideOutputs(t *testing.T) {
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(context.Context, []*message.Message, ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(context.Context, agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			return nil, nil, nil
 		},
-	}
+	})
 
-	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{message.NewText("r1")}, agent.WithSession(agenttest.CreateSession()))
+	messages, options, err := invokeContextProvider(provider, t.Context(), []*message.Message{message.NewText("r1")}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if messages != nil {
-		t.Fatalf("expected nil messages returned by Provide to be honored, got %v", messageStrings(messages))
+	if got := messageStrings(messages); !slices.Equal(got, []string{"r1"}) {
+		t.Fatalf("expected original messages to be preserved, got %v", got)
 	}
-	if options != nil {
-		t.Fatalf("expected nil options returned by Provide to be honored, got %d", len(options))
+	if len(options) != 1 {
+		t.Fatalf("expected original options to be preserved, got %d", len(options))
 	}
 }
 
 func TestContextProvider_Invoking_PropagatesProvideError(t *testing.T) {
 	expected := errors.New("provide failed")
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(context.Context, []*message.Message, ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(context.Context, agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			return nil, nil, expected
 		},
-	}
+	})
 
-	_, _, err := provider.BeforeRun(t.Context(), []*message.Message{message.NewText("r1")}, agent.WithSession(agenttest.CreateSession()))
+	_, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{message.NewText("r1")}, agent.WithSession(agenttest.CreateSession()))
 	if !errors.Is(err, expected) {
 		t.Fatalf("expected Provide error, got %v", err)
+	}
+}
+
+func TestContextProvider_Invoking_FiltersInputMessagesBeforeProvide(t *testing.T) {
+	request := message.NewText("request")
+	ctxMessage := message.NewText("ctx")
+	ctxMessage.Source = message.Source{Type: agent.SourceTypeContextProvider, ID: "other"}
+	var providedInput []*message.Message
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
+		SourceID: "ctx",
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			providedInput = invoking.Messages
+			return nil, nil, nil
+		},
+	})
+
+	messages, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{request, ctxMessage}, agent.WithSession(agenttest.CreateSession()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := messageStrings(providedInput); !slices.Equal(got, []string{"request"}) {
+		t.Fatalf("provided input messages = %v, want [request]", got)
+	}
+	if got := messageStrings(messages); !slices.Equal(got, []string{"request", "ctx"}) {
+		t.Fatalf("output messages = %v, want original unfiltered messages", got)
+	}
+}
+
+func TestContextProvider_Invoking_UsesCustomProvideInputMessageFilter(t *testing.T) {
+	request := message.NewText("request")
+	ctxMessage := message.NewText("ctx")
+	ctxMessage.Source = message.Source{Type: agent.SourceTypeContextProvider, ID: "other"}
+	var providedInput []*message.Message
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
+		SourceID:                  "ctx",
+		ProvideInputMessageFilter: messagefilter.PassThrough,
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			providedInput = invoking.Messages
+			return nil, nil, nil
+		},
+	})
+
+	_, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{request, ctxMessage}, agent.WithSession(agenttest.CreateSession()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := messageStrings(providedInput); !slices.Equal(got, []string{"request", "ctx"}) {
+		t.Fatalf("provided input messages = %v, want unfiltered input", got)
 	}
 }
 
@@ -289,14 +399,14 @@ func TestContextProvider_Invoking_ReturnsProvidedMessagesAndSetsSourceID(t *test
 	provided := message.NewText("ctx")
 	request := message.NewText("request")
 
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return append(messages, provided), options, nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{provided}, nil, nil
 		},
-	}
+	})
 
-	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
+	messages, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -314,47 +424,44 @@ func TestContextProvider_Invoking_ReturnsProvidedMessagesAndSetsSourceID(t *test
 	}
 }
 
-func TestContextProvider_Invoking_SetsSourceIDOnPrependedMessages(t *testing.T) {
+func TestContextProvider_Invoking_AppendsProvidedMessages(t *testing.T) {
 	provided := message.NewText("ctx")
 	request := message.NewText("request")
 
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			out := make([]*message.Message, 0, len(messages)+1)
-			out = append(out, provided)
-			out = append(out, messages...)
-			return out, options, nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{provided}, nil, nil
 		},
-	}
+	})
 
-	messages, _, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
+	messages, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(messages) != 2 {
-		t.Fatalf("expected provided and original messages, got %d", len(messages))
+		t.Fatalf("expected original and provided messages, got %d", len(messages))
 	}
-	if messages[0] == provided {
-		t.Fatal("expected prepended message to be cloned")
+	if messages[0] != request {
+		t.Fatal("expected original message to be preserved first")
 	}
-	if messages[0].Source.ID != "ctx" {
-		t.Fatalf("expected SourceID=ctx, got %q", messages[0].Source.ID)
+	if messages[1] == provided {
+		t.Fatal("expected provided message to be cloned")
 	}
-	if messages[1] != request {
-		t.Fatal("expected original message to be preserved")
+	if messages[1].Source.ID != "ctx" {
+		t.Fatalf("expected SourceID=ctx, got %q", messages[1].Source.ID)
 	}
 }
 
 func TestContextProvider_Invoking_UsesCustomSourceID(t *testing.T) {
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "CustomContextSource",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return append(messages, message.NewText("ctx")), options, nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{message.NewText("ctx")}, nil, nil
 		},
-	}
+	})
 
-	messages, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
+	messages, _, err := invokeContextProvider(provider, t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -367,13 +474,13 @@ func TestContextProvider_Invoking_UsesCustomSourceID(t *testing.T) {
 }
 
 func TestContextProvider_Invoked_PanicsWithoutSourceID(t *testing.T) {
-	provider := &agent.ContextProvider{}
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{})
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected panic")
 		}
 	}()
-	_ = provider.AfterRun(t.Context(), nil, nil, agent.WithSession(agenttest.CreateSession()))
+	_ = invokeContextProviderInvoked(provider, t.Context(), nil, nil, agent.WithSession(agenttest.CreateSession()))
 }
 
 func TestContextProvider_Invoked_CallsStoreAndIncludesExternalRequestMessagesByDefault(t *testing.T) {
@@ -389,17 +496,17 @@ func TestContextProvider_Invoked_CallsStoreAndIncludesExternalRequestMessagesByD
 	var storedRequest []*message.Message
 	var storedResponse []*message.Message
 
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Store: func(_ context.Context, requestMessages, responseMessages []*message.Message, _ ...agent.Option) error {
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
 			called = true
-			storedRequest = requestMessages
-			storedResponse = responseMessages
+			storedRequest = invoked.RequestMessages
+			storedResponse = invoked.ResponseMessages
 			return nil
 		},
-	}
+	})
 
-	err := provider.AfterRun(t.Context(), []*message.Message{req1, req2, req3}, []*message.Message{resp}, agent.WithSession(agenttest.CreateSession()))
+	err := invokeContextProviderInvoked(provider, t.Context(), []*message.Message{req1, req2, req3}, []*message.Message{resp}, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -416,14 +523,14 @@ func TestContextProvider_Invoked_CallsStoreAndIncludesExternalRequestMessagesByD
 
 func TestContextProvider_Invoked_PropagatesStoreError(t *testing.T) {
 	expected := errors.New("store failed")
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Store: func(context.Context, []*message.Message, []*message.Message, ...agent.Option) error {
+		Store: func(context.Context, agent.InvokedContext) error {
 			return expected
 		},
-	}
+	})
 
-	err := provider.AfterRun(t.Context(), []*message.Message{message.NewText("r1")}, nil, agent.WithSession(agenttest.CreateSession()))
+	err := invokeContextProviderInvoked(provider, t.Context(), []*message.Message{message.NewText("r1")}, nil, agent.WithSession(agenttest.CreateSession()))
 	if !errors.Is(err, expected) {
 		t.Fatalf("expected store error, got %v", err)
 	}
@@ -439,14 +546,14 @@ func TestContextProvider_InvokingContext_ReturnsProvidedFields(t *testing.T) {
 		return struct{}{}, nil
 	})
 
-	provider := &agent.ContextProvider{
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
-		Provide: func(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-			return append(messages, providedMsg), append(options, agent.WithTool(providedTool)), nil
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{providedMsg}, []agent.Option{agent.WithTool(providedTool)}, nil
 		},
-	}
+	})
 
-	messages, options, err := provider.BeforeRun(t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()), agent.WithTool(inputTool))
+	messages, options, err := invokeContextProvider(provider, t.Context(), []*message.Message{request}, agent.WithSession(agenttest.CreateSession()), agent.WithTool(inputTool))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/agent/harness/agentmode/agentmode.go
+++ b/agent/harness/agentmode/agentmode.go
@@ -12,7 +12,6 @@ package agentmode
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -147,22 +146,29 @@ func New(cfg Config) *Provider {
 		validModes:   validModes,
 	}
 
-	p.ContextProvider = agent.ContextProvider{
+	p.provider = agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "AgentModeProvider",
 		Provide:  p.provide,
-	}
+	})
 	return p
 }
 
 // Provider is an agent mode context provider.
-// Use [New] to create. The embedded [agent.ContextProvider] can be used
-// directly in agent configuration.
+// Use [New] to create. Provider can be used directly in agent configuration.
 type Provider struct {
-	agent.ContextProvider
+	provider     agent.ContextProvider
 	modes        []Mode
 	defaultMode  string
 	instructions string
 	validModes   map[string]struct{}
+}
+
+func (p *Provider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	return p.provider.Invoking(ctx, invoking)
+}
+
+func (p *Provider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
+	return p.provider.Invoked(ctx, invoked)
 }
 
 func (p *Provider) loadState(opts []agent.Option) *state {
@@ -185,13 +191,14 @@ func (p *Provider) saveState(opts []agent.Option, s *state) {
 	session.Set(stateKey, *s)
 }
 
-func (p *Provider) provide(ctx context.Context, messages []*message.Message, opts ...agent.Option) ([]*message.Message, []agent.Option, error) {
+func (p *Provider) provide(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	opts := invoking.Options
 	st := p.loadState(opts)
 	// Persist the initial state so SetMode can read it.
 	p.saveState(opts, st)
 
 	tools := p.createTools(opts, st)
-	outOpts := slices.Clone(opts)
+	var outOpts []agent.Option
 	for _, t := range tools {
 		outOpts = append(outOpts, agent.WithTool(t))
 	}
@@ -200,17 +207,15 @@ func (p *Provider) provide(ctx context.Context, messages []*message.Message, opt
 	instructionText := p.buildInstructions(st.CurrentMode)
 	outOpts = append(outOpts, agent.WithInstructions(instructionText))
 
-	outMessages := messages
+	var outMessages []*message.Message
 
 	// If the mode was changed externally (e.g. via SetMode), inject a notification
 	// so the agent clearly sees the change in conversation context.
 	if st.PreviousMode != "" {
-		outMessages = make([]*message.Message, 0, len(messages)+1)
 		outMessages = append(outMessages, message.NewText(fmt.Sprintf(
 			"[Mode changed: The operating mode has been switched from %q to %q. You must now adjust your behavior to match the %q mode.]",
 			st.PreviousMode, st.CurrentMode, st.CurrentMode,
 		)))
-		outMessages = append(outMessages, messages...)
 		st.PreviousMode = ""
 		p.saveState(opts, st)
 	}

--- a/agent/harness/agentmode/agentmode_test.go
+++ b/agent/harness/agentmode/agentmode_test.go
@@ -23,6 +23,10 @@ func sessionOpts() []agent.Option {
 	return []agent.Option{agent.WithSession(agenttest.CreateSession())}
 }
 
+func invokeProvider(provider *agentmode.Provider, ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
+}
+
 func collectTools(opts []agent.Option) []tool.Tool {
 	var tools []tool.Tool
 	for _, opt := range opts {
@@ -49,7 +53,7 @@ func TestProvide_ReturnsToolsAndInstructions(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +74,7 @@ func TestProvide_InstructionsIncludeCurrentMode(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +178,7 @@ func TestCustomModes_AppearInInstructions(t *testing.T) {
 	})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +234,7 @@ func TestExternalModeChange_InjectsNotification(t *testing.T) {
 	msgs := newMessages("hi")
 
 	// Initialize state.
-	_, _, err := p.BeforeRun(context.Background(), msgs, opts...)
+	_, _, err := invokeProvider(p, context.Background(), msgs, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +245,7 @@ func TestExternalModeChange_InjectsNotification(t *testing.T) {
 	}
 
 	// Next provide should inject notification.
-	outMessages, _, err := p.BeforeRun(context.Background(), msgs, opts...)
+	outMessages, _, err := invokeProvider(p, context.Background(), msgs, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,11 +268,11 @@ func TestExternalModeChange_NotificationClearedAfterFirstRead(t *testing.T) {
 	opts := sessionOpts()
 	msgs := newMessages("hi")
 
-	_, _, _ = p.BeforeRun(context.Background(), msgs, opts...)
+	_, _, _ = invokeProvider(p, context.Background(), msgs, opts...)
 	_ = p.SetMode("execute", opts...)
 
 	// First read: should have notification.
-	outMessages, _, _ := p.BeforeRun(context.Background(), msgs, opts...)
+	outMessages, _, _ := invokeProvider(p, context.Background(), msgs, opts...)
 	hasNotification := false
 	for _, msg := range outMessages {
 		if strings.Contains(msg.Contents.Text(), "Mode changed") {
@@ -281,7 +285,7 @@ func TestExternalModeChange_NotificationClearedAfterFirstRead(t *testing.T) {
 	}
 
 	// Second read: notification should be cleared.
-	outMessages2, _, _ := p.BeforeRun(context.Background(), msgs, opts...)
+	outMessages2, _, _ := invokeProvider(p, context.Background(), msgs, opts...)
 	for _, msg := range outMessages2 {
 		if strings.Contains(msg.Contents.Text(), "Mode changed") {
 			t.Error("notification should have been cleared after first read")
@@ -295,12 +299,12 @@ func TestExternalModeChange_SameMode_NoNotification(t *testing.T) {
 	opts := sessionOpts()
 	msgs := newMessages("hi")
 
-	_, _, _ = p.BeforeRun(context.Background(), msgs, opts...)
+	_, _, _ = invokeProvider(p, context.Background(), msgs, opts...)
 
 	// Set to same mode.
 	_ = p.SetMode("plan", opts...)
 
-	outMessages, _, _ := p.BeforeRun(context.Background(), msgs, opts...)
+	outMessages, _, _ := invokeProvider(p, context.Background(), msgs, opts...)
 	for _, msg := range outMessages {
 		if strings.Contains(msg.Contents.Text(), "Mode changed") {
 			t.Error("should not inject notification when setting same mode")
@@ -313,7 +317,7 @@ func TestSetMode_ChangesMode(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, _, _ = p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, _, _ = invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 
 	if err := p.SetMode("execute", opts...); err != nil {
 		t.Fatal(err)
@@ -328,10 +332,10 @@ func TestSetMode_ReflectedInInstructions(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, _, _ = p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, _, _ = invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	_ = p.SetMode("execute", opts...)
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +424,7 @@ func TestPublicSetMode_ReflectedInInstructions(t *testing.T) {
 
 	_ = p.SetMode("execute", opts...)
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,11 +440,11 @@ func TestState_PersistsAcrossInvocations(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, _, _ = p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, _, _ = invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	_ = p.SetMode("execute", opts...)
 
 	// Second invocation — mode should persist.
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +466,7 @@ func TestCustomInstructions_OverridesDefault(t *testing.T) {
 	})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +485,7 @@ func TestToolNames(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +509,7 @@ func TestDefaultInstructions_ContainToolNamesAndModeCheckGuidance(t *testing.T) 
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -523,7 +527,7 @@ func TestDefaultInstructions_ModesSectionHeaderFormat(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/harness/todo/todo.go
+++ b/agent/harness/todo/todo.go
@@ -13,7 +13,6 @@ package todo
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 
@@ -82,10 +81,9 @@ type Options struct {
 }
 
 // Provider is an agent context provider that manages todo items.
-// Use [New] to create. The embedded [agent.ContextProvider] can be used
-// directly in agent configuration.
+// Use [New] to create. Provider can be used directly in agent configuration.
 type Provider struct {
-	agent.ContextProvider
+	provider               agent.ContextProvider
 	instructions           string
 	suppressTodoMessage    bool
 	todoListMessageBuilder func([]Item) string
@@ -107,11 +105,19 @@ func New(opts *Options) *Provider {
 		p.todoListMessageBuilder = opts.TodoListMessageBuilder
 	}
 
-	p.ContextProvider = agent.ContextProvider{
+	p.provider = agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "TodoProvider",
 		Provide:  p.provide,
-	}
+	})
 	return p
+}
+
+func (p *Provider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	return p.provider.Invoking(ctx, invoking)
+}
+
+func (p *Provider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
+	return p.provider.Invoked(ctx, invoked)
 }
 
 // GetAllItems returns all todo items from the session state.
@@ -176,10 +182,11 @@ func (p *Provider) getSessionLock(opts []agent.Option) *sync.Mutex {
 	return v.(*sync.Mutex)
 }
 
-func (p *Provider) provide(ctx context.Context, messages []*message.Message, opts ...agent.Option) ([]*message.Message, []agent.Option, error) {
+func (p *Provider) provide(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	opts := invoking.Options
 	tools := p.createTools(opts)
 
-	outOpts := slices.Clone(opts)
+	var outOpts []agent.Option
 	for _, t := range tools {
 		outOpts = append(outOpts, agent.WithTool(t))
 	}
@@ -187,7 +194,7 @@ func (p *Provider) provide(ctx context.Context, messages []*message.Message, opt
 	// Add instructions.
 	outOpts = append(outOpts, agent.WithInstructions(p.instructions))
 
-	outMessages := messages
+	var outMessages []*message.Message
 
 	// Inject current todo list summary so the agent sees outstanding work.
 	if !p.suppressTodoMessage {
@@ -202,9 +209,7 @@ func (p *Provider) provide(ctx context.Context, messages []*message.Message, opt
 		} else {
 			todoMsg = formatTodoListMessage(st.Items)
 		}
-		outMessages = make([]*message.Message, 0, len(messages)+1)
 		outMessages = append(outMessages, message.NewText(todoMsg))
-		outMessages = append(outMessages, messages...)
 	}
 
 	return outMessages, outOpts, nil

--- a/agent/harness/todo/todo_test.go
+++ b/agent/harness/todo/todo_test.go
@@ -24,6 +24,10 @@ func sessionOpts() []agent.Option {
 	return []agent.Option{agent.WithSession(agenttest.CreateSession())}
 }
 
+func invokeProvider(provider *todo.Provider, ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
+}
+
 func collectTools(opts []agent.Option) []tool.Tool {
 	var tools []tool.Tool
 	for _, opt := range opts {
@@ -46,12 +50,12 @@ func collectInstructions(opts []agent.Option) string {
 }
 
 // addItems is a helper that uses the public API to set up todo items via session state.
-// It calls BeforeRun to initialize tools, then uses GetAllItems to verify.
+// It calls Invoking to initialize tools, then uses GetAllItems to verify.
 // Since we can't call tools directly, we manipulate state through the provider's public methods.
-// Instead, we add items by calling BeforeRun which creates tools bound to the session,
-// then we inspect state. For actual item creation, we rely on integration through BeforeRun.
+// Instead, we add items by calling Invoking which creates tools bound to the session,
+// then we inspect state. For actual item creation, we rely on integration through Invoking.
 //
-// For tests that need items, we'll use a workaround: call BeforeRun to get the tools,
+// For tests that need items, we'll use a workaround: call Invoking to get the tools,
 // then invoke the tools via their Call method.
 func callTool(t *testing.T, opts []agent.Option, name string, argsJSON string) string {
 	t.Helper()
@@ -83,7 +87,7 @@ func TestProvide_ReturnsToolsAndInstructions(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +108,7 @@ func TestAddTodos_CreatesSingleItem(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +129,7 @@ func TestAddTodos_CreatesMultipleItems(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +150,7 @@ func TestCompleteTodos_MarksItemComplete(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +175,7 @@ func TestCompleteTodos_MarksMultipleComplete(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +199,7 @@ func TestCompleteTodos_ReturnsZeroForMissingIds(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +215,7 @@ func TestRemoveTodos_RemovesItem(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +237,7 @@ func TestRemoveTodos_RemovesMultipleItems(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +261,7 @@ func TestRemoveTodos_ReturnsZeroForMissingIds(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +277,7 @@ func TestGetRemainingTodos_ReturnsOnlyIncomplete(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +300,7 @@ func TestGetAllTodos_ReturnsAllItems(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,14 +321,14 @@ func TestState_PersistsAcrossInvocations(t *testing.T) {
 	opts := sessionOpts()
 
 	// First invocation: add items.
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
 	callTool(t, outOpts, "todos_add", `{"Arg0":[{"title":"Persist me"}]}`)
 
 	// Second invocation: items should still be there.
-	_, outOpts2, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts2, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +348,7 @@ func TestPublicGetAllTodos_ReturnsAllItems(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +366,7 @@ func TestPublicGetRemainingTodos_ReturnsOnlyIncomplete(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +402,7 @@ func TestCustomInstructions_OverridesDefault(t *testing.T) {
 	})
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -414,7 +418,7 @@ func TestNilOptions_UsesDefaultInstructions(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +434,7 @@ func TestProvide_InjectsEmptyTodoMessage(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	outMessages, _, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	outMessages, _, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +457,7 @@ func TestProvide_InjectsTodoListMessage(t *testing.T) {
 	opts := sessionOpts()
 
 	// First call to get tools and add items.
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +466,7 @@ func TestProvide_InjectsTodoListMessage(t *testing.T) {
 	callTool(t, outOpts, "todos_complete", fmt.Sprintf(`{"Arg0":[{"id":%d,"reason":"done"}]}`, items[0].ID))
 
 	// Second call should inject todo list message.
-	outMessages, _, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	outMessages, _, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +498,7 @@ func TestProvide_SuppressTodoListMessage(t *testing.T) {
 	opts := sessionOpts()
 	msgs := newMessages("hi")
 
-	outMessages, _, err := p.BeforeRun(context.Background(), msgs, opts...)
+	outMessages, _, err := invokeProvider(p, context.Background(), msgs, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +519,7 @@ func TestProvide_CustomTodoListMessageBuilder(t *testing.T) {
 	})
 	opts := sessionOpts()
 
-	outMessages, _, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	outMessages, _, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -543,7 +547,7 @@ func TestProvide_SuppressWinsOverBuilder(t *testing.T) {
 	opts := sessionOpts()
 	msgs := newMessages("hi")
 
-	outMessages, _, err := p.BeforeRun(context.Background(), msgs, opts...)
+	outMessages, _, err := invokeProvider(p, context.Background(), msgs, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -563,7 +567,7 @@ func TestToolNames(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -587,7 +591,7 @@ func TestCompleteTodos_WithReason(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -614,7 +618,7 @@ func TestCompleteToolDescription_MentionsReason(t *testing.T) {
 	p := todo.New(nil)
 	opts := sessionOpts()
 
-	_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +652,7 @@ func TestCompleteTodos_EmptyReasonIsAccepted(t *testing.T) {
 			p := todo.New(nil)
 			opts := sessionOpts()
 
-			_, outOpts, err := p.BeforeRun(context.Background(), newMessages("hi"), opts...)
+			_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/agent/history.go
+++ b/agent/history.go
@@ -15,80 +15,140 @@ const SourceTypeHistoryProvider message.SourceType = "history-provider"
 
 const defaultInMemoryHistorySourceID = "in-memory"
 
-// HistoryProvider provides a conversation-history subset of [ContextProvider]
-// behavior around an agent invocation.
+// HistoryProvider retrieves chat history before an agent invocation and stores
+// newly produced messages after an invocation.
 //
-// A history provider can retrieve prior conversation messages, combine and
-// filter them with the current request messages, mark added messages with this
-// provider's source, and persist filtered request and response messages after
-// the run completes. It cannot add or replace run options, tools, instructions, or
-// other non-message context. Use [ContextProvider] when an extension needs to
-// supply options or context that is not only conversation history.
-type HistoryProvider struct {
+// A history provider is only relevant when the underlying AI service does not
+// manage chat history itself. Implementations are responsible for preserving
+// message order and metadata, returning messages in chronological order, and
+// applying storage-management strategies such as truncation, summarization, or
+// archival when history grows large. It cannot add run options, tools,
+// instructions, or other non-message context. Use [ContextProvider] when an
+// extension needs to supply context that is not only conversation history.
+//
+// # Security considerations
+//
+// Agent Framework does not validate or filter the messages returned by the
+// provider during load — they are accepted as-is and treated identically to
+// user-supplied messages. Implementers must ensure that only trusted data is
+// returned. If the underlying storage is compromised, adversarial content could
+// influence LLM behavior via indirect prompt injection, for example by altering
+// conversation context or impersonating different roles. Messages stored in chat
+// history may contain PII and sensitive conversation content; implementers should
+// consider encryption at rest and appropriate access controls for the storage backend.
+type HistoryProvider interface {
+	// Invoking returns the input messages with this provider's history applied.
+	Invoking(context.Context, InvokingContext) ([]*message.Message, error)
+
+	// Invoked persists history after an agent invocation finishes.
+	Invoked(context.Context, InvokedContext) error
+}
+
+// HistoryProviderConfig configures the provider created by [NewHistoryProvider].
+type HistoryProviderConfig struct {
 	// Unique identifier for this provider instance (required).
 	SourceID string
 
 	// Optional filter applied to messages added by Provide before they are included.
 	// Defaults to passing all added messages through.
-	ProvideFilter messagefilter.Filter
+	ProvideOutputMessageFilter messagefilter.Filter
 
 	// Optional filter applied to request messages before Store.
 	// Defaults to messages that did not come from a history provider.
-	StoreRequestFilter messagefilter.Filter
+	StoreInputRequestMessageFilter messagefilter.Filter
 
 	// Optional filter applied to response messages before Store.
 	// Defaults to passing all response messages through.
-	StoreResponseFilter messagefilter.Filter
+	StoreInputResponseMessageFilter messagefilter.Filter
 
-	// Optional retrieval hook that returns updated history and request messages.
-	// Messages that are not pointer-identical to the original input messages are marked with this provider's source.
-	// Defaults to returning the original messages unchanged.
-	Provide func(context.Context, []*message.Message, ...Option) ([]*message.Message, error)
+	// Optional retrieval hook that returns additional history messages in chronological order.
+	Provide func(context.Context, InvokingContext) ([]*message.Message, error)
 
 	// Optional storage hook. Defaults to no-op.
-	Store func(context.Context, []*message.Message, []*message.Message, ...Option) error
+	Store func(context.Context, InvokedContext) error
 }
 
-// BeforeRun returns the input messages with this provider's history applied.
-func (p *HistoryProvider) BeforeRun(ctx context.Context, messages []*message.Message, options ...Option) ([]*message.Message, error) {
-	if p.SourceID == "" {
+type defaultHistoryProvider struct {
+	config HistoryProviderConfig
+}
+
+// NewHistoryProvider creates the default additive history provider.
+//
+// The provider treats Provide results as additional history messages, filters
+// those messages when ProvideOutputMessageFilter is set, source-stamps them,
+// prepends them to caller-provided request messages, filters stored request and
+// response messages, and skips Store when the run fails.
+func NewHistoryProvider(config HistoryProviderConfig) HistoryProvider {
+	return &defaultHistoryProvider{config: config}
+}
+
+// Invoking returns the input messages with this provider's history applied.
+func (p *defaultHistoryProvider) Invoking(ctx context.Context, invoking InvokingContext) ([]*message.Message, error) {
+	if p.config.SourceID == "" {
 		panic("SourceID is required")
 	}
-	if p.Provide == nil {
-		return messages, nil
+	if p.config.Provide == nil {
+		return invoking.Messages, nil
 	}
 
-	outMessages, err := p.Provide(ctx, messages, options...)
+	providedMessages, err := p.config.Provide(ctx, invoking)
 	if err != nil {
 		return nil, err
 	}
 
-	if outMessages == nil {
-		outMessages = messages
-	}
-
-	if p.ProvideFilter != nil {
-		outMessages, err = p.filterProvidedMessages(ctx, outMessages, messages)
+	if p.config.ProvideOutputMessageFilter != nil {
+		providedMessages, err = p.config.ProvideOutputMessageFilter(ctx, providedMessages)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	markNewMessagesWithSource(outMessages, messages, message.Source{Type: SourceTypeHistoryProvider, ID: p.SourceID}, true)
+	if len(providedMessages) == 0 {
+		return invoking.Messages, nil
+	}
+
+	source := message.Source{Type: SourceTypeHistoryProvider, ID: p.config.SourceID}
+	for i, msg := range providedMessages {
+		if msg == nil || msg.Source == source {
+			continue
+		}
+		marked := msg.Clone()
+		marked.Source = source
+		providedMessages[i] = marked
+	}
+	outMessages := append(providedMessages, invoking.Messages...)
 
 	return outMessages, nil
 }
 
-// AfterRun persists history after an agent invocation finishes.
-func (p *HistoryProvider) AfterRun(ctx context.Context, requestMessages, responseMessages []*message.Message, options ...Option) error {
-	if p.SourceID == "" {
+// Invoked persists history after an agent invocation finishes.
+func (p *defaultHistoryProvider) Invoked(ctx context.Context, invoked InvokedContext) error {
+	if p.config.SourceID == "" {
 		panic("SourceID is required")
 	}
-	requestFilter := p.StoreRequestFilter
+	if invoked.Err != nil {
+		return nil
+	}
+	if p.config.Store == nil {
+		return nil
+	}
+	requestFilter := p.config.StoreInputRequestMessageFilter
 	if requestFilter == nil {
 		requestFilter = notSourceTypes(SourceTypeHistoryProvider)
 	}
-	return runStoreHook(ctx, p.Store, requestFilter, p.StoreResponseFilter, requestMessages, responseMessages, options)
+	responseFilter := p.config.StoreInputResponseMessageFilter
+	if responseFilter == nil {
+		responseFilter = messagefilter.PassThrough
+	}
+	filteredReq, err := requestFilter(ctx, invoked.RequestMessages)
+	if err != nil {
+		return err
+	}
+	filteredResp, err := responseFilter(ctx, invoked.ResponseMessages)
+	if err != nil {
+		return err
+	}
+	return p.config.Store(ctx, InvokedContext{RequestMessages: filteredReq, ResponseMessages: filteredResp, Options: invoked.Options, Err: invoked.Err})
 }
 
 func notSourceTypes(sourceTypes ...message.SourceType) messagefilter.Filter {
@@ -102,77 +162,94 @@ func notSourceTypes(sourceTypes ...message.SourceType) messagefilter.Filter {
 	}
 }
 
-func (p *HistoryProvider) filterProvidedMessages(ctx context.Context, outMessages, inMessages []*message.Message) ([]*message.Message, error) {
-	originals := make(map[*message.Message]struct{}, len(inMessages))
-	for _, msg := range inMessages {
-		originals[msg] = struct{}{}
-	}
-	provided := make([]*message.Message, 0, len(outMessages))
-	for _, msg := range outMessages {
-		if _, ok := originals[msg]; ok {
-			continue
-		}
-		provided = append(provided, msg)
-	}
-	filtered, err := p.ProvideFilter(ctx, provided)
-	if err != nil {
-		return nil, err
-	}
-	kept := make(map[*message.Message]struct{}, len(filtered))
-	for _, msg := range filtered {
-		kept[msg] = struct{}{}
-	}
-	return slices.DeleteFunc(outMessages, func(msg *message.Message) bool {
-		if _, ok := originals[msg]; ok {
-			return false
-		}
-		_, ok := kept[msg]
-		return !ok
-	}), nil
+// InMemoryHistoryProviderConfig configures the provider created by [NewInMemoryHistoryProvider].
+type InMemoryHistoryProviderConfig struct {
+	// SourceID identifies messages loaded from this provider.
+	// When empty, a default in-memory history provider source ID is used.
+	SourceID string
+
+	// StateKey identifies where provider state is stored in the session.
+	// When empty, SourceID is used.
+	StateKey string
+
+	// StateInitializer returns initial messages on first use.
+	// When nil, no initial messages are used.
+	StateInitializer func(*Session) []*message.Message
+
+	// Optional filter applied to messages loaded from storage before they are included.
+	// Defaults to passing all loaded messages through.
+	ProvideOutputMessageFilter messagefilter.Filter
+
+	// Optional filter applied to request messages before storing them.
+	// Defaults to messages that did not come from a history provider.
+	StoreInputRequestMessageFilter messagefilter.Filter
+
+	// Optional filter applied to response messages before storing them.
+	// Defaults to passing all response messages through.
+	StoreInputResponseMessageFilter messagefilter.Filter
+}
+
+type inMemoryHistoryProviderState struct {
+	Messages []*message.Message `json:"messages,omitempty"`
 }
 
 // NewInMemoryHistoryProvider creates a history provider that stores conversation history in the session.
-// If sourceID is empty, it defaults to "in-memory".
-func NewInMemoryHistoryProvider(sourceID string) *HistoryProvider {
+func NewInMemoryHistoryProvider(config InMemoryHistoryProviderConfig) HistoryProvider {
+	sourceID := config.SourceID
 	if sourceID == "" {
 		sourceID = defaultInMemoryHistorySourceID
 	}
-	return &HistoryProvider{
-		SourceID: sourceID,
-		Provide: func(_ context.Context, msgs []*message.Message, options ...Option) ([]*message.Message, error) {
-			session, _ := GetOption(options, WithSession)
+	stateKey := config.StateKey
+	if stateKey == "" {
+		stateKey = sourceID
+	}
+	historyConfig := HistoryProviderConfig{
+		SourceID:                        sourceID,
+		ProvideOutputMessageFilter:      config.ProvideOutputMessageFilter,
+		StoreInputRequestMessageFilter:  config.StoreInputRequestMessageFilter,
+		StoreInputResponseMessageFilter: config.StoreInputResponseMessageFilter,
+		Provide: func(_ context.Context, invoking InvokingContext) ([]*message.Message, error) {
+			session, _ := GetOption(invoking.Options, WithSession)
 			if session == nil {
-				return msgs, nil
+				return nil, nil
 			}
-			var state inmemoryState
-			if _, err := session.Get(sourceID, &state); err != nil {
+			state, err := getInMemoryHistoryProviderState(session, stateKey, config.StateInitializer)
+			if err != nil {
 				return nil, err
 			}
 			if len(state.Messages) == 0 {
-				return msgs, nil
+				return nil, nil
 			}
-			messages := make([]*message.Message, 0, len(state.Messages)+len(msgs))
-			messages = append(messages, state.Messages...)
-			messages = append(messages, msgs...)
-			return messages, nil
+			return slices.Clone(state.Messages), nil
 		},
-		Store: func(_ context.Context, requestMessages, responseMessages []*message.Message, options ...Option) error {
-			session, _ := GetOption(options, WithSession)
+		Store: func(_ context.Context, invoked InvokedContext) error {
+			session, _ := GetOption(invoked.Options, WithSession)
 			if session == nil {
 				return nil
 			}
-			var state inmemoryState
-			if _, err := session.Get(sourceID, &state); err != nil {
+			state, err := getInMemoryHistoryProviderState(session, stateKey, config.StateInitializer)
+			if err != nil {
 				return err
 			}
-			state.Messages = append(state.Messages, requestMessages...)
-			state.Messages = append(state.Messages, responseMessages...)
-			session.Set(sourceID, state)
+			state.Messages = append(state.Messages, invoked.RequestMessages...)
+			state.Messages = append(state.Messages, invoked.ResponseMessages...)
+			session.Set(stateKey, state)
 			return nil
 		},
 	}
+	return NewHistoryProvider(historyConfig)
 }
 
-type inmemoryState struct {
-	Messages []*message.Message `json:"messages,omitempty"`
+func getInMemoryHistoryProviderState(session *Session, stateKey string, initializer func(*Session) []*message.Message) (inMemoryHistoryProviderState, error) {
+	var state inMemoryHistoryProviderState
+	if ok, err := session.Get(stateKey, &state); err != nil {
+		return state, err
+	} else if ok {
+		return state, nil
+	}
+	if initializer != nil {
+		state.Messages = slices.Clone(initializer(session))
+	}
+	session.Set(stateKey, state)
+	return state, nil
 }

--- a/agent/history.go
+++ b/agent/history.go
@@ -10,15 +10,18 @@ import (
 	"github.com/microsoft/agent-framework-go/message/messagefilter"
 )
 
+// SourceTypeHistoryProvider represents a message that originated from a history provider.
+const SourceTypeHistoryProvider message.SourceType = "history-provider"
+
 const defaultInMemoryHistorySourceID = "in-memory"
 
 // HistoryProvider provides a conversation-history subset of [ContextProvider]
 // behavior around an agent invocation.
 //
 // A history provider can retrieve prior conversation messages, combine and
-// filter them with the current request messages, mark added messages with a
-// SourceID, and persist filtered request and response messages after the run
-// completes. It cannot add or replace run options, tools, instructions, or
+// filter them with the current request messages, mark added messages with this
+// provider's source, and persist filtered request and response messages after
+// the run completes. It cannot add or replace run options, tools, instructions, or
 // other non-message context. Use [ContextProvider] when an extension needs to
 // supply options or context that is not only conversation history.
 type HistoryProvider struct {
@@ -30,7 +33,7 @@ type HistoryProvider struct {
 	ProvideFilter messagefilter.Filter
 
 	// Optional filter applied to request messages before Store.
-	// Defaults to messages that did not come from this history provider.
+	// Defaults to messages that did not come from a history provider.
 	StoreRequestFilter messagefilter.Filter
 
 	// Optional filter applied to response messages before Store.
@@ -38,7 +41,7 @@ type HistoryProvider struct {
 	StoreResponseFilter messagefilter.Filter
 
 	// Optional retrieval hook that returns updated history and request messages.
-	// Messages that are not pointer-identical to the original input messages are marked with SourceID.
+	// Messages that are not pointer-identical to the original input messages are marked with this provider's source.
 	// Defaults to returning the original messages unchanged.
 	Provide func(context.Context, []*message.Message, ...Option) ([]*message.Message, error)
 
@@ -71,7 +74,7 @@ func (p *HistoryProvider) BeforeRun(ctx context.Context, messages []*message.Mes
 		}
 	}
 
-	outMessages = p.withHistorySource(outMessages, messages)
+	markNewMessagesWithSource(outMessages, messages, message.Source{Type: SourceTypeHistoryProvider, ID: p.SourceID}, true)
 
 	return outMessages, nil
 }
@@ -81,7 +84,22 @@ func (p *HistoryProvider) AfterRun(ctx context.Context, requestMessages, respons
 	if p.SourceID == "" {
 		panic("SourceID is required")
 	}
-	return runStoreHook(ctx, p.SourceID, p.Store, p.StoreRequestFilter, p.StoreResponseFilter, requestMessages, responseMessages, options)
+	requestFilter := p.StoreRequestFilter
+	if requestFilter == nil {
+		requestFilter = notSourceTypes(SourceTypeHistoryProvider)
+	}
+	return runStoreHook(ctx, p.Store, requestFilter, p.StoreResponseFilter, requestMessages, responseMessages, options)
+}
+
+func notSourceTypes(sourceTypes ...message.SourceType) messagefilter.Filter {
+	return func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
+		return slices.DeleteFunc(messages, func(msg *message.Message) bool {
+			if msg == nil {
+				return false
+			}
+			return slices.Contains(sourceTypes, msg.Source.Type)
+		}), nil
+	}
 }
 
 func (p *HistoryProvider) filterProvidedMessages(ctx context.Context, outMessages, inMessages []*message.Message) ([]*message.Message, error) {
@@ -111,10 +129,6 @@ func (p *HistoryProvider) filterProvidedMessages(ctx context.Context, outMessage
 		_, ok := kept[msg]
 		return !ok
 	}), nil
-}
-
-func (p *HistoryProvider) withHistorySource(outMessages, inMessages []*message.Message) []*message.Message {
-	return markNewMessages(outMessages, inMessages, p.SourceID)
 }
 
 // NewInMemoryHistoryProvider creates a history provider that stores conversation history in the session.

--- a/agent/history_test.go
+++ b/agent/history_test.go
@@ -39,7 +39,7 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 	if messages[0].String() != "request" || messages[1].String() != "response" {
 		t.Fatalf("unexpected output order/content")
 	}
-	if messages[0].SourceID != "in-memory" || messages[1].SourceID != "in-memory" {
+	if messages[0].Source.ID != "in-memory" || messages[1].Source.ID != "in-memory" {
 		t.Fatal("expected history messages to have in-memory source ID")
 	}
 
@@ -96,7 +96,7 @@ func TestNewInMemoryHistoryProvider_ProvidePassesOriginalMessages(t *testing.T) 
 	if messages[0].String() != "request" || messages[1].String() != "response" {
 		t.Fatalf("unexpected output order/content")
 	}
-	if messages[0].SourceID != "InMemoryHistoryProvider" || messages[1].SourceID != "InMemoryHistoryProvider" {
+	if messages[0].Source.ID != "InMemoryHistoryProvider" || messages[1].Source.ID != "InMemoryHistoryProvider" {
 		t.Fatal("expected history messages to have provider source ID")
 	}
 }
@@ -132,11 +132,13 @@ func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesHistoryMes
 
 	user := message.NewText("user")
 	historyMsg := message.NewText("history")
-	historyMsg.SourceID = "k"
+	historyMsg.Source = message.Source{Type: agent.SourceTypeHistoryProvider, ID: "k"}
+	otherHistoryMsg := message.NewText("other history")
+	otherHistoryMsg.Source = message.Source{Type: agent.SourceTypeHistoryProvider, ID: "other"}
 	ctxMsg := message.NewText("ctx")
-	ctxMsg.SourceID = "provider-A"
+	ctxMsg.Source = message.Source{Type: agent.SourceTypeContextProvider, ID: "provider-A"}
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{user, historyMsg, ctxMsg}, nil, agent.WithSession(session)); err != nil {
+	if err := provider.AfterRun(t.Context(), []*message.Message{user, historyMsg, otherHistoryMsg, ctxMsg}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -145,7 +147,7 @@ func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesHistoryMes
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(messages) != 2 || messages[0].String() != "user" || messages[1].String() != "ctx" {
-		t.Fatal("expected default request filter to exclude only history messages")
+		t.Fatal("expected default request filter to exclude all history-provider messages")
 	}
 }
 
@@ -198,7 +200,7 @@ func TestNewInMemoryHistoryProvider_StoreContextMessages(t *testing.T) {
 	provider.StoreRequestFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
 		filtered := make([]*message.Message, 0, len(messages))
 		for _, msg := range messages {
-			if msg.SourceID == "" || msg.SourceID == "provider-A" {
+			if msg.Source.ID == "" || msg.Source.ID == "provider-A" {
 				filtered = append(filtered, msg)
 			}
 		}
@@ -207,7 +209,7 @@ func TestNewInMemoryHistoryProvider_StoreContextMessages(t *testing.T) {
 	session := agenttest.CreateSession()
 	user := message.NewText("user")
 	ctxMsg := message.NewText("ctx")
-	ctxMsg.SourceID = "provider-A"
+	ctxMsg.Source = message.Source{ID: "provider-A"}
 
 	if err := provider.AfterRun(t.Context(), []*message.Message{user, ctxMsg}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -227,7 +229,7 @@ func TestNewInMemoryHistoryProvider_StoreContextMessagesFrom(t *testing.T) {
 	provider.StoreRequestFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
 		filtered := make([]*message.Message, 0, len(messages))
 		for _, msg := range messages {
-			if msg.SourceID == "provider-A" {
+			if msg.Source.ID == "provider-A" {
 				filtered = append(filtered, msg)
 			}
 		}
@@ -235,9 +237,9 @@ func TestNewInMemoryHistoryProvider_StoreContextMessagesFrom(t *testing.T) {
 	}
 	session := agenttest.CreateSession()
 	ctxA := message.NewText("ctx-a")
-	ctxA.SourceID = "provider-A"
+	ctxA.Source = message.Source{ID: "provider-A"}
 	ctxB := message.NewText("ctx-b")
-	ctxB.SourceID = "provider-B"
+	ctxB.Source = message.Source{ID: "provider-B"}
 
 	if err := provider.AfterRun(t.Context(), []*message.Message{ctxA, ctxB}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/agent/history_test.go
+++ b/agent/history_test.go
@@ -11,22 +11,27 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
+func invokeHistoryProvider(provider agent.HistoryProvider, ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, error) {
+	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
+}
+
+func invokeHistoryProviderInvoked(provider agent.HistoryProvider, ctx context.Context, requestMessages, responseMessages []*message.Message, options ...agent.Option) error {
+	return provider.Invoked(ctx, agent.InvokedContext{RequestMessages: requestMessages, ResponseMessages: responseMessages, Options: options})
+}
+
 func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("")
-	if provider.SourceID != "in-memory" {
-		t.Fatalf("expected SourceID=in-memory, got %q", provider.SourceID)
-	}
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{})
 
 	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error storing history: %v", err)
 	}
 
 	newRequest := message.NewText("new request")
-	messages, err := provider.BeforeRun(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error loading history: %v", err)
 	}
@@ -44,10 +49,10 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 	}
 
 	newResponse := message.NewText("new response")
-	if err := provider.AfterRun(t.Context(), messages, []*message.Message{newResponse}, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), messages, []*message.Message{newResponse}, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error storing next turn: %v", err)
 	}
-	messages, err = provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err = invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error loading updated history: %v", err)
 	}
@@ -60,30 +65,17 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 }
 
 func TestNewInMemoryHistoryProvider_ProvidePassesOriginalMessages(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("InMemoryHistoryProvider")
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "InMemoryHistoryProvider"})
 	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error storing history: %v", err)
 	}
 
 	newRequest := message.NewText("new request")
-	messages, err := provider.Provide(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
-	if err != nil {
-		t.Fatalf("unexpected error loading history: %v", err)
-	}
-	if len(messages) != 3 {
-		t.Fatalf("expected 2 history messages plus request, got %d", len(messages))
-	}
-	if messages[2] != newRequest {
-		t.Fatal("expected original request message to be preserved last")
-	}
-	if messages[0].String() != "request" || messages[1].String() != "response" {
-		t.Fatalf("unexpected output order/content")
-	}
-	messages, err = provider.BeforeRun(t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), []*message.Message{newRequest}, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error loading history: %v", err)
 	}
@@ -103,18 +95,18 @@ func TestNewInMemoryHistoryProvider_ProvidePassesOriginalMessages(t *testing.T) 
 
 func TestNewInMemoryHistoryProvider_SourceID_MapsToSessionStateKey(t *testing.T) {
 	session := agenttest.CreateSession()
-	customProvider := agent.NewInMemoryHistoryProvider("custom")
-	defaultProvider := agent.NewInMemoryHistoryProvider("InMemoryHistoryProvider")
+	customProvider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "custom"})
+	defaultProvider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "InMemoryHistoryProvider"})
 
-	if err := customProvider.AfterRun(t.Context(), []*message.Message{message.NewText("custom")}, nil, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(customProvider, t.Context(), []*message.Message{message.NewText("custom")}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error storing custom history: %v", err)
 	}
-	if err := defaultProvider.AfterRun(t.Context(), []*message.Message{message.NewText("default")}, nil, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(defaultProvider, t.Context(), []*message.Message{message.NewText("default")}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error storing default history: %v", err)
 	}
 
-	provider := agent.NewInMemoryHistoryProvider("custom")
-	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "custom"})
+	messages, err := invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,8 +118,66 @@ func TestNewInMemoryHistoryProvider_SourceID_MapsToSessionStateKey(t *testing.T)
 	}
 }
 
-func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesHistoryMessages(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("k")
+func TestNewInMemoryHistoryProvider_StateKey_CanDifferFromSourceID(t *testing.T) {
+	session := agenttest.CreateSession()
+	writer := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "writer", StateKey: "history-state"})
+	reader := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "reader", StateKey: "history-state"})
+
+	if err := invokeHistoryProviderInvoked(writer, t.Context(), []*message.Message{message.NewText("stored")}, nil, agent.WithSession(session)); err != nil {
+		t.Fatalf("unexpected error storing history: %v", err)
+	}
+
+	messages, err := invokeHistoryProvider(reader, t.Context(), nil, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("unexpected error reading history: %v", err)
+	}
+	if len(messages) != 1 || messages[0].String() != "stored" {
+		t.Fatalf("expected stored message, got %v", messageStrings(messages))
+	}
+	if messages[0].Source.ID != "reader" {
+		t.Fatalf("expected reader source ID, got %q", messages[0].Source.ID)
+	}
+}
+
+func TestNewInMemoryHistoryProvider_StateInitializer_SeedsMissingState(t *testing.T) {
+	session := agenttest.CreateSession()
+	initializerCalls := 0
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
+		SourceID: "k",
+		StateInitializer: func(gotSession *agent.Session) []*message.Message {
+			if gotSession != session {
+				t.Fatalf("expected initializer session %p, got %p", session, gotSession)
+			}
+			initializerCalls++
+			return []*message.Message{message.NewText("seed")}
+		},
+	})
+
+	messages, err := invokeHistoryProvider(provider, t.Context(), []*message.Message{message.NewText("request")}, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("unexpected error reading history: %v", err)
+	}
+	if initializerCalls != 1 {
+		t.Fatalf("expected initializer to be called once, got %d", initializerCalls)
+	}
+	if got := messageStrings(messages); len(got) != 2 || got[0] != "seed" || got[1] != "request" {
+		t.Fatalf("messages = %v, want [seed request]", got)
+	}
+	if messages[0].Source.ID != "k" {
+		t.Fatalf("expected seed message source ID k, got %q", messages[0].Source.ID)
+	}
+
+	_, err = invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("unexpected error reading initialized history: %v", err)
+	}
+	if initializerCalls != 1 {
+		t.Fatalf("expected initialized state to be reused, got %d initializer calls", initializerCalls)
+	}
+}
+
+func TestNewInMemoryHistoryProvider_DefaultStoreInputRequestMessageFilter_ExcludesHistoryMessages(t *testing.T) {
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "k"})
 	session := agenttest.CreateSession()
 
 	user := message.NewText("user")
@@ -138,11 +188,11 @@ func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesHistoryMes
 	ctxMsg := message.NewText("ctx")
 	ctxMsg.Source = message.Source{Type: agent.SourceTypeContextProvider, ID: "provider-A"}
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{user, historyMsg, otherHistoryMsg, ctxMsg}, nil, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{user, historyMsg, otherHistoryMsg, ctxMsg}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -152,19 +202,21 @@ func TestNewInMemoryHistoryProvider_DefaultStoreRequestFilter_ExcludesHistoryMes
 }
 
 func TestNewInMemoryHistoryProvider_SkipStoreRequestMessages(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("k")
-	provider.StoreRequestFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
-		return nil, nil
-	}
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
+		SourceID: "k",
+		StoreInputRequestMessageFilter: func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
+			return nil, nil
+		},
+	})
 	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -174,19 +226,21 @@ func TestNewInMemoryHistoryProvider_SkipStoreRequestMessages(t *testing.T) {
 }
 
 func TestNewInMemoryHistoryProvider_SkipStoreResponseMessages(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("k")
-	provider.StoreResponseFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
-		return nil, nil
-	}
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
+		SourceID: "k",
+		StoreInputResponseMessageFilter: func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
+			return nil, nil
+		},
+	})
 	session := agenttest.CreateSession()
 	request := message.NewText("request")
 	response := message.NewText("response")
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -196,26 +250,28 @@ func TestNewInMemoryHistoryProvider_SkipStoreResponseMessages(t *testing.T) {
 }
 
 func TestNewInMemoryHistoryProvider_StoreContextMessages(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("k")
-	provider.StoreRequestFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
-		filtered := make([]*message.Message, 0, len(messages))
-		for _, msg := range messages {
-			if msg.Source.ID == "" || msg.Source.ID == "provider-A" {
-				filtered = append(filtered, msg)
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
+		SourceID: "k",
+		StoreInputRequestMessageFilter: func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
+			filtered := make([]*message.Message, 0, len(messages))
+			for _, msg := range messages {
+				if msg.Source.ID == "" || msg.Source.ID == "provider-A" {
+					filtered = append(filtered, msg)
+				}
 			}
-		}
-		return filtered, nil
-	}
+			return filtered, nil
+		},
+	})
 	session := agenttest.CreateSession()
 	user := message.NewText("user")
 	ctxMsg := message.NewText("ctx")
 	ctxMsg.Source = message.Source{ID: "provider-A"}
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{user, ctxMsg}, nil, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{user, ctxMsg}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -225,27 +281,29 @@ func TestNewInMemoryHistoryProvider_StoreContextMessages(t *testing.T) {
 }
 
 func TestNewInMemoryHistoryProvider_StoreContextMessagesFrom(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("k")
-	provider.StoreRequestFilter = func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
-		filtered := make([]*message.Message, 0, len(messages))
-		for _, msg := range messages {
-			if msg.Source.ID == "provider-A" {
-				filtered = append(filtered, msg)
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
+		SourceID: "k",
+		StoreInputRequestMessageFilter: func(ctx context.Context, messages []*message.Message) ([]*message.Message, error) {
+			filtered := make([]*message.Message, 0, len(messages))
+			for _, msg := range messages {
+				if msg.Source.ID == "provider-A" {
+					filtered = append(filtered, msg)
+				}
 			}
-		}
-		return filtered, nil
-	}
+			return filtered, nil
+		},
+	})
 	session := agenttest.CreateSession()
 	ctxA := message.NewText("ctx-a")
 	ctxA.Source = message.Source{ID: "provider-A"}
 	ctxB := message.NewText("ctx-b")
 	ctxB.Source = message.Source{ID: "provider-B"}
 
-	if err := provider.AfterRun(t.Context(), []*message.Message{ctxA, ctxB}, nil, agent.WithSession(session)); err != nil {
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{ctxA, ctxB}, nil, agent.WithSession(session)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -255,12 +313,12 @@ func TestNewInMemoryHistoryProvider_StoreContextMessagesFrom(t *testing.T) {
 }
 
 func TestNewInMemoryHistoryProvider_Invoking_IgnoresUnreadableState(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("k")
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "k"})
 	session := agenttest.CreateSession()
 	session.Set("k", "not-a-history-state")
 	request := []*message.Message{message.NewText("req")}
 
-	messages, err := provider.BeforeRun(t.Context(), request, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), request, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error when state is unreadable: %v", err)
 	}
@@ -270,18 +328,18 @@ func TestNewInMemoryHistoryProvider_Invoking_IgnoresUnreadableState(t *testing.T
 }
 
 func TestNewInMemoryHistoryProvider_Invoked_OverwritesUnreadableState(t *testing.T) {
-	provider := agent.NewInMemoryHistoryProvider("k")
+	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{SourceID: "k"})
 	session := agenttest.CreateSession()
 	session.Set("k", "not-a-history-state")
 	request := message.NewText("r1")
 	response := message.NewText("a1")
 
-	err := provider.AfterRun(t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session))
+	err := invokeHistoryProviderInvoked(provider, t.Context(), []*message.Message{request}, []*message.Message{response}, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error when state is unreadable: %v", err)
 	}
 
-	messages, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(session))
+	messages, err := invokeHistoryProvider(provider, t.Context(), nil, agent.WithSession(session))
 	if err != nil {
 		t.Fatalf("unexpected error reading stored history: %v", err)
 	}

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -51,7 +51,21 @@ type middlewareRunner struct {
 
 func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
 	next := func(ctx context.Context, outMessages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
-		markNewMessagesWithSource(outMessages, messages, message.Source{Type: SourceTypeMiddleware}, false)
+		originals := make(map[*message.Message]struct{}, len(messages))
+		for _, msg := range messages {
+			originals[msg] = struct{}{}
+		}
+		for i, msg := range outMessages {
+			if _, ok := originals[msg]; ok {
+				continue
+			}
+			if msg == nil || msg.Source != (message.Source{}) {
+				continue
+			}
+			marked := msg.Clone()
+			marked.Source = message.Source{Type: SourceTypeMiddleware}
+			outMessages[i] = marked
+		}
 		return mr.next(ctx, outMessages, opts...)
 	}
 	return mr.Middleware.Run(next, ctx, messages, opts...)

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -9,12 +9,17 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
+// SourceTypeMiddleware represents a message that originated from a middleware component.
+const SourceTypeMiddleware message.SourceType = "middleware"
+
 // Middleware wraps an agent run function to inspect or modify messages, options,
 // response updates, and errors.
 //
 // Use middleware when an extension needs direct control over provider invocation,
 // streaming updates, option propagation, or error handling beyond the
 // request/response message hooks exposed by [ContextProvider].
+// Messages passed to next that were not present in the middleware input are
+// marked with [SourceTypeMiddleware] when they do not already carry a source.
 type Middleware interface {
 	Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error]
 }
@@ -45,5 +50,9 @@ type middlewareRunner struct {
 }
 
 func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
-	return mr.Middleware.Run(mr.next, ctx, messages, opts...)
+	next := func(ctx context.Context, outMessages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
+		markNewMessagesWithSource(outMessages, messages, message.Source{Type: SourceTypeMiddleware}, false)
+		return mr.next(ctx, outMessages, opts...)
+	}
+	return mr.Middleware.Run(next, ctx, messages, opts...)
 }

--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -137,7 +137,7 @@ type providerContext struct {
 }
 
 // NewContextProvider creates a skills context provider from the configured in-memory skills and sources.
-func NewContextProvider(opts ContextProviderOptions) *agent.ContextProvider {
+func NewContextProvider(opts ContextProviderOptions) agent.ContextProvider {
 	if opts.Logger == nil {
 		opts.Logger = slog.New(slog.DiscardHandler)
 	}
@@ -153,10 +153,10 @@ func NewContextProvider(opts ContextProviderOptions) *agent.ContextProvider {
 		logger:  opts.Logger,
 	}
 
-	return &agent.ContextProvider{
+	return agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: cmp.Or(opts.SourceID, "skills"),
 		Provide:  state.provide,
-	}
+	})
 }
 
 // NewInMemorySource creates a skills source backed by the provided in-memory skills.
@@ -199,13 +199,13 @@ func (s *skillSliceSource) Skills(context.Context) ([]*Skill, error) {
 	return s.skills, nil
 }
 
-func (p *providerState) provide(ctx context.Context, messages []*message.Message, options ...agent.Option) (outMessages []*message.Message, outOptions []agent.Option, err error) {
+func (p *providerState) provide(ctx context.Context, invoking agent.InvokingContext) (outMessages []*message.Message, outOptions []agent.Option, err error) {
 	if p.options.DisableCaching {
 		result, err := p.buildContext(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
-		outMessages, outOptions = extendProviderContext(messages, options, result)
+		outMessages, outOptions = providedContext(result)
 		return outMessages, outOptions, nil
 	}
 
@@ -213,7 +213,7 @@ func (p *providerState) provide(ctx context.Context, messages []*message.Message
 	if p.cached != nil {
 		cached := *p.cached
 		p.mu.Unlock()
-		outMessages, outOptions = extendProviderContext(messages, options, cached)
+		outMessages, outOptions = providedContext(cached)
 		return outMessages, outOptions, nil
 	}
 	if p.loading != nil {
@@ -228,11 +228,11 @@ func (p *providerState) provide(ctx context.Context, messages []*message.Message
 			if err != nil {
 				return nil, nil, err
 			}
-			outMessages, outOptions = extendProviderContext(messages, options, result)
+			outMessages, outOptions = providedContext(result)
 			return outMessages, outOptions, nil
 		}
 		cached := *p.cached
-		outMessages, outOptions = extendProviderContext(messages, options, cached)
+		outMessages, outOptions = providedContext(cached)
 		return outMessages, outOptions, nil
 	}
 	p.loading = make(chan struct{})
@@ -259,19 +259,15 @@ func (p *providerState) provide(ctx context.Context, messages []*message.Message
 	if err != nil {
 		return nil, nil, err
 	}
-	outMessages, outOptions = extendProviderContext(messages, options, result)
+	outMessages, outOptions = providedContext(result)
 	return outMessages, outOptions, nil
 }
 
-func extendProviderContext(messages []*message.Message, options []agent.Option, result providerContext) ([]*message.Message, []agent.Option) {
-	outMessages := messages
-	if len(result.Messages) > 0 {
-		outMessages = append(messages, result.Messages...)
-	}
-
-	outOptions := options
+func providedContext(result providerContext) ([]*message.Message, []agent.Option) {
+	outMessages := result.Messages
+	var outOptions []agent.Option
 	if len(result.Options) > 0 {
-		outOptions = append(options, result.Options...)
+		outOptions = append(outOptions, result.Options...)
 	}
 	if strings.TrimSpace(result.Instructions) != "" {
 		outOptions = append(outOptions, agent.WithInstructions(result.Instructions))

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -36,6 +36,10 @@ type countingSource struct {
 	skills []*skills.Skill
 }
 
+func invokeProvider(provider agent.ContextProvider, ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
+}
+
 func (s *countingSource) Skills(context.Context) ([]*skills.Skill, error) {
 	s.count++
 	return s.skills, nil
@@ -97,7 +101,7 @@ func TestProvider_CustomPromptTemplate_LegacyInstructionPlaceholdersRemainLitera
 	}
 }
 
-func providerFromFileSource(source *fsskills.Source, opts *skills.ContextProviderOptions) *agent.ContextProvider {
+func providerFromFileSource(source *fsskills.Source, opts *skills.ContextProviderOptions) agent.ContextProvider {
 	if opts == nil {
 		return skills.NewContextProvider(skills.ContextProviderOptions{Sources: []skills.Source{source}})
 	}
@@ -265,7 +269,7 @@ func TestProvider_RecoversFromPanickingSourceAndResetsLoading(t *testing.T) {
 	source := &panicOnceSource{skill: skill}
 	provider := skills.NewContextProvider(skills.ContextProviderOptions{Sources: []skills.Source{source}})
 
-	_, _, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
+	_, _, err := invokeProvider(provider, t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 	if err == nil {
 		t.Fatal("expected provider to return an error after source panic")
 	}
@@ -279,7 +283,7 @@ func TestProvider_RecoversFromPanickingSourceAndResetsLoading(t *testing.T) {
 	}
 	resultCh := make(chan result, 1)
 	go func() {
-		_, options, err := provider.BeforeRun(t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
+		_, options, err := invokeProvider(provider, t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
 		instructions, _ := agent.GetOption(options, agent.WithInstructions)
 		resultCh <- result{hasInstructions: strings.Contains(instructions, "recovered-skill"), err: err}
 	}()
@@ -609,7 +613,7 @@ func TestNewProvider_ProvideExtendsInput(t *testing.T) {
 	session := agenttest.CreateSession()
 	input := message.NewText("input")
 
-	messages, options, err := provider.Provide(t.Context(), []*message.Message{input}, agent.WithSession(session))
+	messages, options, err := invokeProvider(provider, t.Context(), []*message.Message{input}, agent.WithSession(session))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -634,7 +638,7 @@ func TestNewProvider_ProvideExtendsInput(t *testing.T) {
 func TestProvider_WithEmptySource_ReturnsEmptyProvider(t *testing.T) {
 	provider := skills.NewContextProvider(skills.ContextProviderOptions{})
 	ctx := context.Background()
-	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agenttest.CreateSession()))
+	messages, options, err := invokeProvider(provider, ctx, nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -723,7 +727,7 @@ func TestProvider_SkillFilter_CanFilterOutAllSkills(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agenttest.CreateSession()))
+	messages, options, err := invokeProvider(provider, ctx, nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -66,12 +66,12 @@ func createRelativeFile(t *testing.T, root, relativePath, content string) {
 	}
 }
 
-func newProvider(t *testing.T, roots ...string) *agent.ContextProvider {
+func newProvider(t *testing.T, roots ...string) agent.ContextProvider {
 	t.Helper()
 	return newProviderWithConfig(t, nil, nil, roots...)
 }
 
-func newProviderWithConfig(t *testing.T, sourceOptions *fsskills.SourceOptions, providerOptions *skills.ContextProviderOptions, roots ...string) *agent.ContextProvider {
+func newProviderWithConfig(t *testing.T, sourceOptions *fsskills.SourceOptions, providerOptions *skills.ContextProviderOptions, roots ...string) agent.ContextProvider {
 	t.Helper()
 	if sourceOptions == nil {
 		sourceOptions = &fsskills.SourceOptions{}
@@ -89,10 +89,10 @@ func newProviderWithConfig(t *testing.T, sourceOptions *fsskills.SourceOptions, 
 	return skills.NewContextProvider(resolved)
 }
 
-func captureProviderContext(t *testing.T, provider *agent.ContextProvider) (string, []tool.Tool) {
+func captureProviderContext(t *testing.T, provider agent.ContextProvider) (string, []tool.Tool) {
 	t.Helper()
 	ctx := context.Background()
-	messages, options, err := provider.BeforeRun(ctx, nil, agent.WithSession(agenttest.CreateSession()))
+	messages, options, err := invokeProvider(provider, ctx, nil, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func findTool(t *testing.T, tools []tool.Tool, name string) tool.FuncTool {
 	return nil
 }
 
-func hasSkill(t *testing.T, provider *agent.ContextProvider, name string) bool {
+func hasSkill(t *testing.T, provider agent.ContextProvider, name string) bool {
 	t.Helper()
 	instructions, _ := captureProviderContext(t, provider)
 	return strings.Contains(instructions, name)

--- a/examples/01-get-started/04_memory/main.go
+++ b/examples/01-get-started/04_memory/main.go
@@ -44,7 +44,7 @@ func main() {
 			Config: agent.Config{
 				Name:             "MemoryAgent",
 				Middlewares:      []agent.Middleware{logger}, // for logging agent interactions
-				ContextProviders: []*agent.ContextProvider{newUserMemoryProvider()},
+				ContextProviders: []agent.ContextProvider{newUserMemoryProvider()},
 			},
 		},
 	)
@@ -72,12 +72,12 @@ func main() {
 	demo.Assistantf("[Session State] Stored user name: %s", state.UserName)
 }
 
-func newUserMemoryProvider() *agent.ContextProvider {
-	return &agent.ContextProvider{
+func newUserMemoryProvider() agent.ContextProvider {
+	return agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: userMemorySourceID,
 		Provide:  provideUserMemory,
 		Store:    storeUserMemory,
-	}
+	})
 }
 
 const userMemorySourceID = "user_memory"
@@ -95,20 +95,20 @@ func getProviderState(session *agent.Session) providerState {
 	return state
 }
 
-func provideUserMemory(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-	session, _ := agent.GetOption(options, agent.WithSession)
+func provideUserMemory(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	session, _ := agent.GetOption(invoking.Options, agent.WithSession)
 	state := getProviderState(session)
 	instructions := "You don't know the user's name yet. Ask for it politely."
 	if strings.TrimSpace(state.UserName) != "" {
 		instructions = fmt.Sprintf("The user's name is %s. Always address them by name.", state.UserName)
 	}
-	return messages, append(options, agent.WithInstructions(instructions)), nil
+	return nil, []agent.Option{agent.WithInstructions(instructions)}, nil
 }
 
-func storeUserMemory(ctx context.Context, requestMessages, _ []*message.Message, options ...agent.Option) error {
-	session, _ := agent.GetOption(options, agent.WithSession)
+func storeUserMemory(ctx context.Context, invoked agent.InvokedContext) error {
+	session, _ := agent.GetOption(invoked.Options, agent.WithSession)
 	state := getProviderState(session)
-	for _, msg := range requestMessages {
+	for _, msg := range invoked.RequestMessages {
 		if msg == nil || msg.Role != message.RoleUser {
 			continue
 		}

--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -98,13 +98,13 @@ type fsMessageStore struct {
 	Dir string
 }
 
-func newFSHistoryProvider(dir string) *agent.HistoryProvider {
+func newFSHistoryProvider(dir string) agent.HistoryProvider {
 	store := &fsMessageStore{Dir: dir}
-	return &agent.HistoryProvider{
+	return agent.NewHistoryProvider(agent.HistoryProviderConfig{
 		SourceID: "fsMessageStore",
 		Provide:  store.provideMessages,
 		Store:    store.persistMessages,
-	}
+	})
 }
 
 func (d *fsMessageStore) getFiles(session *agent.Session) []string {
@@ -136,26 +136,20 @@ func (d *fsMessageStore) loadMessages(session *agent.Session) ([]*message.Messag
 	return msgs, nil
 }
 
-func (d *fsMessageStore) provideMessages(_ context.Context, msgs []*message.Message, opts ...agent.Option) ([]*message.Message, error) {
-	session, _ := agent.GetOption(opts, agent.WithSession)
+func (d *fsMessageStore) provideMessages(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, error) {
+	session, _ := agent.GetOption(invoking.Options, agent.WithSession)
 	if session == nil {
-		return msgs, nil
+		return nil, nil
 	}
 	history, err := d.loadMessages(session)
 	if err != nil {
 		return nil, err
 	}
-	if len(history) == 0 {
-		return msgs, nil
-	}
-	messages := make([]*message.Message, 0, len(history)+len(msgs))
-	messages = append(messages, history...)
-	messages = append(messages, msgs...)
-	return messages, nil
+	return history, nil
 }
 
-func (d *fsMessageStore) persistMessages(_ context.Context, requestMessages, responseMessages []*message.Message, opts ...agent.Option) error {
-	session, _ := agent.GetOption(opts, agent.WithSession)
+func (d *fsMessageStore) persistMessages(_ context.Context, invoked agent.InvokedContext) error {
+	session, _ := agent.GetOption(invoked.Options, agent.WithSession)
 	if session == nil {
 		return nil
 	}
@@ -179,12 +173,12 @@ func (d *fsMessageStore) persistMessages(_ context.Context, requestMessages, res
 		files = append(files, msg.ID)
 		return nil
 	}
-	for _, msg := range requestMessages {
+	for _, msg := range invoked.RequestMessages {
 		if err := persist(msg); err != nil {
 			return err
 		}
 	}
-	for _, msg := range responseMessages {
+	for _, msg := range invoked.ResponseMessages {
 		if err := persist(msg); err != nil {
 			return err
 		}

--- a/examples/02-agents/agents/step17_additional_ai_context/main.go
+++ b/examples/02-agents/agents/step17_additional_ai_context/main.go
@@ -128,9 +128,9 @@ func newChatHistoryProvider() *agent.HistoryProvider {
 	// In this case, we explicitly exclude messages from chat history and AI context providers.
 	// You may want to store these messages, depending on their content and your requirements.
 	historyProvider.StoreRequestFilter = messagefilter.NotSources(
-		chatHistorySourceID,
-		todoListSourceID,
-		calendarSearchSourceID,
+		message.Source{Type: agent.SourceTypeHistoryProvider, ID: chatHistorySourceID},
+		message.Source{Type: agent.SourceTypeContextProvider, ID: todoListSourceID},
+		message.Source{Type: agent.SourceTypeContextProvider, ID: calendarSearchSourceID},
 	)
 	return historyProvider
 }

--- a/examples/02-agents/agents/step17_additional_ai_context/main.go
+++ b/examples/02-agents/agents/step17_additional_ai_context/main.go
@@ -56,7 +56,7 @@ You remind users of upcoming calendar events when the user interacts with you.`,
 			Config: agent.Config{
 				Name:            "PersonalAssistant",
 				HistoryProvider: newChatHistoryProvider(),
-				ContextProviders: []*agent.ContextProvider{
+				ContextProviders: []agent.ContextProvider{
 					newTodoListContextProvider(),
 					newCalendarSearchContextProvider(loadNextThreeCalendarEvents),
 				},
@@ -121,18 +121,19 @@ const (
 	calendarSearchSourceID = "calendar_search"
 )
 
-func newChatHistoryProvider() *agent.HistoryProvider {
-	historyProvider := agent.NewInMemoryHistoryProvider(chatHistorySourceID)
-	// Use StoreRequestFilter to provide a custom filter for request messages stored in chat history.
+func newChatHistoryProvider() agent.HistoryProvider {
+	// Use StoreInputRequestMessageFilter to provide a custom filter for request messages stored in chat history.
 	// By default, the history provider stores request messages that did not come from chat history.
 	// In this case, we explicitly exclude messages from chat history and AI context providers.
 	// You may want to store these messages, depending on their content and your requirements.
-	historyProvider.StoreRequestFilter = messagefilter.NotSources(
-		message.Source{Type: agent.SourceTypeHistoryProvider, ID: chatHistorySourceID},
-		message.Source{Type: agent.SourceTypeContextProvider, ID: todoListSourceID},
-		message.Source{Type: agent.SourceTypeContextProvider, ID: calendarSearchSourceID},
-	)
-	return historyProvider
+	return agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
+		SourceID: chatHistorySourceID,
+		StoreInputRequestMessageFilter: messagefilter.NotSources(
+			message.Source{Type: agent.SourceTypeHistoryProvider, ID: chatHistorySourceID},
+			message.Source{Type: agent.SourceTypeContextProvider, ID: todoListSourceID},
+			message.Source{Type: agent.SourceTypeContextProvider, ID: calendarSearchSourceID},
+		),
+	})
 }
 
 type todoListState struct {
@@ -147,11 +148,11 @@ type removeTodoItemArgs struct {
 	Index int `json:"index"`
 }
 
-func newTodoListContextProvider() *agent.ContextProvider {
-	return &agent.ContextProvider{
+func newTodoListContextProvider() agent.ContextProvider {
+	return agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: todoListSourceID,
 		Provide:  provideTodoListContext,
-	}
+	})
 }
 
 func getTodoListState(session *agent.Session) todoListState {
@@ -169,8 +170,8 @@ func setTodoListState(session *agent.Session, state todoListState) {
 	}
 }
 
-func provideTodoListContext(_ context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-	session, _ := agent.GetOption(options, agent.WithSession)
+func provideTodoListContext(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	session, _ := agent.GetOption(invoking.Options, agent.WithSession)
 	state := getTodoListState(session)
 
 	var output strings.Builder
@@ -209,20 +210,13 @@ func provideTodoListContext(_ context.Context, messages []*message.Message, opti
 		return fmt.Sprintf("Removed todo item: %s", removed), nil
 	})
 
-	messages = append(messages, &message.Message{
-		Role: message.RoleUser,
-		Contents: []message.Content{
-			&message.TextContent{Text: output.String()},
-		},
-	})
-	options = append(options, agent.WithTool(addTodoItemTool), agent.WithTool(removeTodoItemTool))
-	return messages, options, nil
+	return []*message.Message{message.NewText(output.String())}, []agent.Option{agent.WithTool(addTodoItemTool), agent.WithTool(removeTodoItemTool)}, nil
 }
 
-func newCalendarSearchContextProvider(loadNextThreeCalendarEvents func(context.Context) ([]string, error)) *agent.ContextProvider {
-	return &agent.ContextProvider{
+func newCalendarSearchContextProvider(loadNextThreeCalendarEvents func(context.Context) ([]string, error)) agent.ContextProvider {
+	return agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: calendarSearchSourceID,
-		Provide: func(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+		Provide: func(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			events, err := loadNextThreeCalendarEvents(ctx)
 			if err != nil {
 				return nil, nil, err
@@ -234,13 +228,7 @@ func newCalendarSearchContextProvider(loadNextThreeCalendarEvents func(context.C
 				_, _ = fmt.Fprintf(&output, " - %s\n", calendarEvent)
 			}
 
-			messages = append(messages, &message.Message{
-				Role: message.RoleUser,
-				Contents: []message.Content{
-					&message.TextContent{Text: output.String()},
-				},
-			})
-			return messages, options, nil
+			return []*message.Message{message.NewText(output.String())}, nil, nil
 		},
-	}
+	})
 }

--- a/examples/02-agents/agents/step18_compaction_pipeline/main.go
+++ b/examples/02-agents/agents/step18_compaction_pipeline/main.go
@@ -103,7 +103,7 @@ Help the user look up prices and compare products.
 When responding, be extra descriptive and use as many words as possible without sounding ridiculous.`,
 			Config: agent.Config{
 				Name: "ShoppingAssistant",
-				ContextProviders: []*agent.ContextProvider{
+				ContextProviders: []agent.ContextProvider{
 					compaction.NewContextProvider(compaction.ContextProviderConfig{
 						Strategy: compactionPipeline,
 						Logger:   slog.New(logger),

--- a/examples/02-agents/agents/step21_shell_with_environment/main.go
+++ b/examples/02-agents/agents/step21_shell_with_environment/main.go
@@ -87,7 +87,7 @@ func runShellEnvironmentDemo(ctx context.Context, client openai.Client, mode she
 			Instructions: instructions,
 			Config: agent.Config{
 				Tools:            []tool.Tool{shell},
-				ContextProviders: []*agent.ContextProvider{envProvider.ContextProvider},
+				ContextProviders: []agent.ContextProvider{envProvider},
 				Middlewares:      []agent.Middleware{logger},
 			},
 		},

--- a/examples/02-agents/agents/step22_foundry_memory/main.go
+++ b/examples/02-agents/agents/step22_foundry_memory/main.go
@@ -73,7 +73,7 @@ func main() {
 			Config: agent.Config{
 				Name:             "TravelAssistantWithFoundryMemory",
 				Middlewares:      []agent.Middleware{logger},
-				ContextProviders: []*agent.ContextProvider{memoryProvider.ContextProvider()},
+				ContextProviders: []agent.ContextProvider{memoryProvider},
 			},
 		},
 	)

--- a/examples/02-agents/skills/step01_file_based_skills/main.go
+++ b/examples/02-agents/skills/step01_file_based_skills/main.go
@@ -59,7 +59,7 @@ func main() {
 			Config: agent.Config{
 				Name:             "UnitConverterAgent",
 				Middlewares:      []agent.Middleware{logger},
-				ContextProviders: []*agent.ContextProvider{skillsProvider},
+				ContextProviders: []agent.ContextProvider{skillsProvider},
 			},
 		},
 	)

--- a/examples/02-agents/skills/step02_code_defined_skills/main.go
+++ b/examples/02-agents/skills/step02_code_defined_skills/main.go
@@ -113,7 +113,7 @@ func main() {
 			Config: agent.Config{
 				Name:             "UnitConverterAgent",
 				Middlewares:      []agent.Middleware{logger},
-				ContextProviders: []*agent.ContextProvider{skillsProvider},
+				ContextProviders: []agent.ContextProvider{skillsProvider},
 			},
 		},
 	)

--- a/examples/02-agents/skills/step03_mixed_skills/main.go
+++ b/examples/02-agents/skills/step03_mixed_skills/main.go
@@ -188,7 +188,7 @@ func main() {
 			Config: agent.Config{
 				Name:             "MultiConverterAgent",
 				Middlewares:      []agent.Middleware{logger},
-				ContextProviders: []*agent.ContextProvider{skillsProvider},
+				ContextProviders: []agent.ContextProvider{skillsProvider},
 			},
 		},
 	)

--- a/message/message.go
+++ b/message/message.go
@@ -21,6 +21,21 @@ const (
 	RoleTool Role = "tool"
 )
 
+// SourceType represents the type of component that generated a message.
+type SourceType string
+
+// SourceTypeExternal is the zero source type for messages that originated outside the agent pipeline.
+const SourceTypeExternal SourceType = ""
+
+// Source represents attribution information for the source of a message.
+type Source struct {
+	// ID is the unique identifier of the source that generated the message.
+	ID string `json:",omitzero"`
+
+	// Type identifies the kind of component that generated the message.
+	Type SourceType `json:",omitzero"`
+}
+
 // Message represents a message in a conversation.
 type Message struct {
 	AdditionalProperties map[string]any `json:",omitzero"`
@@ -28,7 +43,7 @@ type Message struct {
 	Role                 Role
 	ID                   string
 	AuthorName           string    `json:",omitzero"`
-	SourceID             string    `json:",omitzero"`
+	Source               Source    `json:",omitzero"`
 	CreatedAt            time.Time `json:",omitzero"`
 	RawRepresentation    any       `json:"-"`
 }

--- a/message/messagefilter/filter.go
+++ b/message/messagefilter/filter.go
@@ -77,38 +77,39 @@ func None(_ context.Context, messages []*message.Message) ([]*message.Message, e
 	return messages[:0], nil
 }
 
-// ExternalOnly returns only messages without a SourceID.
+// ExternalOnly returns only messages whose source type is external.
 //
+// A zero source type is considered external.
 // The filter operates in place by compacting the input slice.
 func ExternalOnly(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
 	return slices.DeleteFunc(messages, func(msg *message.Message) bool {
 		if msg == nil {
 			return false
 		}
-		return msg.SourceID != ""
+		return msg.Source.Type != message.SourceTypeExternal
 	}), nil
 }
 
-// Sources returns only messages whose SourceID is in the provided allow list.
-func Sources(sourceIDs ...string) Filter {
+// Sources returns only messages whose source is in the provided allow list.
+func Sources(sources ...message.Source) Filter {
 	return func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
 		return slices.DeleteFunc(messages, func(msg *message.Message) bool {
 			if msg == nil {
 				return false
 			}
-			return !slices.Contains(sourceIDs, msg.SourceID)
+			return !slices.Contains(sources, msg.Source)
 		}), nil
 	}
 }
 
-// NotSources returns messages whose SourceID is not in the provided deny list.
-func NotSources(sourceIDs ...string) Filter {
+// NotSources returns messages whose source is not in the provided deny list.
+func NotSources(sources ...message.Source) Filter {
 	return func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
 		return slices.DeleteFunc(messages, func(msg *message.Message) bool {
 			if msg == nil {
 				return false
 			}
-			return slices.Contains(sourceIDs, msg.SourceID)
+			return slices.Contains(sources, msg.Source)
 		}), nil
 	}
 }

--- a/message/messagefilter/filter_test.go
+++ b/message/messagefilter/filter_test.go
@@ -13,7 +13,7 @@ import (
 func TestPassThrough(t *testing.T) {
 	m1 := message.NewText("a")
 	m2 := message.NewText("b")
-	out, err := PassThrough(context.Background(), []*message.Message{m1, m2})
+	out, err := PassThrough(t.Context(), []*message.Message{m1, m2})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestPassThrough(t *testing.T) {
 }
 
 func TestNone(t *testing.T) {
-	out, err := None(context.Background(), []*message.Message{message.NewText("a")})
+	out, err := None(t.Context(), []*message.Message{message.NewText("a")})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -34,9 +34,10 @@ func TestNone(t *testing.T) {
 
 func TestExternalOnly(t *testing.T) {
 	external := message.NewText("external")
+	external.Source.ID = "external-system"
 	internal := message.NewText("internal")
-	internal.SourceID = "provider"
-	out, err := ExternalOnly(context.Background(), []*message.Message{external, internal})
+	internal.Source = message.Source{Type: message.SourceType("provider"), ID: "provider-id"}
+	out, err := ExternalOnly(t.Context(), []*message.Message{external, internal})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,29 +47,33 @@ func TestExternalOnly(t *testing.T) {
 }
 
 func TestSources(t *testing.T) {
+	source := message.Source{Type: message.SourceType("provider"), ID: "a"}
 	allowed := message.NewText("allowed")
-	allowed.SourceID = "a"
+	allowed.Source = source
 	blocked := message.NewText("blocked")
-	blocked.SourceID = "b"
+	blocked.Source = message.Source{Type: message.SourceType("provider"), ID: "b"}
+	sameIDDifferentType := message.NewText("same id")
+	sameIDDifferentType.Source = message.Source{ID: "a"}
 
-	filter := Sources("a")
-	out, err := filter(context.Background(), []*message.Message{allowed, blocked})
+	filter := Sources(source)
+	out, err := filter(t.Context(), []*message.Message{allowed, blocked, sameIDDifferentType})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(out) != 1 || out[0] != allowed {
-		t.Fatal("expected only allowed SourceID messages")
+		t.Fatal("expected only allowed source messages")
 	}
 }
 
 func TestNotSources(t *testing.T) {
+	source := message.Source{Type: message.SourceType("provider"), ID: "b"}
 	keep := message.NewText("keep")
-	keep.SourceID = "a"
+	keep.Source = message.Source{Type: message.SourceType("provider"), ID: "a"}
 	blocked := message.NewText("blocked")
-	blocked.SourceID = "b"
+	blocked.Source = source
 
-	filter := NotSources("b")
-	out, err := filter(context.Background(), []*message.Message{keep, blocked})
+	filter := NotSources(source)
+	out, err := filter(t.Context(), []*message.Message{keep, blocked})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -79,13 +84,15 @@ func TestNotSources(t *testing.T) {
 
 func TestOr_ExternalOnlyOrSources(t *testing.T) {
 	external := message.NewText("external")
+	source := message.Source{Type: message.SourceType("provider"), ID: "a"}
 	allowed := message.NewText("allowed")
-	allowed.SourceID = "a"
+	allowed.Source = source
 	blocked := message.NewText("blocked")
-	blocked.SourceID = "b"
+	blocked.Source.Type = "provider"
+	blocked.Source.ID = "b"
 
-	filter := Or(ExternalOnly, Sources("a"))
-	out, err := filter(context.Background(), []*message.Message{external, allowed, blocked})
+	filter := Or(ExternalOnly, Sources(source))
+	out, err := filter(t.Context(), []*message.Message{external, allowed, blocked})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -96,20 +103,21 @@ func TestOr_ExternalOnlyOrSources(t *testing.T) {
 
 func TestBuiltInFilters_DoNotAddMessages(t *testing.T) {
 	m1 := message.NewText("a")
+	source := message.Source{Type: message.SourceType("provider"), ID: "x"}
 	m2 := message.NewText("b")
-	m2.SourceID = "x"
+	m2.Source = source
 	messages := []*message.Message{m1, m2}
 
 	filters := []Filter{
 		PassThrough,
 		None,
 		ExternalOnly,
-		NotSources("x"),
-		Or(ExternalOnly, Sources("x")),
+		NotSources(source),
+		Or(ExternalOnly, Sources(source)),
 	}
 
 	for _, filter := range filters {
-		out, err := filter(context.Background(), append([]*message.Message(nil), messages...))
+		out, err := filter(t.Context(), append([]*message.Message(nil), messages...))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -123,13 +131,15 @@ func TestBuiltInFilters_DoNotAddMessages(t *testing.T) {
 
 func TestAnd_AppliesFiltersInOrder(t *testing.T) {
 	m1 := message.NewText("external")
+	sourceA := message.Source{Type: message.SourceType("provider"), ID: "a"}
 	m2 := message.NewText("allowed")
-	m2.SourceID = "a"
+	m2.Source = sourceA
 	m3 := message.NewText("blocked")
-	m3.SourceID = "b"
+	m3.Source.Type = "provider"
+	m3.Source.ID = "b"
 
-	filter := And(PassThrough, Or(ExternalOnly, Sources("a")))
-	out, err := filter(context.Background(), []*message.Message{m1, m2, m3})
+	filter := And(PassThrough, Or(ExternalOnly, Sources(sourceA)))
+	out, err := filter(t.Context(), []*message.Message{m1, m2, m3})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,7 +151,7 @@ func TestAnd_AppliesFiltersInOrder(t *testing.T) {
 func TestAnd_SkipsNilFilters(t *testing.T) {
 	m1 := message.NewText("external")
 	filter := And(nil, PassThrough, nil)
-	out, err := filter(context.Background(), []*message.Message{m1})
+	out, err := filter(t.Context(), []*message.Message{m1})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -163,7 +173,7 @@ func TestAnd_StopsOnError(t *testing.T) {
 		},
 	)
 
-	_, err := filter(context.Background(), []*message.Message{message.NewText("a")})
+	_, err := filter(t.Context(), []*message.Message{message.NewText("a")})
 	if !errors.Is(err, expected) {
 		t.Fatalf("expected %v, got %v", expected, err)
 	}
@@ -174,13 +184,15 @@ func TestAnd_StopsOnError(t *testing.T) {
 
 func TestOr_AppliesUnion(t *testing.T) {
 	external := message.NewText("external")
+	sourceA := message.Source{Type: message.SourceType("provider"), ID: "a"}
 	allowed := message.NewText("allowed")
-	allowed.SourceID = "a"
+	allowed.Source = sourceA
 	blocked := message.NewText("blocked")
-	blocked.SourceID = "b"
+	blocked.Source.Type = "provider"
+	blocked.Source.ID = "b"
 
-	filter := Or(ExternalOnly, Sources("a"))
-	out, err := filter(context.Background(), []*message.Message{external, allowed, blocked})
+	filter := Or(ExternalOnly, Sources(sourceA))
+	out, err := filter(t.Context(), []*message.Message{external, allowed, blocked})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -192,7 +204,7 @@ func TestOr_AppliesUnion(t *testing.T) {
 func TestOr_SkipsNilFilters(t *testing.T) {
 	external := message.NewText("external")
 	filter := Or(nil, ExternalOnly, nil)
-	out, err := filter(context.Background(), []*message.Message{external})
+	out, err := filter(t.Context(), []*message.Message{external})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -214,7 +226,7 @@ func TestOr_StopsOnError(t *testing.T) {
 		},
 	)
 
-	_, err := filter(context.Background(), []*message.Message{message.NewText("a")})
+	_, err := filter(t.Context(), []*message.Message{message.NewText("a")})
 	if !errors.Is(err, expected) {
 		t.Fatalf("expected %v, got %v", expected, err)
 	}
@@ -224,7 +236,7 @@ func TestOr_StopsOnError(t *testing.T) {
 }
 
 func TestOr_WithoutFilters_ReturnsNone(t *testing.T) {
-	out, err := Or()(context.Background(), []*message.Message{message.NewText("a")})
+	out, err := Or()(t.Context(), []*message.Message{message.NewText("a")})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/provider/foundryprovider/memory.go
+++ b/provider/foundryprovider/memory.go
@@ -6,7 +6,6 @@ package foundryprovider
 import (
 	"context"
 	"log/slog"
-	"slices"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -52,14 +51,15 @@ type MemoryProvider struct {
 	memoryStoreName string
 	scopeFunc       func(*agent.Session) string
 	config          MemoryProviderConfig
-	provider        *agent.ContextProvider
+	providerConfig  agent.ContextProviderConfig
+	provider        agent.ContextProvider
 }
 
 // NewMemoryProvider creates a Foundry memory provider backed by a Microsoft Foundry Projects memory store.
 //
 // The returned provider is attached to an agent with:
 //
-//	agent.Config{ContextProviders: []*agent.ContextProvider{provider.ContextProvider()}}
+//	agent.Config{ContextProviders: []agent.ContextProvider{provider}}
 //
 // The endpoint must be a project-scoped Microsoft Foundry endpoint, and memoryStoreName must
 // name an existing Foundry memory store. The scope callback is invoked for each run and must
@@ -98,39 +98,38 @@ func newMemoryProvider(client *azaiprojects.MemoryStoresClient, memoryStoreName 
 	if config.SearchInputFilter == nil {
 		config.SearchInputFilter = messagefilter.ExternalOnly
 	}
+	providerConfig := agent.ContextProviderConfig{
+		ProvideInputMessageFilter:      config.SearchInputFilter,
+		SourceID:                       defaultSourceID,
+		StoreInputRequestMessageFilter: messagefilter.ExternalOnly,
+	}
 	p := &MemoryProvider{
 		client:          client,
 		memoryStoreName: memoryStoreName,
 		scopeFunc:       scope,
 		config:          config,
+		providerConfig:  providerConfig,
 	}
-	p.provider = &agent.ContextProvider{
-		SourceID:           defaultSourceID,
-		StoreRequestFilter: messagefilter.ExternalOnly,
-		Provide:            p.provide,
-		Store:              p.store,
-	}
+	p.providerConfig.Provide = p.provide
+	p.providerConfig.Store = p.store
+	p.provider = agent.NewContextProvider(p.providerConfig)
 	return p
 }
 
-// ContextProvider returns the Agent Framework context provider.
-func (p *MemoryProvider) ContextProvider() *agent.ContextProvider {
-	if p == nil {
-		return nil
-	}
-	return p.provider
+func (p *MemoryProvider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	return p.provider.Invoking(ctx, invoking)
 }
 
-func (p *MemoryProvider) provide(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-	searchMessages, err := p.config.SearchInputFilter(ctx, slices.Clone(messages))
-	if err != nil {
-		return nil, nil, err
-	}
-	items := searchMemoryItems(searchMessages)
+func (p *MemoryProvider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
+	return p.provider.Invoked(ctx, invoked)
+}
+
+func (p *MemoryProvider) provide(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	items := searchMemoryItems(invoking.Messages)
 	if len(items) == 0 {
-		return messages, options, nil
+		return nil, nil, nil
 	}
-	session, _ := agent.GetOption(options, agent.WithSession)
+	session, _ := agent.GetOption(invoking.Options, agent.WithSession)
 	scope := p.scope(session)
 	searchOptions := &azaiprojects.MemoryStoresClientSearchMemoriesOptions{
 		Items: items,
@@ -141,26 +140,24 @@ func (p *MemoryProvider) provide(ctx context.Context, messages []*message.Messag
 	result, err := p.client.SearchMemories(ctx, p.memoryStoreName, scope, searchOptions)
 	if err != nil {
 		p.log(ctx, slog.LevelError, "foundrymemory: failed to search memories", "memory_store", p.memoryStoreName, "error", err)
-		return messages, options, nil
+		return nil, nil, nil
 	}
 	memories := memoryContents(result.Memories)
 	p.log(ctx, slog.LevelInfo, "foundrymemory: retrieved memories", "memory_store", p.memoryStoreName, "count", len(memories))
 	if len(memories) == 0 {
-		return messages, options, nil
+		return nil, nil, nil
 	}
 	contextMessage := message.NewText(p.config.ContextPrompt + "\n" + strings.Join(memories, "\n"))
-	out := slices.Clone(messages)
-	out = append(out, contextMessage)
-	return out, options, nil
+	return []*message.Message{contextMessage}, nil, nil
 }
 
-func (p *MemoryProvider) store(ctx context.Context, requestMessages, responseMessages []*message.Message, options ...agent.Option) error {
-	items := updateMemoryItems(requestMessages)
-	items = append(items, updateMemoryItems(responseMessages)...)
+func (p *MemoryProvider) store(ctx context.Context, invoked agent.InvokedContext) error {
+	items := updateMemoryItems(invoked.RequestMessages)
+	items = append(items, updateMemoryItems(invoked.ResponseMessages)...)
 	if len(items) == 0 {
 		return nil
 	}
-	session, _ := agent.GetOption(options, agent.WithSession)
+	session, _ := agent.GetOption(invoked.Options, agent.WithSession)
 	scope := p.scope(session)
 	updateOptions := &azaiprojects.MemoryStoresClientBeginUpdateMemoriesOptions{
 		Items:       items,

--- a/provider/foundryprovider/memory.go
+++ b/provider/foundryprovider/memory.go
@@ -37,10 +37,6 @@ type MemoryProviderConfig struct {
 	// MaxMemories limits the number of memories returned by search. The default is 5.
 	MaxMemories int32
 
-	// SearchInputFilter filters messages used to search for relevant memories. The
-	// default is [messagefilter.ExternalOnly].
-	SearchInputFilter messagefilter.Filter
-
 	// UpdateDelay controls Foundry memory extraction delay in seconds. The default is 0,
 	// which submits memory updates immediately.
 	UpdateDelay int32
@@ -95,9 +91,6 @@ func newMemoryProvider(client *azaiprojects.MemoryStoresClient, memoryStoreName 
 	if config.MaxMemories == 0 {
 		config.MaxMemories = defaultMaxMemories
 	}
-	if config.SearchInputFilter == nil {
-		config.SearchInputFilter = messagefilter.ExternalOnly
-	}
 	p := &MemoryProvider{
 		client:          client,
 		memoryStoreName: memoryStoreName,
@@ -122,7 +115,7 @@ func (p *MemoryProvider) ContextProvider() *agent.ContextProvider {
 }
 
 func (p *MemoryProvider) provide(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-	searchMessages, err := p.config.SearchInputFilter(ctx, slices.Clone(messages))
+	searchMessages, err := messagefilter.ExternalOnly(ctx, slices.Clone(messages))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/provider/foundryprovider/memory.go
+++ b/provider/foundryprovider/memory.go
@@ -37,6 +37,10 @@ type MemoryProviderConfig struct {
 	// MaxMemories limits the number of memories returned by search. The default is 5.
 	MaxMemories int32
 
+	// SearchInputFilter filters messages used to search for relevant memories. The
+	// default is [messagefilter.ExternalOnly].
+	SearchInputFilter messagefilter.Filter
+
 	// UpdateDelay controls Foundry memory extraction delay in seconds. The default is 0,
 	// which submits memory updates immediately.
 	UpdateDelay int32
@@ -91,6 +95,9 @@ func newMemoryProvider(client *azaiprojects.MemoryStoresClient, memoryStoreName 
 	if config.MaxMemories == 0 {
 		config.MaxMemories = defaultMaxMemories
 	}
+	if config.SearchInputFilter == nil {
+		config.SearchInputFilter = messagefilter.ExternalOnly
+	}
 	p := &MemoryProvider{
 		client:          client,
 		memoryStoreName: memoryStoreName,
@@ -115,7 +122,7 @@ func (p *MemoryProvider) ContextProvider() *agent.ContextProvider {
 }
 
 func (p *MemoryProvider) provide(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
-	searchMessages, err := messagefilter.ExternalOnly(ctx, slices.Clone(messages))
+	searchMessages, err := p.config.SearchInputFilter(ctx, slices.Clone(messages))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/provider/foundryprovider/memory_test.go
+++ b/provider/foundryprovider/memory_test.go
@@ -82,11 +82,31 @@ func TestNewMemoryProviderDefaultsMatchFoundryMemoryOptions(t *testing.T) {
 	if provider.config.UpdateDelay != 0 {
 		t.Fatalf("UpdateDelay = %d, want immediate", provider.config.UpdateDelay)
 	}
+	if provider.config.SearchInputFilter == nil {
+		t.Fatal("SearchInputFilter was not defaulted")
+	}
 	if provider.ContextProvider().StoreRequestFilter == nil {
 		t.Fatal("StoreRequestFilter was not defaulted")
 	}
 	if provider.ContextProvider().SourceID != defaultSourceID {
 		t.Fatalf("SourceID = %q, want %q", provider.ContextProvider().SourceID, defaultSourceID)
+	}
+}
+
+func TestNewMemoryProviderUsesCustomSearchInputFilter(t *testing.T) {
+	called := false
+	filter := func(context.Context, []*message.Message) ([]*message.Message, error) {
+		called = true
+		return nil, nil
+	}
+	provider := NewMemoryProvider(validEndpoint, validCredential, "memory", validScope, MemoryProviderConfig{SearchInputFilter: filter})
+
+	_, _, err := provider.provide(context.Background(), []*message.Message{message.NewText("hello")})
+	if err != nil {
+		t.Fatalf("provide error = %v", err)
+	}
+	if !called {
+		t.Fatal("custom search input filter was not called")
 	}
 }
 

--- a/provider/foundryprovider/memory_test.go
+++ b/provider/foundryprovider/memory_test.go
@@ -85,28 +85,8 @@ func TestNewMemoryProviderDefaultsMatchFoundryMemoryOptions(t *testing.T) {
 	if provider.ContextProvider().StoreRequestFilter == nil {
 		t.Fatal("StoreRequestFilter was not defaulted")
 	}
-	if provider.config.SearchInputFilter == nil {
-		t.Fatal("SearchInputFilter was not defaulted")
-	}
 	if provider.ContextProvider().SourceID != defaultSourceID {
 		t.Fatalf("SourceID = %q, want %q", provider.ContextProvider().SourceID, defaultSourceID)
-	}
-}
-
-func TestNewMemoryProviderUsesCustomSearchInputFilter(t *testing.T) {
-	called := false
-	filter := func(context.Context, []*message.Message) ([]*message.Message, error) {
-		called = true
-		return nil, nil
-	}
-	provider := NewMemoryProvider(validEndpoint, validCredential, "memory", validScope, MemoryProviderConfig{SearchInputFilter: filter})
-
-	_, _, err := provider.provide(context.Background(), []*message.Message{message.NewText("hello")})
-	if err != nil {
-		t.Fatalf("provide error = %v", err)
-	}
-	if !called {
-		t.Fatal("custom search input filter was not called")
 	}
 }
 

--- a/provider/foundryprovider/memory_test.go
+++ b/provider/foundryprovider/memory_test.go
@@ -63,9 +63,6 @@ func TestNewMemoryProviderSucceedsWithValidParameters(t *testing.T) {
 	if provider == nil {
 		t.Fatal("provider is nil")
 	}
-	if provider.ContextProvider() == nil {
-		t.Fatal("context provider is nil")
-	}
 	if got := provider.scope(nil); got != "user-456" {
 		t.Fatalf("scope = %q, want user-456", got)
 	}
@@ -85,11 +82,11 @@ func TestNewMemoryProviderDefaultsMatchFoundryMemoryOptions(t *testing.T) {
 	if provider.config.SearchInputFilter == nil {
 		t.Fatal("SearchInputFilter was not defaulted")
 	}
-	if provider.ContextProvider().StoreRequestFilter == nil {
-		t.Fatal("StoreRequestFilter was not defaulted")
+	if provider.providerConfig.StoreInputRequestMessageFilter == nil {
+		t.Fatal("StoreInputRequestMessageFilter was not defaulted")
 	}
-	if provider.ContextProvider().SourceID != defaultSourceID {
-		t.Fatalf("SourceID = %q, want %q", provider.ContextProvider().SourceID, defaultSourceID)
+	if provider.providerConfig.SourceID != defaultSourceID {
+		t.Fatalf("SourceID = %q, want %q", provider.providerConfig.SourceID, defaultSourceID)
 	}
 }
 
@@ -101,7 +98,7 @@ func TestNewMemoryProviderUsesCustomSearchInputFilter(t *testing.T) {
 	}
 	provider := NewMemoryProvider(validEndpoint, validCredential, "memory", validScope, MemoryProviderConfig{SearchInputFilter: filter})
 
-	_, _, err := provider.provide(context.Background(), []*message.Message{message.NewText("hello")})
+	_, _, err := provider.Invoking(t.Context(), agent.InvokingContext{Messages: []*message.Message{message.NewText("hello")}})
 	if err != nil {
 		t.Fatalf("provide error = %v", err)
 	}
@@ -128,7 +125,7 @@ func TestStoreLogsUpdateFailureAndDoesNotReturnError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	provider := NewMemoryProvider(validEndpoint, validCredential, "memory", validScope, MemoryProviderConfig{ClientOptions: clientOptions, Logger: logger})
 
-	err := provider.store(context.Background(), []*message.Message{message.NewText("remember me")}, nil)
+	err := provider.store(t.Context(), agent.InvokedContext{RequestMessages: []*message.Message{message.NewText("remember me")}})
 	if err != nil {
 		t.Fatalf("store error = %v", err)
 	}

--- a/tool/shelltool/environment.go
+++ b/tool/shelltool/environment.go
@@ -99,10 +99,9 @@ type EnvironmentProviderConfig struct {
 // EnvironmentProvider probes a local shell and injects shell-specific
 // instructions through an [agent.ContextProvider].
 type EnvironmentProvider struct {
-	*agent.ContextProvider
-
 	executor Executor
 	config   EnvironmentProviderConfig
+	provider agent.ContextProvider
 
 	mu           sync.Mutex
 	current      *ShellEnvironmentSnapshot
@@ -125,11 +124,19 @@ func NewEnvironmentProvider(executor Executor, config EnvironmentProviderConfig)
 	if sourceID == "" {
 		sourceID = defaultShellEnvironmentSourceID
 	}
-	p.ContextProvider = &agent.ContextProvider{
+	p.provider = agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: sourceID,
 		Provide:  p.provide,
-	}
+	})
 	return p
+}
+
+func (p *EnvironmentProvider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+	return p.provider.Invoking(ctx, invoking)
+}
+
+func (p *EnvironmentProvider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
+	return p.provider.Invoked(ctx, invoked)
 }
 
 // CurrentSnapshot returns the most recently captured snapshot, if one exists.
@@ -159,7 +166,7 @@ func (p *EnvironmentProvider) Refresh(ctx context.Context) (ShellEnvironmentSnap
 	return cloneShellEnvironmentSnapshot(snapshot), nil
 }
 
-func (p *EnvironmentProvider) provide(ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+func (p *EnvironmentProvider) provide(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 	snapshot, err := p.snapshot(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -169,7 +176,7 @@ func (p *EnvironmentProvider) provide(ctx context.Context, messages []*message.M
 		formatter = DefaultShellEnvironmentInstructions
 	}
 	instructions := formatter(snapshot)
-	return messages, append(options, agent.WithInstructions(instructions)), nil
+	return nil, []agent.Option{agent.WithInstructions(instructions)}, nil
 }
 
 func (p *EnvironmentProvider) snapshot(ctx context.Context) (ShellEnvironmentSnapshot, error) {

--- a/tool/shelltool/shelltool.go
+++ b/tool/shelltool/shelltool.go
@@ -30,7 +30,7 @@
 //	env := shelltool.NewEnvironmentProvider(t, shelltool.EnvironmentProviderConfig{})
 //	cfg := agent.Config{
 //		Tools:            []tool.Tool{t},
-//		ContextProviders: []*agent.ContextProvider{env.ContextProvider},
+//		ContextProviders: []agent.ContextProvider{env},
 //	}
 package shelltool
 

--- a/tool/shelltool/shelltool_test.go
+++ b/tool/shelltool/shelltool_test.go
@@ -17,8 +17,13 @@ import (
 	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool/shelltool"
 )
+
+func invokeProvider(provider *shelltool.EnvironmentProvider, ctx context.Context, messages []*message.Message, options ...agent.Option) ([]*message.Message, []agent.Option, error) {
+	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
+}
 
 // --------------------------------------------------------------------------
 // Result.FormatForModel
@@ -214,7 +219,7 @@ func TestEnvironmentProvider_customFormatterOverridesDefault(t *testing.T) {
 		},
 	})
 
-	_, options, err := env.BeforeRun(t.Context(), nil)
+	_, options, err := invokeProvider(env, t.Context(), nil)
 	if err != nil {
 		t.Fatalf("provide shell environment: %v", err)
 	}
@@ -266,7 +271,7 @@ func TestEnvironmentProvider_providesInstructionsAndSnapshot(t *testing.T) {
 		ProbeTools:     []string{},
 	})
 
-	_, options, err := env.BeforeRun(t.Context(), nil)
+	_, options, err := invokeProvider(env, t.Context(), nil)
 	if err != nil {
 		t.Fatalf("provide shell environment: %v", err)
 	}
@@ -335,14 +340,14 @@ func TestEnvironmentProvider_failedProvideAllowsRetry(t *testing.T) {
 
 	canceled, cancel := context.WithCancel(t.Context())
 	cancel()
-	if _, _, err := env.BeforeRun(canceled, nil); err == nil {
+	if _, _, err := invokeProvider(env, canceled, nil); err == nil {
 		t.Fatal("expected canceled provider run to fail")
 	}
 	if _, ok := env.CurrentSnapshot(); ok {
 		t.Fatal("did not expect snapshot after failed provider run")
 	}
 
-	if _, _, err := env.BeforeRun(t.Context(), nil); err != nil {
+	if _, _, err := invokeProvider(env, t.Context(), nil); err != nil {
 		t.Fatalf("retry provider run: %v", err)
 	}
 	if _, ok := env.CurrentSnapshot(); !ok {
@@ -367,14 +372,14 @@ func TestEnvironmentProvider_firstCallFailsNextCallRetriesAndSucceeds(t *testing
 		ProbeTools:     []string{},
 	})
 
-	if _, _, err := env.BeforeRun(t.Context(), nil); !errors.Is(err, boom) {
+	if _, _, err := invokeProvider(env, t.Context(), nil); !errors.Is(err, boom) {
 		t.Fatalf("first provider run error = %v, want boom", err)
 	}
 	if _, ok := env.CurrentSnapshot(); ok {
 		t.Fatal("did not expect snapshot after failed provider run")
 	}
 
-	if _, _, err := env.BeforeRun(t.Context(), nil); err != nil {
+	if _, _, err := invokeProvider(env, t.Context(), nil); err != nil {
 		t.Fatalf("retry provider run: %v", err)
 	}
 	snapshot, ok := env.CurrentSnapshot()
@@ -404,14 +409,14 @@ func TestEnvironmentProvider_firstCallCanceledNextCallSucceeds(t *testing.T) {
 	canceled, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	if _, _, err := env.BeforeRun(canceled, nil); !errors.Is(err, context.Canceled) {
+	if _, _, err := invokeProvider(env, canceled, nil); !errors.Is(err, context.Canceled) {
 		t.Fatalf("first provider run error = %v, want context canceled", err)
 	}
 	if _, ok := env.CurrentSnapshot(); ok {
 		t.Fatal("did not expect snapshot after canceled provider run")
 	}
 
-	if _, _, err := env.BeforeRun(t.Context(), nil); err != nil {
+	if _, _, err := invokeProvider(env, t.Context(), nil); err != nil {
 		t.Fatalf("retry provider run: %v", err)
 	}
 	snapshot, ok := env.CurrentSnapshot()

--- a/workflow/agentworkflow/groupchat_test.go
+++ b/workflow/agentworkflow/groupchat_test.go
@@ -652,7 +652,7 @@ func newGroupChatDoubleEchoAgent(id string) *agent.Agent {
 	}
 	return agent.New(
 		agent.ProviderConfig{ProviderName: "group-chat-double-echo", Run: run},
-		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"}},
+		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: agent.NewHistoryProvider(agent.HistoryProviderConfig{SourceID: "noop-history"})},
 	)
 }
 
@@ -743,7 +743,7 @@ func newGroupChatApprovalAgent(id string) *groupChatApprovalAgent {
 	}
 	agentState.Agent = agent.New(
 		agent.ProviderConfig{ProviderName: "group-chat-approval", Run: run},
-		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"}},
+		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: agent.NewHistoryProvider(agent.HistoryProviderConfig{SourceID: "noop-history"})},
 	)
 	return agentState
 }
@@ -797,7 +797,7 @@ func newGroupChatFunctionCallAgent(id string) *groupChatFunctionCallAgent {
 	}
 	agentState.Agent = agent.New(
 		agent.ProviderConfig{ProviderName: "group-chat-function-call", Run: run},
-		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"}},
+		agent.Config{ID: id, Name: id, DisableFuncAutoCall: true, HistoryProvider: agent.NewHistoryProvider(agent.HistoryProviderConfig{SourceID: "noop-history"})},
 	)
 	return agentState
 }
@@ -823,7 +823,7 @@ func newGroupChatRecordingAgent(name string) *groupChatRecordingAgent {
 		agent.Config{
 			ID:              name,
 			Name:            name,
-			HistoryProvider: &agent.HistoryProvider{SourceID: "noop-history"},
+			HistoryProvider: agent.NewHistoryProvider(agent.HistoryProviderConfig{SourceID: "noop-history"}),
 		},
 	)
 	return recorder

--- a/workflow/agentworkflow/hosting_test.go
+++ b/workflow/agentworkflow/hosting_test.go
@@ -195,7 +195,7 @@ func newRecordingAgent(calls *[][]*message.Message) *agent.Agent {
 			ID:                  testAgentID,
 			Name:                testAgentName,
 			DisableFuncAutoCall: true,
-			HistoryProvider:     &agent.HistoryProvider{SourceID: "noop"},
+			HistoryProvider:     agent.NewHistoryProvider(agent.HistoryProviderConfig{SourceID: "noop"}),
 		},
 	)
 }
@@ -1283,7 +1283,7 @@ func TestHostedAgent_FunctionResultMessageMetadataMatchesHostedAgent(t *testing.
 	}
 	a := agent.New(
 		agent.ProviderConfig{ProviderName: "metadata", Run: run},
-		agent.Config{ID: agentID, DisableFuncAutoCall: true, HistoryProvider: &agent.HistoryProvider{SourceID: "noop"}},
+		agent.Config{ID: agentID, DisableFuncAutoCall: true, HistoryProvider: agent.NewHistoryProvider(agent.HistoryProviderConfig{SourceID: "noop"})},
 	)
 	host := agentworkflow.New(a, agentworkflow.Config{InterceptUnterminatedFunctionCalls: true})
 	exec := resultExecutor(host, "42")


### PR DESCRIPTION
## Summary
- align context and history provider lifecycles with the .NET Agent Framework patterns (`Invoking`/`Invoked` plus shared invocation context objects)
- make context and history providers interface-based with additive default implementations and .NET-aligned filter names
- update default and in-memory history behavior, including `InMemoryHistoryProviderConfig` with state key, initializer, and filter hooks
- migrate built-in providers, examples, and tests to the revised provider APIs

## Tests
- go test ./...
- git diff --cached --check