### PR TITLE
Align data URI and URI content behavior with MEAI

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -533,6 +533,18 @@ type URIContent struct {
 	URI       string
 }
 
+func NewURIContent(uri string, mediaType string) (*URIContent, error) {
+	if err := validateURIContentURI(uri); err != nil {
+		return nil, err
+	}
+	if mediaType == "" {
+		mediaType = inferMediaTypeFromURI(uri)
+	} else if !isValidMediaType(mediaType) {
+		return nil, fmt.Errorf("invalid media type: %s", mediaType)
+	}
+	return &URIContent{URI: uri, MediaType: mediaType}, nil
+}
+
 func (t *URIContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -183,6 +183,80 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestDataContentUnmarshalDefaultsMissingMediaType(t *testing.T) {
+	var content message.DataContent
+	if err := json.Unmarshal([]byte(`{"Type":"data","URI":"data:,hello%20world+literal"}`), &content); err != nil {
+		t.Fatal(err)
+	}
+	if content.MediaType != "text/plain;charset=US-ASCII" {
+		t.Fatalf("MediaType = %q, want text/plain;charset=US-ASCII", content.MediaType)
+	}
+	data, err := content.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello world+literal" {
+		t.Fatalf("data = %q, want hello world+literal", string(data))
+	}
+}
+
+func TestDataContentUnmarshalPreservesInvalidPercentEscapes(t *testing.T) {
+	var content message.DataContent
+	if err := json.Unmarshal([]byte(`{"Type":"data","URI":"data:,hello%20%ZZ+there"}`), &content); err != nil {
+		t.Fatal(err)
+	}
+	data, err := content.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello%20%ZZ+there" {
+		t.Fatalf("data = %q, want original invalid URL data", string(data))
+	}
+}
+
+func TestNewURIContentInfersMediaType(t *testing.T) {
+	content, err := message.NewURIContent("https://example.com/images/chart.png?size=large", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.MediaType != "image/png" {
+		t.Fatalf("MediaType = %q, want image/png", content.MediaType)
+	}
+
+	content, err = message.NewURIContent("https://example.com/download", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.MediaType != "application/octet-stream" {
+		t.Fatalf("MediaType = %q, want application/octet-stream", content.MediaType)
+	}
+}
+
+func TestNewURIContentValidatesURI(t *testing.T) {
+	if _, err := message.NewURIContent("relative/path.png", ""); err == nil {
+		t.Fatal("expected relative URI to fail")
+	}
+	if _, err := message.NewURIContent("https://exa mple.com/image.png", ""); err == nil {
+		t.Fatal("expected invalid host URI to fail")
+	}
+	if _, err := message.NewURIContent("https://example.com/%ZZ.png", ""); err == nil {
+		t.Fatal("expected invalid percent escape URI to fail")
+	}
+}
+
+func TestNewURIContentUsesExplicitMediaType(t *testing.T) {
+	content, err := message.NewURIContent("https://example.com/image.png", "image/jpeg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.MediaType != "image/jpeg" {
+		t.Fatalf("MediaType = %q, want image/jpeg", content.MediaType)
+	}
+	if _, err := message.NewURIContent("https://example.com/image.png", "not a media type"); err == nil {
+		t.Fatal("expected invalid media type to fail")
+	}
+}
+
 func TestContentEncoding_UnmarshalMissingTypeUsesRawContent(t *testing.T) {
 	const rawContent = `{"Provider":"github","Payload":{"value":42}}`
 	data := []byte(`[` + rawContent + `]`)

--- a/message/datauri.go
+++ b/message/datauri.go
@@ -6,10 +6,16 @@ import (
 	"encoding/base64"
 	"fmt"
 	"mime"
+	"net/url"
+	"path"
 	"strings"
 )
 
-const dataURIScheme = "data:"
+const (
+	dataURIScheme              = "data:"
+	dataURIDefaultMediaType    = "text/plain;charset=US-ASCII"
+	uriContentDefaultMediaType = "application/octet-stream"
+)
 
 // dataURI represents a parsed data URI with its components.
 // Based on RFC 2397: https://datatracker.ietf.org/doc/html/rfc2397
@@ -50,13 +56,15 @@ func parseDataURI(uri string) (*dataURI, error) {
 
 	// Validate the media type, if present
 	mediaType := strings.TrimSpace(metadata)
-	if mediaType != "" && !isValidMediaType(mediaType) {
+	if mediaType == "" {
+		mediaType = dataURIDefaultMediaType
+	} else if !isValidMediaType(mediaType) {
 		return nil, fmt.Errorf("invalid data URI format: the media type is not valid")
 	}
 	return &dataURI{
 		Data:      data,
 		IsBase64:  isBase64,
-		MediaType: strings.ToLower(mediaType),
+		MediaType: mediaType,
 	}, nil
 }
 
@@ -65,7 +73,11 @@ func (d *dataURI) data() string {
 	if d.IsBase64 {
 		return d.Data
 	}
-	return base64.StdEncoding.EncodeToString([]byte(d.Data))
+	data, err := url.PathUnescape(d.Data)
+	if err != nil {
+		data = d.Data
+	}
+	return base64.StdEncoding.EncodeToString([]byte(data))
 }
 
 // isValidMediaType validates that a media type is valid.
@@ -76,7 +88,8 @@ func isValidMediaType(mediaType string) bool {
 
 	// Check for common known media types for fast path
 	switch mediaType {
-	case "application/json", "application/octet-stream", "application/pdf", "application/xml",
+	case dataURIDefaultMediaType,
+		"application/json", "application/octet-stream", "application/pdf", "application/xml",
 		"audio/mpeg", "audio/ogg", "audio/wav",
 		"image/apng", "image/avif", "image/bmp", "image/gif", "image/jpeg", "image/png",
 		"image/svg+xml", "image/tiff", "image/webp",
@@ -95,14 +108,51 @@ func topLevelMediaType(mediaType string) string {
 	if mediaType == "" {
 		return ""
 	}
-	slashIndex := strings.IndexByte(mediaType, '/')
+	before, _, ok := strings.Cut(mediaType, "/")
 	var topLevel string
-	if slashIndex < 0 {
+	if !ok {
 		topLevel = mediaType
 	} else {
-		topLevel = mediaType[:slashIndex]
+		topLevel = before
 	}
 	return strings.ToLower(strings.TrimSpace(topLevel))
+}
+
+func validateURIContentURI(rawURI string) error {
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return fmt.Errorf("invalid uri: %w", err)
+	}
+	if parsed == nil || !parsed.IsAbs() {
+		return fmt.Errorf("invalid uri: uri must be absolute")
+	}
+	if (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host == "" {
+		return fmt.Errorf("invalid uri: host is required for %s uri", parsed.Scheme)
+	}
+	return nil
+}
+
+func inferMediaTypeFromURI(rawURI string) string {
+	pathPart := rawURI
+	if parsed, err := url.Parse(rawURI); err == nil {
+		if parsed.Path != "" {
+			pathPart = parsed.Path
+		} else if parsed.Opaque != "" {
+			pathPart = parsed.Opaque
+		}
+	}
+	if i := strings.IndexAny(pathPart, "?#"); i >= 0 {
+		pathPart = pathPart[:i]
+	}
+	if ext := path.Ext(pathPart); ext != "" {
+		if mediaType := mime.TypeByExtension(ext); mediaType != "" {
+			if parsed, _, err := mime.ParseMediaType(mediaType); err == nil {
+				return parsed
+			}
+			return mediaType
+		}
+	}
+	return uriContentDefaultMediaType
 }
 
 // isValidBase64Data tests whether the value is a valid base64 string without whitespace.


### PR DESCRIPTION
## Summary
- default data URIs without an explicit media type to `text/plain;charset=US-ASCII`
- normalize non-base64 data URI payloads through URL decoding before storing base64 data
- add `NewURIContent(uri, mediaType)` with optional-by-empty-string media type inference from URI file extension

## Upstream MEAI parity
- dotnet/extensions#7247
- dotnet/extensions#7398

## Validation
- `go test ./message`