### PR TITLE
Support upgraded provider SDK features

### DIFF
--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -402,6 +402,23 @@ func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUp
 			CreatedAt: eventTime(evt),
 			Contents:  message.Contents{&message.TextContent{Text: e.Delta}},
 		}}, nil
+	case *aguiEvents.ReasoningMessageContentEvent:
+		return []*agent.ResponseUpdate{{
+			Role:      message.RoleAssistant,
+			MessageID: e.MessageID,
+			CreatedAt: eventTime(evt),
+			Contents:  message.Contents{&message.TextReasoningContent{Text: e.Delta}},
+		}}, nil
+	case *aguiEvents.ReasoningEncryptedValueEvent:
+		if e.Subtype != aguiEvents.ReasoningEncryptedValueSubtypeMessage {
+			return nil, nil
+		}
+		return []*agent.ResponseUpdate{{
+			Role:      message.RoleAssistant,
+			MessageID: e.EntityID,
+			CreatedAt: eventTime(evt),
+			Contents:  message.Contents{&message.TextReasoningContent{ProtectedData: e.EncryptedValue}},
+		}}, nil
 	case *aguiEvents.ToolCallStartEvent:
 		a.pending[e.ToolCallID] = &pendingToolCall{Name: e.ToolCallName, MessageID: cmp.Or(deref(e.ParentMessageID), e.ToolCallID)}
 		return nil, nil

--- a/provider/aguiprovider/agui_test.go
+++ b/provider/aguiprovider/agui_test.go
@@ -241,6 +241,46 @@ func TestAGUIAgentRun_WithSession_PreservesHistoryAcrossMultipleTurns(t *testing
 	}
 }
 
+func TestAGUIAgentRun_MapsReasoningEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input aguiTypes.RunAgentInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent(input.ThreadID, input.RunID))
+		writeSSE(t, w, aguiEvents.NewReasoningMessageStartEvent("reasoning-1", "assistant"))
+		writeSSE(t, w, aguiEvents.NewReasoningMessageContentEvent("reasoning-1", "thinking"))
+		writeSSE(t, w, aguiEvents.NewReasoningEncryptedValueEvent(aguiEvents.ReasoningEncryptedValueSubtypeMessage, "reasoning-1", "protected"))
+		writeSSE(t, w, aguiEvents.NewReasoningMessageEndEvent("reasoning-1"))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent(input.ThreadID, input.RunID))
+	}))
+	defer server.Close()
+
+	a := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := a.Run(context.Background(), []*message.Message{message.NewText("hi")}).Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	var reasoning []message.TextReasoningContent
+	for content := range resp.Contents() {
+		if rc, ok := content.(*message.TextReasoningContent); ok {
+			reasoning = append(reasoning, *rc)
+		}
+	}
+	if len(reasoning) != 1 {
+		t.Fatalf("reasoning content count = %d, want 1", len(reasoning))
+	}
+	if reasoning[0].Text != "thinking" {
+		t.Errorf("reasoning text = %q, want %q", reasoning[0].Text, "thinking")
+	}
+	if reasoning[0].ProtectedData != "protected" {
+		t.Errorf("reasoning protected data = %q, want %q", reasoning[0].ProtectedData, "protected")
+	}
+}
+
 func TestAGUIAgentRun_InvokesTools_WhenFunctionCallsReturned(t *testing.T) {
 	var mu sync.Mutex
 	requestCount := 0

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -208,9 +208,20 @@ func toUsageDetailsDelta(usage anthropic.MessageDeltaUsage) message.UsageDetails
 func (a *client) buildBlock(index int, v any, contents []message.Content, functions map[int]*message.FunctionCallContent) []message.Content {
 	switch v := v.(type) {
 	case anthropic.TextBlock:
+		var annotations []message.Annotation
+		for _, citation := range v.Citations {
+			annotations = append(annotations, &message.CitationAnnotation{
+				FileID:            citation.FileID,
+				Snippet:           citation.CitedText,
+				Title:             cmp.Or(citation.DocumentTitle, citation.Title),
+				URL:               citation.URL,
+				RawRepresentation: citation,
+			})
+		}
 		contents = append(contents, &message.TextContent{
 			Text: v.Text,
 			ContentHeader: message.ContentHeader{
+				Annotations:       annotations,
 				RawRepresentation: v,
 			},
 		})

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/provider/anthropicprovider"
 )
 
@@ -165,6 +166,69 @@ func TestConfigInstructions(t *testing.T) {
 	messages, _ := req["messages"].([]any)
 	if len(messages) != 1 {
 		t.Fatalf("messages length = %d, want 1", len(messages))
+	}
+}
+
+func TestTextCitationsBecomeAnnotations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_citations",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-3-5-sonnet-20241022",
+			"stop_reason":"end_turn",
+			"stop_sequence":null,
+			"content":[{
+				"type":"text",
+				"text":"The answer cites the docs.",
+				"citations":[{
+					"type":"web_search_result_location",
+					"cited_text":"source excerpt",
+					"encrypted_index":"enc_123",
+					"title":"Example Source",
+					"url":"https://example.com/source"
+				}]
+			}],
+			"usage":{"input_tokens":10,"output_tokens":5}
+		}`)
+	}))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+	resp, err := a.RunText(t.Context(), "cite something").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var text *message.TextContent
+	for content := range resp.Contents() {
+		if tc, ok := content.(*message.TextContent); ok {
+			text = tc
+			break
+		}
+	}
+	if text == nil {
+		t.Fatal("expected text content")
+	}
+	if len(text.Annotations) != 1 {
+		t.Fatalf("annotations length = %d, want 1", len(text.Annotations))
+	}
+	citation, ok := text.Annotations[0].(*message.CitationAnnotation)
+	if !ok {
+		t.Fatalf("annotation type = %T, want *message.CitationAnnotation", text.Annotations[0])
+	}
+	if citation.URL != "https://example.com/source" {
+		t.Errorf("citation URL = %q, want %q", citation.URL, "https://example.com/source")
+	}
+	if citation.Title != "Example Source" {
+		t.Errorf("citation Title = %q, want %q", citation.Title, "Example Source")
+	}
+	if citation.Snippet != "source excerpt" {
+		t.Errorf("citation Snippet = %q, want %q", citation.Snippet, "source excerpt")
+	}
+	if citation.RawRepresentation == nil {
+		t.Error("citation RawRepresentation is nil")
 	}
 }
 

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -194,6 +194,9 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 				// Use ParametersJsonSchema to pass through the JSON schema directly.
 				decl.ParametersJsonSchema = schema
 			}
+			if schema := ft.ReturnSchema(); schema != nil {
+				decl.ResponseJsonSchema = schema
+			}
 			funcDecls = append(funcDecls, decl)
 		}
 	}
@@ -355,6 +358,20 @@ func buildRequestParts(msg *message.Message, callIDToName map[string]string) ([]
 					MIMEType: c.MediaType,
 				},
 			})
+		case *message.URIContent:
+			parts = append(parts, &genai.Part{
+				FileData: &genai.FileData{
+					FileURI:  c.URI,
+					MIMEType: c.MediaType,
+				},
+			})
+		case *message.HostedFileContent:
+			parts = append(parts, &genai.Part{
+				FileData: &genai.FileData{
+					FileURI:  c.FileID,
+					MIMEType: c.MediaType,
+				},
+			})
 		}
 	}
 	return parts, nil
@@ -402,7 +419,65 @@ func buildResponsePart(part *genai.Part, contents []message.Content) ([]message.
 			},
 		})
 	}
+	if part.InlineData != nil {
+		contents = append(contents, &message.DataContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: part},
+			Data:          base64.StdEncoding.EncodeToString(part.InlineData.Data),
+			MediaType:     part.InlineData.MIMEType,
+		})
+	}
+	if part.FileData != nil {
+		header := message.ContentHeader{RawRepresentation: part}
+		if part.FileData.DisplayName != "" {
+			header.AdditionalProperties = map[string]any{"displayName": part.FileData.DisplayName}
+		}
+		contents = append(contents, &message.URIContent{
+			ContentHeader: header,
+			URI:           part.FileData.FileURI,
+			MediaType:     part.FileData.MIMEType,
+		})
+	}
+	if part.ExecutableCode != nil {
+		contents = append(contents, &message.CodeInterpreterToolCallContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: part},
+			CallID:        part.ExecutableCode.ID,
+			Inputs: message.Contents{&message.DataContent{
+				Data:      base64.StdEncoding.EncodeToString([]byte(part.ExecutableCode.Code)),
+				MediaType: geminiCodeMediaType(part.ExecutableCode.Language),
+			}},
+		})
+	}
+	if part.CodeExecutionResult != nil {
+		contents = append(contents, codeExecutionResultContent(part))
+	}
 	return contents, nil
+}
+
+func geminiCodeMediaType(language genai.Language) string {
+	if language == genai.LanguagePython {
+		return "text/x-python"
+	}
+	return "text/plain"
+}
+
+func codeExecutionResultContent(part *genai.Part) *message.CodeInterpreterToolResultContent {
+	result := part.CodeExecutionResult
+	output := message.Content(&message.TextContent{
+		Text:          result.Output,
+		ContentHeader: message.ContentHeader{RawRepresentation: part},
+	})
+	if result.Outcome != "" && result.Outcome != genai.OutcomeOK {
+		output = &message.ErrorContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: part},
+			Message:       result.Output,
+			ErrorCode:     string(result.Outcome),
+		}
+	}
+	return &message.CodeInterpreterToolResultContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: part},
+		CallID:        result.ID,
+		Outputs:       message.Contents{output},
+	}
 }
 
 // toFunctionResponseMap converts a FunctionResultContent's result to the map[string]any

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -409,6 +409,13 @@ func TestToolCall_NonStreaming(t *testing.T) {
 	if name, _ := decl["name"].(string); name != "get_weather" {
 		t.Errorf("tools[0].functionDeclarations[0].name = %q, want %q", name, "get_weather")
 	}
+	responseSchema, ok := decl["responseJsonSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("tools[0].functionDeclarations[0].responseJsonSchema = %T, want object", decl["responseJsonSchema"])
+	}
+	if responseType, _ := responseSchema["type"].(string); responseType != "string" {
+		t.Errorf("responseJsonSchema.type = %q, want %q", responseType, "string")
+	}
 
 	// Verify the response contains a FunctionCallContent.
 	var gotFuncCall *message.FunctionCallContent
@@ -950,6 +957,147 @@ func TestDataInRequest(t *testing.T) {
 				t.Errorf("inlineData.mimeType = %q, want %q", mime, tc.mediaType)
 			}
 		})
+	}
+}
+
+func TestURIAndHostedFileInRequest(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	server := httptest.NewServer(captureAndRespond(t, bodyCh, "application/json", minimalTextResponse("ok")))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+	messages := []*message.Message{{
+		Role: message.RoleUser,
+		Contents: []message.Content{
+			&message.URIContent{URI: "gs://bucket/image.png", MediaType: "image/png"},
+			&message.HostedFileContent{FileID: "gs://bucket/doc.pdf", Name: "doc.pdf", MediaType: "application/pdf"},
+		},
+	}}
+	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(<-bodyCh, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	contents, _ := req["contents"].([]any)
+	if len(contents) != 1 {
+		t.Fatalf("contents length = %d, want 1", len(contents))
+	}
+	content0, _ := contents[0].(map[string]any)
+	parts, _ := content0["parts"].([]any)
+	if len(parts) != 2 {
+		t.Fatalf("parts length = %d, want 2", len(parts))
+	}
+	for i, wantURI := range []string{"gs://bucket/image.png", "gs://bucket/doc.pdf"} {
+		part, _ := parts[i].(map[string]any)
+		fileData, _ := part["fileData"].(map[string]any)
+		if fileData == nil {
+			t.Fatalf("parts[%d].fileData missing", i)
+		}
+		if fileURI, _ := fileData["fileUri"].(string); fileURI != wantURI {
+			t.Errorf("parts[%d].fileData.fileUri = %q, want %q", i, fileURI, wantURI)
+		}
+	}
+}
+
+func TestResponseWithFileAndInlineData(t *testing.T) {
+	resp := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"role": "model",
+					"parts": []any{
+						map[string]any{"inlineData": map[string]any{"mimeType": "image/png", "data": "aW1hZ2U="}},
+						map[string]any{"fileData": map[string]any{"displayName": "doc.pdf", "mimeType": "application/pdf", "fileUri": "gs://bucket/doc.pdf"}},
+					},
+				},
+				"finishReason": "STOP",
+			},
+		},
+	}
+	respBody, _ := json.Marshal(resp)
+
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "application/json", string(respBody)))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+	result, err := a.RunText(t.Context(), "return media").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data *message.DataContent
+	var uri *message.URIContent
+	for content := range result.Contents() {
+		switch c := content.(type) {
+		case *message.DataContent:
+			data = c
+		case *message.URIContent:
+			uri = c
+		}
+	}
+	if data == nil || data.Data != "aW1hZ2U=" || data.MediaType != "image/png" {
+		t.Fatalf("data content = %#v", data)
+	}
+	if uri == nil || uri.URI != "gs://bucket/doc.pdf" || uri.MediaType != "application/pdf" {
+		t.Fatalf("uri content = %#v", uri)
+	}
+	if uri.AdditionalProperties["displayName"] != "doc.pdf" {
+		t.Fatalf("uri displayName = %#v, want doc.pdf", uri.AdditionalProperties["displayName"])
+	}
+}
+
+func TestResponseWithCodeExecutionParts(t *testing.T) {
+	resp := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"role": "model",
+					"parts": []any{
+						map[string]any{"executableCode": map[string]any{"id": "code_1", "language": "PYTHON", "code": "print(1)"}},
+						map[string]any{"codeExecutionResult": map[string]any{"id": "code_1", "outcome": "OUTCOME_OK", "output": "1\n"}},
+					},
+				},
+				"finishReason": "STOP",
+			},
+		},
+	}
+	respBody, _ := json.Marshal(resp)
+
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "application/json", string(respBody)))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+	result, err := a.RunText(t.Context(), "run code").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var call *message.CodeInterpreterToolCallContent
+	var codeResult *message.CodeInterpreterToolResultContent
+	for content := range result.Contents() {
+		switch c := content.(type) {
+		case *message.CodeInterpreterToolCallContent:
+			call = c
+		case *message.CodeInterpreterToolResultContent:
+			codeResult = c
+		}
+	}
+	if call == nil || call.CallID != "code_1" || len(call.Inputs) != 1 {
+		t.Fatalf("code call = %#v", call)
+	}
+	input, ok := call.Inputs[0].(*message.DataContent)
+	if !ok || input.MediaType != "text/x-python" {
+		t.Fatalf("code input = %#v", call.Inputs[0])
+	}
+	if codeResult == nil || codeResult.CallID != "code_1" || len(codeResult.Outputs) != 1 {
+		t.Fatalf("code result = %#v", codeResult)
+	}
+	output, ok := codeResult.Outputs[0].(*message.TextContent)
+	if !ok || output.Text != "1\n" {
+		t.Fatalf("code output = %#v", codeResult.Outputs[0])
 	}
 }
 

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -470,7 +470,11 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 						},
 					})
 				default:
-					// For other URI content types, just ignore, they are not supported yet.
+					contents = append(contents, responses.ResponseInputContentUnionParam{
+						OfInputFile: &responses.ResponseInputFileParam{
+							FileURL: openai.String(c.URI),
+						},
+					})
 				}
 			case *message.DataContent:
 				switch c.TopLevelMediaType() {
@@ -481,12 +485,22 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 							Detail:   responses.ResponseInputImageDetail(imageDetail(c.AdditionalProperties)),
 						},
 					})
+				default:
+					file := responses.ResponseInputFileParam{
+						FileData: openai.String(c.URI()),
+					}
+					if c.Name != "" {
+						file.Filename = openai.String(c.Name)
+					}
+					contents = append(contents, responses.ResponseInputContentUnionParam{OfInputFile: &file})
 				}
 			case *message.HostedFileContent:
+				file := responses.ResponseInputFileParam{FileID: openai.String(c.FileID)}
+				if c.Name != "" {
+					file.Filename = openai.String(c.Name)
+				}
 				contents = append(contents, responses.ResponseInputContentUnionParam{
-					OfInputFile: &responses.ResponseInputFileParam{
-						FileID: openai.String(c.FileID),
-					},
+					OfInputFile: &file,
 				})
 			}
 		}
@@ -856,6 +870,14 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 				}
 			}
 			currentUpdate.Contents = append(currentUpdate.Contents, &output)
+
+		case responses.ResponseOutputItemMcpApprovalRequest:
+			currentUpdate.Contents = append(currentUpdate.Contents, mcpApprovalRequestContent(out))
+
+		case responses.ResponseOutputItemImageGenerationCall:
+			if content := imageGenerationContent(out); content != nil {
+				currentUpdate.Contents = append(currentUpdate.Contents, content)
+			}
 		}
 	}
 
@@ -1088,6 +1110,12 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 			content := &message.TextContent{Text: outputText.String()}
 			content.RawRepresentation = item
 			u.Contents = []message.Content{content}
+		case responses.ResponseOutputItemMcpApprovalRequest:
+			u.Contents = []message.Content{mcpApprovalRequestContent(item)}
+		case responses.ResponseOutputItemImageGenerationCall:
+			if content := imageGenerationContent(item); content != nil {
+				u.Contents = []message.Content{content}
+			}
 		default:
 			u = createUpdate(message.RoleAssistant, nil)
 		}
@@ -1110,6 +1138,36 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 	}
 
 	return u, nil
+}
+
+func mcpApprovalRequestContent(item responses.ResponseOutputItemMcpApprovalRequest) *message.ToolApprovalRequestContent {
+	return &message.ToolApprovalRequestContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: item},
+		RequestID:     item.ID,
+		ToolCall: &message.MCPServerToolCallContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: item},
+			Arguments:     item.Arguments,
+			CallID:        item.ID,
+			Name:          item.Name,
+			ServerName:    item.ServerLabel,
+		},
+	}
+}
+
+func imageGenerationContent(item responses.ResponseOutputItemImageGenerationCall) *message.DataContent {
+	if item.Result == "" {
+		return nil
+	}
+	name := ""
+	if item.ID != "" {
+		name = item.ID + ".png"
+	}
+	return &message.DataContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: item},
+		Data:          item.Result,
+		MediaType:     "image/png",
+		Name:          name,
+	}
 }
 
 func populateAnnotations(anns []responses.ResponseOutputTextAnnotationUnion, content *message.TextContent) {

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -1865,6 +1865,121 @@ func TestResponsesNonStreamingResponseWithIncompleteReason_MapsFinishReason(t *t
 	}
 }
 
+func TestResponsesNonStreamingMCPApprovalRequest_MapsApprovalContent(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}]
+            }
+            `
+
+	const output = `
+            {
+              "id":"resp_001",
+              "object":"response",
+              "created_at":1741892091,
+              "status":"completed",
+              "model":"gpt-4o-mini",
+              "output":[{
+                "type":"mcp_approval_request",
+                "id":"approval_123",
+                "server_label":"github",
+                "name":"create_issue",
+                "arguments":"{\"title\":\"Bug\"}"
+              }]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	resp, err := a.RunText(t.Context(), "test").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	approval := firstToolApprovalRequest(t, resp)
+	if approval.RequestID != "approval_123" {
+		t.Errorf("RequestID = %q, want %q", approval.RequestID, "approval_123")
+	}
+	mcpCall, ok := approval.ToolCall.(*message.MCPServerToolCallContent)
+	if !ok {
+		t.Fatalf("ToolCall = %T, want *message.MCPServerToolCallContent", approval.ToolCall)
+	}
+	if mcpCall.ServerName != "github" {
+		t.Errorf("ServerName = %q, want %q", mcpCall.ServerName, "github")
+	}
+	if mcpCall.Name != "create_issue" {
+		t.Errorf("Name = %q, want %q", mcpCall.Name, "create_issue")
+	}
+	if mcpCall.Arguments != `{"title":"Bug"}` {
+		t.Errorf("Arguments = %q, want title JSON", mcpCall.Arguments)
+	}
+	if approval.RawRepresentation == nil || mcpCall.RawRepresentation == nil {
+		t.Error("RawRepresentation is nil")
+	}
+}
+
+func TestResponsesStreamingMCPApprovalRequest_MapsApprovalContent(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}],
+                "stream":true
+            }
+            `
+
+	const output = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,"item":{"type":"mcp_approval_request","id":"approval_123","server_label":"github","name":"create_issue","arguments":"{\"title\":\"Bug\"}"}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+
+`
+
+	server := newTestResponsesServerStreaming(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	var approval *message.ToolApprovalRequestContent
+	for update, err := range a.RunText(t.Context(), "test", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		for _, content := range update.Contents {
+			if req, ok := content.(*message.ToolApprovalRequestContent); ok {
+				approval = req
+			}
+		}
+	}
+
+	if approval == nil {
+		t.Fatal("expected ToolApprovalRequestContent")
+	}
+	mcpCall, ok := approval.ToolCall.(*message.MCPServerToolCallContent)
+	if !ok {
+		t.Fatalf("ToolCall = %T, want *message.MCPServerToolCallContent", approval.ToolCall)
+	}
+	if approval.RequestID != "approval_123" || mcpCall.ServerName != "github" || mcpCall.Name != "create_issue" {
+		t.Fatalf("approval = %#v, tool call = %#v", approval, mcpCall)
+	}
+}
+
+func firstToolApprovalRequest(t *testing.T, resp *agent.Response) *message.ToolApprovalRequestContent {
+	t.Helper()
+	for content := range resp.Contents() {
+		if req, ok := content.(*message.ToolApprovalRequestContent); ok {
+			return req
+		}
+	}
+	t.Fatal("expected ToolApprovalRequestContent")
+	return nil
+}
+
 func TestResponsesResponseFormatSchemaConvertsJSONSchema(t *testing.T) {
 	type payload struct {
 		Name string `json:"name"`
@@ -3098,7 +3213,10 @@ func TestResponsesUserMessageWithVariousContentTypes_ConvertsCorrectly(t *testin
                         "role":"user",
                         "content":[
                             {"type":"input_text","text":"Here is some text"},
-                            {"type":"input_image","image_url":"https://example.com/image.jpg","detail":"high"}
+							{"type":"input_image","image_url":"https://example.com/image.jpg","detail":"high"},
+							{"type":"input_file","file_url":"https://example.com/document.pdf"},
+							{"type":"input_file","file_data":"data:application/pdf;base64,cGRmZGF0YQ==","filename":"report.pdf"},
+							{"type":"input_file","file_id":"file_123","filename":"hosted.pdf"}
                         ]
                     }
                 ]
@@ -3142,6 +3260,20 @@ func TestResponsesUserMessageWithVariousContentTypes_ConvertsCorrectly(t *testin
 						AdditionalProperties: map[string]any{"detail": "high"},
 					},
 				},
+				&message.URIContent{
+					URI:       "https://example.com/document.pdf",
+					MediaType: "application/pdf",
+				},
+				&message.DataContent{
+					Data:      "cGRmZGF0YQ==",
+					MediaType: "application/pdf",
+					Name:      "report.pdf",
+				},
+				&message.HostedFileContent{
+					FileID:    "file_123",
+					Name:      "hosted.pdf",
+					MediaType: "application/pdf",
+				},
 			},
 		},
 	}
@@ -3164,6 +3296,111 @@ func TestResponsesUserMessageWithVariousContentTypes_ConvertsCorrectly(t *testin
 	if responseText != "Processed" {
 		t.Errorf("expected response text 'Processed', got %q", responseText)
 	}
+}
+
+func TestResponsesNonStreamingImageGenerationCall_MapsToDataContent(t *testing.T) {
+	const imageBase64 = "iVBORw0KGgo="
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"draw"}]}]
+            }
+            `
+
+	const output = `
+            {
+              "id":"resp_001",
+              "object":"response",
+              "created_at":1741892091,
+              "status":"completed",
+              "model":"gpt-4o-mini",
+              "output":[{
+                "type":"image_generation_call",
+                "id":"ig_123",
+                "status":"completed",
+                "result":"` + imageBase64 + `"
+              }]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	resp, err := a.RunText(t.Context(), "draw").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	image := firstDataContent(t, resp)
+	if image.Data != imageBase64 {
+		t.Errorf("Data = %q, want %q", image.Data, imageBase64)
+	}
+	if image.MediaType != "image/png" {
+		t.Errorf("MediaType = %q, want %q", image.MediaType, "image/png")
+	}
+	if image.Name != "ig_123.png" {
+		t.Errorf("Name = %q, want %q", image.Name, "ig_123.png")
+	}
+	if image.RawRepresentation == nil {
+		t.Error("RawRepresentation is nil")
+	}
+}
+
+func TestResponsesStreamingImageGenerationCall_MapsToDataContent(t *testing.T) {
+	const imageBase64 = "iVBORw0KGgo="
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"draw"}]}],
+                "stream":true
+            }
+            `
+
+	const output = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,"item":{"type":"image_generation_call","id":"ig_123","status":"completed","result":"` + imageBase64 + `"}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+
+`
+
+	server := newTestResponsesServerStreaming(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	var image *message.DataContent
+	for update, err := range a.RunText(t.Context(), "draw", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		for _, content := range update.Contents {
+			if data, ok := content.(*message.DataContent); ok {
+				image = data
+			}
+		}
+	}
+
+	if image == nil {
+		t.Fatal("expected DataContent")
+	}
+	if image.Data != imageBase64 || image.MediaType != "image/png" || image.Name != "ig_123.png" {
+		t.Fatalf("image content = %#v", image)
+	}
+}
+
+func firstDataContent(t *testing.T, resp *agent.Response) *message.DataContent {
+	t.Helper()
+	for content := range resp.Contents() {
+		if data, ok := content.(*message.DataContent); ok {
+			return data
+		}
+	}
+	t.Fatal("expected DataContent")
+	return nil
 }
 
 func TestResponsesToolCallResult_DataContent_SerializesAsInputImage(t *testing.T) {


### PR DESCRIPTION
## Why

Recent SDK upgrades added useful provider features that our adapters were not yet surfacing. This PR updates the adapters so users get richer responses and better round-tripping instead of silently losing provider data.

## What changed

- Preserves Anthropic citations as framework citation annotations.
- Maps AG-UI reasoning events into reasoning content.
- Adds Gemini support for tool return schemas, file parts, inline media responses, code execution parts, and returned file display names.
- Adds OpenAI Responses support for hosted MCP approval requests, non-image user file inputs, and image generation results.

## Validation

- `go test ./provider/aguiprovider ./provider/anthropicprovider ./provider/geminiprovider ./provider/openaiprovider -count=1`