### PR TITLE
Add DisableStoreOutput for Responses agents

### DIFF
--- a/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
+++ b/examples/02-agents/agents/step07_3rdparty_session_storage/main.go
@@ -38,7 +38,8 @@ func main() {
 		token,
 		foundryprovider.ModelDeployment(demo.FoundryModel),
 		foundryprovider.AgentConfig{
-			Instructions: "You are good at telling jokes.",
+			Instructions:       "You are good at telling jokes.",
+			DisableStoreOutput: true,
 			Config: agent.Config{
 				Name:            "Joker",
 				HistoryProvider: newFSHistoryProvider(tmpDir),

--- a/examples/02-agents/agents/step17_additional_ai_context/main.go
+++ b/examples/02-agents/agents/step17_additional_ai_context/main.go
@@ -40,6 +40,7 @@ func main() {
 			Instructions: `You are a helpful personal assistant.
 You manage a TODO list for the user. When the user has completed one of the tasks it can be removed from the TODO list. Only provide the list of TODO items if asked.
 You remind users of upcoming calendar events when the user interacts with you.`,
+			DisableStoreOutput: true,
 			Config: agent.Config{
 				Name:            "PersonalAssistant",
 				HistoryProvider: newChatHistoryProvider(),
@@ -115,10 +116,9 @@ func newChatHistoryProvider() agent.HistoryProvider {
 	// You may want to store these messages, depending on their content and your requirements.
 	return agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
 		SourceID: chatHistorySourceID,
-		StoreInputRequestMessageFilter: messagefilter.NotSources(
-			message.Source{Type: agent.SourceTypeHistoryProvider, ID: chatHistorySourceID},
-			message.Source{Type: agent.SourceTypeContextProvider, ID: todoListSourceID},
-			message.Source{Type: agent.SourceTypeContextProvider, ID: calendarSearchSourceID},
+		StoreInputRequestMessageFilter: messagefilter.NotSourceTypes(
+			agent.SourceTypeHistoryProvider,
+			agent.SourceTypeContextProvider,
 		),
 	})
 }

--- a/examples/02-agents/providers/azure/openai_responses/main.go
+++ b/examples/02-agents/providers/azure/openai_responses/main.go
@@ -22,11 +22,13 @@ var logger = demo.NewLogger(
 func main() {
 	token := demo.AzureTokenCredential()
 
+	client := openai.NewClient(
+		option.WithBaseURL(demo.Endpoint),
+		azure.WithTokenCredential(token),
+	)
+
 	a := openaiprovider.NewResponsesAgent(
-		openai.NewClient(
-			option.WithBaseURL(demo.Endpoint),
-			azure.WithTokenCredential(token),
-		),
+		client,
 		openaiprovider.AgentConfig{
 			Model:        demo.Deployment,
 			Instructions: "You are good at telling jokes.",
@@ -38,5 +40,27 @@ func main() {
 	)
 
 	resp, err := a.RunText(context.Background(), "Tell me a joke about a pirate.").Collect()
+	demo.Response(resp, err)
+
+	// Create a responses based agent with "store"=false.
+	// This means that chat history is managed locally by Agent Framework
+	// instead of being stored in the service (default).
+	storeDisabledAgent := openaiprovider.NewResponsesAgent(
+		openai.NewClient(
+			option.WithBaseURL(demo.Endpoint),
+			azure.WithTokenCredential(token),
+		),
+		openaiprovider.AgentConfig{
+			Model:              demo.Deployment,
+			Instructions:       "You are good at telling jokes.",
+			DisableStoreOutput: true,
+			Config: agent.Config{
+				Name:        "Joker",
+				Middlewares: []agent.Middleware{logger},
+			},
+		},
+	)
+
+	resp, err = storeDisabledAgent.RunText(context.Background(), "Tell me a joke about a pirate.").Collect()
 	demo.Response(resp, err)
 }

--- a/message/messagefilter/filter.go
+++ b/message/messagefilter/filter.go
@@ -102,6 +102,18 @@ func Sources(sources ...message.Source) Filter {
 	}
 }
 
+// NotSourceTypes returns messages whose source type is not in the provided deny list.
+func NotSourceTypes(sourceTypes ...message.SourceType) Filter {
+	return func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
+		return slices.DeleteFunc(messages, func(msg *message.Message) bool {
+			if msg == nil {
+				return false
+			}
+			return slices.Contains(sourceTypes, msg.Source.Type)
+		}), nil
+	}
+}
+
 // NotSources returns messages whose source is not in the provided deny list.
 func NotSources(sources ...message.Source) Filter {
 	return func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {

--- a/message/messagefilter/filter_test.go
+++ b/message/messagefilter/filter_test.go
@@ -82,6 +82,22 @@ func TestNotSources(t *testing.T) {
 	}
 }
 
+func TestNotSourceTypes(t *testing.T) {
+	keep := message.NewText("keep")
+	keep.Source = message.Source{Type: message.SourceType("provider-a"), ID: "same-id"}
+	blocked := message.NewText("blocked")
+	blocked.Source = message.Source{Type: message.SourceType("provider-b"), ID: "same-id"}
+
+	filter := NotSourceTypes(message.SourceType("provider-b"))
+	out, err := filter(t.Context(), []*message.Message{keep, blocked})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 || out[0] != keep {
+		t.Fatal("expected messages not in denied source type")
+	}
+}
+
 func TestOr_ExternalOnlyOrSources(t *testing.T) {
 	external := message.NewText("external")
 	source := message.Source{Type: message.SourceType("provider"), ID: "a"}

--- a/provider/foundryprovider/agent.go
+++ b/provider/foundryprovider/agent.go
@@ -28,6 +28,10 @@ type AgentConfig struct {
 	// They are ignored for server-side Foundry prompt agents, whose instructions are owned by the service.
 	Instructions string
 
+	// DisableStoreOutput disables service-side Responses output storage.
+	// Use this when local session history providers own conversation state.
+	DisableStoreOutput bool
+
 	// OpenAIOptions are appended to the OpenAI-compatible per-agent client options.
 	OpenAIOptions []option.RequestOption
 }
@@ -117,7 +121,6 @@ func newFoundryAgent(credential azcore.TokenCredential, config AgentConfig, mode
 	if mode.agentName != "" {
 		instructions = ""
 	}
-
 	openAIOptions := []option.RequestOption{
 		option.WithBaseURL(mode.baseURL),
 		azure.WithTokenCredential(credential, azure.WithTokenCredentialScopes([]string{azureAIResourceScope})),
@@ -129,9 +132,10 @@ func newFoundryAgent(credential azcore.TokenCredential, config AgentConfig, mode
 	config.Middlewares = append([]agent.Middleware{clientHeadersMiddleware{}, servedModelMiddleware{}}, config.Middlewares...)
 
 	return openaiprovider.NewResponsesAgent(openai.NewClient(openAIOptions...), openaiprovider.AgentConfig{
-		Config:       config.Config,
-		Instructions: instructions,
-		Model:        mode.model,
+		Config:             config.Config,
+		Instructions:       instructions,
+		Model:              mode.model,
+		DisableStoreOutput: config.DisableStoreOutput,
 	})
 }
 

--- a/provider/foundryprovider/agent_test.go
+++ b/provider/foundryprovider/agent_test.go
@@ -52,6 +52,35 @@ func TestNewAgentUsesProjectResponsesEndpointAndConfig(t *testing.T) {
 	}
 }
 
+func TestNewAgentDisableStoreOutputSetsStoreFalse(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := jsonMap(t, mustReadBody(t, r))
+		if body["store"] != false {
+			t.Fatalf("store = %#v, want false", body["store"])
+		}
+		writeResponsesOK(w)
+	}))
+	defer server.Close()
+
+	foundryAgent := newFoundryAgent(t, server, foundryprovider.ModelDeployment("gpt-4o-mini"), foundryprovider.AgentConfig{
+		DisableStoreOutput: true,
+		Config: agent.Config{
+			DisableFuncAutoCall: true,
+		},
+	})
+	session, err := foundryAgent.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := foundryAgent.RunText(t.Context(), "hello", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("RunText error = %v", err)
+	}
+	if got := session.ServiceID(); got != "" {
+		t.Fatalf("session ServiceID = %q, want empty", got)
+	}
+}
+
 func TestNewAgentRunsAgainstFoundryAgentEndpoint(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/projects/proj/agents/my-agent/endpoint/protocols/openai/responses" {

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -54,6 +54,12 @@ type AgentConfig struct {
 	// Instructions are provided to OpenAI as system instructions for each run.
 	Instructions string
 
+	// DisableStoreOutput is used only by [NewResponsesAgent]. It disables
+	// service-side output storage and prevents response IDs from being saved into
+	// agent sessions for later continuation.
+	// It is ignored by [NewChatCompletionsAgent].
+	DisableStoreOutput bool
+
 	Model string
 }
 

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -104,6 +104,9 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 
 		// Helper to update conversation ID after response completes
 		updateConversationID := func(responseID string) {
+			if a.config.DisableStoreOutput {
+				return
+			}
 			if session != nil && !keepConversationID && responseID != "" {
 				session.SetServiceID(responseID)
 			}
@@ -158,7 +161,7 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 		}
 
 		// Build request parameters
-		body, err := responsesBuildCompletionParams(a.config.Model, messages, options)
+		body, err := responsesBuildCompletionParams(a.config, messages, options)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -216,12 +219,15 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 }
 
 // buildCompletionParams constructs the parameters for the OpenAI chat completion API.
-func responsesBuildCompletionParams(model string, messages []*message.Message, opts []agent.Option) (responses.ResponseNewParams, error) {
+func responsesBuildCompletionParams(config AgentConfig, messages []*message.Message, opts []agent.Option) (responses.ResponseNewParams, error) {
 	var params responses.ResponseNewParams
 	if p, ok := agent.GetOption(opts, ResponsesNewParams); ok {
 		params = p
 	}
-	params.Model = cmp.Or(params.Model, model)
+	if config.DisableStoreOutput {
+		params.Store = openai.Bool(false)
+	}
+	params.Model = cmp.Or(params.Model, config.Model)
 	instructions := slices.Collect(agent.AllOptions(opts, agent.WithInstructions))
 	if len(instructions) > 0 {
 		params.Instructions = openai.String(strings.Join(instructions, "\n"))
@@ -506,12 +512,15 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 		}
 
 	case message.RoleAssistant:
+		var outputContents []responses.ResponseOutputMessageContentUnionParam
 		for _, c := range msg.Contents {
 			switch c := c.(type) {
 			case *message.TextContent:
-				contents = append(contents, responses.ResponseInputContentUnionParam{
-					OfInputText: &responses.ResponseInputTextParam{
-						Text: c.Text,
+				outputContents = append(outputContents, responses.ResponseOutputMessageContentUnionParam{
+					OfOutputText: &responses.ResponseOutputTextParam{
+						// TODO: Convert message annotations back to Responses output-text annotations.
+						Annotations: []responses.ResponseOutputTextAnnotationUnionParam{},
+						Text:        c.Text,
 					},
 				})
 			case *message.TextReasoningContent:
@@ -527,9 +536,15 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 					OfReasoning: &reasoning,
 				})
 			case *message.FunctionCallContent:
-				// Function calls from assistant messages are NOT sent as input
-				// Only function call outputs (from tool role) are sent
+				resp = append(resp, responses.ResponseInputItemParamOfFunctionCall(c.Arguments, c.CallID, c.Name))
 			}
+		}
+		if len(outputContents) > 0 {
+			id := msg.ID
+			if id == "" {
+				id = fmt.Sprintf("msg_local_%d", len(resp))
+			}
+			resp = append(resp, responses.ResponseInputItemParamOfOutputMessage(outputContents, id, responses.ResponseOutputMessageStatusCompleted))
 		}
 
 	case message.RoleTool:

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -101,10 +101,11 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 			session = t
 			keepConversationID = session.ServiceID() != "" && strings.HasPrefix(session.ServiceID(), "conv_")
 		}
+		disableStoreOutput := responsesDisableStoreOutput(a.config, options)
 
 		// Helper to update conversation ID after response completes
 		updateConversationID := func(responseID string) {
-			if a.config.DisableStoreOutput {
+			if disableStoreOutput {
 				return
 			}
 			if session != nil && !keepConversationID && responseID != "" {
@@ -224,10 +225,7 @@ func responsesBuildCompletionParams(config AgentConfig, messages []*message.Mess
 	if p, ok := agent.GetOption(opts, ResponsesNewParams); ok {
 		params = p
 	}
-	if !param.IsOmitted(params.Store) {
-		return responses.ResponseNewParams{}, fmt.Errorf("openaiprovider: per-run ResponsesNewParams.Store is not supported; use AgentConfig.DisableStoreOutput")
-	}
-	if config.DisableStoreOutput {
+	if config.DisableStoreOutput && param.IsOmitted(params.Store) {
 		params.Store = openai.Bool(false)
 	}
 	params.Model = cmp.Or(params.Model, config.Model)
@@ -447,6 +445,13 @@ func responsesBuildCompletionParams(config AgentConfig, messages []*message.Mess
 		}
 	}
 	return params, nil
+}
+
+func responsesDisableStoreOutput(config AgentConfig, opts []agent.Option) bool {
+	if p, ok := agent.GetOption(opts, ResponsesNewParams); ok && !param.IsOmitted(p.Store) {
+		return !p.Store.Or(true)
+	}
+	return config.DisableStoreOutput
 }
 
 // responsesBuildMessageParam converts an agent.Message to one or more OpenAI message parameters.

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -224,6 +224,9 @@ func responsesBuildCompletionParams(config AgentConfig, messages []*message.Mess
 	if p, ok := agent.GetOption(opts, ResponsesNewParams); ok {
 		params = p
 	}
+	if !param.IsOmitted(params.Store) {
+		return responses.ResponseNewParams{}, fmt.Errorf("openaiprovider: per-run ResponsesNewParams.Store is not supported; use AgentConfig.DisableStoreOutput")
+	}
 	if config.DisableStoreOutput {
 		params.Store = openai.Bool(false)
 	}
@@ -513,6 +516,19 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 
 	case message.RoleAssistant:
 		var outputContents []responses.ResponseOutputMessageContentUnionParam
+		outputGroup := 0
+		flushOutputContents := func() {
+			if len(outputContents) == 0 {
+				return
+			}
+			id := msg.ID
+			if id == "" || outputGroup > 0 {
+				id = fmt.Sprintf("msg_local_%d", len(resp))
+			}
+			resp = append(resp, responses.ResponseInputItemParamOfOutputMessage(outputContents, id, responses.ResponseOutputMessageStatusCompleted))
+			outputContents = nil
+			outputGroup++
+		}
 		for _, c := range msg.Contents {
 			switch c := c.(type) {
 			case *message.TextContent:
@@ -524,6 +540,7 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 					},
 				})
 			case *message.TextReasoningContent:
+				flushOutputContents()
 				// Reasoning content is added as a separate input item
 				var reasoning responses.ResponseReasoningItemParam
 				if c.ProtectedData != "" {
@@ -536,16 +553,11 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 					OfReasoning: &reasoning,
 				})
 			case *message.FunctionCallContent:
+				flushOutputContents()
 				resp = append(resp, responses.ResponseInputItemParamOfFunctionCall(c.Arguments, c.CallID, c.Name))
 			}
 		}
-		if len(outputContents) > 0 {
-			id := msg.ID
-			if id == "" {
-				id = fmt.Sprintf("msg_local_%d", len(resp))
-			}
-			resp = append(resp, responses.ResponseInputItemParamOfOutputMessage(outputContents, id, responses.ResponseOutputMessageStatusCompleted))
-		}
+		flushOutputContents()
 
 	case message.RoleTool:
 		for _, c := range msg.Contents {

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -225,8 +225,13 @@ func responsesBuildCompletionParams(config AgentConfig, messages []*message.Mess
 	if p, ok := agent.GetOption(opts, ResponsesNewParams); ok {
 		params = p
 	}
-	if config.DisableStoreOutput && param.IsOmitted(params.Store) {
-		params.Store = openai.Bool(false)
+	if responsesDisableStoreOutput(config, opts) {
+		if param.IsOmitted(params.Store) {
+			params.Store = openai.Bool(false)
+		}
+		if !slices.Contains(params.Include, responses.ResponseIncludableReasoningEncryptedContent) {
+			params.Include = append(params.Include, responses.ResponseIncludableReasoningEncryptedContent)
+		}
 	}
 	params.Model = cmp.Or(params.Model, config.Model)
 	instructions := slices.Collect(agent.AllOptions(opts, agent.WithInstructions))

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -707,7 +707,9 @@ func TestResponsesMultipleMessages_NonStreaming(t *testing.T) {
                     {
                         "type": "message",
                         "role": "assistant",
-                        "content": [{"type": "input_text", "text": "hi, how are you?"}]
+						"content": [{"type": "output_text", "text": "hi, how are you?", "annotations": []}],
+						"id": "msg_local_1",
+						"status": "completed"
                     },
                     {
                         "type": "message",
@@ -1353,6 +1355,12 @@ func TestResponsesFunctionCallWithResult_NonStreaming(t *testing.T) {
                         "content": [{"type": "input_text", "text": "What's the weather in Seattle?"}]
                     },
                     {
+						"type": "function_call",
+						"call_id": "call_abc123",
+						"name": "get_weather",
+						"arguments": "{\"location\":\"Seattle, WA\"}"
+					},
+					{
                         "type": "function_call_output",
                         "call_id": "call_abc123",
                         "output": "{\"temperature\":72,\"condition\":\"sunny\"}"
@@ -1546,6 +1554,12 @@ func TestResponsesFunctionCall_UsesCallIDWhenDifferentFromID(t *testing.T) {
 						"type": "message",
 						"role": "user",
 						"content": [{"type": "input_text", "text": "What's the weather in Amsterdam?"}]
+					},
+					{
+						"type": "function_call",
+						"call_id": "call_weather_001",
+						"name": "get_weather",
+						"arguments": "{\"location\":\"Amsterdam\"}"
 					},
 					{
 						"type": "function_call_output",
@@ -4349,6 +4363,72 @@ func TestResponsesConversationId_AsResponseId_NonStreaming(t *testing.T) {
 	// After the call, session conversation id should be updated to the new response ID
 	if got := session.ServiceID(); got != "resp_67890" {
 		t.Errorf("expected ConversationId resp_67890, got %s", got)
+	}
+}
+
+func TestDisableStoreOutputDoesNotUseOrUpdateResponseID(t *testing.T) {
+	const input = `
+						{
+								"store":false,
+								"model":"gpt-4o-mini",
+								"input":[{
+										"type":"message",
+										"role":"user",
+										"content":[{"type":"input_text","text":"hello"}]
+								}]
+						}
+						`
+
+	const output = `
+						{
+							"id": "resp_67890",
+							"object": "response",
+							"created_at": 1741891428,
+							"status": "completed",
+							"model": "gpt-4o-mini-2024-07-18",
+							"output": [
+								{
+									"type": "message",
+									"id": "msg_67d32764fcdc8191bcf2e444d4088804058a5e08c46a181d",
+									"status": "completed",
+									"role": "assistant",
+									"content": [
+										{
+											"type": "output_text",
+											"text": "Hello!",
+											"annotations": []
+										}
+									]
+								}
+							]
+						}
+						`
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := openaiprovider.NewResponsesAgent(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiprovider.AgentConfig{
+			Model:              "gpt-4o-mini",
+			DisableStoreOutput: true,
+			Config:             agent.Config{DisableFuncAutoCall: true},
+		},
+	)
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = a.RunText(t.Context(), "hello",
+		agent.WithSession(session),
+	).Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	if got := session.ServiceID(); got != "" {
+		t.Errorf("session ServiceID = %q, want empty", got)
 	}
 }
 

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -793,6 +793,68 @@ func TestResponsesMultipleMessages_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestResponsesAssistantReplayPreservesContentOrder(t *testing.T) {
+	const input = `
+			{
+				"input": [
+					{
+						"type": "message",
+						"role": "assistant",
+						"content": [{"type": "output_text", "text": "Before tool.", "annotations": []}],
+						"id": "msg_local_0",
+						"status": "completed"
+					},
+					{
+						"type": "function_call",
+						"call_id": "call_abc123",
+						"name": "get_weather",
+						"arguments": "{\"location\":\"Seattle\"}"
+					},
+					{
+						"type": "message",
+						"role": "assistant",
+						"content": [{"type": "output_text", "text": "After tool.", "annotations": []}],
+						"id": "msg_local_2",
+						"status": "completed"
+					}
+				],
+				"model": "gpt-4o-mini"
+			}
+			`
+	const output = `
+			{
+			  "id": "resp_test",
+			  "object": "response",
+			  "created_at": 1727894187,
+			  "status": "completed",
+			  "model": "gpt-4o-mini-2024-07-18",
+			  "output": [{
+				  "type": "message",
+				  "id": "msg_test",
+				  "status": "completed",
+				  "role": "assistant",
+				  "content": [{"type": "output_text", "text": "done", "annotations": []}]
+			  }]
+			}
+			`
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	messages := []*message.Message{
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.TextContent{Text: "Before tool."},
+			&message.FunctionCallContent{CallID: "call_abc123", Name: "get_weather", Arguments: `{"location":"Seattle"}`},
+			&message.TextContent{Text: "After tool."},
+		}},
+	}
+
+	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestResponsesDataContentMessage_Image_NonStreaming(t *testing.T) {
 	// A minimal 1x1 PNG image as a data URI (red pixel)
 	_ = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
@@ -4429,6 +4491,32 @@ func TestDisableStoreOutputDoesNotUseOrUpdateResponseID(t *testing.T) {
 
 	if got := session.ServiceID(); got != "" {
 		t.Errorf("session ServiceID = %q, want empty", got)
+	}
+}
+
+func TestResponsesNewParamsStoreIsUnsupportedPerRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unexpected request")
+	}))
+	defer server.Close()
+
+	a := openaiprovider.NewResponsesAgent(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiprovider.AgentConfig{
+			Model:              "gpt-4o-mini",
+			DisableStoreOutput: true,
+			Config:             agent.Config{DisableFuncAutoCall: true},
+		},
+	)
+
+	_, err := a.RunText(t.Context(), "hello",
+		openaiprovider.ResponsesNewParams(responses.ResponseNewParams{Store: openai.Bool(false)}),
+	).Collect()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "per-run ResponsesNewParams.Store is not supported") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -4494,10 +4494,45 @@ func TestDisableStoreOutputDoesNotUseOrUpdateResponseID(t *testing.T) {
 	}
 }
 
-func TestResponsesNewParamsStoreIsUnsupportedPerRun(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("unexpected request")
-	}))
+func TestResponsesNewParamsStoreOverridesDisableStoreOutput(t *testing.T) {
+	const input = `
+		{
+			"store":true,
+			"model":"gpt-4o-mini",
+			"input":[{
+				"type":"message",
+				"role":"user",
+				"content":[{"type":"input_text","text":"hello"}]
+			}]
+		}
+		`
+
+	const output = `
+		{
+			"id": "resp_67890",
+			"object": "response",
+			"created_at": 1741891428,
+			"status": "completed",
+			"model": "gpt-4o-mini-2024-07-18",
+			"output": [
+				{
+					"type": "message",
+					"id": "msg_67d32764fcdc8191bcf2e444d4088804058a5e08c46a181d",
+					"status": "completed",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "output_text",
+							"text": "Hello!",
+							"annotations": []
+						}
+					]
+				}
+			]
+		}
+		`
+
+	server := newTestResponsesServer(t, input, output)
 	defer server.Close()
 
 	a := openaiprovider.NewResponsesAgent(
@@ -4508,15 +4543,87 @@ func TestResponsesNewParamsStoreIsUnsupportedPerRun(t *testing.T) {
 			Config:             agent.Config{DisableFuncAutoCall: true},
 		},
 	)
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := a.RunText(t.Context(), "hello",
+	_, err = a.RunText(t.Context(), "hello",
+		agent.WithSession(session),
+		openaiprovider.ResponsesNewParams(responses.ResponseNewParams{Store: openai.Bool(true)}),
+	).Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	if got := session.ServiceID(); got != "resp_67890" {
+		t.Errorf("session ServiceID = %q, want resp_67890", got)
+	}
+}
+
+func TestResponsesNewParamsStoreFalseDoesNotUpdateResponseID(t *testing.T) {
+	const input = `
+		{
+			"store":false,
+			"model":"gpt-4o-mini",
+			"input":[{
+				"type":"message",
+				"role":"user",
+				"content":[{"type":"input_text","text":"hello"}]
+			}]
+		}
+		`
+
+	const output = `
+		{
+			"id": "resp_67890",
+			"object": "response",
+			"created_at": 1741891428,
+			"status": "completed",
+			"model": "gpt-4o-mini-2024-07-18",
+			"output": [
+				{
+					"type": "message",
+					"id": "msg_67d32764fcdc8191bcf2e444d4088804058a5e08c46a181d",
+					"status": "completed",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "output_text",
+							"text": "Hello!",
+							"annotations": []
+						}
+					]
+				}
+			]
+		}
+		`
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := openaiprovider.NewResponsesAgent(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiprovider.AgentConfig{
+			Model:  "gpt-4o-mini",
+			Config: agent.Config{DisableFuncAutoCall: true},
+		},
+	)
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = a.RunText(t.Context(), "hello",
+		agent.WithSession(session),
 		openaiprovider.ResponsesNewParams(responses.ResponseNewParams{Store: openai.Bool(false)}),
 	).Collect()
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "per-run ResponsesNewParams.Store is not supported") {
+	if err != nil {
 		t.Fatalf("error = %v", err)
+	}
+
+	if got := session.ServiceID(); got != "" {
+		t.Errorf("session ServiceID = %q, want empty", got)
 	}
 }
 

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -4432,6 +4432,7 @@ func TestDisableStoreOutputDoesNotUseOrUpdateResponseID(t *testing.T) {
 	const input = `
 						{
 								"store":false,
+								"include":["reasoning.encrypted_content"],
 								"model":"gpt-4o-mini",
 								"input":[{
 										"type":"message",
@@ -4565,6 +4566,7 @@ func TestResponsesNewParamsStoreFalseDoesNotUpdateResponseID(t *testing.T) {
 	const input = `
 		{
 			"store":false,
+			"include":["reasoning.encrypted_content"],
 			"model":"gpt-4o-mini",
 			"input":[{
 				"type":"message",
@@ -4624,6 +4626,59 @@ func TestResponsesNewParamsStoreFalseDoesNotUpdateResponseID(t *testing.T) {
 
 	if got := session.ServiceID(); got != "" {
 		t.Errorf("session ServiceID = %q, want empty", got)
+	}
+}
+
+func TestResponsesNewParamsStoreFalseDoesNotDuplicateReasoningInclude(t *testing.T) {
+	const input = `
+		{
+			"store":false,
+			"include":["reasoning.encrypted_content"],
+			"model":"gpt-4o-mini",
+			"input":[{
+				"type":"message",
+				"role":"user",
+				"content":[{"type":"input_text","text":"hello"}]
+			}]
+		}
+		`
+
+	const output = `
+		{
+			"id": "resp_67890",
+			"object": "response",
+			"created_at": 1741891428,
+			"status": "completed",
+			"model": "gpt-4o-mini-2024-07-18",
+			"output": [{
+				"type": "message",
+				"id": "msg_67d32764fcdc8191bcf2e444d4088804058a5e08c46a181d",
+				"status": "completed",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "Hello!", "annotations": []}]
+			}]
+		}
+		`
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := openaiprovider.NewResponsesAgent(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiprovider.AgentConfig{
+			Model:  "gpt-4o-mini",
+			Config: agent.Config{DisableFuncAutoCall: true},
+		},
+	)
+
+	_, err := a.RunText(t.Context(), "hello",
+		openaiprovider.ResponsesNewParams(responses.ResponseNewParams{
+			Store:   openai.Bool(false),
+			Include: []responses.ResponseIncludable{responses.ResponseIncludableReasoningEncryptedContent},
+		}),
+	).Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
This ports the .NET SDK's stored-output-disabled Responses behavior to Go, so apps that manage their own local history can opt out of service-side Responses output storage in the same way.

The change adds `DisableStoreOutput` to OpenAI and Foundry Responses-backed agent configs, sends `store=false` when enabled, includes `reasoning.encrypted_content` for stateless reasoning continuity, and avoids saving response IDs into sessions that cannot safely continue from non-stored outputs. Per-run `ResponsesNewParams.Store` is also supported and takes precedence over the instance-level `DisableStoreOutput` setting for that run.

It also teaches the Responses provider to replay local assistant messages and function-call history in a Responses-compatible shape while preserving the original assistant content order, then updates the related examples to use local history with output storage disabled.

## Validation
- `go test -count=1 ./provider/openaiprovider ./provider/foundryprovider ./message/messagefilter ./examples/02-agents/agents/step07_3rdparty_session_storage ./examples/02-agents/agents/step17_additional_ai_context ./examples/02-agents/providers/azure/openai_responses`
