### PR TITLE
Avoid argv allocation size overflow

### DIFF
--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -623,13 +624,7 @@ func (s resolvedShell) persistentArgv() ([]string, error) {
 }
 
 func combineArgv(extra, suffix []string) []string {
-	if len(extra) == 0 {
-		return append([]string(nil), suffix...)
-	}
-	combined := make([]string, 0, len(extra)+len(suffix))
-	combined = append(combined, extra...)
-	combined = append(combined, suffix...)
-	return combined
+	return slices.Concat(extra, suffix)
 }
 
 func classifyShellKind(shell string) shellKind {


### PR DESCRIPTION
## Summary
- Replace the overflow-prone `len(extra)+len(suffix)` capacity calculation in shell argv construction with `slices.Concat(extra, suffix)`.
- Preserve the existing copy semantics while avoiding unchecked integer overflow in allocation size computation.

Fixes [Size computation for allocation may overflow · Code scanning alert #1 · microsoft/agent-framework-go](https://github.com/microsoft/agent-framework-go/security/code-scanning/1).

## Validation
- `go test -count=1 ./tool/shelltool`
