### PR TITLE
Add verifyexamples command

### DIFF
--- a/cmd/verifyexamples/README.md
+++ b/cmd/verifyexamples/README.md
@@ -1,0 +1,91 @@
+# Verify Examples
+
+`verifyexamples` runs selected Go examples and verifies their output. It is the Go port of the corresponding .NET example verifier.
+
+The .NET verifier is the reference shape for this command: explicit example sets, category filtering, deterministic substring checks, optional AI verification for nondeterministic output, per-example stdin, environment-based skips, and optional log/CSV/Markdown output.
+
+## Usage
+
+Run from the repository root:
+
+```
+go run ./cmd/verifyexamples
+```
+
+Run specific examples by name:
+
+```
+go run ./cmd/verifyexamples 01_get_started_05_first_workflow 03_workflows_loop
+```
+
+Run a category:
+
+```
+go run ./cmd/verifyexamples --category 01-get-started
+go run ./cmd/verifyexamples --category 02-agents
+go run ./cmd/verifyexamples --category 03-workflows
+```
+
+Useful options:
+
+```
+go run ./cmd/verifyexamples --parallel 16
+go run ./cmd/verifyexamples --log results.log
+go run ./cmd/verifyexamples --csv results.csv
+go run ./cmd/verifyexamples --md results.md
+go run ./cmd/verifyexamples --build
+```
+
+By default, example processes run with `go run -mod=readonly .`. Passing `--build` uses plain `go run .`.
+
+## Security Notice
+
+`verifyexamples` executes example programs from this repository. Review any example before adding it to the registry, especially if it starts servers, opens files, uses shell commands, or calls external services.
+
+Some examples and AI verification use credentials from environment variables. Do not put secrets in example inputs, expected output, logs, CSV/Markdown reports, or committed files. AI verification may send captured stdout/stderr to the configured Foundry model, so examples that print sensitive values should be skipped or rewritten before being registered.
+
+## Verification
+
+Each example definition can include:
+
+- `MustContain`: substrings that must appear in stdout.
+- `MustNotContain`: substrings that must not appear in stdout.
+- `IsDeterministic`: skips AI verification when exact checks are sufficient.
+- `ExpectedOutputDescription`: semantic expectations for AI verification.
+- `Inputs` and `InputDelay`: lines to send to stdin for interactive examples.
+- `RequiredEnvironmentVariables`: missing values skip the example.
+- `OptionalEnvironmentVariables`: missing values also skip when they would cause prompts or nondeterministic hangs.
+- `SkipReason`: structural skip reason for servers, multi-process examples, or external service requirements.
+
+AI verification is enabled when `FOUNDRY_PROJECT_ENDPOINT` is set. `FOUNDRY_MODEL` is optional and defaults to `gpt-4o-mini`.
+
+## Example Registry
+
+All example definitions live in `examples.go`, grouped into these static sets:
+
+- `getStartedExamples`
+- `agentsExamples`
+- `workflowExamples`
+
+`example_sets.go` only contains helper logic for category lookup and `inputLines`. Do not add filesystem discovery for examples; this command should stay aligned with the .NET verifier, where known examples are registered explicitly.
+
+When adding an example:
+
+1. Prefer the matching .NET verifier entry as the behavioral source of truth.
+2. Map it to the closest existing Go example path.
+3. If the Go example has drifted from the .NET scenario, fix the example when practical instead of weakening the verifier expectation.
+4. Use deterministic `MustContain` checks for local or stable examples.
+5. Use `ExpectedOutputDescription` for LLM output, with env gates so examples skip cleanly when credentials are missing.
+6. Avoid registering servers, clients that require separately running servers, or examples that do not terminate.
+
+Run the focused tests after editing the registry:
+
+```
+go test ./cmd/verifyexamples
+```
+
+For runnable local examples, also run a targeted verifier command:
+
+```
+go run ./cmd/verifyexamples <example_name> --parallel 1
+```

--- a/cmd/verifyexamples/example_sets.go
+++ b/cmd/verifyexamples/example_sets.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"slices"
+	"strings"
+)
+
+func allExamples() []ExampleDefinition {
+	var examples []ExampleDefinition
+	for _, category := range availableCategories() {
+		examples = append(examples, exampleSets[category]...)
+	}
+	return examples
+}
+
+func lookupExampleSet(category string) ([]ExampleDefinition, bool) {
+	for name, examples := range exampleSets {
+		if strings.EqualFold(name, category) {
+			return examples, true
+		}
+	}
+	return nil, false
+}
+
+func availableCategories() []string {
+	categories := make([]string, 0, len(exampleSets))
+	for category := range exampleSets {
+		categories = append(categories, category)
+	}
+	slices.Sort(categories)
+	return categories
+}
+
+func inputLines(values ...string) []*string {
+	inputs := make([]*string, 0, len(values))
+	for _, value := range values {
+		value := value
+		inputs = append(inputs, &value)
+	}
+	return inputs
+}

--- a/cmd/verifyexamples/example_sets_test.go
+++ b/cmd/verifyexamples/example_sets_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExampleDefinitionsHaveUniqueNamesAndExistingPaths(t *testing.T) {
+	repoRoot, err := resolveRepoRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]string{}
+	for _, example := range allExamples() {
+		if example.Name == "" {
+			t.Fatalf("example with path %q has empty name", example.ProjectPath)
+		}
+		if previousPath, ok := seen[example.Name]; ok {
+			t.Fatalf("example name %q is duplicated for %q and %q", example.Name, previousPath, example.ProjectPath)
+		}
+		seen[example.Name] = example.ProjectPath
+		if example.ProjectPath == "" {
+			t.Fatalf("example %q has empty project path", example.Name)
+		}
+		path := filepath.Join(repoRoot, filepath.FromSlash(example.ProjectPath))
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			t.Fatalf("example %q project path %q is not an existing directory", example.Name, example.ProjectPath)
+		}
+		if example.SkipReason == "" {
+			goFiles, err := filepath.Glob(filepath.Join(path, "*.go"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(goFiles) == 0 {
+				t.Fatalf("example %q project path %q has no Go files and is not skipped", example.Name, example.ProjectPath)
+			}
+		}
+	}
+}

--- a/cmd/verifyexamples/examples.go
+++ b/cmd/verifyexamples/examples.go
@@ -1,0 +1,867 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import "time"
+
+var exampleSets = map[string][]ExampleDefinition{
+	"01-get-started": getStartedExamples,
+	"02-agents":      agentsExamples,
+	"03-workflows":   workflowExamples,
+}
+
+var getStartedExamples = []ExampleDefinition{
+	{
+		Name:                         "01_get_started_01_hello_agent",
+		ProjectPath:                  "examples/01-get-started/01_hello_agent",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"There should be two separate joke responses — one from a non-streaming call and one from a streaming call.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "01_get_started_02_add_tools",
+		ProjectPath:                  "examples/01-get-started/02_add_tools",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain information about the weather in Amsterdam.",
+			"The response should mention that it is cloudy with a high of 15°C (or equivalent), since this comes from a tool that returns a canned response.",
+			"There should be two responses — one from a non-streaming call and one from a streaming call.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "01_get_started_03_multi_turn",
+		ProjectPath:                  "examples/01-get-started/03_multi_turn",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"After the initial joke, there should be a modified version that includes emojis and is told in the voice of a pirate's parrot.",
+			"The pattern repeats: first a non-streaming pirate joke + parrot version, then a streaming pirate joke + parrot version.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "01_get_started_04_memory",
+		ProjectPath:                  "examples/01-get-started/04_memory",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain: []string{
+			">> Use session with blank memory",
+			">> Use deserialized session with previously created memories",
+			">> Read memories using memory component",
+			"MEMORY - User Name:",
+			"MEMORY - User Age:",
+			">> Use new session with previously created memories",
+		},
+		ExpectedOutputDescription: []string{
+			"In the blank-memory section, the agent should respond to the user's messages and may ask for missing name or age details.",
+			"After the session is serialized and deserialized, the agent should recall the user's name and age.",
+			"The memory readout should include the captured user name and age.",
+			"In the new-session section, the agent should know the user's name and age from the transferred memory.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:            "01_get_started_05_first_workflow",
+		ProjectPath:     "examples/01-get-started/05_first_workflow",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Input: \"Hello, World!\"",
+			"UppercaseExecutor: HELLO, WORLD!",
+			"ReverseExecutor: !DLROW ,OLLEH",
+		},
+	},
+}
+
+var agentsExamples = []ExampleDefinition{
+	{
+		Name:                         "02_agents_agents_step01_running",
+		ProjectPath:                  "examples/02-agents/agents/step01_running",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain two separate joke responses about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step02_multiturn_conversation",
+		ProjectPath:                  "examples/02-agents/agents/step02_multiturn_conversation",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a pirate joke and a later version in a pirate parrot voice with emojis.",
+			"The pattern should appear for both non-streaming and streaming turns.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step03_using_function_tools",
+		ProjectPath:                  "examples/02-agents/agents/step03_using_function_tools",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain information about the weather in Amsterdam.",
+			"The response should mention that it is cloudy with a high of 15°C (or equivalent), since this comes from a tool that returns a canned response.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step04_using_function_tools_with_approvals",
+		ProjectPath:                  "examples/02-agents/agents/step04_using_function_tools_with_approvals",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		Inputs:                       inputLines("Y"),
+		InputDelay:                   5 * time.Second,
+		ExpectedOutputDescription: []string{
+			"The output should show a tool approval request for the weather function.",
+			"After approval, the agent should answer with the weather in Amsterdam.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step05_structured_output",
+		ProjectPath:                  "examples/02-agents/agents/step05_structured_output",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain: []string{
+			"Structured Output:",
+			"Name:",
+			"Age:",
+			"Occupation:",
+		},
+		ExpectedOutputDescription: []string{
+			"The output should show structured person information for John Smith.",
+			"The structured output should include name, age, and occupation fields.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step06_persisted_conversation",
+		ProjectPath:                  "examples/02-agents/agents/step06_persisted_conversation",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should start with a joke about a pirate.",
+			"After serializing and loading the session, the second response should retell the same joke in a pirate voice with emojis, demonstrating preserved context.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step07_3rdparty_session_storage",
+		ProjectPath:                  "examples/02-agents/agents/step07_3rdparty_session_storage",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain:                  []string{"--- Serialized session ---"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a pirate joke response and a serialized session JSON block.",
+			"The second response should use the persisted third-party history to continue the earlier conversation.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step08_observability",
+		ProjectPath:                  "examples/02-agents/agents/step08_observability",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke response from the agent and observability trace output.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step09_dependency_injection",
+		ProjectPath:                  "examples/02-agents/agents/step09_dependency_injection",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Example is currently a TODO placeholder and produces no output.",
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step10_as_mcp_tool",
+		ProjectPath:                  "examples/02-agents/agents/step10_as_mcp_tool",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Runs as an MCP stdio server that does not exit on its own.",
+	},
+	{
+		Name:                         "02_agents_agents_step11_using_images",
+		ProjectPath:                  "examples/02-agents/agents/step11_using_images",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should describe an image of a nature boardwalk or walkway scene.",
+			"It should mention elements like a wooden boardwalk or path, greenery or vegetation, and an outdoor natural setting.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step12_as_function_tool",
+		ProjectPath:                  "examples/02-agents/agents/step12_as_function_tool",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should be a response about the weather in Amsterdam, written in French.",
+			"The response should reference the tool result: cloudy weather with a high of 15°C.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step17_additional_ai_context",
+		ProjectPath:                  "examples/02-agents/agents/step17_additional_ai_context",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show a personal assistant managing a todo list across multiple turns.",
+			"The assistant should acknowledge adding items like picking up milk, taking Sally to soccer practice, and making a dentist appointment for Jimmy.",
+			"There should be a JSON block showing the serialized session state.",
+			"The final response should reference the calendar appointments (doctor at 15:00, team meeting at 17:00, birthday party at 20:00).",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step18_compaction_pipeline",
+		ProjectPath:                  "examples/02-agents/agents/step18_compaction_pipeline",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show a turn-by-turn shopping conversation with user prompts and assistant replies.",
+			"The output may include message-count lines showing chat history compaction.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_agents_step22_foundry_memory",
+		ProjectPath:                  "examples/02-agents/agents/step22_foundry_memory",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL", "AZURE_AI_MEMORY_STORE_ID", "AZURE_AI_EMBEDDING_DEPLOYMENT_NAME"},
+		MustContain: []string{
+			"Foundry Memory",
+		},
+		ExpectedOutputDescription: []string{
+			"The output should show Foundry memory being used across multiple agent sessions.",
+			"The later response should recall facts from the earlier conversation using shared Foundry memory.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_azure_openai_chat_completion",
+		ProjectPath:                  "examples/02-agents/providers/azure/openai_chat_completion",
+		RequiredEnvironmentVariables: []string{"AZURE_OPENAI_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"AZURE_OPENAI_DEPLOYMENT_NAME"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_azure_openai_responses",
+		ProjectPath:                  "examples/02-agents/providers/azure/openai_responses",
+		RequiredEnvironmentVariables: []string{"AZURE_OPENAI_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"AZURE_OPENAI_DEPLOYMENT_NAME"},
+		ExpectedOutputDescription: []string{
+			"The output should contain two separate joke responses about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_azure_ai_project",
+		ProjectPath:                  "examples/02-agents/providers/azure/ai_project",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate from a Foundry project-backed agent.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_azure_foundry_model",
+		ProjectPath:                  "examples/02-agents/providers/azure/foundry_model",
+		RequiredEnvironmentVariables: []string{"AZURE_OPENAI_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"AZURE_OPENAI_DEPLOYMENT_NAME", "FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step01_basic",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step01_basic",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke response from the Foundry-backed agent.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step02_1_multiturn",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step02_1_multiturn",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a pirate joke and a follow-up cat-and-dog joke that uses the earlier joke as an anchor.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step02_2_multiturn_with_server_conversations",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step02_2_multiturn_with_server_conversations",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain multiple joke responses showing a multi-turn server-managed conversation.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step03_function_tools",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step03_function_tools",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain information about the weather in Amsterdam.",
+			"The response should reference cloudy weather with a high of 15 degrees Celsius from the tool result.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step04_function_tools_with_approvals",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step04_function_tools_with_approvals",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		Inputs:                       inputLines("Y", "Y", "Y"),
+		InputDelay:                   3 * time.Second,
+		ExpectedOutputDescription: []string{
+			"The output should contain a prompt asking the user to approve a tool call, followed by weather information about Amsterdam.",
+			"The response should mention cloudy weather with a high of 15°C.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step05_structured_output",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step05_structured_output",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain:                  []string{"Structured Output:", "Name:", "Age:", "Occupation:"},
+		ExpectedOutputDescription: []string{
+			"The output should show structured person information with name, age, and occupation fields.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step06_persisted_conversations",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step06_persisted_conversations",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a pirate joke followed by a follow-up response after session serialization and deserialization.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step07_observability",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step07_observability",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke response from the agent and observability trace output.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step09_mcp_client_as_tools",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step09_mcp_client_as_tools",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show an agent using Microsoft Learn MCP tools to search or retrieve documentation.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step10_images",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step10_images",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should describe an image of a nature walkway or boardwalk scene.",
+			"It should mention elements like a wooden path, greenery, and an outdoor setting.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step11_as_function_tool",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step11_as_function_tool",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should be a response about the weather in Amsterdam, written in French.",
+			"The response should reference the tool result: cloudy weather with a high of 15°C.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step12_middleware",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step12_middleware",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain multiple middleware examples or demonstrate middleware intercepting a harmful request before a normal agent response.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step13_plugins",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step13_plugins",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain information about both the current time and the weather in Seattle.",
+			"The weather information should be similar to: cloudy with a high of 15°C. Exact phrasing may vary.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step14_code_interpreter",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step14_code_interpreter",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show the code interpreter being used to solve sin(x) + x^2 = 42.",
+			"It may show computed answers, code, or annotations with file references.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step18_bing_custom_search",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step18_bing_custom_search",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT", "AZURE_AI_CUSTOM_SEARCH_CONNECTION_ID", "AZURE_AI_CUSTOM_SEARCH_INSTANCE_NAME"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Requires Bing Custom Search connection.",
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step19_sharepoint",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step19_sharepoint",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT", "SHAREPOINT_PROJECT_CONNECTION_ID"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Requires SharePoint connection.",
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step20_microsoft_fabric",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step20_microsoft_fabric",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT", "FABRIC_PROJECT_CONNECTION_ID"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Requires Microsoft Fabric connection.",
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step21_web_search",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step21_web_search",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show an agent using web search to answer a question, with response text and citation annotations.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_foundry_step23_local_mcp",
+		ProjectPath:                  "examples/02-agents/providers/foundry/step23_local_mcp",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show an agent using the Microsoft Learn MCP server to search for documentation and provide a response.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_openai",
+		ProjectPath:                  "examples/02-agents/providers/openai",
+		RequiredEnvironmentVariables: []string{"OPENAI_API_KEY"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_gemini",
+		ProjectPath:                  "examples/02-agents/providers/gemini",
+		RequiredEnvironmentVariables: []string{"GEMINI_API_KEY"},
+		OptionalEnvironmentVariables: []string{"GEMINI_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_providers_anthropic",
+		ProjectPath:                  "examples/02-agents/providers/anthrophic",
+		RequiredEnvironmentVariables: []string{"ANTHROPIC_API_KEY"},
+		ExpectedOutputDescription: []string{
+			"The output should contain a joke about a pirate.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:        "02_agents_a2a_as_function_tools",
+		ProjectPath: "examples/02-agents/a2a/as_function_tools",
+		SkipReason:  "Requires a running A2A example server.",
+	},
+	{
+		Name:        "02_agents_a2a_polling_for_task_completion",
+		ProjectPath: "examples/02-agents/a2a/polling_for_task_completion",
+		SkipReason:  "Requires a running A2A example server.",
+	},
+	{
+		Name:        "02_agents_a2a_protocol_selection",
+		ProjectPath: "examples/02-agents/a2a/protocol_selection",
+		SkipReason:  "Requires a running A2A example server.",
+	},
+	{
+		Name:        "02_agents_a2a_stream_reconnection",
+		ProjectPath: "examples/02-agents/a2a/stream_reconnection",
+		SkipReason:  "Requires a running A2A example server.",
+	},
+	{
+		Name:        "02_agents_providers_a2a",
+		ProjectPath: "examples/02-agents/providers/a2a",
+		SkipReason:  "Requires a running A2A example server.",
+	},
+	{
+		Name:        "02_agents_agui_step01_getting_started_client",
+		ProjectPath: "examples/02-agents/agui/step01_getting_started/client",
+		SkipReason:  "Requires a running AGUI example server.",
+	},
+	{
+		Name:                         "02_agents_agui_step01_getting_started_server",
+		ProjectPath:                  "examples/02-agents/agui/step01_getting_started/server",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Starts an AGUI web server that does not exit.",
+	},
+	{
+		Name:        "02_agents_agui_step02_backend_tools_client",
+		ProjectPath: "examples/02-agents/agui/step02_backend_tools/client",
+		SkipReason:  "Requires a running AGUI example server.",
+	},
+	{
+		Name:                         "02_agents_agui_step02_backend_tools_server",
+		ProjectPath:                  "examples/02-agents/agui/step02_backend_tools/server",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Starts an AGUI web server that does not exit.",
+	},
+	{
+		Name:        "02_agents_agui_step03_frontend_tools_client",
+		ProjectPath: "examples/02-agents/agui/step03_frontend_tools/client",
+		SkipReason:  "Requires a running AGUI example server.",
+	},
+	{
+		Name:                         "02_agents_agui_step03_frontend_tools_server",
+		ProjectPath:                  "examples/02-agents/agui/step03_frontend_tools/server",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Starts an AGUI web server that does not exit.",
+	},
+	{
+		Name:        "02_agents_agui_step04_human_in_loop_client",
+		ProjectPath: "examples/02-agents/agui/step04_human_in_loop/client",
+		SkipReason:  "Requires a running AGUI example server.",
+	},
+	{
+		Name:                         "02_agents_agui_step04_human_in_loop_server",
+		ProjectPath:                  "examples/02-agents/agui/step04_human_in_loop/server",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Starts an AGUI web server that does not exit.",
+	},
+	{
+		Name:        "02_agents_agui_step05_state_management_client",
+		ProjectPath: "examples/02-agents/agui/step05_state_management/client",
+		SkipReason:  "Requires a running AGUI example server.",
+	},
+	{
+		Name:                         "02_agents_agui_step05_state_management_server",
+		ProjectPath:                  "examples/02-agents/agui/step05_state_management/server",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Starts an AGUI web server that does not exit.",
+	},
+	{
+		Name:                         "02_agents_mcp_agent_mcp_server",
+		ProjectPath:                  "examples/02-agents/mcp/agent_mcp_server",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Starts an MCP server that does not exit.",
+	},
+	{
+		Name:        "02_agents_providers_github_copilot",
+		ProjectPath: "examples/02-agents/providers/github-copilot",
+		Inputs:      inputLines("Y", "Y", "Y"),
+		InputDelay:  3 * time.Second,
+		ExpectedOutputDescription: []string{
+			"The output should contain a response listing files in the current directory.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_skills_step01_file_based_skills",
+		ProjectPath:                  "examples/02-agents/skills/step01_file_based_skills",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain:                  []string{"File-Based Skills"},
+		ExpectedOutputDescription: []string{
+			"The output should show the agent converting 26.2 miles to kilometers and 75 kilograms to pounds.",
+			"The response should contain approximate numeric values for both conversions.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_skills_step02_code_defined_skills",
+		ProjectPath:                  "examples/02-agents/skills/step02_code_defined_skills",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain:                  []string{"Code-Defined Skills"},
+		ExpectedOutputDescription: []string{
+			"The output should show the agent converting 26.2 miles to kilometers and 75 kilograms to pounds.",
+			"The response should contain approximate numeric values for both conversions.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "02_agents_skills_step03_mixed_skills",
+		ProjectPath:                  "examples/02-agents/skills/step03_mixed_skills",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show the agent using mixed file-based and code-defined skills.",
+			"The response should include useful unit conversion results.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+}
+
+var workflowExamples = []ExampleDefinition{
+	{
+		Name:            "03_workflows_01_start_here_01_streaming",
+		ProjectPath:     "examples/03-workflows/01-start-here/01_streaming",
+		IsDeterministic: true,
+		MustContain: []string{
+			"UppercaseExecutor",
+			"ReverseTextExecutor: !DLROW ,OLLEH",
+		},
+	},
+	{
+		Name:                         "03_workflows_01_start_here_02_agents_in_workflows",
+		ProjectPath:                  "examples/03-workflows/01-start-here/02_agents_in_workflows",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show agent responses from a translation workflow.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "03_workflows_01_start_here_03_agent_workflow_patterns",
+		ProjectPath:                  "examples/03-workflows/01-start-here/03_agent_workflow_patterns",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		Inputs:                       inputLines("sequential"),
+		InputDelay:                   3 * time.Second,
+		ExpectedOutputDescription: []string{
+			"The output should show a sequential workflow pattern with multiple agents executing tasks in order.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "03_workflows_01_start_here_04_multi_model_service",
+		ProjectPath:                  "examples/03-workflows/01-start-here/04_multi_model_service",
+		RequiredEnvironmentVariables: []string{"BEDROCK_ACCESS_KEY", "BEDROCK_SECRET_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"},
+		SkipReason:                   "Requires multiple external provider API keys (Bedrock, Anthropic, OpenAI).",
+	},
+	{
+		Name:            "03_workflows_01_start_here_05_subworkflow",
+		ProjectPath:     "examples/03-workflows/01-start-here/05_subworkflow",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Building subworkflow: Uppercase -> Reverse -> Append Suffix",
+			"Building parent workflow: Prefix -> SubWorkflow -> PostProcess",
+			"Final output:",
+		},
+	},
+	{
+		Name:                         "03_workflows_01_start_here_06_mixed_workflow_agents_and_executors",
+		ProjectPath:                  "examples/03-workflows/01-start-here/06_mixed_workflow_agents_and_executors",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		Inputs:                       inputLines("What is 2 plus 2?"),
+		InputDelay:                   3 * time.Second,
+		ExpectedOutputDescription: []string{
+			"The output should show agents and executors working together to process a user question.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "03_workflows_01_start_here_07_writer_critic_workflow",
+		ProjectPath:                  "examples/03-workflows/01-start-here/07_writer_critic_workflow",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain:                  []string{"Writer Critic Workflow"},
+		ExpectedOutputDescription: []string{
+			"The output should show a writer-critic iteration workflow with writer and critic sections.",
+			"The critic should either approve or request revisions.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "03_workflows_agents_custom_agent_executors",
+		ProjectPath:                  "examples/03-workflows/agents/custom_agent_executors",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show custom workflow events including slogan generation and feedback.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "03_workflows_agents_group_chat_tool_approval",
+		ProjectPath:                  "examples/03-workflows/agents/group_chat_tool_approval",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain:                  []string{"Starting group chat workflow for software deployment..."},
+		ExpectedOutputDescription: []string{
+			"The output should show a group chat workflow with QA and DevOps agents for software deployment.",
+			"There should be approval requests for tool calls.",
+			"The workflow should show interaction between QA and DevOps agents toward deployment.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:                         "03_workflows_agents_workflow_as_an_agent",
+		ProjectPath:                  "examples/03-workflows/agents/workflow_as_an_agent",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show a conversational workflow responding to user questions about city park design.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:            "03_workflows_checkpoint_checkpoint_and_rehydrate",
+		ProjectPath:     "examples/03-workflows/checkpoint/checkpoint_and_rehydrate",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Workflow completed with result:",
+			"Number of checkpoints created:",
+			"Hydrating a new workflow instance from the 6th checkpoint.",
+		},
+	},
+	{
+		Name:            "03_workflows_checkpoint_checkpoint_and_resume",
+		ProjectPath:     "examples/03-workflows/checkpoint/checkpoint_and_resume",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Workflow completed with result:",
+			"Number of checkpoints created:",
+			"Restoring from the 6th checkpoint.",
+		},
+	},
+	{
+		Name:        "03_workflows_checkpoint_checkpoint_with_human_in_the_loop",
+		ProjectPath: "examples/03-workflows/checkpoint/checkpoint_with_human_in_the_loop",
+		Inputs:      inputLines("50", "25", "40", "45", "42", "50", "25", "40", "45", "42"),
+		InputDelay:  time.Second,
+		MustContain: []string{
+			"Workflow completed with result:",
+			"Number of checkpoints created:",
+			"Restored run completed with result:",
+		},
+		ExpectedOutputDescription: []string{
+			"The output should show a number guessing workflow with higher/lower hints that eventually reaches the correct number.",
+			"The output should demonstrate checkpoint save and restore behavior.",
+		},
+	},
+	{
+		Name:        "03_workflows_concurrent_map_reduce",
+		ProjectPath: "examples/03-workflows/concurrent/map_reduce",
+		MustContain: []string{"Map Reduce Workflow", "reduced_results_reduce_executor_"},
+	},
+	{
+		Name:                         "03_workflows_concurrent_concurrent",
+		ProjectPath:                  "examples/03-workflows/concurrent/concurrent",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		ExpectedOutputDescription: []string{
+			"The output should show results from concurrent agent processing.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
+		Name:            "03_workflows_conditional_edges_01_edge_condition",
+		ProjectPath:     "examples/03-workflows/conditional-edges/01_edge_condition",
+		IsDeterministic: true,
+		MustContain:     []string{"Email marked as spam: matched suspicious wording"},
+	},
+	{
+		Name:            "03_workflows_conditional_edges_02_switch_case",
+		ProjectPath:     "examples/03-workflows/conditional-edges/02_switch_case",
+		IsDeterministic: true,
+		MustContain:     []string{"Email queued for review: needs manual invoice review"},
+	},
+	{
+		Name:            "03_workflows_conditional_edges_03_multi_selection",
+		ProjectPath:     "examples/03-workflows/conditional-edges/03_multi_selection",
+		IsDeterministic: true,
+		MustContain:     []string{"Email sent:", "Logged: Summary:"},
+	},
+	{
+		Name:        "03_workflows_human_in_the_loop_human_in_the_loop_basic",
+		ProjectPath: "examples/03-workflows/human-in-the-loop/human_in_the_loop_basic",
+		Inputs:      inputLines("50", "25", "40", "45", "42"),
+		InputDelay:  time.Second,
+		MustContain: []string{"found in"},
+		ExpectedOutputDescription: []string{
+			"The output should show a number guessing game with higher/lower hints that eventually reaches the correct number 42.",
+		},
+	},
+	{
+		Name:        "03_workflows_loop",
+		ProjectPath: "examples/03-workflows/loop",
+		MustContain: []string{"found in"},
+	},
+	{
+		Name:            "03_workflows_shared_states",
+		ProjectPath:     "examples/03-workflows/shared-states",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Total Paragraphs:",
+			"Total Words:",
+		},
+	},
+	{
+		Name:                         "03_workflows_observability_workflow_as_an_agent",
+		ProjectPath:                  "examples/03-workflows/observability/workflow_as_an_agent",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Interactive console with ReadLine loop; requires OTLP endpoint.",
+	},
+	{
+		Name:            "03_workflows_subworkflows_nested_order_processing",
+		ProjectPath:     "examples/03-workflows/subworkflows/nested_order_processing",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Nested Sub-Workflows",
+			"Starting order processing",
+			"Order completed:",
+		},
+	},
+}

--- a/cmd/verifyexamples/main.go
+++ b/cmd/verifyexamples/main.go
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This tool runs the examples under examples/ and verifies their output.
+// Deterministic examples are verified with exact string matching.
+// Non-deterministic LLM examples are verified using an agent-framework agent when FOUNDRY_PROJECT_ENDPOINT is set.
+//
+// Usage:
+//   go run ./cmd/verifyexamples                                      # Run all examples
+//   go run ./cmd/verifyexamples 01_get_started_05_first_workflow     # Run a specific example by name
+//   go run ./cmd/verifyexamples --category 01-get-started            # Run one category
+//   go run ./cmd/verifyexamples --parallel 16                        # Run up to 16 examples concurrently
+//   go run ./cmd/verifyexamples --log results.log                    # Write sequential log to file
+//   go run ./cmd/verifyexamples --csv results.csv                    # Write CSV summary to file
+//   go run ./cmd/verifyexamples --md results.md                      # Write Markdown summary to file
+//   go run ./cmd/verifyexamples --build                              # Allow normal module writes during go run
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/provider/foundryprovider"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	start := time.Now()
+	repoRoot, err := resolveRepoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	options, ok := parseOptions(args, os.Stderr)
+	if !ok {
+		return 1
+	}
+
+	foundryEndpoint := os.Getenv("FOUNDRY_PROJECT_ENDPOINT")
+	foundryModel := os.Getenv("FOUNDRY_MODEL")
+	if foundryModel == "" {
+		foundryModel = "gpt-4o-mini"
+	}
+
+	var verifierAgent semanticVerifier
+	if foundryEndpoint != "" {
+		credential, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create verifier credential: %v\n", err)
+			return 1
+		}
+		verifierAgent = foundryprovider.NewAgent(
+			foundryEndpoint,
+			credential,
+			foundryprovider.ModelDeployment(foundryModel),
+			foundryprovider.AgentConfig{
+				Instructions: verifierInstructions,
+				Config: agent.Config{
+					Name: "OutputVerifier",
+				},
+			},
+		)
+	}
+
+	var logWriter *LogFileWriter
+	if options.LogFilePath != "" {
+		logWriter = NewLogFileWriter(options.LogFilePath)
+		if err := logWriter.WriteHeader(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+	}
+
+	reporter := NewConsoleReporter(os.Stdout)
+	fmt.Printf("Foundry endpoint: %s, Model: %s\n", displayEnv(foundryEndpoint), foundryModel)
+	orchestrator := VerificationOrchestrator{
+		verifier:      ExampleVerifier{verifierAgent: verifierAgent},
+		reporter:      reporter,
+		logWriter:     logWriter,
+		repoRoot:      repoRoot,
+		timeout:       3 * time.Minute,
+		buildExamples: options.BuildExamples,
+	}
+	run := orchestrator.RunAll(context.Background(), options.Examples, options.MaxParallelism)
+	elapsed := time.Since(start)
+	ordered := orderedResults(run)
+	reporter.PrintSummary(ordered, run.Skipped, elapsed)
+
+	if logWriter != nil {
+		if err := logWriter.WriteSummary(ordered, run.Skipped, elapsed); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Printf("Log written to: %s\n", options.LogFilePath)
+	}
+	if options.CsvFilePath != "" {
+		if err := writeCSV(options.CsvFilePath, ordered, run.Skipped, options.Examples); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Printf("CSV written to: %s\n", options.CsvFilePath)
+	}
+	if options.MarkdownFilePath != "" {
+		if err := writeMarkdown(options.MarkdownFilePath, ordered, run.Skipped, elapsed); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Printf("Markdown written to: %s\n", options.MarkdownFilePath)
+	}
+
+	for _, result := range ordered {
+		if !result.Passed {
+			return 1
+		}
+	}
+	return 0
+}
+
+func resolveRepoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find repository root from %s", wd)
+		}
+	}
+}
+
+func displayEnv(value string) string {
+	if value == "" {
+		return "(not set - AI verification disabled)"
+	}
+	return value
+}
+
+const verifierInstructions = `You are a test output verifier. You will be given:
+1. The actual stdout output of a program
+2. The stderr output, if any
+3. A list of expectations about what the output should contain or demonstrate
+
+Determine whether the actual output satisfies each expectation. Be reasonable: output from an LLM will not match exact wording, but the semantic intent should be clearly satisfied.
+
+In your response, return JSON with:
+- ai_reasoning: a brief overall assessment
+- expectation_results: exactly one entry for each expectation, in the same order
+- each entry must echo the expectation text and include detail citing evidence from the output`

--- a/cmd/verifyexamples/options.go
+++ b/cmd/verifyexamples/options.go
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+type VerifyOptions struct {
+	MaxParallelism   int
+	CsvFilePath      string
+	MarkdownFilePath string
+	LogFilePath      string
+	BuildExamples    bool
+	Examples         []ExampleDefinition
+}
+
+func parseOptions(args []string, stderr io.Writer) (VerifyOptions, bool) {
+	argList := slices.Clone(args)
+	categoryFilter, ok := extractArg(&argList, "--category", stderr)
+	if !ok {
+		return VerifyOptions{}, false
+	}
+	logFilePath, ok := extractArg(&argList, "--log", stderr)
+	if !ok {
+		return VerifyOptions{}, false
+	}
+	csvFilePath, ok := extractArg(&argList, "--csv", stderr)
+	if !ok {
+		return VerifyOptions{}, false
+	}
+	markdownFilePath, ok := extractArg(&argList, "--md", stderr)
+	if !ok {
+		return VerifyOptions{}, false
+	}
+	buildExamples := extractFlag(&argList, "--build")
+
+	maxParallelism := 8
+	parallelArg, ok := extractArg(&argList, "--parallel", stderr)
+	if !ok {
+		return VerifyOptions{}, false
+	}
+	if parallelArg != "" {
+		p, err := strconv.Atoi(parallelArg)
+		if err != nil || p <= 0 {
+			fmt.Fprintf(stderr, "Invalid value for --parallel: %s.\n", parallelArg)
+			return VerifyOptions{}, false
+		}
+		maxParallelism = p
+	}
+
+	var examples []ExampleDefinition
+	if categoryFilter != "" {
+		categoryList, ok := lookupExampleSet(categoryFilter)
+		if !ok {
+			fmt.Fprintf(stderr, "Unknown category %q. Available: %s\n", categoryFilter, strings.Join(availableCategories(), ", "))
+			return VerifyOptions{}, false
+		}
+		examples = categoryList
+	} else {
+		examples = allExamples()
+	}
+
+	if len(argList) > 0 {
+		nameFilter := make(map[string]bool, len(argList))
+		for _, name := range argList {
+			nameFilter[strings.ToLower(name)] = true
+		}
+
+		var filtered []ExampleDefinition
+		for _, example := range examples {
+			if nameFilter[strings.ToLower(example.Name)] {
+				filtered = append(filtered, example)
+			}
+		}
+		examples = filtered
+	}
+
+	if len(examples) == 0 {
+		var names []string
+		for _, example := range allExamples() {
+			names = append(names, example.Name)
+		}
+		fmt.Fprintf(stderr, "No matching examples found. Available: %s\n", strings.Join(names, ", "))
+		return VerifyOptions{}, false
+	}
+
+	return VerifyOptions{
+		MaxParallelism:   maxParallelism,
+		CsvFilePath:      csvFilePath,
+		MarkdownFilePath: markdownFilePath,
+		LogFilePath:      logFilePath,
+		BuildExamples:    buildExamples,
+		Examples:         examples,
+	}, true
+}
+
+func extractArg(args *[]string, flag string, stderr io.Writer) (string, bool) {
+	for i, arg := range *args {
+		if arg != flag {
+			continue
+		}
+		if i+1 >= len(*args) {
+			fmt.Fprintf(stderr, "Missing value for %s.\n", flag)
+			*args = append((*args)[:i], (*args)[i+1:]...)
+			return "", false
+		}
+		value := (*args)[i+1]
+		*args = append((*args)[:i], (*args)[i+2:]...)
+		return value, true
+	}
+	return "", true
+}
+
+func extractFlag(args *[]string, flag string) bool {
+	for i, arg := range *args {
+		if arg == flag {
+			*args = append((*args)[:i], (*args)[i+1:]...)
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/verifyexamples/options_test.go
+++ b/cmd/verifyexamples/options_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseOptionsFiltersCategoryAndNames(t *testing.T) {
+	var stderr bytes.Buffer
+	options, ok := parseOptions([]string{"--category", "01-get-started", "01_get_started_05_first_workflow", "--parallel", "2", "--build"}, &stderr)
+	if !ok {
+		t.Fatalf("parseOptions failed: %s", stderr.String())
+	}
+	if options.MaxParallelism != 2 {
+		t.Fatalf("MaxParallelism = %d, want 2", options.MaxParallelism)
+	}
+	if !options.BuildExamples {
+		t.Fatal("BuildExamples = false, want true")
+	}
+	if len(options.Examples) != 1 || options.Examples[0].Name != "01_get_started_05_first_workflow" {
+		t.Fatalf("Examples = %#v, want only first workflow", options.Examples)
+	}
+}
+
+func TestParseOptionsRejectsMissingFlagValue(t *testing.T) {
+	var stderr bytes.Buffer
+	_, ok := parseOptions([]string{"--csv"}, &stderr)
+	if ok {
+		t.Fatal("parseOptions succeeded, want failure")
+	}
+	if stderr.String() == "" {
+		t.Fatal("stderr is empty")
+	}
+}

--- a/cmd/verifyexamples/orchestrator.go
+++ b/cmd/verifyexamples/orchestrator.go
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type VerificationOrchestrator struct {
+	verifier      ExampleVerifier
+	reporter      *ConsoleReporter
+	logWriter     *LogFileWriter
+	repoRoot      string
+	timeout       time.Duration
+	buildExamples bool
+}
+
+func (o VerificationOrchestrator) RunAll(ctx context.Context, examples []ExampleDefinition, maxParallelism int) RunAllResult {
+	var skipped []SkippedExample
+	var runnable []ExampleDefinition
+	var exampleOrder []string
+
+	for _, example := range examples {
+		exampleOrder = append(exampleOrder, example.Name)
+		if example.SkipReason != "" {
+			skipped = append(skipped, SkippedExample{Name: example.Name, Reason: example.SkipReason})
+			o.reporter.WriteLineWithPrefix(example.Name, "SKIPPED — "+example.SkipReason)
+			if o.logWriter != nil {
+				_ = o.logWriter.WriteSkipped(example.Name, example.SkipReason)
+			}
+			continue
+		}
+		if reason := missingEnvironmentReason(example); reason != "" {
+			skipped = append(skipped, SkippedExample{Name: example.Name, Reason: reason})
+			o.reporter.WriteLineWithPrefix(example.Name, "SKIPPED — "+reason)
+			if o.logWriter != nil {
+				_ = o.logWriter.WriteSkipped(example.Name, reason)
+			}
+			continue
+		}
+		runnable = append(runnable, example)
+	}
+
+	o.reporter.WriteLineWithPrefix("runner", fmt.Sprintf("Running %d examples (max %d parallel)...", len(runnable), maxParallelism))
+	results := make(map[string]VerificationResult)
+	var resultsLock sync.Mutex
+	semaphore := make(chan struct{}, maxParallelism)
+	var wg sync.WaitGroup
+	for _, example := range runnable {
+		example := example
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+			result := o.runSingle(ctx, example)
+			resultsLock.Lock()
+			results[example.Name] = result
+			resultsLock.Unlock()
+		}()
+	}
+	wg.Wait()
+	return RunAllResult{Results: results, Skipped: skipped, ExampleOrder: exampleOrder}
+}
+
+func (o VerificationOrchestrator) runSingle(ctx context.Context, example ExampleDefinition) VerificationResult {
+	logLines := []string{fmt.Sprintf("[%s] Running...", example.Name)}
+	o.reporter.WriteLineWithPrefix(example.Name, "Running...")
+	projectPath := filepath.Join(o.repoRoot, filepath.FromSlash(example.ProjectPath))
+	run := runExample(ctx, projectPath, o.timeout, o.buildExamples, example.Inputs, example.InputDelay)
+
+	completed := fmt.Sprintf("Completed (%.1fs, exit=%d). Verifying...", run.Elapsed.Seconds(), run.ExitCode)
+	logLines = append(logLines, fmt.Sprintf("[%s] %s", example.Name, completed))
+	o.reporter.WriteLineWithPrefix(example.Name, completed)
+
+	result := o.verifier.Verify(ctx, example, run)
+	if result.Passed {
+		logLines = append(logLines, fmt.Sprintf("[%s] PASSED", example.Name))
+		o.reporter.WriteLineWithPrefix(example.Name, "PASSED")
+	} else {
+		logLines = append(logLines, fmt.Sprintf("[%s] FAILED", example.Name))
+		o.reporter.WriteLineWithPrefix(example.Name, "FAILED")
+		for _, failure := range result.Failures {
+			line := "  ✗ " + failure
+			logLines = append(logLines, fmt.Sprintf("[%s] %s", example.Name, line))
+			o.reporter.WriteLineWithPrefix(example.Name, line)
+		}
+	}
+	if result.AIReasoning != "" {
+		line := "  AI: " + truncate(result.AIReasoning, 300)
+		logLines = append(logLines, fmt.Sprintf("[%s] %s", example.Name, line))
+		o.reporter.WriteLineWithPrefix(example.Name, line)
+	}
+	result.Stdout = run.Stdout
+	result.Stderr = run.Stderr
+	result.LogLines = logLines
+	if o.logWriter != nil {
+		_ = o.logWriter.WriteExampleResult(result)
+	}
+	return result
+}
+
+func missingEnvironmentReason(example ExampleDefinition) string {
+	var missingRequired []string
+	for _, envName := range example.RequiredEnvironmentVariables {
+		if os.Getenv(envName) == "" {
+			missingRequired = append(missingRequired, envName)
+		}
+	}
+	var missingOptional []string
+	for _, envName := range example.OptionalEnvironmentVariables {
+		if os.Getenv(envName) == "" {
+			missingOptional = append(missingOptional, envName)
+		}
+	}
+	var reasons []string
+	if len(missingRequired) > 0 {
+		reasons = append(reasons, "Missing required: "+strings.Join(missingRequired, ", "))
+	}
+	if len(missingOptional) > 0 {
+		reasons = append(reasons, "Missing optional (would cause console prompt hang): "+strings.Join(missingOptional, ", "))
+	}
+	return strings.Join(reasons, "; ")
+}
+
+func orderedResults(run RunAllResult) []VerificationResult {
+	results := make([]VerificationResult, 0, len(run.Results))
+	for _, name := range run.ExampleOrder {
+		result, ok := run.Results[name]
+		if ok {
+			results = append(results, result)
+		}
+	}
+	return results
+}

--- a/cmd/verifyexamples/reporter.go
+++ b/cmd/verifyexamples/reporter.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+type ConsoleReporter struct {
+	w    io.Writer
+	lock sync.Mutex
+}
+
+func NewConsoleReporter(w io.Writer) *ConsoleReporter {
+	return &ConsoleReporter{w: w}
+}
+
+func (r *ConsoleReporter) WriteLineWithPrefix(exampleName string, message string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	fmt.Fprintf(r.w, "[%s] %s\n", exampleName, message)
+}
+
+func (r *ConsoleReporter) PrintSummary(orderedResults []VerificationResult, skipped []SkippedExample, elapsed time.Duration) {
+	passCount := 0
+	failCount := 0
+	for _, result := range orderedResults {
+		if result.Passed {
+			passCount++
+		} else {
+			failCount++
+		}
+	}
+
+	fmt.Fprintln(r.w)
+	fmt.Fprintln(r.w, "────────────────────────────────────────────────────────────")
+	fmt.Fprintln(r.w, "SUMMARY")
+	for _, result := range orderedResults {
+		marker := "✗"
+		if result.Passed {
+			marker = "✓"
+		}
+		fmt.Fprintf(r.w, "  %s %s: %s\n", marker, result.ExampleName, result.Summary)
+	}
+	for _, skippedExample := range skipped {
+		fmt.Fprintf(r.w, "  ○ %s: Skipped — %s\n", skippedExample.Name, skippedExample.Reason)
+	}
+
+	fmt.Fprintf(r.w, "\nResults: %d passed", passCount)
+	if failCount > 0 {
+		fmt.Fprintf(r.w, ", %d failed", failCount)
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintf(r.w, ", %d skipped", len(skipped))
+	}
+	fmt.Fprintf(r.w, "\nElapsed: %02d:%02d:%02d\n", int(elapsed.Hours()), int(elapsed.Minutes())%60, int(elapsed.Seconds())%60)
+}

--- a/cmd/verifyexamples/runner.go
+++ b/cmd/verifyexamples/runner.go
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+)
+
+func runExample(ctx context.Context, projectPath string, timeout time.Duration, build bool, inputs []*string, inputDelay time.Duration) ExampleRunResult {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"run"}
+	if !build {
+		args = append(args, "-mod=readonly")
+	}
+	args = append(args, ".")
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = projectPath
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	var stdin io.WriteCloser
+	var err error
+	if len(inputs) > 0 {
+		stdin, err = cmd.StdinPipe()
+		if err != nil {
+			return ExampleRunResult{Stderr: err.Error(), ExitCode: -1}
+		}
+	}
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		return ExampleRunResult{Stderr: err.Error(), ExitCode: -1}
+	}
+
+	if stdin != nil {
+		go feedInputs(ctx, stdin, inputs, inputDelay)
+	}
+
+	err = cmd.Wait()
+	elapsed := time.Since(start)
+	if ctx.Err() == context.DeadlineExceeded {
+		return ExampleRunResult{
+			Stdout:   stdout.String(),
+			Stderr:   fmt.Sprintf("TIMEOUT: Example did not complete within %.0fs.\n%s", timeout.Seconds(), stderr.String()),
+			ExitCode: -1,
+			Elapsed:  elapsed,
+		}
+	}
+
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+			if stderr.Len() > 0 {
+				stderr.WriteByte('\n')
+			}
+			stderr.WriteString(err.Error())
+		}
+	}
+
+	return ExampleRunResult{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+		Elapsed:  elapsed,
+	}
+}
+
+func feedInputs(ctx context.Context, stdin io.WriteCloser, inputs []*string, inputDelay time.Duration) {
+	defer stdin.Close()
+	for _, input := range inputs {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(inputDelay):
+		}
+		if input == nil {
+			continue
+		}
+		_, _ = fmt.Fprintln(stdin, *input)
+	}
+}

--- a/cmd/verifyexamples/types.go
+++ b/cmd/verifyexamples/types.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import "time"
+
+type ExampleDefinition struct {
+	Name                         string
+	ProjectPath                  string
+	RequiredEnvironmentVariables []string
+	OptionalEnvironmentVariables []string
+	SkipReason                   string
+	MustContain                  []string
+	MustNotContain               []string
+	IsDeterministic              bool
+	ExpectedOutputDescription    []string
+	Inputs                       []*string
+	InputDelay                   time.Duration
+}
+
+type ExampleRunResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	Elapsed  time.Duration
+}
+
+type VerificationResult struct {
+	ExampleName string
+	Passed      bool
+	Summary     string
+	Failures    []string
+	AIReasoning string
+	Stdout      string
+	Stderr      string
+	LogLines    []string
+}
+
+type SkippedExample struct {
+	Name   string
+	Reason string
+}
+
+type RunAllResult struct {
+	Results      map[string]VerificationResult
+	Skipped      []SkippedExample
+	ExampleOrder []string
+}

--- a/cmd/verifyexamples/verifier.go
+++ b/cmd/verifyexamples/verifier.go
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/agent"
+)
+
+type semanticVerifier interface {
+	RunText(context.Context, string, ...agent.Option) agent.ResponseStream
+}
+
+type ExampleVerifier struct {
+	verifierAgent semanticVerifier
+}
+
+func (v ExampleVerifier) Verify(ctx context.Context, example ExampleDefinition, run ExampleRunResult) VerificationResult {
+	var failures []string
+	if run.ExitCode != 0 {
+		failures = append(failures, fmt.Sprintf("Exit code was %d, expected 0. Stderr: %s", run.ExitCode, truncate(run.Stderr, 500)))
+	}
+	for _, expected := range example.MustContain {
+		if !strings.Contains(run.Stdout, expected) {
+			failures = append(failures, fmt.Sprintf("Output missing expected substring: %q", expected))
+		}
+	}
+	for _, unexpected := range example.MustNotContain {
+		if strings.Contains(run.Stdout, unexpected) {
+			failures = append(failures, fmt.Sprintf("Output contains unexpected substring: %q", unexpected))
+		}
+	}
+
+	aiReasoning := ""
+	if !example.IsDeterministic && len(example.ExpectedOutputDescription) > 0 {
+		if v.verifierAgent == nil {
+			failures = append(failures, "AI verification required but no AI agent configured (missing FOUNDRY_PROJECT_ENDPOINT).")
+		} else {
+			reasoning, unmet := v.verifyWithAI(ctx, run.Stdout, run.Stderr, example.ExpectedOutputDescription)
+			aiReasoning = reasoning
+			for _, unmetExpectation := range unmet {
+				failures = append(failures, "AI expectation not met: "+unmetExpectation)
+			}
+		}
+	}
+
+	passed := len(failures) == 0
+	summary := fmt.Sprintf("%d check(s) failed", len(failures))
+	if passed {
+		summary = "All checks passed"
+	}
+	return VerificationResult{
+		ExampleName: example.Name,
+		Passed:      passed,
+		Summary:     summary,
+		Failures:    failures,
+		AIReasoning: aiReasoning,
+	}
+}
+
+func (v ExampleVerifier) verifyWithAI(ctx context.Context, stdout string, stderr string, expectations []string) (string, []string) {
+	var expectationList strings.Builder
+	for i, expectation := range expectations {
+		fmt.Fprintf(&expectationList, "  %d. %s\n", i+1, expectation)
+	}
+
+	stderrSection := ""
+	if strings.TrimSpace(stderr) != "" {
+		stderrSection = fmt.Sprintf("\nStderr output:\n---\n%s\n---\n", truncate(stderr, 2000))
+	}
+
+	prompt := fmt.Sprintf(`Actual program output:
+---
+%s
+---
+%s
+Expectations to verify:
+%s
+Does the output satisfy all expectations?
+Respond with only JSON matching this shape:
+{"pass":true,"ai_reasoning":"brief overall assessment","expectation_results":[{"expectation":"text","met":true,"detail":"evidence"}]}
+`, truncate(stdout, 4000), stderrSection, expectationList.String())
+
+	var result aiVerificationResponse
+	response, err := v.verifierAgent.RunText(ctx, prompt, agent.WithStructuredOutput(&result)).Collect()
+	if err != nil {
+		return "AI verification error: " + err.Error(), []string{"AI verification error: " + err.Error()}
+	}
+
+	if len(result.ExpectationResults) == 0 && response != nil && response.String() != "" {
+		_ = json.Unmarshal([]byte(response.String()), &result)
+	}
+	if !result.Pass && len(result.ExpectationResults) == 0 {
+		text := "AI verification returned no structured expectation results."
+		if response != nil && strings.TrimSpace(response.String()) != "" {
+			text += " Raw: " + truncate(response.String(), 500)
+		}
+		return text, []string{text}
+	}
+
+	reasoning := result.AIReasoning
+	if strings.TrimSpace(reasoning) == "" {
+		reasoning = "(no reasoning provided)"
+	}
+	var unmet []string
+	for _, expectation := range result.ExpectationResults {
+		if expectation.Met {
+			continue
+		}
+		detail := expectation.Expectation
+		if strings.TrimSpace(expectation.Detail) != "" {
+			detail += " - " + expectation.Detail
+		}
+		unmet = append(unmet, detail)
+	}
+	if len(unmet) == 0 && !result.Pass {
+		unmet = append(unmet, reasoning)
+	}
+	return reasoning, unmet
+}
+
+type aiVerificationResponse struct {
+	Pass               bool                  `json:"pass"`
+	AIReasoning        string                `json:"ai_reasoning"`
+	ExpectationResults []aiExpectationResult `json:"expectation_results"`
+}
+
+type aiExpectationResult struct {
+	Expectation string `json:"expectation"`
+	Met         bool   `json:"met"`
+	Detail      string `json:"detail"`
+}
+
+func truncate(text string, maxLength int) string {
+	if len(text) <= maxLength {
+		return text
+	}
+	return text[:maxLength] + "... (truncated)"
+}

--- a/cmd/verifyexamples/verifier_test.go
+++ b/cmd/verifyexamples/verifier_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestVerifyDeterministicOutput(t *testing.T) {
+	verifier := ExampleVerifier{}
+	result := verifier.Verify(context.Background(), ExampleDefinition{
+		Name:            "example",
+		IsDeterministic: true,
+		MustContain:     []string{"hello"},
+		MustNotContain:  []string{"panic"},
+	}, ExampleRunResult{Stdout: "hello world", ExitCode: 0})
+	if !result.Passed {
+		t.Fatalf("Passed = false, failures: %#v", result.Failures)
+	}
+}
+
+func TestVerifyRequiresAIAgentForSemanticChecks(t *testing.T) {
+	verifier := ExampleVerifier{}
+	result := verifier.Verify(context.Background(), ExampleDefinition{
+		Name:                      "example",
+		ExpectedOutputDescription: []string{"contains a joke"},
+	}, ExampleRunResult{Stdout: "hello world", ExitCode: 0})
+	if result.Passed {
+		t.Fatal("Passed = true, want failure")
+	}
+	if len(result.Failures) != 1 {
+		t.Fatalf("Failures = %#v, want one", result.Failures)
+	}
+}

--- a/cmd/verifyexamples/writers.go
+++ b/cmd/verifyexamples/writers.go
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"html"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type LogFileWriter struct {
+	path string
+	lock sync.Mutex
+}
+
+func NewLogFileWriter(path string) *LogFileWriter {
+	return &LogFileWriter{path: path}
+}
+
+func (w *LogFileWriter) WriteHeader() error {
+	content := fmt.Sprintf("Example Verification Log — %s UTC\n%s\n\n", time.Now().UTC().Format("2006-01-02 15:04:05"), strings.Repeat("═", 72))
+	return os.WriteFile(w.path, []byte(content), 0o666)
+}
+
+func (w *LogFileWriter) WriteSkipped(name string, reason string) error {
+	return w.append(fmt.Sprintf("── %s ──\nStatus: SKIPPED — %s\n\n", name, reason))
+}
+
+func (w *LogFileWriter) WriteExampleResult(result VerificationResult) error {
+	var sb strings.Builder
+	sb.WriteString(strings.Repeat("─", 72))
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "── %s ──\n", result.ExampleName)
+	if result.Passed {
+		sb.WriteString("Status: PASSED\n\n")
+	} else {
+		sb.WriteString("Status: FAILED\n\n")
+	}
+	for _, line := range result.LogLines {
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	sb.WriteByte('\n')
+	if strings.TrimSpace(result.Stdout) != "" {
+		sb.WriteString("--- stdout ---\n")
+		sb.WriteString(strings.TrimRight(result.Stdout, "\r\n"))
+		sb.WriteString("\n--- end stdout ---\n\n")
+	}
+	if strings.TrimSpace(result.Stderr) != "" {
+		sb.WriteString("--- stderr ---\n")
+		sb.WriteString(strings.TrimRight(result.Stderr, "\r\n"))
+		sb.WriteString("\n--- end stderr ---\n\n")
+	}
+	if len(result.Failures) > 0 {
+		sb.WriteString("Failures:\n")
+		for _, failure := range result.Failures {
+			fmt.Fprintf(&sb, "  ✗ %s\n", failure)
+		}
+		sb.WriteByte('\n')
+	}
+	if result.AIReasoning != "" {
+		sb.WriteString("AI Reasoning:\n")
+		sb.WriteString(result.AIReasoning)
+		sb.WriteString("\n\n")
+	}
+	return w.append(sb.String())
+}
+
+func (w *LogFileWriter) WriteSummary(orderedResults []VerificationResult, skipped []SkippedExample, elapsed time.Duration) error {
+	passCount := 0
+	failCount := 0
+	for _, result := range orderedResults {
+		if result.Passed {
+			passCount++
+		} else {
+			failCount++
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(strings.Repeat("═", 72))
+	sb.WriteString("\nSUMMARY\n\n")
+	for _, result := range orderedResults {
+		marker := "✗"
+		if result.Passed {
+			marker = "✓"
+		}
+		fmt.Fprintf(&sb, "  %s %s: %s\n", marker, result.ExampleName, result.Summary)
+	}
+	for _, skippedExample := range skipped {
+		fmt.Fprintf(&sb, "  ○ %s: Skipped — %s\n", skippedExample.Name, skippedExample.Reason)
+	}
+	fmt.Fprintf(&sb, "\nResults: %d passed", passCount)
+	if failCount > 0 {
+		fmt.Fprintf(&sb, ", %d failed", failCount)
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintf(&sb, ", %d skipped", len(skipped))
+	}
+	fmt.Fprintf(&sb, "\nElapsed: %02d:%02d:%02d\n", int(elapsed.Hours()), int(elapsed.Minutes())%60, int(elapsed.Seconds())%60)
+	return w.append(sb.String())
+}
+
+func (w *LogFileWriter) append(text string) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(text)
+	return err
+}
+
+func writeCSV(path string, orderedResults []VerificationResult, skipped []SkippedExample, examples []ExampleDefinition) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	pathLookup := map[string]string{}
+	for _, example := range examples {
+		pathLookup[example.Name] = example.ProjectPath
+	}
+	w := csv.NewWriter(file)
+	defer w.Flush()
+	if err := w.Write([]string{"Example", "ProjectPath", "Status", "FailedChecks", "Failures"}); err != nil {
+		return err
+	}
+	for _, result := range orderedResults {
+		status := "FAILED"
+		if result.Passed {
+			status = "PASSED"
+		}
+		if err := w.Write([]string{result.ExampleName, pathLookup[result.ExampleName], status, fmt.Sprint(len(result.Failures)), strings.Join(result.Failures, "; ")}); err != nil {
+			return err
+		}
+	}
+	for _, skippedExample := range skipped {
+		if err := w.Write([]string{skippedExample.Name, pathLookup[skippedExample.Name], "SKIPPED", "0", skippedExample.Reason}); err != nil {
+			return err
+		}
+	}
+	return w.Error()
+}
+
+func writeMarkdown(path string, orderedResults []VerificationResult, skipped []SkippedExample, elapsed time.Duration) error {
+	passCount := 0
+	failCount := 0
+	for _, result := range orderedResults {
+		if result.Passed {
+			passCount++
+		} else {
+			failCount++
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("# Example Verification Results\n\n")
+	fmt.Fprintf(&sb, "**%d passed, %d failed, %d skipped** | Elapsed: %02d:%02d:%02d\n\n", passCount, failCount, len(skipped), int(elapsed.Hours()), int(elapsed.Minutes())%60, int(elapsed.Seconds())%60)
+	sb.WriteString("| Example | Status | Failed Checks | Failures |\n")
+	sb.WriteString("|--------|--------|---------------|----------|\n")
+	for _, result := range orderedResults {
+		status := "❌ FAILED"
+		if result.Passed {
+			status = "✅ PASSED"
+		}
+		fmt.Fprintf(&sb, "| %s | %s | %d | %s |\n", mdEscape(result.ExampleName), status, len(result.Failures), mdEscape(strings.Join(result.Failures, "; ")))
+	}
+	for _, skippedExample := range skipped {
+		fmt.Fprintf(&sb, "| %s | ⏭️ SKIPPED | 0 | %s |\n", mdEscape(skippedExample.Name), mdEscape(skippedExample.Reason))
+	}
+
+	var failuresWithReasoning []VerificationResult
+	for _, result := range orderedResults {
+		if !result.Passed && result.AIReasoning != "" {
+			failuresWithReasoning = append(failuresWithReasoning, result)
+		}
+	}
+	if len(failuresWithReasoning) > 0 {
+		sb.WriteString("\n## Failure Details\n\n")
+		for _, result := range failuresWithReasoning {
+			fmt.Fprintf(&sb, "<details><summary><strong>%s</strong></summary>\n\n", html.EscapeString(result.ExampleName))
+			for _, failure := range result.Failures {
+				fmt.Fprintf(&sb, "- %s\n", mdEscape(failure))
+			}
+			sb.WriteString("\n**AI Reasoning:**\n\n```\n")
+			sb.WriteString(result.AIReasoning)
+			sb.WriteString("\n```\n\n</details>\n\n")
+		}
+	}
+	return os.WriteFile(path, []byte(sb.String()), 0o666)
+}
+
+func mdEscape(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(value, "|", "\\|"), "\n", " "), "\r", "")
+}

--- a/cmd/verifyexamples/writers_test.go
+++ b/cmd/verifyexamples/writers_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteCSV(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.csv")
+	err := writeCSV(path,
+		[]VerificationResult{{ExampleName: "example", Passed: false, Failures: []string{"missing, thing"}}},
+		[]SkippedExample{{Name: "skipped", Reason: "missing env"}},
+		[]ExampleDefinition{{Name: "example", ProjectPath: "examples/example"}, {Name: "skipped", ProjectPath: "examples/skipped"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "FAILED") || !strings.Contains(string(content), "SKIPPED") {
+		t.Fatalf("CSV content missing statuses:\n%s", content)
+	}
+}
+
+func TestWriteMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.md")
+	err := writeMarkdown(path, []VerificationResult{{ExampleName: "example", Passed: true}}, nil, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "Example Verification Results") || !strings.Contains(string(content), "PASSED") {
+		t.Fatalf("Markdown content missing expected text:\n%s", content)
+	}
+}


### PR DESCRIPTION
This adds `verifyexamples`, a Go command that ports the .NET verify-samples tool into this repository. It keeps the same overall model: registered examples are grouped by category, each example can define deterministic output checks, environment-gated skips, stdin inputs, and optional semantic verification for output that needs an LLM-backed judgment.

The expected outputs are aligned with the .NET verifier expectations. On top of the example-alignment work, the current registered example checks pass because the previous PRs fixed the known divergences between the Go examples and the .NET examples. That lets this PR focus on bringing over the verifier command itself instead of weakening expectations to match drift.

Validation works by running each registered example with `go run -mod=readonly .` by default, collecting stdout, stderr, duration, and exit code, then checking the result against the example definition. Stable examples use substring checks for expected and forbidden output. Examples that need credentials skip cleanly when required environment variables are missing, and examples with nondeterministic model output can use Foundry-backed semantic verification when `FOUNDRY_PROJECT_ENDPOINT` is available. The command can also write Markdown, CSV, and log reports for local or CI use.

For now this is command-only. Once LLM credentials are integrated into the repository secrets, we will be able to wire this into a weekly scheduled workflow so the examples are continuously verified against the .NET-aligned expectations.

Validation performed: `go test -count=1 ./cmd/verifyexamples`.
