### PR TITLE
[dotnet-code] Extract fan-in envelope filtering helper

### DIFF
--- a/workflow/internal/execution/edgerunner.go
+++ b/workflow/internal/execution/edgerunner.go
@@ -241,18 +241,10 @@ func (em *EdgeRunner) PrepareDeliveryForEdge(ctx context.Context, edge workflow.
 		if len(targets) != 1 {
 			panic("stateful edges only support single target executor")
 		}
-		// Filter envelopes whose message type is not handled by any target.
-		filtered := envelopes[:0]
-		for _, env := range envelopes {
-			runtimeType, err := em.messageRuntimeType(ctx, env)
-			if err != nil {
-				return nil, err
-			}
-			if canHandleRuntimeType(targets[0], runtimeType) {
-				filtered = append(filtered, env)
-			}
+		envelopes, err = em.filterEnvelopesForTarget(ctx, envelopes, targets[0])
+		if err != nil {
+			return nil, err
 		}
-		envelopes = filtered
 	}
 	if len(targets) == 0 || len(envelopes) == 0 {
 		// Type mismatch.
@@ -264,6 +256,20 @@ func (em *EdgeRunner) PrepareDeliveryForEdge(ctx context.Context, edge workflow.
 		Targets:   targets,
 		Envelopes: envelopes,
 	}, nil
+}
+
+func (em *EdgeRunner) filterEnvelopesForTarget(ctx context.Context, envelopes []*MessageEnvelope, target *workflow.Executor) ([]*MessageEnvelope, error) {
+	filtered := envelopes[:0]
+	for _, env := range envelopes {
+		runtimeType, err := em.messageRuntimeType(ctx, env)
+		if err != nil {
+			return nil, err
+		}
+		if canHandleRuntimeType(target, runtimeType) {
+			filtered = append(filtered, env)
+		}
+	}
+	return filtered, nil
 }
 
 func selectedTargetIDs(edge workflow.Edge, envelope *MessageEnvelope) []string {


### PR DESCRIPTION
This pull request refactors how message envelopes are filtered for stateful edges in the `EdgeRunner` logic. The main change is the extraction of the envelope filtering logic into a new helper method, which improves code readability and maintainability.

Refactoring for clarity and maintainability:

* Extracted the envelope filtering logic from `PrepareDeliveryForEdge` into a new method `filterEnvelopesForTarget`, reducing code duplication and making the main function easier to read (`workflow/internal/execution/edgerunner.go`, [[1]](diffhunk://#diff-d4a743ee4885322476257d760b3fae398df12c1b56b3d45708f438c5a4c9b708L244-L255) [[2]](diffhunk://#diff-d4a743ee4885322476257d760b3fae398df12c1b56b3d45708f438c5a4c9b708R261-R274).
* Updated `PrepareDeliveryForEdge` to use the new `filterEnvelopesForTarget` method, ensuring consistent filtering of envelopes for a single target executor (`workflow/internal/execution/edgerunner.go`, [workflow/internal/execution/edgerunner.goL244-L255](diffhunk://#diff-d4a743ee4885322476257d760b3fae398df12c1b56b3d45708f438c5a4c9b708L244-L255)).

- https://github.com/microsoft/agent-framework-go/issues/433