### PR TITLE
[dotnet-port-api] Align skill approval options with .NET

### DIFF
--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -60,8 +60,19 @@ type ContextProviderOptions struct {
 	// The template must contain {skills}.
 	SkillsInstructionPrompt string
 
-	// ScriptApproval marks the run_skill_script tool as requiring approval.
-	ScriptApproval bool
+	// DisableLoadSkillApproval disables approval for the load_skill tool.
+	// When false (the default), invoking load_skill requires approval.
+	DisableLoadSkillApproval bool
+
+	// DisableReadSkillResourceApproval disables approval for the
+	// read_skill_resource tool. When false (the default), invoking
+	// read_skill_resource requires approval.
+	DisableReadSkillResourceApproval bool
+
+	// DisableRunSkillScriptApproval disables approval for the
+	// run_skill_script tool. When false (the default), invoking
+	// run_skill_script requires approval.
+	DisableRunSkillScriptApproval bool
 
 	// IncludeDetailedErrors includes script execution error details in the
 	// run_skill_script result returned to the model.
@@ -365,33 +376,31 @@ func indexSkills(skills []*Skill) providedSkillSet {
 }
 
 func (p *providerState) buildTools(skills providedSkillSet) []tool.Tool {
-	tools := []tool.Tool{
-		functool.MustNew(
-			functool.Config{
-				Name:        "load_skill",
-				Description: "Loads the full content of a specific skill.",
-			},
-			func(callCtx context.Context, in struct {
-				SkillName string `json:"skillName" jsonschema:"The name of the skill to load"`
-			},
-			) (string, error) {
-				return p.loadSkill(callCtx, skills, in.SkillName)
-			},
-		),
-		functool.MustNew(
-			functool.Config{
-				Name:        "read_skill_resource",
-				Description: "Reads a resource associated with a skill, such as references, assets, or dynamic data.",
-			},
-			func(callCtx context.Context, in struct {
-				SkillName    string `json:"skillName" jsonschema:"The name of the skill"`
-				ResourceName string `json:"resourceName" jsonschema:"The exact resource name to read"`
-			},
-			) (any, error) {
-				return p.readSkillResource(callCtx, skills, in.SkillName, in.ResourceName), nil
-			},
-		),
-	}
+	loadSkillTool := functool.MustNew(
+		functool.Config{
+			Name:        "load_skill",
+			Description: "Loads the full content of a specific skill.",
+		},
+		func(callCtx context.Context, in struct {
+			SkillName string `json:"skillName" jsonschema:"The name of the skill to load"`
+		},
+		) (string, error) {
+			return p.loadSkill(callCtx, skills, in.SkillName)
+		},
+	)
+	readSkillResourceTool := functool.MustNew(
+		functool.Config{
+			Name:        "read_skill_resource",
+			Description: "Reads a resource associated with a skill, such as references, assets, or dynamic data.",
+		},
+		func(callCtx context.Context, in struct {
+			SkillName    string `json:"skillName" jsonschema:"The name of the skill"`
+			ResourceName string `json:"resourceName" jsonschema:"The exact resource name to read"`
+		},
+		) (any, error) {
+			return p.readSkillResource(callCtx, skills, in.SkillName, in.ResourceName), nil
+		},
+	)
 
 	runScript := functool.MustNew(
 		functool.Config{
@@ -408,10 +417,17 @@ func (p *providerState) buildTools(skills providedSkillSet) []tool.Tool {
 		},
 	)
 
-	if p.options.ScriptApproval {
-		return append(tools, tool.ApprovalRequiredFunc(runScript))
+	if !p.options.DisableLoadSkillApproval {
+		loadSkillTool = tool.ApprovalRequiredFunc(loadSkillTool)
 	}
-	return append(tools, runScript)
+	if !p.options.DisableReadSkillResourceApproval {
+		readSkillResourceTool = tool.ApprovalRequiredFunc(readSkillResourceTool)
+	}
+	if !p.options.DisableRunSkillScriptApproval {
+		runScript = tool.ApprovalRequiredFunc(runScript)
+	}
+
+	return []tool.Tool{loadSkillTool, readSkillResourceTool, runScript}
 }
 
 func (p *providerState) loadSkill(ctx context.Context, skills providedSkillSet, skillName string) (string, error) {

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -24,11 +24,35 @@ import (
 
 func funcToolPointer(t *testing.T, value tool.FuncTool) uintptr {
 	t.Helper()
-	rv := reflect.ValueOf(value)
-	if rv.Kind() != reflect.Pointer {
-		t.Fatalf("expected pointer-backed tool, got %T", value)
+	current := value
+	for {
+		rv := reflect.ValueOf(current)
+		if rv.Kind() == reflect.Pointer {
+			return rv.Pointer()
+		}
+		if rv.Kind() != reflect.Struct || rv.NumField() != 1 {
+			t.Fatalf("expected pointer-backed tool, got %T", current)
+		}
+		embedded, ok := rv.Field(0).Interface().(tool.FuncTool)
+		if !ok {
+			t.Fatalf("expected pointer-backed tool, got %T", current)
+		}
+		current = embedded
 	}
-	return rv.Pointer()
+}
+
+func assertToolApprovalRequired(t *testing.T, value tool.FuncTool, want bool) {
+	t.Helper()
+	approval, ok := value.(tool.ApprovalRequiredTool)
+	if !ok {
+		if want {
+			t.Fatalf("expected %q to implement ApprovalRequiredTool", value.Name())
+		}
+		return
+	}
+	if got := approval.ApprovalRequired(); got != want {
+		t.Fatalf("expected %q approval requirement to be %t, got %t", value.Name(), want, got)
+	}
 }
 
 type countingSource struct {
@@ -147,18 +171,18 @@ func TestProvider_FromFileSourceWithMultipleFileSystems_DiscoversMultipleSkills(
 	}
 }
 
-func TestProvider_WithScriptsNoScriptApproval_DoesNotWrapRunScriptTool(t *testing.T) {
+func TestProvider_DefaultApproval_RequiresAllSkillTools(t *testing.T) {
 	root := t.TempDir()
-	createSkillDir(t, root, "no-approval-skill", "No approval test", "Body.")
-	createRelativeFile(t, filepath.Join(root, "no-approval-skill"), "scripts/run.py", "print('hello')")
+	createSkillDir(t, root, "approval-skill", "Approval test", "Body.")
+	createRelativeFile(t, filepath.Join(root, "approval-skill"), "docs/readme.md", "hello")
+	createRelativeFile(t, filepath.Join(root, "approval-skill"), "scripts/run.py", "print('hello')")
 	provider := newProviderWithConfig(t, &fsskills.SourceOptions{ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 		return "ok", nil
 	}}, nil, root)
 
 	_, tools := captureProviderContext(t, provider)
-	runTool := findTool(t, tools, "run_skill_script")
-	if approval, ok := runTool.(tool.ApprovalRequiredTool); ok && approval.ApprovalRequired() {
-		t.Fatal("did not expect run_skill_script to require approval by default")
+	for _, name := range []string{"load_skill", "read_skill_resource", "run_skill_script"} {
+		assertToolApprovalRequired(t, findTool(t, tools, name), true)
 	}
 }
 
@@ -527,22 +551,81 @@ func TestProvider_RunSkillScript_IncludesNilRunnerDetailsWhenEnabled(t *testing.
 	}
 }
 
-func TestProvider_ScriptApproval_MarksToolAsApprovalRequired(t *testing.T) {
+func TestProvider_DisableSkillToolApprovalOptions_DisableApprovalPerTool(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "approval-skill", "Approval skill", "Body.")
 	createRelativeFile(t, filepath.Join(root, "approval-skill"), "scripts/run.py", "print('ok')")
+	createRelativeFile(t, filepath.Join(root, "approval-skill"), "docs/readme.md", "docs")
 
 	provider := newProviderWithConfig(t, &fsskills.SourceOptions{
 		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
 			return "ok", nil
 		},
-	}, &skills.ContextProviderOptions{ScriptApproval: true}, root)
+	}, &skills.ContextProviderOptions{
+		DisableLoadSkillApproval:         true,
+		DisableReadSkillResourceApproval: true,
+		DisableRunSkillScriptApproval:    true,
+	}, root)
 
 	_, tools := captureProviderContext(t, provider)
-	runTool := findTool(t, tools, "run_skill_script")
-	approval, ok := runTool.(tool.ApprovalRequiredTool)
-	if !ok || !approval.ApprovalRequired() {
-		t.Fatal("expected run_skill_script to require approval")
+	for _, name := range []string{"load_skill", "read_skill_resource", "run_skill_script"} {
+		assertToolApprovalRequired(t, findTool(t, tools, name), false)
+	}
+}
+
+func TestProvider_DisableSkillToolApprovalOptions_AffectOnlyTargetTool(t *testing.T) {
+	root := t.TempDir()
+	createSkillDir(t, root, "approval-skill", "Approval skill", "Body.")
+	createRelativeFile(t, filepath.Join(root, "approval-skill"), "scripts/run.py", "print('ok')")
+	createRelativeFile(t, filepath.Join(root, "approval-skill"), "docs/readme.md", "docs")
+
+	tests := []struct {
+		name string
+		opts skills.ContextProviderOptions
+		want map[string]bool
+	}{
+		{
+			name: "load_skill",
+			opts: skills.ContextProviderOptions{DisableLoadSkillApproval: true},
+			want: map[string]bool{
+				"load_skill":          false,
+				"read_skill_resource": true,
+				"run_skill_script":    true,
+			},
+		},
+		{
+			name: "read_skill_resource",
+			opts: skills.ContextProviderOptions{DisableReadSkillResourceApproval: true},
+			want: map[string]bool{
+				"load_skill":          true,
+				"read_skill_resource": false,
+				"run_skill_script":    true,
+			},
+		},
+		{
+			name: "run_skill_script",
+			opts: skills.ContextProviderOptions{DisableRunSkillScriptApproval: true},
+			want: map[string]bool{
+				"load_skill":          true,
+				"read_skill_resource": true,
+				"run_skill_script":    false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newProviderWithConfig(t, &fsskills.SourceOptions{
+				ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
+					return "ok", nil
+				},
+			}, &tt.opts, root)
+
+			_, tools := captureProviderContext(t, provider)
+			for name, want := range tt.want {
+				assertToolApprovalRequired(t, findTool(t, tools, name), want)
+			}
+		})
 	}
 }
 

--- a/docs/dotnet-go-sdk-feature-comparison.md
+++ b/docs/dotnet-go-sdk-feature-comparison.md
@@ -113,7 +113,7 @@ Within overlapping features, the main misalignments are API shape and ecosystem 
 
 - The file/inline skill model is similar: frontmatter, content, resources, scripts, sources/providers.
 - .NET adds class-based skills, attribute-based resources/scripts, and DI-backed skill construction. Go has programmatic in-memory skills and script runners, but no class/DI reflection equivalent.
-- Both Go and .NET support the three skill tools (`load_skill`, `read_skill_resource`, `run_skill_script`); in Go, they are registered when skills are discovered or provided, and when present the tools return descriptive errors if the requested resource or script is not found. Go also exposes `ContextProviderOptions.IncludeDetailedErrors` to opt in to detailed script execution errors, matching .NET's `AgentSkillsProviderOptions.IncludeDetailedErrors`.
+- Both Go and .NET support the three skill tools (`load_skill`, `read_skill_resource`, `run_skill_script`); in Go, they are registered when skills are discovered or provided, and when present the tools return descriptive errors if the requested resource or script is not found. Go also exposes per-tool approval controls (`DisableLoadSkillApproval`, `DisableReadSkillResourceApproval`, `DisableRunSkillScriptApproval`) plus `ContextProviderOptions.IncludeDetailedErrors`, matching the corresponding .NET `AgentSkillsProviderOptions` surface.
 
 ### Workflows
 


### PR DESCRIPTION
Port .NET skill provider per-tool approval options to Go by replacing the single run-script approval flag with load, read, and script-specific controls.

- https://github.com/microsoft/agent-framework-go/issues/434