### PR TITLE
[dotnet-code] Clarify router type handling internals

### DIFF
--- a/workflow/route.go
+++ b/workflow/route.go
@@ -183,6 +183,11 @@ type typeHandlingInfo struct {
 	autoOutput  bool
 }
 
+func (info typeHandlingInfo) forRuntimeType(runtimeType reflect.Type) typeHandlingInfo {
+	info.runtimeType = runtimeType
+	return info
+}
+
 // newMessageRouter creates a router and indexes typed handlers by TypeID.
 func newMessageRouter(handlers map[reflect.Type]MessageHandlerFunc, handlerOutputTypes map[reflect.Type]reflect.Type, catchAll CatchAllFunc) *messageRouter {
 	outputTypes := make(map[reflect.Type]struct{}, len(handlerOutputTypes))
@@ -309,7 +314,7 @@ func (mr *messageRouter) findHandler(messageType reflect.Type) (typeHandlingInfo
 	for _, interfaceType := range mr.interfaceHandlers {
 		if messageType.AssignableTo(interfaceType) {
 			info := mr.typedHandlers[interfaceType]
-			info.runtimeType = messageType
+			info = info.forRuntimeType(messageType)
 			mr.typeInfos.Store(typeID, info)
 			return info, true
 		}

--- a/workflow/route_test.go
+++ b/workflow/route_test.go
@@ -110,3 +110,35 @@ func TestMessageRouterRoutesPortableValueAfterInterfaceMatchIsCached(t *testing.
 		t.Fatalf("RouteMessage portable result = %v, want portable", result.result)
 	}
 }
+
+func TestMessageRouterCachedInterfaceHandlerPreservesAutoOutput(t *testing.T) {
+	var rb RouteBuilder
+	rb.AddHandlerRaw(reflect.TypeFor[routeTestMessage](), reflect.TypeFor[string](), func(_ *Context, msg any) (any, error) {
+		message, ok := msg.(routeTestMessage)
+		if !ok {
+			t.Fatalf("handler message = %T, want routeTestMessage", msg)
+		}
+		return message.routeMarker(), nil
+	})
+	router, err := rb.build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	if _, handled := router.routeMessage(&Context{Context: context.Background()}, routeTestConcrete{value: "first"}); !handled {
+		t.Fatal("RouteMessage concrete handled = false, want true")
+	}
+	result, handled := router.routeMessage(&Context{Context: context.Background()}, AnyPortableValue(routeTestConcrete{value: "portable"}))
+	if !handled {
+		t.Fatal("RouteMessage portable handled = false, want true")
+	}
+	if result.err != nil {
+		t.Fatalf("RouteMessage portable error = %v", result.err)
+	}
+	if !result.autoOutput {
+		t.Fatal("RouteMessage portable autoOutput = false, want true")
+	}
+	if result.result != "portable" {
+		t.Fatalf("RouteMessage portable result = %v, want portable", result.result)
+	}
+}


### PR DESCRIPTION
This pull request improves the way interface-based message handlers are cached and ensures that handler metadata, such as the `autoOutput` flag, is preserved correctly. The main changes include refactoring how runtime type information is set when caching handlers and adding a test to confirm the correct behavior.

### Improvements to handler caching and metadata preservation

* Added a new method `forRuntimeType` to the `typeHandlingInfo` struct to safely set the `runtimeType` field when caching handlers, ensuring all other handler metadata (like `autoOutput`) remains intact.
* Updated the handler caching logic in `messageRouter.findHandler` to use the new `forRuntimeType` method, preventing accidental overwrites of other fields.

### Testing enhancements

* Added a new test, `TestMessageRouterCachedInterfaceHandlerPreservesAutoOutput`, to verify that the `autoOutput` flag is preserved when an interface handler is cached and reused for portable values.

- https://github.com/microsoft/agent-framework-go/issues/438