### PR TITLE
[dotnet-port-fixes] Preserve fan-in barrier checkpoint state on resume

### DIFF
--- a/workflow/inproc/checkpoint_test.go
+++ b/workflow/inproc/checkpoint_test.go
@@ -377,6 +377,101 @@ func TestCheckpoint_RestoreClearsQueuedExternalResponsesBeforeImport(t *testing.
 	}
 }
 
+func TestCheckpoint_ResumePreservesFanInBarrierBufferedMessages(t *testing.T) {
+	for _, env := range checkpointTestEnvironments() {
+		t.Run(env.name, func(t *testing.T) {
+			ctx := context.Background()
+			manager := checkpoint.NewInMemoryManager()
+			wf := createCheckpointFanInBarrierWorkflow(t, "before")
+
+			pendingRequest, checkpointInfo := capturePendingRequestAndCheckpointFromRun(
+				t,
+				ctx,
+				env.env,
+				manager,
+				wf,
+			)
+
+			replayedRequest := resumeAndAssertFanInBarrierRelease(
+				t,
+				ctx,
+				env.env,
+				manager,
+				wf,
+				checkpointInfo,
+				[]string{"before", "after"},
+			)
+			if replayedRequest.RequestID != pendingRequest.RequestID {
+				t.Fatalf("replayed request ID = %q, want %q", replayedRequest.RequestID, pendingRequest.RequestID)
+			}
+		})
+	}
+}
+
+func TestCheckpoint_ResumePreservesFanInBarrierBufferedMessages_MultiSource(t *testing.T) {
+	for _, env := range checkpointTestEnvironments() {
+		t.Run(env.name, func(t *testing.T) {
+			ctx := context.Background()
+			manager := checkpoint.NewInMemoryManager()
+			wf := createCheckpointFanInBarrierWorkflow(t, "before-1", "before-2")
+
+			pendingRequest, checkpointInfo := capturePendingRequestAndCheckpointFromRun(
+				t,
+				ctx,
+				env.env,
+				manager,
+				wf,
+			)
+
+			replayedRequest := resumeAndAssertFanInBarrierRelease(
+				t,
+				ctx,
+				env.env,
+				manager,
+				wf,
+				checkpointInfo,
+				[]string{"before-1", "before-2", "after"},
+			)
+			if replayedRequest.RequestID != pendingRequest.RequestID {
+				t.Fatalf("replayed request ID = %q, want %q", replayedRequest.RequestID, pendingRequest.RequestID)
+			}
+		})
+	}
+}
+
+func TestCheckpoint_ResumeFanInBarrierCheckpointCanBeResumedTwice(t *testing.T) {
+	for _, env := range checkpointTestEnvironments() {
+		t.Run(env.name, func(t *testing.T) {
+			ctx := context.Background()
+			manager := checkpoint.NewInMemoryManager()
+			wf := createCheckpointFanInBarrierWorkflow(t, "before")
+
+			pendingRequest, checkpointInfo := capturePendingRequestAndCheckpointFromRun(
+				t,
+				ctx,
+				env.env,
+				manager,
+				wf,
+			)
+
+			for attempt := 0; attempt < 2; attempt++ {
+				replayedRequest := resumeAndAssertFanInBarrierRelease(
+					t,
+					ctx,
+					env.env,
+					manager,
+					wf,
+					checkpointInfo,
+					[]string{"before", "after"},
+				)
+				if replayedRequest.RequestID != pendingRequest.RequestID {
+					t.Fatalf("attempt %d replayed request ID = %q, want %q", attempt, replayedRequest.RequestID, pendingRequest.RequestID)
+				}
+			}
+		})
+	}
+}
+
 func TestCheckpoint_RestorePreservesExecutorInstancesDuringImport(t *testing.T) {
 	ctx := context.Background()
 	manager := checkpoint.NewInMemoryManager()
@@ -754,6 +849,112 @@ func createCheckpointChainWorkflow(t *testing.T, ids ...string) *workflow.Workfl
 	return wf
 }
 
+func createCheckpointFanInBarrierWorkflow(t *testing.T, beforeValues ...string) *workflow.Workflow {
+	t.Helper()
+	if len(beforeValues) == 0 {
+		t.Fatal("expected at least one pre-checkpoint barrier value")
+	}
+
+	forwardInput := func(id string) workflow.ExecutorBinding {
+		return workflow.ExecutorBinding{
+			ID:               id,
+			ImplementationID: "*workflow.Executor",
+			NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+				return &workflow.Executor{
+					ID: id,
+					DisableAutoSendMessageHandlerResultObject: true,
+					DisableAutoYieldOutputHandlerResultObject: true,
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.SendsMessageType(reflect.TypeFor[string]())
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+							return nil, ctx.SendMessage("", msg)
+						})
+						return rb, nil
+					},
+				}, nil
+			},
+		}
+	}
+
+	constantMessage := func(id string, value string) workflow.ExecutorBinding {
+		return workflow.ExecutorBinding{
+			ID:               id,
+			ImplementationID: "*workflow.Executor",
+			NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+				return &workflow.Executor{
+					ID: id,
+					DisableAutoSendMessageHandlerResultObject: true,
+					DisableAutoYieldOutputHandlerResultObject: true,
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.SendsMessageType(reflect.TypeFor[string]())
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, _ any) (any, error) {
+							return nil, ctx.SendMessage("", value)
+						})
+						return rb, nil
+					},
+				}, nil
+			},
+		}
+	}
+
+	yieldOutput := func(id string) workflow.ExecutorBinding {
+		return workflow.ExecutorBinding{
+			ID:               id,
+			ImplementationID: "*workflow.Executor",
+			NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
+				return &workflow.Executor{
+					ID: id,
+					DisableAutoSendMessageHandlerResultObject: true,
+					DisableAutoYieldOutputHandlerResultObject: true,
+					ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+						rb.YieldsOutputType(reflect.TypeFor[string]())
+						rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+							return nil, ctx.YieldOutput(msg)
+						})
+						return rb, nil
+					},
+				}, nil
+			},
+		}
+	}
+
+	requestPort := workflow.RequestPort{
+		ID:       "Approval",
+		Request:  reflect.TypeFor[string](),
+		Response: reflect.TypeFor[string](),
+	}
+	requestPortBinding := requestPort.Bind()
+
+	start := forwardInput("Start")
+	kickoff := forwardInput("Kickoff")
+	afterResume := constantMessage("AfterResume", "after")
+	sink := yieldOutput("Sink")
+
+	earlyBindings := make([]workflow.ExecutorBinding, 0, len(beforeValues))
+	for i, value := range beforeValues {
+		earlyBindings = append(earlyBindings, constantMessage("Early"+string(rune('A'+i)), value))
+	}
+
+	builder := workflow.NewBuilder(start)
+	for _, binding := range earlyBindings {
+		builder = builder.AddEdge(start, binding)
+	}
+	builder = builder.
+		AddEdge(start, kickoff).
+		AddEdge(kickoff, requestPortBinding).
+		AddEdge(requestPortBinding, afterResume)
+
+	barrierSources := append(slices.Clone(earlyBindings), afterResume)
+	wf, err := builder.
+		AddFanInBarrierEdge(barrierSources, sink).
+		WithOutputFrom(sink).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return wf
+}
+
 type checkpointTestEnvironment struct {
 	name string
 	env  *inproc.ExecutionEnvironment
@@ -813,6 +1014,18 @@ func collectEvents(events func(func(workflow.Event) bool)) []workflow.Event {
 	return result
 }
 
+func outputValues(events []workflow.Event) []string {
+	var outputs []string
+	for _, evt := range events {
+		if outEvt, ok := evt.(workflow.OutputEvent); ok {
+			if output, ok := outEvt.Output.(string); ok {
+				outputs = append(outputs, output)
+			}
+		}
+	}
+	return outputs
+}
+
 func readStreamToHalt(t *testing.T, ctx context.Context, run *inproc.StreamingRun) []workflow.Event {
 	t.Helper()
 	var events []workflow.Event
@@ -846,6 +1059,82 @@ func capturePendingRequestAndCheckpointFromStream(t *testing.T, ctx context.Cont
 		t.Fatal("expected checkpoint")
 	}
 	return pendingRequest, checkpointInfo
+}
+
+func capturePendingRequestAndCheckpointFromRun(t *testing.T, ctx context.Context, env *inproc.ExecutionEnvironment, manager checkpoint.Manager, wf *workflow.Workflow) (*workflow.ExternalRequest, workflow.CheckpointInfo) {
+	t.Helper()
+	run, err := env.WithCheckpointing(manager).Run(ctx, wf, "start")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	pendingRequest := firstRequest(t, run.OutgoingEvents())
+	checkpointInfo, ok := run.LastCheckpoint()
+	if !ok {
+		t.Fatal("expected checkpoint")
+	}
+	if err := run.Close(ctx); err != nil {
+		t.Fatalf("Close run: %v", err)
+	}
+	return pendingRequest, checkpointInfo
+}
+
+func resumeAndAssertFanInBarrierRelease(t *testing.T, ctx context.Context, env *inproc.ExecutionEnvironment, manager checkpoint.Manager, wf *workflow.Workflow, checkpointInfo workflow.CheckpointInfo, wantOutputs []string) *workflow.ExternalRequest {
+	t.Helper()
+	resumed, err := env.WithCheckpointing(manager).Resume(ctx, wf, checkpointInfo)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	defer func() {
+		if err := resumed.Close(ctx); err != nil {
+			t.Errorf("Close resumed run: %v", err)
+		}
+	}()
+
+	replayedRequests := collectRequests(resumed.NewEvents())
+	if len(replayedRequests) != 1 {
+		t.Fatalf("replayed request count = %d, want 1", len(replayedRequests))
+	}
+
+	status, err := resumed.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus before response: %v", err)
+	}
+	if status != inproc.RunStatusPendingRequests {
+		t.Fatalf("status before response = %v, want PendingRequests", status)
+	}
+
+	response, err := replayedRequests[0].CreateResponse("approved")
+	if err != nil {
+		t.Fatalf("CreateResponse: %v", err)
+	}
+	if _, err := resumed.Resume(ctx, response); err != nil {
+		t.Fatalf("Resume with response: %v", err)
+	}
+
+	completionEvents := collectEvents(resumed.NewEvents())
+	if hasErrorEvents(completionEvents) {
+		t.Fatalf("unexpected completion error events: %#v", completionEvents)
+	}
+	if hasEventType[workflow.RequestInfoEvent](completionEvents) {
+		t.Fatal("did not expect duplicate RequestInfoEvent after response")
+	}
+
+	gotOutputs := outputValues(completionEvents)
+	slices.Sort(gotOutputs)
+	wantOutputs = slices.Clone(wantOutputs)
+	slices.Sort(wantOutputs)
+	if !slices.Equal(gotOutputs, wantOutputs) {
+		t.Fatalf("completion outputs = %v, want %v", gotOutputs, wantOutputs)
+	}
+
+	status, err = resumed.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus after response: %v", err)
+	}
+	if status != inproc.RunStatusIdle {
+		t.Fatalf("status after response = %v, want Idle", status)
+	}
+	return replayedRequests[0]
 }
 
 func hasErrorEvents(events []workflow.Event) bool {

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -114,15 +114,13 @@ func newInProcessRunner(
 		return nil, err
 	}
 
-	edgeMap := execution.NewEdgeRunner(wf, stepTracer, runContext.ensureExecutor)
-
 	runner := &runner{
 		sessionID:            sessionID,
 		startExecutorID:      wf.StartExecutorID(),
 		wf:                   wf,
 		runContext:           runContext,
 		checkpointMgr:        checkpointMgr,
-		edgeMap:              edgeMap,
+		edgeMap:              runContext.edgeMap,
 		stepTracer:           stepTracer,
 		outgoingEvents:       outgoingEvents,
 		knownValidInputTypes: make(map[reflect.Type]struct{}),


### PR DESCRIPTION
## Summary

Fixes fan-in barrier checkpoint resume parity by wiring the in-process runner to checkpoint the same live `EdgeRunner` instance used for routing, instead of a separate copy that never observed buffered fan-in state.

Also adds checkpoint/resume regression coverage for fan-in barriers so buffered pre-checkpoint messages survive resume, multi-source barriers release correctly after the remaining source arrives, and the same checkpoint can be resumed more than once.

## Ported .NET PRs

- microsoft/agent-framework#6574 - harden fan-in barrier checkpoint state and extend resume coverage
  - Upstream commit: [`074ac68a6c284ec9532f118a6593d3a300ef1693`](https://github.com/microsoft/agent-framework/commit/074ac68a6c284ec9532f118a6593d3a300ef1693)

## Breaking Changes

No.

## Tests and Examples

- `go test ./workflow/...`
- Added fan-in barrier checkpoint/resume regression tests in `workflow/inproc/checkpoint_test.go`
- No examples changed

## Notes

This stays within the existing Go API surface. The behavior change is internal checkpoint-state correctness for fan-in barriers during resume.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/28915398513) · 1.6K AIC · ⌖ 72.6 AIC · ⊞ 21.7K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.60, model: gpt-5.4, id: 28915398513, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/28915398513 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #449