### PR TITLE
[dotnet-code] Clarify group chat prefixed state clearing

### DIFF
--- a/workflow/agentworkflow/groupchat.go
+++ b/workflow/agentworkflow/groupchat.go
@@ -515,16 +515,15 @@ func restoreGroupChatManagerCheckpoint(ctx *workflow.Context, manager *GroupChat
 
 func prefixingWorkflowContext(inner *workflow.Context, prefix string) *workflow.Context {
 	wrapped := *inner
-	wrap := func(key string) string { return prefix + key }
 
 	if inner.ReadState != nil {
 		wrapped.ReadState = func(key string, scope string) (any, error) {
-			return inner.ReadState(wrap(key), scope)
+			return inner.ReadState(prefixWorkflowStateKey(prefix, key), scope)
 		}
 	}
 	if inner.ReadOrInitState != nil {
 		wrapped.ReadOrInitState = func(key string, scope string, initFunc func(context.Context, string, string) (any, error)) (any, error) {
-			return inner.ReadOrInitState(wrap(key), scope, func(ctx context.Context, wrappedKey string, wrappedScope string) (any, error) {
+			return inner.ReadOrInitState(prefixWorkflowStateKey(prefix, key), scope, func(ctx context.Context, wrappedKey string, wrappedScope string) (any, error) {
 				if initFunc == nil {
 					return nil, nil
 				}
@@ -553,23 +552,29 @@ func prefixingWorkflowContext(inner *workflow.Context, prefix string) *workflow.
 	}
 	if inner.QueueStateUpdate != nil {
 		wrapped.QueueStateUpdate = func(key string, scope string, value any) error {
-			return inner.QueueStateUpdate(wrap(key), scope, value)
+			return inner.QueueStateUpdate(prefixWorkflowStateKey(prefix, key), scope, value)
 		}
 	}
 	if inner.QueueClearScope != nil && inner.ReadStateKeys != nil && inner.QueueStateUpdate != nil {
 		wrapped.QueueClearScope = func(scope string) error {
-			for key, err := range wrapped.ReadStateKeys(scope) {
+			for key, err := range inner.ReadStateKeys(scope) {
 				if err != nil {
 					return err
 				}
-				if err := wrapped.QueueStateUpdate(key, scope, nil); err != nil {
-					return err
+				if strings.HasPrefix(key, prefix) {
+					if err := inner.QueueStateUpdate(key, scope, nil); err != nil {
+						return err
+					}
 				}
 			}
 			return nil
 		}
 	}
 	return &wrapped
+}
+
+func prefixWorkflowStateKey(prefix string, key string) string {
+	return prefix + key
 }
 
 func readMessageSliceState(ctx *workflow.Context, key string) ([]*message.Message, error) {

--- a/workflow/agentworkflow/groupchat_test.go
+++ b/workflow/agentworkflow/groupchat_test.go
@@ -494,6 +494,35 @@ func TestRoundRobinGroupChatManager_CheckpointRestoresCursor(t *testing.T) {
 	}
 }
 
+func TestPrefixingWorkflowContext_QueueClearScopeClearsOnlyPrefixedState(t *testing.T) {
+	state := map[string]any{
+		groupChatManagerStateKey:                                      groupChatManagerState{IterationCount: 3},
+		groupChatManagerSubclassStateKeyPref + "next_index":           roundRobinGroupChatManagerState{NextIndex: 1},
+		groupChatManagerSubclassStateKeyPref + "custom_manager_state": "clear",
+		"other_state": "keep",
+	}
+	ctx := prefixingWorkflowContext(newGroupChatStateContext(t.Context(), state), groupChatManagerSubclassStateKeyPref)
+
+	if ctx.QueueClearScope == nil {
+		t.Fatal("QueueClearScope = nil, want prefixed clear implementation")
+	}
+	if err := ctx.QueueClearScope(""); err != nil {
+		t.Fatalf("QueueClearScope: %v", err)
+	}
+	if _, ok := state[groupChatManagerSubclassStateKeyPref+"next_index"]; ok {
+		t.Fatal("prefixed next_index state was not cleared")
+	}
+	if _, ok := state[groupChatManagerSubclassStateKeyPref+"custom_manager_state"]; ok {
+		t.Fatal("prefixed custom manager state was not cleared")
+	}
+	if _, ok := state[groupChatManagerStateKey]; !ok {
+		t.Fatalf("base manager state %q was cleared", groupChatManagerStateKey)
+	}
+	if got := state["other_state"]; got != "keep" {
+		t.Fatalf("other state = %v, want keep", got)
+	}
+}
+
 func TestRoundRobinGroupChatManager_SelectNextAgentCyclesAndWraps(t *testing.T) {
 	agentA := newGroupChatLabelAgent("a", "A", "from-a")
 	agentB := newGroupChatLabelAgent("b", "B", "from-b")
@@ -1051,6 +1080,12 @@ func newGroupChatStateContext(ctx context.Context, state map[string]any) *workfl
 				return nil
 			}
 			state[key] = value
+			return nil
+		},
+		QueueClearScope: func(string) error {
+			for key := range state {
+				delete(state, key)
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary

Clarifies the unexported group chat workflow context wrapper by extracting explicit prefixed state-key construction and making `QueueClearScope` iterate raw state keys before clearing only manager-prefixed entries. This mirrors the .NET `PrefixingWorkflowContext` structure more closely and makes future .NET-to-Go group chat checkpoint ports easier to compare.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/GroupChatManager.cs` - `PrefixingWorkflowContext` scopes subclass state keys and clears only keys with the manager prefix.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- Added `TestPrefixingWorkflowContext_QueueClearScopeClearsOnlyPrefixedState` to preserve scoped clear behavior.
- Ran `gofmt -w workflow/agentworkflow/groupchat.go workflow/agentworkflow/groupchat_test.go`.
- Ran `go test ./workflow/agentworkflow`.

## Notes

Rejected sampled candidates:

- `dotnet/src/Microsoft.Agents.AI.Workflows/OutputTagJsonConverter.cs` - Go output tag handling was already small and changing JSON null/empty semantics risked behavior churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/ExpandoObjectExtensions.cs` - no clear matching Go declarative/PowerFx implementation area was present for a safe portability cleanup.
- `dotnet/src/Microsoft.Agents.AI/LoggingAgentBuilderExtensions.cs` - skipped because open PR https://github.com/microsoft/agent-framework-go/pull/446 already covers adjacent agent telemetry/tracing work.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/28980643830) · 357.4 AIC · ⌖ 44.6 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 28980643830, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/28980643830 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #451