### PR TITLE
[dotnet-code] Extract message forwarding helpers

### DIFF
--- a/message/messageworkflow/messageforwarding.go
+++ b/message/messageworkflow/messageforwarding.go
@@ -41,32 +41,48 @@ func ConfigureForwarding(executor *workflow.Executor, options *ForwardingOptions
 				reflect.TypeFor[workflow.TurnToken](),
 			)
 			if stringMessageRole != "" {
-				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, ctx.SendMessage("", &message.Message{
-						Role:     stringMessageRole,
-						Contents: []message.Content{&message.TextContent{Text: msg.(string)}},
-					})
-				})
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, forwardStringMessage(stringMessageRole))
 			}
 			rb.RouteBuilder.
-				AddHandlerRaw(reflect.TypeFor[*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, ctx.SendMessage("", msg.(*message.Message))
-				}).
-				AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, ctx.SendMessage("", msg.([]*message.Message))
-				}).
-				AddHandlerRaw(reflect.TypeFor[iter.Seq[*message.Message]](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					messages := make([]*message.Message, 0)
-					for msg := range msg.(iter.Seq[*message.Message]) {
-						messages = append(messages, msg)
-					}
-					return struct{}{}, ctx.SendMessage("", messages)
-				}).
-				AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, ctx.SendMessage("", msg.(workflow.TurnToken))
-				})
+				AddHandlerRaw(reflect.TypeFor[*message.Message](), nil, forwardMessage).
+				AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, forwardMessages).
+				AddHandlerRaw(reflect.TypeFor[iter.Seq[*message.Message]](), nil, forwardMessageSeq).
+				AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, forwardTurnToken)
 			return rb, nil
 		},
 	}
 	executor.Extend(&forwardingExecutor)
+}
+
+func forwardStringMessage(role message.Role) func(*workflow.Context, any) (any, error) {
+	return func(ctx *workflow.Context, msg any) (any, error) {
+		return struct{}{}, ctx.SendMessage("", &message.Message{
+			Role:     role,
+			Contents: []message.Content{&message.TextContent{Text: msg.(string)}},
+		})
+	}
+}
+
+func forwardMessage(ctx *workflow.Context, msg any) (any, error) {
+	return struct{}{}, ctx.SendMessage("", msg.(*message.Message))
+}
+
+func forwardMessages(ctx *workflow.Context, msg any) (any, error) {
+	return struct{}{}, ctx.SendMessage("", msg.([]*message.Message))
+}
+
+func forwardMessageSeq(ctx *workflow.Context, msg any) (any, error) {
+	return struct{}{}, ctx.SendMessage("", messageSeqToSlice(msg.(iter.Seq[*message.Message])))
+}
+
+func forwardTurnToken(ctx *workflow.Context, msg any) (any, error) {
+	return struct{}{}, ctx.SendMessage("", msg.(workflow.TurnToken))
+}
+
+func messageSeqToSlice(seq iter.Seq[*message.Message]) []*message.Message {
+	messages := make([]*message.Message, 0)
+	for msg := range seq {
+		messages = append(messages, msg)
+	}
+	return messages
 }


### PR DESCRIPTION
## Summary

Extracted the message workflow forwarding handlers into small unexported helper functions. This keeps Go's forwarding executor structure closer to the .NET `ChatForwardingExecutor`, where forwarding behavior is expressed as named private methods, making future .NET-to-Go ports easier to compare without changing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/ChatForwardingExecutor.cs` - uses private forwarding helpers for chat messages, message collections, string conversion, and turn tokens.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./message/messageworkflow`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentContinuationToken.cs` mapped to existing Go continuation internals, but the current shape was already compact and a change risked token compatibility.
- `dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs` includes public option surface and .NET-only decorator settings, so changing Go internals there would be higher risk or feature-shaped.
- `dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AHostingJsonUtilities.cs` is AOT/System.Text.Json-specific with no direct Go JSON utility counterpart.

Also avoided open `[dotnet-code]` PR overlap in router type handling (#447) and workflow edge runner filtering (#444).


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/28903649569) · 289.7 AIC · ⌖ 30.4 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 28903649569, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/28903649569 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #448