### PR TITLE
[dotnet-code] Align tool approval state internals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,20 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    # The actions below are pinned inside the generated *.lock.yml files by
+    # `gh aw compile` and must stay in lockstep with the gh-aw compiler version.
+    # Dependabot bumping them desyncs a lock from the compiler that produced it
+    # (which breaks the workflow or trips the verify-aw-locks gate). Advance these
+    # by bumping the gh-aw compiler and recompiling, not via Dependabot.
+    # Note: actions/checkout is also used in the hand-authored workflows; ignoring
+    # it here freezes it there too (bump manually or via a gh-aw compiler upgrade).
     ignore:
       - dependency-name: "github/gh-aw-actions*" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+      - dependency-name: "actions/checkout"
+      - dependency-name: "actions/download-artifact"
+      - dependency-name: "actions/github-script"
+      - dependency-name: "actions/setup-node"
+      - dependency-name: "actions/upload-artifact"
     groups:
       codeql-action:
         patterns:

--- a/.github/workflows/dotnet-code-portability-nightly.lock.yml
+++ b/.github/workflows/dotnet-code-portability-nightly.lock.yml
@@ -32,7 +32,7 @@
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
-#   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#   - actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -147,7 +147,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
       - name: Checkout .github and .agents folders
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -408,7 +408,7 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -1271,7 +1271,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository for patch context
         if: needs.agent.outputs.has_patch == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       # --- Threat Detection ---
@@ -1548,7 +1548,7 @@ jobs:
             await main();
       - name: Checkout repository (trusted default branch for comment events)
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request') && (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment')
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1556,7 +1556,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout repository
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request') && github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-port-api-nightly.lock.yml
+++ b/.github/workflows/dotnet-port-api-nightly.lock.yml
@@ -32,7 +32,7 @@
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
-#   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#   - actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -146,7 +146,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
       - name: Checkout .github and .agents folders
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -407,7 +407,7 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -1269,7 +1269,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository for patch context
         if: needs.agent.outputs.has_patch == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       # --- Threat Detection ---
@@ -1546,7 +1546,7 @@ jobs:
             await main();
       - name: Checkout repository (trusted default branch for comment events)
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request') && (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment')
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1554,7 +1554,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout repository
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request') && github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-port-fixes-nightly.lock.yml
+++ b/.github/workflows/dotnet-port-fixes-nightly.lock.yml
@@ -32,7 +32,7 @@
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
-#   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#   - actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -146,7 +146,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
       - name: Checkout .github and .agents folders
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -407,7 +407,7 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -1269,7 +1269,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository for patch context
         if: needs.agent.outputs.has_patch == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       # --- Threat Detection ---
@@ -1546,7 +1546,7 @@ jobs:
             await main();
       - name: Checkout repository (trusted default branch for comment events)
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request') && (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment')
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1554,7 +1554,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout repository
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request') && github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-api-consistency-review.lock.yml
+++ b/.github/workflows/go-api-consistency-review.lock.yml
@@ -31,15 +31,15 @@
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
-#   - actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-#   - actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-#   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#   - actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#   - actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#   - actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0
+#   - github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -168,7 +168,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
       - name: Checkout .github and .agents folders
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -415,7 +415,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -436,7 +436,7 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Create gh-aw temp directory
@@ -449,7 +449,7 @@ jobs:
       - name: Create cache-memory directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_cache_memory_dir.sh"
       - name: Restore cache-memory file share data
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
           path: /tmp/gh-aw/cache-memory
@@ -1095,7 +1095,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1291,7 +1291,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1319,7 +1319,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository for patch context
         if: needs.agent.outputs.has_patch == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       # --- Threat Detection ---
@@ -1553,7 +1553,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1629,7 +1629,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1659,7 +1659,7 @@ jobs:
           fi
       - name: Save cache-memory to cache (default)
         if: steps.check_cache_default.outputs.has_content == 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
           path: /tmp/gh-aw/cache-memory

--- a/.github/workflows/verify-aw-locks.yml
+++ b/.github/workflows/verify-aw-locks.yml
@@ -1,0 +1,56 @@
+name: Verify agentic workflow locks
+
+# The *.lock.yml files under .github/workflows are generated artifacts produced by
+# `gh aw compile` from their *.md sources. They embed a `github/gh-aw-actions/setup`
+# pin alongside `require()` calls to the .cjs helper scripts that action installs at
+# runtime, and the two must stay in lockstep at a single gh-aw compiler version.
+#
+# This gate recompiles with the pinned compiler and fails if any committed lock file
+# is out of date -- catching drift from manual edits, a mismatched local gh-aw
+# version, or a Dependabot bump of an action pin inside a generated lock file.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.md'
+      - '.github/workflows/*.lock.yml'
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+env:
+  # Keep in sync with the compiler_version embedded in the committed *.lock.yml files.
+  GH_AW_VERSION: v0.79.8
+
+jobs:
+  verify-locks:
+    name: Verify lock files are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pinned gh-aw extension
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh extension install github/gh-aw --pin "${GH_AW_VERSION}"
+
+      - name: Recompile agentic workflows
+        run: gh aw compile
+
+      - name: Fail if lock files are out of date
+        shell: bash
+        run: |
+          # Use `git status --porcelain` (not `git diff`) so newly generated but
+          # uncommitted (untracked) lock files -- e.g. when a PR adds a new *.md
+          # workflow -- also fail the job, not just modifications to tracked files.
+          changes="$(git status --porcelain -- '.github/workflows/*.lock.yml')"
+          if [[ -n "$changes" ]]; then
+            echo "::error::Agentic workflow lock files are out of date (modified or uncommitted):"
+            echo "$changes"
+            echo "Run 'gh aw compile' with gh-aw ${GH_AW_VERSION} and commit the regenerated *.lock.yml files."
+            exit 1
+          fi

--- a/agent/harness/toolapproval/toolapproval.go
+++ b/agent/harness/toolapproval/toolapproval.go
@@ -51,9 +51,9 @@ func (r Rule) matches(toolName string, arguments map[string]string) bool {
 
 // state is persisted in the session across turns.
 type state struct {
-	Rules              []Rule                                 `json:"rules,omitempty"`
-	CollectedResponses []*message.ToolApprovalResponseContent `json:"collectedResponses,omitempty"`
-	QueuedRequests     []*message.ToolApprovalRequestContent  `json:"queuedRequests,omitempty"`
+	Rules                      []Rule                                 `json:"rules,omitempty"`
+	CollectedApprovalResponses []*message.ToolApprovalResponseContent `json:"collectedResponses,omitempty"`
+	QueuedApprovalRequests     []*message.ToolApprovalRequestContent  `json:"queuedRequests,omitempty"`
 }
 
 func loadState(opts []agent.Option) state {
@@ -109,9 +109,9 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 			yield(nil, err)
 			return
 		}
-		if len(st.QueuedRequests) > 0 {
-			next := st.QueuedRequests[0]
-			st.QueuedRequests = st.QueuedRequests[1:]
+		if len(st.QueuedApprovalRequests) > 0 {
+			next := st.QueuedApprovalRequests[0]
+			st.QueuedApprovalRequests = st.QueuedApprovalRequests[1:]
 			saveState(opts, st)
 			yield(&agent.ResponseUpdate{
 				Role:     message.RoleAssistant,
@@ -124,10 +124,10 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 		for {
 			// Inject collected approval responses as user messages.
 			callMessages := messages
-			if len(st.CollectedResponses) > 0 {
-				injected := responseMessage(st.CollectedResponses)
+			if len(st.CollectedApprovalResponses) > 0 {
+				injected := responseMessage(st.CollectedApprovalResponses)
 				callMessages = append(slices.Clone(messages), injected)
-				st.CollectedResponses = nil
+				st.CollectedApprovalResponses = nil
 			}
 
 			var approvalRequests []*message.ToolApprovalRequestContent
@@ -171,8 +171,8 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 			if len(needsApproval) > 0 {
 				// Surface the first unapproved request, queue the rest.
 				first := needsApproval[0]
-				st.QueuedRequests = append(st.QueuedRequests, needsApproval[1:]...)
-				st.CollectedResponses = append(st.CollectedResponses, autoApproved...)
+				st.QueuedApprovalRequests = append(st.QueuedApprovalRequests, needsApproval[1:]...)
+				st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, autoApproved...)
 
 				// Non-approval updates were already yielded during streaming.
 				if !yield(&agent.ResponseUpdate{
@@ -188,7 +188,7 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 
 			// All were auto-approved — collect responses and loop to call
 			// inner agent again with the approvals injected.
-			st.CollectedResponses = append(st.CollectedResponses, autoApproved...)
+			st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, autoApproved...)
 			// Non-approval updates were already yielded during streaming.
 		}
 	}
@@ -222,11 +222,11 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 					}
 				}
 				if resp.InnerResponse != nil {
-					st.CollectedResponses = append(st.CollectedResponses, resp.InnerResponse)
+					st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, resp.InnerResponse)
 				}
 			case *message.ToolApprovalResponseContent:
 				hasApproval = true
-				st.CollectedResponses = append(st.CollectedResponses, resp)
+				st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, resp)
 			}
 		}
 		if hasApproval {
@@ -266,22 +266,22 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 // are for tools that do not require approval, or match an auto-approval rule,
 // adding auto-approve responses to collected.
 func drainAutoApprovable(ctx context.Context, cfg Config, st *state, opts []agent.Option) error {
-	if len(st.QueuedRequests) == 0 {
+	if len(st.QueuedApprovalRequests) == 0 {
 		return nil
 	}
 	var remaining []*message.ToolApprovalRequestContent
-	for _, req := range st.QueuedRequests {
+	for _, req := range st.QueuedApprovalRequests {
 		approved, err := isAutoApprovable(ctx, cfg, st.Rules, opts, req)
 		if err != nil {
 			return err
 		}
 		if approved {
-			st.CollectedResponses = append(st.CollectedResponses, req.CreateResponse(true, ""))
+			st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, req.CreateResponse(true, ""))
 		} else {
 			remaining = append(remaining, req)
 		}
 	}
-	st.QueuedRequests = remaining
+	st.QueuedApprovalRequests = remaining
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Renamed the internal Go tool-approval session state fields from `CollectedResponses` / `QueuedRequests` to `CollectedApprovalResponses` / `QueuedApprovalRequests` so the structure more closely matches the corresponding .NET `ToolApprovalState`. The persisted JSON field names are unchanged, so existing serialized session state remains compatible.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalState.cs` - defines `CollectedApprovalResponses` and `QueuedApprovalRequests` in the persisted tool approval state.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/harness/toolapproval`

## Notes

Rejected candidates from the random .NET sample:
- `dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellEnvironmentProvider.cs` - Go already has the matching probed tool-name validation, duplicate handling, and focused tests.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Models/ToolChoice.cs` - the closest Go surface is public `tool.ToolMode`, so changing it would risk public API churn.

No open `[dotnet-code]` PRs were found before editing.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/28883295867) · 346.3 AIC · ⌖ 81.4 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 28883295867, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/28883295867 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #442