### PR TITLE
Fix duplicate and corrupted streamed Anthropic tool calls

### DIFF
--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -127,6 +127,7 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 		var modelID string
 		var usage message.UsageDetails
 		functions := make(map[int]*message.FunctionCallContent)
+		inputPlaceholders := make(map[int]string)
 
 		for stream.Next() {
 			event := stream.Current()
@@ -141,13 +142,27 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				usage.Add(toUsageDetailsDelta(event.Usage))
 			case anthropic.ContentBlockStartEvent:
 				contents = a.buildBlock(int(event.Index), event.ContentBlock.AsAny(), contents, functions)
+				// A streamed tool_use start event carries only an input
+				// placeholder; the arguments arrive as input_json_delta
+				// events. Set the placeholder aside so deltas accumulate
+				// from scratch, and restore it on stop if no deltas came.
+				if fn, ok := functions[int(event.Index)]; ok {
+					inputPlaceholders[int(event.Index)] = fn.Arguments
+					fn.Arguments = ""
+				}
 			case anthropic.ContentBlockDeltaEvent:
 				contents = a.buildDelta(int(event.Index), event.Delta.AsAny(), contents, functions)
 			case anthropic.ContentBlockStopEvent:
-				indices := slices.Collect(maps.Keys(functions))
-				slices.Sort(indices)
-				for _, id := range indices {
-					contents = append(contents, functions[id])
+				// Emit only the function call whose block just finished;
+				// earlier blocks were already emitted by their own stop
+				// events.
+				if fn, ok := functions[int(event.Index)]; ok {
+					if fn.Arguments == "" {
+						fn.Arguments = inputPlaceholders[int(event.Index)]
+					}
+					contents = append(contents, fn)
+					delete(functions, int(event.Index))
+					delete(inputPlaceholders, int(event.Index))
 				}
 			}
 

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -32,7 +32,8 @@ func newTestClient(t *testing.T, server *httptest.Server) *agent.Agent {
 		anthropicprovider.AgentConfig{
 			Model:  "claude-3-5-sonnet-20241022",
 			Config: agent.Config{DisableFuncAutoCall: true},
-		})
+		},
+	)
 }
 
 // nestedKey traverses a decoded JSON map following the given path of keys and
@@ -146,7 +147,8 @@ func TestConfigInstructions(t *testing.T) {
 			Config: agent.Config{
 				DisableFuncAutoCall: true,
 			},
-		})
+		},
+	)
 
 	if _, err := a.RunText(t.Context(), "hi").Collect(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -319,5 +321,81 @@ func TestStructuredOutput_Streaming(t *testing.T) {
 	}
 	if out.Age != 25 {
 		t.Errorf("out.Age = %d, want %d", out.Age, 25)
+	}
+}
+
+// parallelToolUseStreamingResponse returns an SSE stream that delivers two
+// tool_use content blocks, mirroring how the API streams parallel tool calls.
+func parallelToolUseStreamingResponse() string {
+	return "" +
+		"event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_stream02","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Paris\"}"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_02","name":"get_time","input":{}}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"zone\":\"CET\"}"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":1}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":5}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n"
+}
+
+// TestStreaming_ParallelToolCalls_NoDuplicates verifies that each streamed
+// tool_use block yields exactly one FunctionCallContent. A content_block_stop
+// event must only emit the function call for the block that stopped, not
+// re-emit previously completed ones.
+func TestStreaming_ParallelToolCalls_NoDuplicates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, parallelToolUseStreamingResponse())
+	}))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+
+	calls := make(map[string]int)
+	arguments := make(map[string]string)
+	for update, err := range a.RunText(t.Context(), "weather and time in Paris", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if update == nil {
+			continue
+		}
+		for _, c := range update.Contents {
+			if fcc, ok := c.(*message.FunctionCallContent); ok {
+				calls[fcc.CallID]++
+				arguments[fcc.CallID] = fcc.Arguments
+			}
+		}
+	}
+
+	want := map[string]int{"toolu_01": 1, "toolu_02": 1}
+	for id, wantCount := range want {
+		if calls[id] != wantCount {
+			t.Errorf("FunctionCallContent for %s yielded %d times, want %d", id, calls[id], wantCount)
+		}
+	}
+	for id := range calls {
+		if _, ok := want[id]; !ok {
+			t.Errorf("unexpected FunctionCallContent with CallID %s", id)
+		}
+	}
+
+	if got, want := arguments["toolu_01"], `{"city":"Paris"}`; got != want {
+		t.Errorf("toolu_01 arguments = %q, want %q", got, want)
+	}
+	if got, want := arguments["toolu_02"], `{"zone":"CET"}`; got != want {
+		t.Errorf("toolu_02 arguments = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs in `provider/anthropicprovider`'s streaming path that break streamed tool calls, most visibly with parallel tool use:

1. **Duplicate tool call emission.** Every `content_block_stop` event re-emitted *all* accumulated function calls (the `functions` map was walked in full and never pruned), instead of only the block that stopped. With two or more `tool_use` blocks in one streamed response — Anthropic's normal shape for parallel tool calls — the first call was yielded again on every later block stop. Downstream consumers such as the `toolautocall` middleware accumulate `FunctionCallContent` without CallID dedup, so the same tool call was **executed more than once**.

2. **Corrupted argument JSON.** A streamed `tool_use` `content_block_start` event carries only an input placeholder (`"input": {}`); the real arguments arrive via `input_json_delta` events. `buildBlock` seeded `Arguments` with that placeholder and the deltas were appended after it, so every streamed tool call produced invalid arguments like `{}{"city":"Paris"}`.

## Fix

In the streaming loop:
- `content_block_stop` now emits only `functions[event.Index]` and deletes it from the map, so each function call is yielded exactly once, when its block completes.
- The start-event input placeholder is set aside so `input_json_delta` fragments accumulate from scratch; if a block produces no deltas, the placeholder is restored on stop, preserving prior behavior for calls whose input arrives on the start event.

The non-streaming path is unchanged (its single end-of-response map walk was already correct).

No public API changes.

## Tests

- Added `TestStreaming_ParallelToolCalls_NoDuplicates`: replays an SSE stream with two parallel `tool_use` blocks through an `httptest.Server` (matching the existing test style) and asserts each `CallID` is yielded exactly once with correctly assembled arguments. The test fails on `main` with `FunctionCallContent for toolu_01 yielded 2 times, want 1` and `toolu_01 arguments = "{}{\"city\":\"Paris\"}"`.
- `go test -race -shuffle=on ./...` passes.
- `gofmt`/`gofumpt` clean, `go vet` clean.