### PR TITLE
Fix nil update dereference in tool approval middleware

### DIFF
--- a/agent/harness/toolapproval/toolapproval.go
+++ b/agent/harness/toolapproval/toolapproval.go
@@ -136,6 +136,13 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 					yield(nil, err)
 					return
 				}
+				if update == nil {
+					if !yield(nil, nil) {
+						saveState(opts, st)
+						return
+					}
+					continue
+				}
 				stripped, requests := splitApprovalRequestContents(update)
 				approvalRequests = append(approvalRequests, requests...)
 				if stripped != nil {

--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -124,7 +124,8 @@ func TestToolApproval_SurfacesFirstApprovalRequest(t *testing.T) {
 
 	mw := toolapproval.New(toolapproval.Config{})
 	session := agenttest.CreateSession()
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		agent.WithSession(session),
 	)
@@ -184,7 +185,8 @@ func TestToolApproval_AlwaysApproveToolCreatesRule(t *testing.T) {
 	opts := []agent.Option{agent.WithSession(session)}
 
 	// Turn 1: Get the approval request.
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -205,7 +207,8 @@ func TestToolApproval_AlwaysApproveToolCreatesRule(t *testing.T) {
 
 	// Turn 2: Send the always-approve response. The queued requests from the
 	// inner agent should now be auto-approved and the inner agent called again.
-	updates = collectUpdates(t, mw, runner.Run,
+	updates = collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{alwaysApproveResp}}},
 		opts...,
 	)
@@ -245,7 +248,8 @@ func TestToolApproval_QueuedRequestsSurfacedOneAtATime(t *testing.T) {
 	opts := []agent.Option{agent.WithSession(session)}
 
 	// Turn 1: Get first approval request.
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -263,7 +267,8 @@ func TestToolApproval_QueuedRequestsSurfacedOneAtATime(t *testing.T) {
 
 	// Turn 2: Approve r1, should get r2 next.
 	resp := firstReq.CreateResponse(true, "")
-	updates = collectUpdates(t, mw, runner.Run,
+	updates = collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{resp}}},
 		opts...,
 	)
@@ -335,7 +340,8 @@ func TestToolApproval_AlwaysApproveToolWithArgumentsMatchesByValue(t *testing.T)
 	session := agenttest.CreateSession()
 	opts := []agent.Option{agent.WithSession(session)}
 
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -352,7 +358,8 @@ func TestToolApproval_AlwaysApproveToolWithArgumentsMatchesByValue(t *testing.T)
 		t.Fatal("expected approval request in turn 1")
 	}
 
-	updates = collectUpdates(t, mw, runner.Run,
+	updates = collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolWithArgumentsResponse()}}},
 		opts...,
 	)
@@ -409,7 +416,8 @@ func TestToolApproval_AlwaysApproveToolWithNoArgumentsDoesNotMatchCallWithArgume
 	session := agenttest.CreateSession()
 	opts := []agent.Option{agent.WithSession(session)}
 
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -426,7 +434,8 @@ func TestToolApproval_AlwaysApproveToolWithNoArgumentsDoesNotMatchCallWithArgume
 		t.Fatal("expected approval request in turn 1")
 	}
 
-	updates = collectUpdates(t, mw, runner.Run,
+	updates = collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolWithArgumentsResponse()}}},
 		opts...,
 	)
@@ -484,7 +493,8 @@ func TestToolApproval_AlwaysApproveToolWithNoArgumentsMatchesLaterNoArgumentsCal
 	session := agenttest.CreateSession()
 	opts := []agent.Option{agent.WithSession(session)}
 
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -501,7 +511,8 @@ func TestToolApproval_AlwaysApproveToolWithNoArgumentsMatchesLaterNoArgumentsCal
 		t.Fatal("expected approval request in turn 1")
 	}
 
-	updates = collectUpdates(t, mw, runner.Run,
+	updates = collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolWithArgumentsResponse()}}},
 		opts...,
 	)
@@ -536,7 +547,8 @@ func TestToolApproval_AlwaysApproveToolWithNoArgumentsPersistsEmptyArguments(t *
 
 	mw := toolapproval.New(toolapproval.Config{})
 	session := agenttest.CreateSession()
-	collectUpdates(t, mw, runner.Run,
+	collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{req.AlwaysApproveToolWithArgumentsResponse()}}},
 		agent.WithSession(session),
 	)
@@ -593,7 +605,8 @@ func TestToolApproval_NonApprovalRequiredToolAutoApproved(t *testing.T) {
 	}
 
 	// Turn 1: middleware should surface only deploy, auto-approve list.
-	turn1 := collectUpdates(t, mw, runner.Run,
+	turn1 := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -615,7 +628,8 @@ func TestToolApproval_NonApprovalRequiredToolAutoApproved(t *testing.T) {
 
 	// Turn 2: approve deploy; inner agent should receive responses for both list and deploy.
 	deployResp := approvalReqs[0].CreateResponse(true, "")
-	turn2 := collectUpdates(t, mw, runner.Run,
+	turn2 := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{deployResp}}},
 		opts...,
 	)
@@ -689,7 +703,8 @@ func TestToolApproval_NonApprovalRequiredQueuedRequestDrained(t *testing.T) {
 	session := agenttest.CreateSession()
 
 	// Turn 1: no tool options → both deploy and list are treated as requiring approval.
-	turn1 := collectUpdates(t, mw, runner.Run,
+	turn1 := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		agent.WithSession(session),
 	)
@@ -713,7 +728,8 @@ func TestToolApproval_NonApprovalRequiredQueuedRequestDrained(t *testing.T) {
 		agent.WithSession(session),
 		agent.WithTool(newNoopTool("list")), // list does NOT require approval
 	}
-	turn2 := collectUpdates(t, mw, runner.Run,
+	turn2 := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{deployResp}}},
 		optsWithList...,
 	)
@@ -762,7 +778,8 @@ func TestToolApproval_AutoApprovalRule_ApprovesMatchingTool(t *testing.T) {
 	mw := toolapproval.New(cfg)
 	session := agenttest.CreateSession()
 
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		agent.WithSession(session),
 	)
@@ -807,7 +824,8 @@ func TestToolApproval_AutoApprovalRule_DoesNotMatchSurfacesToCaller(t *testing.T
 	}
 	mw := toolapproval.New(cfg)
 
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 	)
 
@@ -861,7 +879,8 @@ func TestToolApproval_MultipleAutoApprovalRules_FirstMatchWins(t *testing.T) {
 	mw := toolapproval.New(cfg)
 	session := agenttest.CreateSession()
 
-	collectUpdates(t, mw, runner.Run,
+	collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		agent.WithSession(session),
 	)
@@ -904,7 +923,8 @@ func TestToolApproval_StandingRuleTakesPrecedenceOverAutoApprovalRule(t *testing
 	opts := []agent.Option{agent.WithSession(session)}
 
 	// Turn 1: auto-approval rule is called (no standing rule yet).
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -955,7 +975,8 @@ func TestToolApproval_AutoApprovalRule_ApprovesQueuedRequests(t *testing.T) {
 	opts := []agent.Option{agent.WithSession(session)}
 
 	// Turn 1: r1 (SafeTool) is auto-approved; r2 (DangerousTool) is surfaced.
-	updates := collectUpdates(t, mw, runner.Run,
+	updates := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -1047,7 +1068,8 @@ func TestToolApproval_QueuedStandingRuleShortCircuitsAutoApprovalEvaluation(t *t
 	session := agenttest.CreateSession()
 	opts := []agent.Option{agent.WithSession(session)}
 
-	turn1 := collectUpdates(t, mw, runner.Run,
+	turn1 := collectUpdates(
+		t, mw, runner.Run,
 		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
 		opts...,
 	)
@@ -1087,5 +1109,44 @@ func TestToolApproval_QueuedStandingRuleShortCircuitsAutoApprovalEvaluation(t *t
 	}
 	if ruleCalls != 2 {
 		t.Fatalf("expected auto-approval rule to be called only in turn 1, got %d calls", ruleCalls)
+	}
+}
+
+func TestToolApproval_NilUpdatePassthrough(t *testing.T) {
+	// Providers and middlewares may yield nil updates; toolautocall forwards
+	// them and the agent run loop skips them. The approval middleware must
+	// tolerate them rather than dereferencing nil.
+	next := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			if !yield(nil, nil) {
+				return
+			}
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: []message.Content{&message.TextContent{Text: "done"}},
+			}, nil)
+		}
+	}
+
+	mw := toolapproval.New(toolapproval.Config{})
+	updates := collectUpdates(t, mw, next, []*message.Message{
+		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "hi"}}},
+	})
+
+	var nilUpdates, textUpdates int
+	for _, u := range updates {
+		if u == nil {
+			nilUpdates++
+			continue
+		}
+		if tc, ok := u.Contents[0].(*message.TextContent); ok && tc.Text == "done" {
+			textUpdates++
+		}
+	}
+	if nilUpdates != 1 {
+		t.Errorf("expected 1 nil update forwarded, got %d", nilUpdates)
+	}
+	if textUpdates != 1 {
+		t.Errorf("expected 1 text update, got %d", textUpdates)
 	}
 }

--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -1139,8 +1139,10 @@ func TestToolApproval_NilUpdatePassthrough(t *testing.T) {
 			nilUpdates++
 			continue
 		}
-		if tc, ok := u.Contents[0].(*message.TextContent); ok && tc.Text == "done" {
-			textUpdates++
+		for _, c := range u.Contents {
+			if tc, ok := c.(*message.TextContent); ok && tc.Text == "done" {
+				textUpdates++
+			}
 		}
 	}
 	if nilUpdates != 1 {


### PR DESCRIPTION
## Summary

The tool approval middleware (`agent/harness/toolapproval`) dereferences every update from the inner run without a nil check: the main loop passes each update straight into `splitApprovalRequestContents`, which iterates `u.Contents`.

Nil updates are legal in a response stream — the agent run loop skips them (`agent.go`), and the `toolautocall` middleware explicitly forwards them downstream (`autocall.go`). `toolapproval` is the only consumer in the codebase missing this guard, so composing it with `toolautocall` (or any provider that yields a nil update) panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
  toolapproval.splitApprovalRequestContents(0x0)
      agent/harness/toolapproval/toolapproval.go:422
  toolapproval.run.func1-range1(...)
      agent/harness/toolapproval/toolapproval.go:139
```

## Fix

Forward nil updates downstream (matching `toolautocall`'s behavior) instead of classifying them, preserving stream semantics for outer consumers.

No public API changes.

## Tests

- Added `TestToolApproval_NilUpdatePassthrough`, which drives the middleware with an inner run that yields a nil update followed by a text update. On `main` it fails with the SIGSEGV above; with the fix it passes and asserts the nil update is forwarded and the text update is delivered.
- `go test -race -shuffle=on ./...` passes.
- `gofmt`/`gofumpt` clean, `go vet` clean.