### PR TITLE
Validate Foundry toolbox names as single path segments

### DIFF
--- a/internal/azaiprojects/toolbox_name.go
+++ b/internal/azaiprojects/toolbox_name.go
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package azaiprojects
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// validateToolboxName guards every toolbox request builder that interpolates a
+// caller-supplied name into the request path (for example
+// "/toolboxes/{name}/versions"). It ensures the name resolves to a single,
+// intact path segment so a caller-influenced value cannot change the request
+// target — the Go counterpart of the upstream .NET FoundryToolboxService
+// EnsureSafeToolboxName check (microsoft/agent-framework#6890).
+//
+// Unlike .NET, the Go request builders percent-escape the name with
+// url.PathEscape before it reaches the wire, so an "effect-based" check that
+// rebuilds and re-parses the URL would accept "a/b" (it round-trips as the
+// escaped single segment "a%2Fb"). Instead this validates the name directly,
+// rejecting path separators, traversal, and query/fragment delimiters in both
+// the raw name and its percent-decoded form — an encoded separator such as
+// "%2F" must be rejected here because a downstream proxy could decode it back
+// into a separator.
+func validateToolboxName(name string) error {
+	if name == "" {
+		return errors.New("parameter name cannot be empty")
+	}
+	if !isSafeToolboxSegment(name) {
+		return fmt.Errorf("toolbox name %q is not a valid single-segment identifier: "+
+			"it must resolve to a single path segment and must not alter the request target", name)
+	}
+	// A percent-encoded separator (e.g. "%2F") stays a single segment through
+	// url.PathEscape but decodes back into a separator at a downstream proxy,
+	// so validate the decoded form too. A malformed escape sequence cannot
+	// round-trip to an intact segment, so treat a decode error as unsafe.
+	decoded, err := url.PathUnescape(name)
+	if err != nil || !isSafeToolboxSegment(decoded) {
+		return fmt.Errorf("toolbox name %q is not a valid single-segment identifier: "+
+			"it must resolve to a single path segment and must not alter the request target", name)
+	}
+	return nil
+}
+
+// isSafeToolboxSegment reports whether s is a single, intact URL path segment:
+// non-empty, not a "."/".." traversal segment, and free of the separators and
+// delimiters ("/", "\", "?", "#") that would move the request target.
+//
+// TODO(learning): implement this predicate. Consider:
+//   - the empty string and the traversal segments "." and ".." must be rejected;
+//   - a separator or delimiter anywhere in s ends the segment early or starts a
+//     new one — strings.ContainsAny with the set `/\?#` is the concise check;
+//   - keep it forgiving otherwise (":", "@", "~", or an interior dot are fine),
+//     so legitimate names are not blocked.
+func isSafeToolboxSegment(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	// "\\" is a single backslash. Any of these characters would end the path
+	// segment early or start a new one, moving the request target.
+	return !strings.ContainsAny(s, "/\\?#")
+}

--- a/internal/azaiprojects/toolbox_name.go
+++ b/internal/azaiprojects/toolbox_name.go
@@ -47,13 +47,6 @@ func validateToolboxName(name string) error {
 // isSafeToolboxSegment reports whether s is a single, intact URL path segment:
 // non-empty, not a "."/".." traversal segment, and free of the separators and
 // delimiters ("/", "\", "?", "#") that would move the request target.
-//
-// TODO(learning): implement this predicate. Consider:
-//   - the empty string and the traversal segments "." and ".." must be rejected;
-//   - a separator or delimiter anywhere in s ends the segment early or starts a
-//     new one — strings.ContainsAny with the set `/\?#` is the concise check;
-//   - keep it forgiving otherwise (":", "@", "~", or an interior dot are fine),
-//     so legitimate names are not blocked.
 func isSafeToolboxSegment(s string) bool {
 	if s == "" || s == "." || s == ".." {
 		return false

--- a/internal/azaiprojects/toolbox_name_test.go
+++ b/internal/azaiprojects/toolbox_name_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package azaiprojects
+
+import (
+	"context"
+	"testing"
+)
+
+func TestValidateToolboxName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid single-segment identifiers.
+		{"simple", "my-toolbox", false},
+		{"underscores and digits", "tool_box_1", false},
+		{"interior dot", "v1.2.3", false},
+		{"allowed specials", "a:b@c~d", false},
+
+		// Empty.
+		{"empty", "", true},
+
+		// Raw separators and delimiters.
+		{"forward slash", "a/b", true},
+		{"leading slash", "/evil", true},
+		{"backslash", "a\\b", true},
+		{"question mark", "a?b", true},
+		{"hash", "a#b", true},
+
+		// Traversal segments.
+		{"dot", ".", true},
+		{"dotdot", "..", true},
+
+		// Percent-encoded separators / traversal decode back to unsafe forms.
+		{"encoded slash lower", "a%2fb", true},
+		{"encoded slash upper", "a%2Fb", true},
+		{"encoded backslash", "a%5cb", true},
+		{"encoded question", "a%3fb", true},
+		{"encoded hash", "a%23b", true},
+		{"encoded dotdot", "%2e%2e", true},
+
+		// Malformed percent-escape cannot round-trip to a safe segment.
+		{"malformed percent", "a%2gb", true},
+		{"trailing percent", "toolbox%", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateToolboxName(tt.input)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateToolboxName(%q) = nil, want error", tt.input)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validateToolboxName(%q) = %v, want nil", tt.input, err)
+			}
+		})
+	}
+}
+
+// TestToolboxRequestBuildersRejectUnsafeNames verifies that every toolbox
+// request builder that interpolates a name into the request path refuses a
+// target-altering name before building the request, and still accepts a valid
+// one. The *CreateRequest methods only assemble the request (no network I/O),
+// so a bare client with just an endpoint is enough to exercise them.
+func TestToolboxRequestBuildersRejectUnsafeNames(t *testing.T) {
+	client := &ToolboxesClient{endpoint: "https://example.com"}
+	ctx := context.Background()
+
+	builders := map[string]func(name string) error{
+		"CreateToolboxVersion": func(name string) error {
+			_, err := client.createToolboxVersionCreateRequest(ctx, name, nil, nil)
+			return err
+		},
+		"DeleteToolbox": func(name string) error {
+			_, err := client.deleteToolboxCreateRequest(ctx, name, nil)
+			return err
+		},
+		"DeleteToolboxVersion": func(name string) error {
+			_, err := client.deleteToolboxVersionCreateRequest(ctx, name, "v1", nil)
+			return err
+		},
+		"GetToolbox": func(name string) error {
+			_, err := client.getToolboxCreateRequest(ctx, name, nil)
+			return err
+		},
+		"GetToolboxVersion": func(name string) error {
+			_, err := client.getToolboxVersionCreateRequest(ctx, name, "v1", nil)
+			return err
+		},
+		"ListToolboxVersions": func(name string) error {
+			_, err := client.listToolboxVersionsCreateRequest(ctx, name, &ToolboxesClientListToolboxVersionsOptions{})
+			return err
+		},
+		"UpdateToolbox": func(name string) error {
+			_, err := client.updateToolboxCreateRequest(ctx, name, "v1", nil)
+			return err
+		},
+	}
+
+	for op, build := range builders {
+		t.Run(op+"/rejects_traversal", func(t *testing.T) {
+			if err := build(".."); err == nil {
+				t.Errorf("%s built a request for name %q, want error", op, "..")
+			}
+		})
+		t.Run(op+"/rejects_encoded_separator", func(t *testing.T) {
+			if err := build("a%2Fb"); err == nil {
+				t.Errorf("%s built a request for name %q, want error", op, "a%2Fb")
+			}
+		})
+		t.Run(op+"/accepts_valid_name", func(t *testing.T) {
+			if err := build("my-toolbox"); err != nil {
+				t.Errorf("%s(%q) returned %v, want nil", op, "my-toolbox", err)
+			}
+		})
+	}
+}

--- a/internal/azaiprojects/z_toolboxes_client.go
+++ b/internal/azaiprojects/z_toolboxes_client.go
@@ -56,8 +56,8 @@ func (client *ToolboxesClient) CreateToolboxVersion(ctx context.Context, name st
 // createToolboxVersionCreateRequest creates the CreateToolboxVersion request.
 func (client *ToolboxesClient) createToolboxVersionCreateRequest(ctx context.Context, name string, tools []ToolboxToolClassification, options *ToolboxesClientCreateToolboxVersionOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	if err := validateToolboxName(name); err != nil {
+		return nil, err
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
@@ -133,8 +133,8 @@ func (client *ToolboxesClient) DeleteToolbox(ctx context.Context, name string, o
 // deleteToolboxCreateRequest creates the DeleteToolbox request.
 func (client *ToolboxesClient) deleteToolboxCreateRequest(ctx context.Context, name string, _ *ToolboxesClientDeleteToolboxOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	if err := validateToolboxName(name); err != nil {
+		return nil, err
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
@@ -177,8 +177,8 @@ func (client *ToolboxesClient) DeleteToolboxVersion(ctx context.Context, name st
 // deleteToolboxVersionCreateRequest creates the DeleteToolboxVersion request.
 func (client *ToolboxesClient) deleteToolboxVersionCreateRequest(ctx context.Context, name string, version string, _ *ToolboxesClientDeleteToolboxVersionOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions/{version}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	if err := validateToolboxName(name); err != nil {
+		return nil, err
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	if version == "" {
@@ -224,8 +224,8 @@ func (client *ToolboxesClient) GetToolbox(ctx context.Context, name string, opti
 // getToolboxCreateRequest creates the GetToolbox request.
 func (client *ToolboxesClient) getToolboxCreateRequest(ctx context.Context, name string, _ *ToolboxesClientGetToolboxOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	if err := validateToolboxName(name); err != nil {
+		return nil, err
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -279,8 +279,8 @@ func (client *ToolboxesClient) GetToolboxVersion(ctx context.Context, name strin
 // getToolboxVersionCreateRequest creates the GetToolboxVersion request.
 func (client *ToolboxesClient) getToolboxVersionCreateRequest(ctx context.Context, name string, version string, _ *ToolboxesClientGetToolboxVersionOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions/{version}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	if err := validateToolboxName(name); err != nil {
+		return nil, err
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	if version == "" {
@@ -346,8 +346,8 @@ func (client *ToolboxesClient) NewListToolboxVersionsPager(name string, options 
 // listToolboxVersionsCreateRequest creates the ListToolboxVersions request.
 func (client *ToolboxesClient) listToolboxVersionsCreateRequest(ctx context.Context, name string, options *ToolboxesClientListToolboxVersionsOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	if err := validateToolboxName(name); err != nil {
+		return nil, err
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -483,8 +483,8 @@ func (client *ToolboxesClient) UpdateToolbox(ctx context.Context, name string, d
 // updateToolboxCreateRequest creates the UpdateToolbox request.
 func (client *ToolboxesClient) updateToolboxCreateRequest(ctx context.Context, name string, defaultVersion string, _ *ToolboxesClientUpdateToolboxOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	if err := validateToolboxName(name); err != nil {
+		return nil, err
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.endpoint, urlPath))


### PR DESCRIPTION
## Summary

The internal Azure AI Projects toolbox request builders in `internal/azaiprojects` interpolate a caller-supplied toolbox name directly into the request path (e.g. `/toolboxes/{name}`, `/toolboxes/{name}/versions/{version}`). A name that does not resolve to a single, intact path segment — a `.`/`..` traversal segment, or one containing a separator/delimiter (`/`, `\`, `?`, `#`) or their percent-encoded forms — could alter the request target.

This ports the upstream .NET `FoundryToolboxService.EnsureSafeToolboxName` validation (microsoft/agent-framework#6890, commit `2c7aadce`) to Go.

## Fix

- Add a shared `validateToolboxName` helper (`internal/azaiprojects/toolbox_name.go`) and call it from every toolbox request builder that interpolates a name: `CreateToolboxVersion`, `DeleteToolbox`, `DeleteToolboxVersion`, `GetToolbox`, `GetToolboxVersion`, `ListToolboxVersions`, `UpdateToolbox`.
- The helper rejects the empty string, `.`/`..`, and any raw or percent-decoded separator/delimiter, returning an error before the request is built (the empty-name check each builder previously performed is subsumed by the helper).

### Note on the .NET port

.NET validates by rebuilding the proxy URL and re-parsing it to confirm the name lands as one intact segment. That approach does not translate directly to Go: the Go request builders percent-escape the name with `url.PathEscape` **before** it reaches the wire, so `a/b` would round-trip as the single escaped segment `a%2Fb` and an effect-based check would accept it. The Go helper therefore validates the raw name **and** its `url.PathUnescape`d form directly — an encoded separator such as `%2F` is rejected here because a downstream proxy could decode it back into a separator.

### Note on the generated file

`z_toolboxes_client.go` is code-generated (`DO NOT EDIT`), but it is the single point where names enter the request path, so the validator call is added there (mirroring how the .NET fix patched its hosting service). CI does not run the TypeSpec generator, so the checked-in file is effectively source; the emitter would need the same one-line call re-applied on regeneration.

## Public API

No exported Go symbols change; the port is limited to internal Azure AI Projects request construction.

## Tests

- Added `internal/azaiprojects/toolbox_name_test.go`: a table covering valid names, empty, raw separators, `.`/`..` traversal, percent-encoded separators/traversal, and malformed escapes; plus request-builder coverage asserting every affected toolbox operation rejects a traversal name and an encoded separator and accepts a valid name.
- `go test -race -shuffle=on ./internal/azaiprojects ./provider/foundryprovider` passes.
- `go build ./...` and `go vet ./...` clean.

Closes #479