### PR TITLE
[dotnet-code] Extract lockstep event drain helper

### DIFF
--- a/workflow/internal/execution/eventstream.go
+++ b/workflow/internal/execution/eventstream.go
@@ -483,28 +483,6 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 			}
 		}()
 
-		drainEvents := func() bool {
-			var hadRequestHaltEvent bool
-			for {
-				evt, ok := l.eventQueue.Dequeue()
-				if !ok {
-					break
-				}
-				if errors.Is(linkedCtx.Err(), context.Canceled) {
-					return false
-				}
-				if _, ok := evt.(workflow.RequestHaltEvent); ok {
-					hadRequestHaltEvent = true
-					continue
-				}
-				if !yield(evt, nil) {
-					return false
-				}
-			}
-
-			return !hadRequestHaltEvent && linkedCtx.Err() == nil
-		}
-
 		l.setStatus(RunStatusRunning)
 
 		var runActivity *observability.Activity
@@ -522,7 +500,7 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 			yield(nil, err)
 			return
 		}
-		if !drainEvents() {
+		if !l.drainAndFilterEvents(linkedCtx, yield) {
 			return
 		}
 
@@ -542,7 +520,7 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 					return
 				}
 
-				if !drainEvents() {
+				if !l.drainAndFilterEvents(linkedCtx, yield) {
 					return
 				}
 			}
@@ -577,6 +555,28 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 			}
 		}
 	}
+}
+
+func (l *lockstepRunEventStream) drainAndFilterEvents(ctx context.Context, yield func(workflow.Event, error) bool) bool {
+	var hadRequestHaltEvent bool
+	for {
+		evt, ok := l.eventQueue.Dequeue()
+		if !ok {
+			break
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return false
+		}
+		if _, ok := evt.(workflow.RequestHaltEvent); ok {
+			hadRequestHaltEvent = true
+			continue
+		}
+		if !yield(evt, nil) {
+			return false
+		}
+	}
+
+	return !hadRequestHaltEvent && ctx.Err() == nil
 }
 
 func (l *lockstepRunEventStream) shouldBreak(status RunStatus, blockOnPendingRequest bool, ctx context.Context) bool {


### PR DESCRIPTION
## Summary

Extracted lockstep event draining and request-halt filtering into a focused unexported helper. This keeps the Go workflow event-stream internals closer to the .NET `LockstepRunEventStream.DrainAndFilterEvents` structure and makes future .NET-to-Go comparisons easier without changing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/LockstepRunEventStream.cs` - contains the focused `DrainAndFilterEvents` helper used by the lockstep event stream.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w workflow/internal/execution/eventstream.go`
- `go test ./workflow/internal/execution`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/CheckpointManagerImpl.cs` - Go checkpoint managers already separate in-memory and JSON store behavior; a tiny alignment change risked touching public constructor behavior or validation.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeConnection.cs` - closest Go type is public API, so structural changes would risk public surface churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Reflection/IMessageHandler.cs` - the sampled .NET interface is obsolete and has no direct Go implementation to safely align.

Avoided the existing open `[dotnet-code]` PR https://github.com/microsoft/agent-framework-go/pull/468 because it covers a different agent workflow candidate area.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29211731503) · 261.2 AIC · ⌖ 53.3 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29211731503, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29211731503 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #474