### PR TITLE
[dotnet-code] Refactor fan-in edge state reset

### DIFF
--- a/workflow/internal/execution/edgerunner.go
+++ b/workflow/internal/execution/edgerunner.go
@@ -33,6 +33,21 @@ type statefulEdgeState struct {
 	unseen          map[string]struct{}
 }
 
+func newStatefulEdgeState(sourceIDs []string) *statefulEdgeState {
+	state := &statefulEdgeState{
+		sourceIDs: sourceIDs,
+	}
+	state.resetUnseen()
+	return state
+}
+
+func (s *statefulEdgeState) resetUnseen() {
+	s.unseen = make(map[string]struct{}, len(s.sourceIDs))
+	for _, id := range s.sourceIDs {
+		s.unseen[id] = struct{}{}
+	}
+}
+
 func (s *statefulEdgeState) MarshalJSON() ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -73,12 +88,7 @@ func (s *statefulEdgeState) processMessage(sourceID string, envelope *MessageEnv
 	}
 	taken := s.pendingMessages
 	s.pendingMessages = nil
-	if s.unseen == nil {
-		s.unseen = make(map[string]struct{}, len(s.sourceIDs))
-	}
-	for _, id := range s.sourceIDs {
-		s.unseen[id] = struct{}{}
-	}
+	s.resetUnseen()
 	s.mu.Unlock()
 
 	if len(taken) == 0 {
@@ -126,14 +136,7 @@ func NewEdgeRunner(wf *workflow.Workflow, tracer StepTracer, ensureExecutor func
 			if statefulEdges == nil {
 				statefulEdges = make(map[int]*statefulEdgeState)
 			}
-			unseen := make(map[string]struct{}, len(edge.Connection.SourceIDs))
-			for _, id := range edge.Connection.SourceIDs {
-				unseen[id] = struct{}{}
-			}
-			statefulEdges[edge.Index] = &statefulEdgeState{
-				sourceIDs: edge.Connection.SourceIDs,
-				unseen:    unseen,
-			}
+			statefulEdges[edge.Index] = newStatefulEdgeState(edge.Connection.SourceIDs)
 		}
 	}
 

--- a/workflow/internal/execution/edgerunner.go
+++ b/workflow/internal/execution/edgerunner.go
@@ -42,7 +42,11 @@ func newStatefulEdgeState(sourceIDs []string) *statefulEdgeState {
 }
 
 func (s *statefulEdgeState) resetUnseen() {
-	s.unseen = make(map[string]struct{}, len(s.sourceIDs))
+	if s.unseen == nil {
+		s.unseen = make(map[string]struct{}, len(s.sourceIDs))
+	} else {
+		clear(s.unseen)
+	}
 	for _, id := range s.sourceIDs {
 		s.unseen[id] = struct{}{}
 	}


### PR DESCRIPTION
## Summary

Refactored the workflow internal fan-in edge state setup so initialization and cycle reset share the same unexported helper path. This keeps the Go `statefulEdgeState` structure closer to the .NET `FanInEdgeState` constructor/reset shape and makes future .NET-to-Go comparisons easier without changing routing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/FanInEdgeState.cs` - initializes `Unseen` from `SourceIds` and resets it after releasing buffered fan-in messages.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w workflow/internal/execution/edgerunner.go`
- `go test ./workflow/internal/execution ./workflow/inproc`

## Notes

Rejected sampled candidates:

- `dotnet/src/Microsoft.Agents.AI.Abstractions/ChatMessageExtensions.cs` - corresponding Go message attribution/forwarding internals are adjacent to existing open `[dotnet-code]` message-forwarding work noted in current open PRs, so skipped to avoid overlap.
- `dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellFamily.cs` - Go shell family values are public API and already intentionally include an unknown/default value, so a structural alignment change would risk public API or behavior churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/DataValueExtensions.cs` / declarative workflow files - no narrow corresponding Go production helper was evident from the sampled area without adding feature surface or placeholders.

Overlap check found no open fan-in/FanInEdgeState PRs before committing.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29170681743) · 186.5 AIC · ⌖ 29.7 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29170681743, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29170681743 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #471