### PR TITLE
[dotnet-code] Consolidate workflow edge connection construction

### DIFF
--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -122,10 +122,7 @@ func (wb *Builder) AddDirectEdge(source ExecutorBinding, target ExecutorBinding,
 	if wb.err != nil {
 		return wb
 	}
-	conn := EdgeConnection{
-		SourceIDs: []string{source.ID},
-		SinkIDs:   []string{target.ID},
-	}
+	conn := newEdgeConnection([]string{source.ID}, []string{target.ID})
 	if condition == nil && slices.ContainsFunc(wb.conditionlessConnections, func(c EdgeConnection) bool {
 		return conn.Equal(c)
 	}) {
@@ -167,10 +164,7 @@ func (wb *Builder) AddFanOutEdge(source ExecutorBinding, targets []ExecutorBindi
 		}
 		sinkIDs = append(sinkIDs, target.ID)
 	}
-	conn := EdgeConnection{
-		SourceIDs: []string{source.ID},
-		SinkIDs:   sinkIDs,
-	}
+	conn := newEdgeConnection([]string{source.ID}, sinkIDs)
 	edge := Edge{
 		Connection: conn,
 		Index:      wb.edgeIdx(),
@@ -197,11 +191,8 @@ func (wb *Builder) AddFanInBarrierEdge(sources []ExecutorBinding, target Executo
 		sourceIDs = append(sourceIDs, source.ID)
 	}
 	edge := Edge{
-		Connection: EdgeConnection{
-			SourceIDs: sourceIDs,
-			SinkIDs:   []string{target.ID},
-		},
-		Index: wb.edgeIdx(),
+		Connection: newEdgeConnection(sourceIDs, []string{target.ID}),
+		Index:      wb.edgeIdx(),
 	}
 	applyEdgeOptions(&edge, opts)
 	for _, id := range sourceIDs {

--- a/workflow/edge.go
+++ b/workflow/edge.go
@@ -79,6 +79,13 @@ type EdgeConnection struct {
 	SinkIDs   []string
 }
 
+func newEdgeConnection(sourceIDs []string, sinkIDs []string) EdgeConnection {
+	return EdgeConnection{
+		SourceIDs: sourceIDs,
+		SinkIDs:   sinkIDs,
+	}
+}
+
 func (c EdgeConnection) Equal(other EdgeConnection) bool {
 	return slices.Equal(c.SourceIDs, other.SourceIDs) && slices.Equal(c.SinkIDs, other.SinkIDs)
 }


### PR DESCRIPTION
## Summary

Consolidated workflow builder edge endpoint construction through a small unexported `newEdgeConnection` helper. This keeps the Go workflow edge internals closer to the .NET `EdgeConnection` construction shape, making future .NET-to-Go comparisons easier while leaving the exported `EdgeConnection` struct and behavior unchanged.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeConnection.cs` - central edge connection type constructed from ordered source and sink ID lists.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w workflow/edge.go workflow/builder.go`
- `go test ./workflow`

## Notes

Rejected sampled candidates:

- `dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/WorkflowHostExecutor.cs` - closest Go equivalents are broader subworkflow hosting/runtime paths, and open PR https://github.com/microsoft/agent-framework-go/pull/468 already covers adjacent aggregate-turn workflow internals.
- `dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSourceOptions.cs` - Go file-based skills surface is much smaller and does not expose equivalent internal option plumbing, so a structural cleanup would risk adding shape without existing behavior.
- `dotnet/src/Microsoft.Agents.AI.Abstractions/AgentAbstractionsJsonUtilities.cs` - Go JSON utilities are spread across generic internal helpers and workflow checkpoint serialization, with no narrow corresponding production cleanup from this sample.

Additional sampled files reviewed included OpenAI hosting model/response files, durable workflow envelopes/events, and tests/samples that were skipped because they were either outside the Go implementation surface or not appropriate for production portability cleanup.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29128252911) · 409.6 AIC · ⌖ 42.9 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29128252911, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29128252911 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #469