### PR TITLE
[dotnet-port-fixes] Validate Foundry toolbox path segments

### DIFF
--- a/internal/azaiprojects/toolbox_name.go
+++ b/internal/azaiprojects/toolbox_name.go
@@ -22,11 +22,30 @@ func replaceToolboxNamePathParameter(endpoint, urlPath, name string) (string, er
 }
 
 func validateToolboxNamePathSegment(endpoint, name string) error {
+	// Always reject dot-only names and names containing raw path/query/fragment
+	// separators or backslashes — independent of whether a base endpoint is available.
+	if name == "." || name == ".." {
+		return errToolboxNameMustBeSinglePathSegment
+	}
+	if strings.ContainsAny(name, "/?#\\") {
+		return errToolboxNameMustBeSinglePathSegment
+	}
+	// Reject percent-encoded separators and percent itself (catches double-encoding).
+	nameLower := strings.ToLower(name)
+	if strings.Contains(nameLower, "%2f") || // encoded /
+		strings.Contains(nameLower, "%3f") || // encoded ?
+		strings.Contains(nameLower, "%23") || // encoded #
+		strings.Contains(nameLower, "%5c") || // encoded \
+		strings.Contains(nameLower, "%25") { // encoded % (prevents double-encoding)
+		return errToolboxNameMustBeSinglePathSegment
+	}
+
+	// When a valid absolute base URL is available, also verify via URL construction
+	// that the name resolves to exactly one intact path segment.
 	baseEndpoint := strings.TrimRight(endpoint, "/")
 	if baseEndpoint == "" {
 		return nil
 	}
-
 	baseURL, err := url.Parse(baseEndpoint)
 	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" {
 		return nil

--- a/internal/azaiprojects/toolbox_name.go
+++ b/internal/azaiprojects/toolbox_name.go
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azaiprojects
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+var errToolboxNameMustBeSinglePathSegment = errors.New("parameter name must resolve to a single path segment")
+
+func replaceToolboxNamePathParameter(endpoint, urlPath, name string) (string, error) {
+	if name == "" {
+		return "", errors.New("parameter name cannot be empty")
+	}
+	if err := validateToolboxNamePathSegment(endpoint, name); err != nil {
+		return "", err
+	}
+	return strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name)), nil
+}
+
+func validateToolboxNamePathSegment(endpoint, name string) error {
+	baseEndpoint := strings.TrimRight(endpoint, "/")
+	if baseEndpoint == "" {
+		return nil
+	}
+
+	baseURL, err := url.Parse(baseEndpoint)
+	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" {
+		return nil
+	}
+
+	candidate, err := url.Parse(baseEndpoint + "/toolboxes/" + name + "/mcp")
+	if err != nil {
+		return errToolboxNameMustBeSinglePathSegment
+	}
+
+	if candidate.Scheme != baseURL.Scheme || candidate.Host != baseURL.Host || candidate.RawQuery != "" || candidate.Fragment != "" {
+		return errToolboxNameMustBeSinglePathSegment
+	}
+
+	prefix := strings.TrimRight(baseURL.Path, "/") + "/toolboxes/"
+	path := candidate.Path
+	const suffix = "/mcp"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return errToolboxNameMustBeSinglePathSegment
+	}
+
+	segment := path[len(prefix) : len(path)-len(suffix)]
+	if segment == "" || strings.Contains(segment, "/") || strings.Contains(segment, "\\") || segment == "." || segment == ".." || segment != name {
+		return errToolboxNameMustBeSinglePathSegment
+	}
+
+	return nil
+}

--- a/internal/azaiprojects/toolbox_name_test.go
+++ b/internal/azaiprojects/toolbox_name_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azaiprojects
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestValidateToolboxNamePathSegment(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "https://example.test/base"
+	validNames := []string{
+		"toolbox",
+		"tool.box",
+		"toolbox:v1@prod",
+		"toolbox(name)",
+	}
+	for _, name := range validNames {
+		t.Run("valid/"+name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := validateToolboxNamePathSegment(endpoint, name); err != nil {
+				t.Fatalf("validateToolboxNamePathSegment(%q) error = %v", name, err)
+			}
+		})
+	}
+
+	invalidNames := []string{
+		".",
+		"..",
+		"toolbox/sub",
+		"toolbox%2Fsub",
+		"toolbox%252Fsub",
+		"toolbox?query",
+		"toolbox%3Fquery",
+		"toolbox#fragment",
+		"toolbox%23fragment",
+		"toolbox\\sub",
+		"toolbox%5Csub",
+	}
+	for _, name := range invalidNames {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateToolboxNamePathSegment(endpoint, name)
+			if !errors.Is(err, errToolboxNameMustBeSinglePathSegment) {
+				t.Fatalf("validateToolboxNamePathSegment(%q) error = %v, want %v", name, err, errToolboxNameMustBeSinglePathSegment)
+			}
+		})
+	}
+}
+
+func TestToolboxesClientRequestBuildersRejectUnsafeNames(t *testing.T) {
+	t.Parallel()
+
+	client := &ToolboxesClient{endpoint: "https://example.test/base"}
+	ctx := context.Background()
+	builders := map[string]func(string) error{
+		"createToolboxVersion": func(name string) error {
+			_, err := client.createToolboxVersionCreateRequest(ctx, name, nil, nil)
+			return err
+		},
+		"deleteToolbox": func(name string) error {
+			_, err := client.deleteToolboxCreateRequest(ctx, name, nil)
+			return err
+		},
+		"deleteToolboxVersion": func(name string) error {
+			_, err := client.deleteToolboxVersionCreateRequest(ctx, name, "v1", nil)
+			return err
+		},
+		"getToolbox": func(name string) error {
+			_, err := client.getToolboxCreateRequest(ctx, name, nil)
+			return err
+		},
+		"getToolboxVersion": func(name string) error {
+			_, err := client.getToolboxVersionCreateRequest(ctx, name, "v1", nil)
+			return err
+		},
+		"listToolboxVersions": func(name string) error {
+			_, err := client.listToolboxVersionsCreateRequest(ctx, name, nil)
+			return err
+		},
+		"updateToolbox": func(name string) error {
+			_, err := client.updateToolboxCreateRequest(ctx, name, "v1", nil)
+			return err
+		},
+	}
+
+	for builderName, builder := range builders {
+		t.Run(builderName, func(t *testing.T) {
+			t.Parallel()
+
+			err := builder("toolbox%2Fsub")
+			if !errors.Is(err, errToolboxNameMustBeSinglePathSegment) {
+				t.Fatalf("%s error = %v, want %v", builderName, err, errToolboxNameMustBeSinglePathSegment)
+			}
+		})
+	}
+}

--- a/internal/azaiprojects/toolbox_name_test.go
+++ b/internal/azaiprojects/toolbox_name_test.go
@@ -12,23 +12,12 @@ import (
 func TestValidateToolboxNamePathSegment(t *testing.T) {
 	t.Parallel()
 
-	endpoint := "https://example.test/base"
 	validNames := []string{
 		"toolbox",
 		"tool.box",
 		"toolbox:v1@prod",
 		"toolbox(name)",
 	}
-	for _, name := range validNames {
-		t.Run("valid/"+name, func(t *testing.T) {
-			t.Parallel()
-
-			if err := validateToolboxNamePathSegment(endpoint, name); err != nil {
-				t.Fatalf("validateToolboxNamePathSegment(%q) error = %v", name, err)
-			}
-		})
-	}
-
 	invalidNames := []string{
 		".",
 		"..",
@@ -42,13 +31,39 @@ func TestValidateToolboxNamePathSegment(t *testing.T) {
 		"toolbox\\sub",
 		"toolbox%5Csub",
 	}
-	for _, name := range invalidNames {
-		t.Run("invalid/"+name, func(t *testing.T) {
+
+	endpoints := []string{
+		"https://example.test/base",
+		"",
+		"not-a-valid-url",
+	}
+
+	for _, endpoint := range endpoints {
+		endpoint := endpoint
+		t.Run("endpoint="+endpoint, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateToolboxNamePathSegment(endpoint, name)
-			if !errors.Is(err, errToolboxNameMustBeSinglePathSegment) {
-				t.Fatalf("validateToolboxNamePathSegment(%q) error = %v, want %v", name, err, errToolboxNameMustBeSinglePathSegment)
+			for _, name := range validNames {
+				name := name
+				t.Run("valid/"+name, func(t *testing.T) {
+					t.Parallel()
+
+					if err := validateToolboxNamePathSegment(endpoint, name); err != nil {
+						t.Fatalf("validateToolboxNamePathSegment(%q) error = %v", name, err)
+					}
+				})
+			}
+
+			for _, name := range invalidNames {
+				name := name
+				t.Run("invalid/"+name, func(t *testing.T) {
+					t.Parallel()
+
+					err := validateToolboxNamePathSegment(endpoint, name)
+					if !errors.Is(err, errToolboxNameMustBeSinglePathSegment) {
+						t.Fatalf("validateToolboxNamePathSegment(%q) error = %v, want %v", name, err, errToolboxNameMustBeSinglePathSegment)
+					}
+				})
 			}
 		})
 	}

--- a/internal/azaiprojects/z_toolboxes_client.go
+++ b/internal/azaiprojects/z_toolboxes_client.go
@@ -56,10 +56,11 @@ func (client *ToolboxesClient) CreateToolboxVersion(ctx context.Context, name st
 // createToolboxVersionCreateRequest creates the CreateToolboxVersion request.
 func (client *ToolboxesClient) createToolboxVersionCreateRequest(ctx context.Context, name string, tools []ToolboxToolClassification, options *ToolboxesClientCreateToolboxVersionOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	var err error
+	urlPath, err = replaceToolboxNamePathParameter(client.endpoint, urlPath, name)
+	if err != nil {
+		return nil, err
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
@@ -133,10 +134,11 @@ func (client *ToolboxesClient) DeleteToolbox(ctx context.Context, name string, o
 // deleteToolboxCreateRequest creates the DeleteToolbox request.
 func (client *ToolboxesClient) deleteToolboxCreateRequest(ctx context.Context, name string, _ *ToolboxesClientDeleteToolboxOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	var err error
+	urlPath, err = replaceToolboxNamePathParameter(client.endpoint, urlPath, name)
+	if err != nil {
+		return nil, err
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
@@ -177,10 +179,11 @@ func (client *ToolboxesClient) DeleteToolboxVersion(ctx context.Context, name st
 // deleteToolboxVersionCreateRequest creates the DeleteToolboxVersion request.
 func (client *ToolboxesClient) deleteToolboxVersionCreateRequest(ctx context.Context, name string, version string, _ *ToolboxesClientDeleteToolboxVersionOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions/{version}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	var err error
+	urlPath, err = replaceToolboxNamePathParameter(client.endpoint, urlPath, name)
+	if err != nil {
+		return nil, err
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	if version == "" {
 		return nil, errors.New("parameter version cannot be empty")
 	}
@@ -224,10 +227,11 @@ func (client *ToolboxesClient) GetToolbox(ctx context.Context, name string, opti
 // getToolboxCreateRequest creates the GetToolbox request.
 func (client *ToolboxesClient) getToolboxCreateRequest(ctx context.Context, name string, _ *ToolboxesClientGetToolboxOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	var err error
+	urlPath, err = replaceToolboxNamePathParameter(client.endpoint, urlPath, name)
+	if err != nil {
+		return nil, err
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
@@ -279,10 +283,11 @@ func (client *ToolboxesClient) GetToolboxVersion(ctx context.Context, name strin
 // getToolboxVersionCreateRequest creates the GetToolboxVersion request.
 func (client *ToolboxesClient) getToolboxVersionCreateRequest(ctx context.Context, name string, version string, _ *ToolboxesClientGetToolboxVersionOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions/{version}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	var err error
+	urlPath, err = replaceToolboxNamePathParameter(client.endpoint, urlPath, name)
+	if err != nil {
+		return nil, err
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	if version == "" {
 		return nil, errors.New("parameter version cannot be empty")
 	}
@@ -346,10 +351,11 @@ func (client *ToolboxesClient) NewListToolboxVersionsPager(name string, options 
 // listToolboxVersionsCreateRequest creates the ListToolboxVersions request.
 func (client *ToolboxesClient) listToolboxVersionsCreateRequest(ctx context.Context, name string, options *ToolboxesClientListToolboxVersionsOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}/versions"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	var err error
+	urlPath, err = replaceToolboxNamePathParameter(client.endpoint, urlPath, name)
+	if err != nil {
+		return nil, err
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
@@ -483,10 +489,11 @@ func (client *ToolboxesClient) UpdateToolbox(ctx context.Context, name string, d
 // updateToolboxCreateRequest creates the UpdateToolbox request.
 func (client *ToolboxesClient) updateToolboxCreateRequest(ctx context.Context, name string, defaultVersion string, _ *ToolboxesClientUpdateToolboxOptions) (*policy.Request, error) {
 	urlPath := "/toolboxes/{name}"
-	if name == "" {
-		return nil, errors.New("parameter name cannot be empty")
+	var err error
+	urlPath, err = replaceToolboxNamePathParameter(client.endpoint, urlPath, name)
+	if err != nil {
+		return nil, err
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Ported the Foundry toolbox request-target validation fix from .NET by rejecting toolbox names that do not resolve to a single intact path segment before building internal Azure AI Projects toolbox requests. The Go change stays internal to `internal/azaiprojects`: toolbox request builders now share a validation helper, unsafe raw or percent-encoded separators/query/fragment delimiters are rejected, and request-builder tests cover the affected toolbox operations.

Upstream commit: `2c7aadce4edee173b6bdcb285a1b2a2ac95585cc` (https://github.com/microsoft/agent-framework/commit/2c7aadce4edee173b6bdcb285a1b2a2ac95585cc)

## Ported .NET PRs

- microsoft/agent-framework#6890 - validate Foundry toolbox names as single path segments before building toolbox proxy URLs.

## Breaking Changes

No.

## Tests and Examples

- Added `internal/azaiprojects/toolbox_name_test.go` to cover valid names, invalid raw and percent-encoded target-altering names, and all toolbox request builders that interpolate toolbox names.
- Ran `go test ./internal/azaiprojects ./provider/foundryprovider`.
- Ran `go test ./...`.

## Notes

- No exported Go symbols changed; the port is limited to internal Azure AI Projects request construction.
- Checked existing `[dotnet-port-fixes]` / `[dotnet-port-api]` workflow issues and PRs before implementation and found no existing port for upstream PR #6890.
- Other recent upstream candidates were skipped because they were already aligned in Go, broader than a narrow nightly fix, or less clearly applicable than this internal request-target validation change.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29221857187) · 1.5K AIC · ⌖ 35.2 AIC · ⊞ 21.7K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.60, model: gpt-5.4, id: 29221857187, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29221857187 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #479