### PR TITLE
Fix dead PortableValue guard in workflow route builder

### DIFF
--- a/workflow/route.go
+++ b/workflow/route.go
@@ -91,7 +91,7 @@ func (rb *RouteBuilder) AddHandlerRaw(messageType reflect.Type, outputType refle
 	if rb.err != nil {
 		return rb
 	}
-	if reflect.TypeOf(messageType) == reflect.TypeFor[PortableValue]() {
+	if messageType == reflect.TypeFor[PortableValue]() {
 		rb.err = errors.New("cannot register a handler for PortableValue. Use AddCatchAll() instead")
 		return rb
 	}

--- a/workflow/route_test.go
+++ b/workflow/route_test.go
@@ -5,6 +5,7 @@ package workflow
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -44,6 +45,20 @@ func TestMessageRouterRoutesAssignableInterfaceHandler(t *testing.T) {
 	}
 	if result.result != "handled" {
 		t.Fatalf("RouteMessage result = %v, want handled", result.result)
+	}
+}
+
+func TestAddHandlerRawRejectsPortableValue(t *testing.T) {
+	var rb RouteBuilder
+	rb.AddHandlerRaw(reflect.TypeFor[PortableValue](), nil, func(_ *Context, _ any) (any, error) {
+		return nil, nil
+	})
+	_, err := rb.build()
+	if err == nil {
+		t.Fatal("build() error = nil, want error rejecting a PortableValue handler")
+	}
+	if !strings.Contains(err.Error(), "PortableValue") {
+		t.Fatalf("build() error = %q, want mention of PortableValue", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`RouteBuilder.AddHandlerRaw` guards against registering a typed handler for `PortableValue` (callers should use `AddCatchAll()` instead). The guard is dead code:

```go
if reflect.TypeOf(messageType) == reflect.TypeFor[PortableValue]() {
```

`messageType` is already a `reflect.Type`, so `reflect.TypeOf(messageType)` returns the *dynamic* type of that interface value — the unexported `*reflect.rtype` — which never equals `reflect.TypeFor[PortableValue]()`. The condition is always false, so a handler registered for `PortableValue` is silently accepted instead of being rejected, colliding with the router's dedicated portable-value routing path.

## Fix

Compare the `reflect.Type` value directly, matching the idiom already used in the same package at `portable.go:143` (`if typ == reflect.TypeFor[PortableValue]()`):

```go
if messageType == reflect.TypeFor[PortableValue]() {
```

## Test

Adds `TestAddHandlerRawRejectsPortableValue`, which registers a `PortableValue` handler and asserts `build()` returns an error. It fails on `main` (`build() error = nil`) and passes with the fix.

## Verification

- `go test -race -shuffle=on ./workflow` — passing
- `go vet ./workflow`, `gofmt`, `gofumpt` — clean
- `go build ./...` — clean