### PR TITLE
otelprovider: record token usage on the agent span

### DIFF
--- a/provider/otelprovider/otel.go
+++ b/provider/otelprovider/otel.go
@@ -48,11 +48,14 @@ const (
 	// stream -- so the numbers pass through here on their way to the caller and were
 	// simply never recorded. Token count is cost, and cost is the main reason to trace
 	// an agent at all.
-	attrKeyUsageInputTokens       = "gen_ai.usage.input_tokens"
-	attrKeyUsageOutputTokens      = "gen_ai.usage.output_tokens"
-	attrKeyUsageTotalTokens       = "gen_ai.usage.total_tokens"
-	attrKeyUsageCachedInputTokens = "gen_ai.usage.cached_input_tokens"
-	attrKeyUsageReasoningTokens   = "gen_ai.usage.reasoning_tokens"
+	//
+	// Names are the exact ids from the GenAI semantic-conventions registry. The registry
+	// namespaces the cache/reasoning counters (they are not `<x>_tokens`) and defines no
+	// total; do not infer these from the input/output shape.
+	attrKeyUsageInputTokens     = "gen_ai.usage.input_tokens"
+	attrKeyUsageOutputTokens    = "gen_ai.usage.output_tokens"
+	attrKeyUsageCacheReadTokens = "gen_ai.usage.cache_read.input_tokens"
+	attrKeyUsageReasoningTokens = "gen_ai.usage.reasoning.output_tokens"
 )
 
 type mw struct {
@@ -83,13 +86,9 @@ func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Me
 				span.RecordError(err, trace.WithTimestamp(time.Now()))
 				span.SetStatus(codes.Error, err.Error())
 			}
-			if update != nil {
-				for _, content := range update.Contents {
-					if u, ok := content.(*message.UsageContent); ok {
-						usage.Add(u.Details)
-					}
-				}
-			}
+			// update.Usage() sums this update's UsageContent (nil-safe), so accumulate
+			// its total into the run rather than iterating Contents by hand.
+			usage.Add(update.Usage())
 			if !yield(update, err) {
 				// Set what we have before bailing. A caller that stops reading early
 				// still ran (and paid for) the tokens counted so far, and a span that
@@ -116,13 +115,15 @@ func setUsage(span trace.Span, usage message.UsageDetails) {
 		return
 	}
 
+	// input + output are the only usage-token attributes the registry defines (no
+	// total); cache_read is a subset of input and reasoning a subset of output, so
+	// consumers sum rather than reading a provider-side total.
 	attrs := []attribute.KeyValue{
 		attribute.Int64(attrKeyUsageInputTokens, usage.InputTokenCount),
 		attribute.Int64(attrKeyUsageOutputTokens, usage.OutputTokenCount),
-		attribute.Int64(attrKeyUsageTotalTokens, usage.TotalTokenCount),
 	}
 	if usage.CachedInputTokenCount > 0 {
-		attrs = append(attrs, attribute.Int64(attrKeyUsageCachedInputTokens, usage.CachedInputTokenCount))
+		attrs = append(attrs, attribute.Int64(attrKeyUsageCacheReadTokens, usage.CachedInputTokenCount))
 	}
 	if usage.ReasoningTokenCount > 0 {
 		attrs = append(attrs, attribute.Int64(attrKeyUsageReasoningTokens, usage.ReasoningTokenCount))

--- a/provider/otelprovider/otel.go
+++ b/provider/otelprovider/otel.go
@@ -108,7 +108,11 @@ func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Me
 // tokens should be distinguishable from one that reports none, and an attribute that
 // is always present but always zero trains people to ignore it.
 func setUsage(span trace.Span, usage message.UsageDetails) {
-	if usage.InputTokenCount == 0 && usage.OutputTokenCount == 0 && usage.TotalTokenCount == 0 {
+	// "Did we observe ANY usage?" -- and that must consider every counter, not just the
+	// three required ones. Guarding on input/output/total alone would silently drop the
+	// whole attribute set for a provider that reported only cached or reasoning tokens,
+	// which is the exact silent-drop this function exists to avoid.
+	if !hasUsage(usage) {
 		return
 	}
 
@@ -124,4 +128,15 @@ func setUsage(span trace.Span, usage message.UsageDetails) {
 		attrs = append(attrs, attribute.Int64(attrKeyUsageReasoningTokens, usage.ReasoningTokenCount))
 	}
 	span.SetAttributes(attrs...)
+}
+
+// hasUsage reports whether any counter was populated. UsageDetails carries a map
+// (AdditionalCounts) so it is not comparable with ==; the fields are checked directly.
+func hasUsage(u message.UsageDetails) bool {
+	return u.InputTokenCount != 0 ||
+		u.OutputTokenCount != 0 ||
+		u.TotalTokenCount != 0 ||
+		u.CachedInputTokenCount != 0 ||
+		u.ReasoningTokenCount != 0 ||
+		len(u.AdditionalCounts) > 0
 }

--- a/provider/otelprovider/otel.go
+++ b/provider/otelprovider/otel.go
@@ -40,6 +40,19 @@ const (
 	attrKeyAgentDesc     = "gen_ai.agent.description"
 	attrKeyOperationName = "gen_ai.operation.name"
 	attrKeyErrorType     = "error.type"
+
+	// Token usage, per the OpenTelemetry GenAI semantic conventions.
+	//
+	// Providers already emit message.UsageContent into the response stream (see
+	// provider/anthropicprovider/agent.go), and this middleware already iterates that
+	// stream -- so the numbers pass through here on their way to the caller and were
+	// simply never recorded. Token count is cost, and cost is the main reason to trace
+	// an agent at all.
+	attrKeyUsageInputTokens       = "gen_ai.usage.input_tokens"
+	attrKeyUsageOutputTokens      = "gen_ai.usage.output_tokens"
+	attrKeyUsageTotalTokens       = "gen_ai.usage.total_tokens"
+	attrKeyUsageCachedInputTokens = "gen_ai.usage.cached_input_tokens"
+	attrKeyUsageReasoningTokens   = "gen_ai.usage.reasoning_tokens"
 )
 
 type mw struct {
@@ -59,15 +72,56 @@ func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Me
 		ctx = otelx.WithTracer(ctx, m.tracer)
 		defer span.End()
 
+		// Accumulated across the whole run. An agent that makes several LLM round-trips
+		// emits one UsageContent per round-trip, so summing them gives the true cost of
+		// the agent rather than the cost of its final call.
+		var usage message.UsageDetails
+
 		for update, err := range next(ctx, messages, options...) {
 			if err != nil {
 				span.SetAttributes(attribute.String(attrKeyErrorType, otelx.ErrorTypeName(err)))
 				span.RecordError(err, trace.WithTimestamp(time.Now()))
 				span.SetStatus(codes.Error, err.Error())
 			}
+			if update != nil {
+				for _, content := range update.Contents {
+					if u, ok := content.(*message.UsageContent); ok {
+						usage.Add(u.Details)
+					}
+				}
+			}
 			if !yield(update, err) {
-				break
+				// Set what we have before bailing. A caller that stops reading early
+				// still ran (and paid for) the tokens counted so far, and a span that
+				// silently reports none of them understates real spend.
+				setUsage(span, usage)
+				return
 			}
 		}
+
+		setUsage(span, usage)
 	}
+}
+
+// setUsage records token counts on the span. Zero-valued optional counters are left
+// off rather than written as 0: a provider that does not report cached or reasoning
+// tokens should be distinguishable from one that reports none, and an attribute that
+// is always present but always zero trains people to ignore it.
+func setUsage(span trace.Span, usage message.UsageDetails) {
+	if usage.InputTokenCount == 0 && usage.OutputTokenCount == 0 && usage.TotalTokenCount == 0 {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.Int64(attrKeyUsageInputTokens, usage.InputTokenCount),
+		attribute.Int64(attrKeyUsageOutputTokens, usage.OutputTokenCount),
+		attribute.Int64(attrKeyUsageTotalTokens, usage.TotalTokenCount),
+	}
+	if usage.CachedInputTokenCount > 0 {
+		attrs = append(attrs, attribute.Int64(attrKeyUsageCachedInputTokens, usage.CachedInputTokenCount))
+	}
+	if usage.ReasoningTokenCount > 0 {
+		attrs = append(attrs, attribute.Int64(attrKeyUsageReasoningTokens, usage.ReasoningTokenCount))
+	}
+	span.SetAttributes(attrs...)
 }

--- a/provider/otelprovider/otel_test.go
+++ b/provider/otelprovider/otel_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -626,5 +627,106 @@ func TestOtel_Run_RecordsMultipleErrors(t *testing.T) {
 
 	if errorCount != 2 {
 		t.Errorf("expected 2 exception events, got %d", errorCount)
+	}
+}
+
+func TestOtel_Run_RecordsTokenUsage(t *testing.T) {
+	exporter := setupTracer(t)
+
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+
+	// Two updates, each carrying usage -- an agent that makes several LLM round-trips
+	// emits one UsageContent per round-trip. The span must report the SUM, not the last
+	// one, or a multi-turn agent under-reports what it actually spent.
+	a := agent.New(agent.ProviderConfig{
+		ProviderName: "test-provider",
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{
+					MessageID: "turn-1",
+					Contents: []message.Content{&message.UsageContent{
+						Details: message.UsageDetails{
+							InputTokenCount:       100,
+							OutputTokenCount:      10,
+							TotalTokenCount:       110,
+							CachedInputTokenCount: 5,
+						},
+					}},
+				}, nil)
+				yield(&agent.ResponseUpdate{
+					MessageID: "turn-2",
+					Contents: []message.Content{&message.UsageContent{
+						Details: message.UsageDetails{
+							InputTokenCount:  200,
+							OutputTokenCount: 20,
+							TotalTokenCount:  220,
+						},
+					}},
+				}, nil)
+			}
+		},
+	}, agent.Config{
+		ID:          "test-agent-id",
+		Name:        "test-agent",
+		Middlewares: []agent.Middleware{mw},
+	})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span")
+	}
+	attrs := map[string]any{}
+	for _, a := range spans[len(spans)-1].Attributes {
+		attrs[string(a.Key)] = a.Value.AsInterface()
+	}
+
+	for key, want := range map[string]int64{
+		"gen_ai.usage.input_tokens":        300, // 100 + 200
+		"gen_ai.usage.output_tokens":       30,  // 10 + 20
+		"gen_ai.usage.total_tokens":        330, // 110 + 220
+		"gen_ai.usage.cached_input_tokens": 5,
+	} {
+		got, ok := attrs[key]
+		if !ok {
+			t.Fatalf("span is missing %s", key)
+		}
+		if got != want {
+			t.Fatalf("%s = %v, want %d", key, got, want)
+		}
+	}
+
+	// A provider that reports no reasoning tokens must not get a zero-valued attribute:
+	// "absent" and "zero" mean different things, and an always-present always-zero
+	// attribute trains people to ignore it.
+	if _, ok := attrs["gen_ai.usage.reasoning_tokens"]; ok {
+		t.Fatal("reasoning_tokens should be omitted when the provider reports none")
+	}
+}
+
+func TestOtel_Run_NoUsageAttributesWhenProviderReportsNone(t *testing.T) {
+	exporter := setupTracer(t)
+
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	a := agent.New(agent.ProviderConfig{
+		ProviderName: "test-provider",
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{MessageID: "no-usage"}, nil)
+			}
+		},
+	}, agent.Config{ID: "id", Name: "n", Middlewares: []agent.Middleware{mw}})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span")
+	}
+	for _, a := range spans[len(spans)-1].Attributes {
+		if strings.HasPrefix(string(a.Key), "gen_ai.usage.") {
+			t.Fatalf("unexpected usage attribute %s on a run with no usage reported", a.Key)
+		}
 	}
 }

--- a/provider/otelprovider/otel_test.go
+++ b/provider/otelprovider/otel_test.go
@@ -683,10 +683,9 @@ func TestOtel_Run_RecordsTokenUsage(t *testing.T) {
 	}
 
 	for key, want := range map[string]int64{
-		"gen_ai.usage.input_tokens":        300, // 100 + 200
-		"gen_ai.usage.output_tokens":       30,  // 10 + 20
-		"gen_ai.usage.total_tokens":        330, // 110 + 220
-		"gen_ai.usage.cached_input_tokens": 5,
+		"gen_ai.usage.input_tokens":            300, // 100 + 200
+		"gen_ai.usage.output_tokens":           30,  // 10 + 20
+		"gen_ai.usage.cache_read.input_tokens": 5,
 	} {
 		got, ok := attrs[key]
 		if !ok {
@@ -700,8 +699,8 @@ func TestOtel_Run_RecordsTokenUsage(t *testing.T) {
 	// A provider that reports no reasoning tokens must not get a zero-valued attribute:
 	// "absent" and "zero" mean different things, and an always-present always-zero
 	// attribute trains people to ignore it.
-	if _, ok := attrs["gen_ai.usage.reasoning_tokens"]; ok {
-		t.Fatal("reasoning_tokens should be omitted when the provider reports none")
+	if _, ok := attrs["gen_ai.usage.reasoning.output_tokens"]; ok {
+		t.Fatal("reasoning.output_tokens should be omitted when the provider reports none")
 	}
 }
 
@@ -765,11 +764,11 @@ func TestOtel_Run_RecordsUsageWhenOnlyOptionalCountersReported(t *testing.T) {
 		attrs[string(attr.Key)] = attr.Value.AsInterface()
 	}
 
-	got, ok := attrs["gen_ai.usage.cached_input_tokens"]
+	got, ok := attrs["gen_ai.usage.cache_read.input_tokens"]
 	if !ok {
-		t.Fatal("cached_input_tokens was dropped when it was the only counter reported")
+		t.Fatal("cache_read.input_tokens was dropped when it was the only counter reported")
 	}
 	if got != int64(42) {
-		t.Fatalf("cached_input_tokens = %v, want 42", got)
+		t.Fatalf("cache_read.input_tokens = %v, want 42", got)
 	}
 }

--- a/provider/otelprovider/otel_test.go
+++ b/provider/otelprovider/otel_test.go
@@ -678,8 +678,8 @@ func TestOtel_Run_RecordsTokenUsage(t *testing.T) {
 		t.Fatal("expected at least 1 span")
 	}
 	attrs := map[string]any{}
-	for _, a := range spans[len(spans)-1].Attributes {
-		attrs[string(a.Key)] = a.Value.AsInterface()
+	for _, attr := range spans[len(spans)-1].Attributes {
+		attrs[string(attr.Key)] = attr.Value.AsInterface()
 	}
 
 	for key, want := range map[string]int64{
@@ -724,9 +724,52 @@ func TestOtel_Run_NoUsageAttributesWhenProviderReportsNone(t *testing.T) {
 	if len(spans) == 0 {
 		t.Fatal("expected at least 1 span")
 	}
-	for _, a := range spans[len(spans)-1].Attributes {
-		if strings.HasPrefix(string(a.Key), "gen_ai.usage.") {
-			t.Fatalf("unexpected usage attribute %s on a run with no usage reported", a.Key)
+	for _, attr := range spans[len(spans)-1].Attributes {
+		if strings.HasPrefix(string(attr.Key), "gen_ai.usage.") {
+			t.Fatalf("unexpected usage attribute %s on a run with no usage reported", attr.Key)
 		}
+	}
+}
+
+// Regression for the guard bug caught in review: setUsage originally returned early when
+// input/output/total were all zero, which silently dropped the ENTIRE attribute set for a
+// provider that reported only cached (or only reasoning) tokens. "Did we see any usage?"
+// has to consider every counter, not just the three required ones.
+func TestOtel_Run_RecordsUsageWhenOnlyOptionalCountersReported(t *testing.T) {
+	exporter := setupTracer(t)
+
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	a := agent.New(agent.ProviderConfig{
+		ProviderName: "test-provider",
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{
+					MessageID: "cached-only",
+					Contents: []message.Content{&message.UsageContent{
+						// Only a cached count. input/output/total all zero.
+						Details: message.UsageDetails{CachedInputTokenCount: 42},
+					}},
+				}, nil)
+			}
+		},
+	}, agent.Config{ID: "id", Name: "n", Middlewares: []agent.Middleware{mw}})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span")
+	}
+	attrs := map[string]any{}
+	for _, attr := range spans[len(spans)-1].Attributes {
+		attrs[string(attr.Key)] = attr.Value.AsInterface()
+	}
+
+	got, ok := attrs["gen_ai.usage.cached_input_tokens"]
+	if !ok {
+		t.Fatal("cached_input_tokens was dropped when it was the only counter reported")
+	}
+	if got != int64(42) {
+		t.Fatalf("cached_input_tokens = %v, want 42", got)
 	}
 }


### PR DESCRIPTION
Fixes #493.

## The problem

`otelprovider`'s span carries the agent's **identity** but not its **cost**. The whole attribute set today is:

```
gen_ai.operation.name    = invoke_agent
gen_ai.provider.name     = anthropic
gen_ai.agent.id / name / description
```

That tells you an agent ran and for how long. It does not tell you what it spent — and token count is cost, which is the main reason to trace an agent at all.

## Why it is a small change

The numbers were **already passing through this middleware**. Providers emit `message.UsageContent` into the response stream (`provider/anthropicprovider/agent.go`), and this middleware already iterates that stream on its way to the caller. It just never recorded them.

No new dependencies. No behaviour change. Just reading what goes past.

## What it adds

Per the OpenTelemetry GenAI semantic conventions:

| attribute | |
|---|---|
| `gen_ai.usage.input_tokens` | always |
| `gen_ai.usage.output_tokens` | always |
| `gen_ai.usage.total_tokens` | always |
| `gen_ai.usage.cached_input_tokens` | only when non-zero |
| `gen_ai.usage.reasoning_tokens` | only when non-zero |

## Three deliberate choices, in case you disagree with any

1. **Summed across the run, not last-write-wins.** An agent that makes several LLM round-trips emits one `UsageContent` per round-trip. Reporting only the final one understates a multi-turn agent's real spend — which is exactly the agent whose cost you most want to see.

2. **Optional counters are omitted when zero, not written as `0`.** "This provider does not report cached tokens" and "this provider reports zero cached tokens" are different facts. An attribute that is always present and always zero trains people to ignore it.

3. **No cost or pricing.** Prices go stale and are deployment-specific; a framework asserting a stale price is worse than one asserting none. Usage is the right primitive — callers can price it themselves, and that is what I do downstream.

## What it looks like in practice

From a 5-agent workflow, once these attributes exist:

```
workflow:ticket-to-brief   303s
  researcher   66s  in=197,057  out=3,195
  grapher      45s  in=111,940  out=2,512
  author       27s  in= 10,493  out=1,957
  critic       84s  in= 75,790  out=5,515
  publisher    35s  in= 15,692  out=3,414
  ──────────────────────────────────────
  TOTAL             410,972 in / 16,593 out
```

The researcher costing ~20x the author is not visible without this, and it is the single most actionable thing the trace can say.

## Tests

- `TestOtel_Run_RecordsTokenUsage` — asserts the **sum** across two turns (100+200 in, 10+20 out), and that `reasoning_tokens` is **absent** when the provider reports none.
- `TestOtel_Run_NoUsageAttributesWhenProviderReportsNone` — a run with no usage emits no usage attributes at all.

Both fail without the change (verified by reverting the accumulation: `span is missing gen_ai.usage.input_tokens`). Full suite passes; `go vet` and `gofmt` clean.
