### PR TITLE
Clarify SearchDepth scope in fsskills documentation

### DIFF
--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -62,6 +62,12 @@ type SourceOptions struct {
 	// files within each skill directory. A value of 1 searches only the skill
 	// root; a value of 2 (the default) also searches one level of subdirectories.
 	// Values less than 1 are treated as the default.
+	//
+	// SearchDepth applies only to resource and script discovery within a skill
+	// directory. It does not affect the discovery of skill directories
+	// themselves (those containing a SKILL.md), which is bounded independently.
+	// This mirrors the .NET SDK, where the two concerns are configured
+	// separately.
 	SearchDepth int
 
 	// ResourceFilter is an optional predicate applied to each candidate resource
@@ -185,6 +191,11 @@ func discoverSkillDirectories(filesystems []fs.FS) []discoveredSkillDir {
 	return results
 }
 
+// searchForSkills locates skill directories (those containing a SKILL.md).
+// This discovery is intentionally bounded by defaultSearchDepth and is
+// independent of SourceOptions.SearchDepth, which governs only resource and
+// script discovery within an already-discovered skill directory. This matches
+// the .NET SDK, which bounds the two concerns separately.
 func searchForSkills(filesystem fs.FS, dir string, results *[]discoveredSkillDir, currentDepth int) {
 	skillPath := path.Join(dir, skillFileName)
 	if _, err := fs.Stat(filesystem, skillPath); err == nil {

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -182,6 +182,26 @@ func TestFileSource_SkillBeyondMaxDepth_NotDiscovered(t *testing.T) {
 	}
 }
 
+func TestFileSource_SearchDepth_DoesNotAffectSkillDirectoryDiscovery(t *testing.T) {
+	root := t.TempDir()
+	// A skill directory nested four levels below the filesystem root.
+	createSkillDir(t, filepath.Join(root, "l1", "l2", "l3"), "deep-skill", "Deep", "Body.")
+
+	// SearchDepth governs only within-skill resource/script discovery; it must
+	// not widen skill-directory discovery, which is bounded independently. Even
+	// a large SearchDepth leaves the deeply-nested skill directory undiscovered.
+	deep := fsskills.NewSourceOptions(fsskills.SourceOptions{SearchDepth: 4}, os.DirFS(root))
+	loaded, err := deep.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, skill := range loaded {
+		if skill.Frontmatter.Name == "deep-skill" {
+			t.Fatal("SearchDepth must not cause skill-directory discovery beyond the fixed bound")
+		}
+	}
+}
+
 func TestFileSource_ReadResource_ValidResource_ReturnsContent(t *testing.T) {
 	root := t.TempDir()
 	createSkillDirWithResource(t, root, "read-skill", "A skill", "See docs.", "references/doc.md", "Document content here.")


### PR DESCRIPTION
## Summary

Following review, this PR is repurposed from a behavior change to a documentation clarification.

`SearchDepth` controls only resource and script discovery *within* an already-discovered skill directory. Skill-directory discovery (locating `SKILL.md` directories) is bounded independently and intentionally, matching the .NET SDK. That scope was not explicit in the option's documentation, which is what led to the original misread.

## Change

- Document the intended scope on `SourceOptions.SearchDepth` and on `searchForSkills`.
- Add `TestFileSource_SearchDepth_DoesNotAffectSkillDirectoryDiscovery`, which asserts that a large `SearchDepth` does **not** widen skill-directory discovery — locking in the intended contract.

No behavior change; the functional code is identical to `main`.

## Verification

- `go test -race -shuffle=on ./agent/skills/...` — passing
- `go vet`, `gofmt`, `gofumpt` — clean