### PR TITLE
Seed the checkpoint scope-key hasher for deterministic restore

### DIFF
--- a/workflow/internal/checkpoint/checkpoint_json.go
+++ b/workflow/internal/checkpoint/checkpoint_json.go
@@ -16,8 +16,16 @@ type scopeKeyHasherImpl struct{}
 
 var scopeKeyHasherInstance hashmap.Hasher[workflow.ScopeKey] = scopeKeyHasherImpl{}
 
+// scopeKeyHashSeed is a fixed process-wide seed. maphash.Hash's zero value
+// picks a new random seed on first use, so without SetSeed the same key would
+// hash differently on every call — breaking Load/Delete and shared-scope key
+// collapse on a map restored from JSON. state.go seeds its ScopeKey hasher the
+// same way.
+var scopeKeyHashSeed = maphash.MakeSeed()
+
 func (scopeKeyHasherImpl) Hash(s workflow.ScopeKey) uint64 {
 	var h maphash.Hash
+	h.SetSeed(scopeKeyHashSeed)
 	s.Hash(&h)
 	return h.Sum64()
 }

--- a/workflow/internal/checkpoint/json_test.go
+++ b/workflow/internal/checkpoint/json_test.go
@@ -4,6 +4,7 @@ package checkpoint_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -113,5 +114,30 @@ func TestRunnerStateData_JsonRoundtrip(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.ResponsePortOwners, state.ResponsePortOwners) {
 		t.Fatalf("ResponsePortOwners = %+v, want %+v", got.ResponsePortOwners, state.ResponsePortOwners)
+	}
+}
+
+// A Checkpoint's StateData map is rebuilt from JSON on Unmarshal. Its scope-key
+// hasher must use a fixed seed: a zero-value maphash.Hash picks a new random
+// seed on every call, so Load on a restored map would miss the key it just
+// stored (and shared-scope keys would not collapse).
+func TestCheckpoint_JsonRoundtrip_StateDataRemainsLoadable(t *testing.T) {
+	key := workflow.ScopeKey{ID: workflow.ScopeID{ExecutorID: "exec1"}, Key: "k"}
+	keyJSON, err := json.Marshal(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	valJSON, err := json.Marshal(workflow.AnyPortableValue("v"))
+	if err != nil {
+		t.Fatalf("marshal value: %v", err)
+	}
+	data := []byte(fmt.Sprintf(`{"StateData":[{"Key":%s,"Value":%s}]}`, keyJSON, valJSON))
+
+	var cp checkpoint.Checkpoint
+	if err := json.Unmarshal(data, &cp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := cp.StateData.Load(key); !ok {
+		t.Fatal("restored StateData.Load(key) = false: the scope-key hasher is not deterministic across calls")
 	}
 }


### PR DESCRIPTION
## Summary

`Checkpoint.UnmarshalJSON` (workflow/internal/checkpoint/checkpoint_json.go) rebuilds `StateData` with `scopeKeyHasherImpl`, whose `Hash` used a **zero-value** `maphash.Hash`:

```go
func (scopeKeyHasherImpl) Hash(s workflow.ScopeKey) uint64 {
	var h maphash.Hash   // zero value → new RANDOM seed on first use
	s.Hash(&h)
	return h.Sum64()
}
```

A zero-value `maphash.Hash` selects a fresh random seed on first use, so the **same `ScopeKey` hashes to a different value on every call**. On the `hashmap.Map` produced by unmarshal this means:

- **`Load`/`Delete`/overwrite break** — the value stored during unmarshal is hashed with one seed, and a later `Load` re-hashes with a different seed and misses.
- **Shared-scope keys no longer collapse** — two keys that are `Equal` (shared scope ignores the executor ID) get different hashes and are kept as separate entries, so `StateManager.ImportState` re-imports both and which value survives a restore is non-deterministic.

The sibling hasher in `workflow/internal/execution/state.go` already seeds with a fixed process-wide `theSeed`; the checkpoint copy just forgot to.

## Fix

Add a fixed process-wide `scopeKeyHashSeed = maphash.MakeSeed()` and `h.SetSeed(scopeKeyHashSeed)` in `Hash`, mirroring `state.go`.

## Public API

No exported symbols change.

## Tests

Adds `TestCheckpoint_JsonRoundtrip_StateDataRemainsLoadable` (black-box, in `json_test.go`): round-trips a `Checkpoint` through JSON and asserts its `StateData` is still `Load`-able. It fails before this change (`Load` returns false) and passes after. (Existing tests missed it because they only consume restored `StateData` via `.All()` iteration, which is seed-independent.)