### PR TITLE
Do not wrap pointer-to-struct functool inputs

### DIFF
--- a/tool/functool/func.go
+++ b/tool/functool/func.go
@@ -128,7 +128,14 @@ func inputFormatFor[T any]() (format *jsonformat.Format, wrapped bool, err error
 	if typ == reflect.TypeFor[any]() {
 		return nil, false, fmt.Errorf("input type any is not supported by HandlerFor; use Handler for dynamic inputs")
 	}
-	if typ.Kind() != reflect.Struct {
+	// Dereference pointers so a *Struct input produces the same flat schema as
+	// a Struct input (jsonformat.ForType treats pointers equivalently); only
+	// genuinely non-struct inputs are wrapped in inputWrapper.
+	elem := typ
+	for elem.Kind() == reflect.Pointer {
+		elem = elem.Elem()
+	}
+	if elem.Kind() != reflect.Struct {
 		typ = reflect.TypeFor[inputWrapper[T]]()
 		wrapped = true
 	}

--- a/tool/functool/func_test.go
+++ b/tool/functool/func_test.go
@@ -262,3 +262,24 @@ func TestFuncTool_NewRejectsAnyInput(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// A *Struct input must produce the same flat schema as a Struct input and accept
+// flat arguments, not be wrapped in an inputWrapper (which would require {"Arg0":{...}}).
+func TestFuncTool_PointerStructInput_UsesFlatSchema(t *testing.T) {
+	type In struct {
+		V string `json:"v"`
+	}
+	tl := functool.MustNew(functool.Config{Name: "t", Description: "d"}, func(_ context.Context, in *In) (string, error) {
+		if in == nil {
+			return "", nil
+		}
+		return in.V, nil
+	})
+	ret, err := tl.Call(t.Context(), `{"v":"hi"}`)
+	if err != nil {
+		t.Fatalf("Call with flat args failed for *struct input: %v", err)
+	}
+	if ret != "hi" {
+		t.Errorf("ret = %v, want hi", ret)
+	}
+}


### PR DESCRIPTION
## Summary

`inputFormatFor` (tool/functool/func.go) wraps any input whose `Kind` is not `reflect.Struct` in `inputWrapper[T]`. A **pointer-to-struct** handler has `Kind == reflect.Ptr`, so it gets wrapped — producing a nested `{"Arg0":{...}}` schema and rejecting the flat arguments that the equivalent value-receiver handler accepts:

```go
type In struct{ V string `json:"v"` }
functool.MustNew(cfg, func(ctx context.Context, in *In) (string, error) { ... }).
    Call(ctx, `{"v":"hi"}`)
// → validation error: validating root: unexpected additional properties ["v"]
```

This contradicts `jsonformat.ForType`, which deliberately dereferences pointers at the root ("Pointers are treated equivalently to non-pointers … with no benefit" to wrapping the root object). So `*Struct` and `Struct` handlers should produce the same flat schema, but today only `Struct` does.

## Fix

Dereference pointers before the struct check, so only genuinely non-struct inputs are wrapped.

## Public API

No exported symbols change.

## Tests

Adds `TestFuncTool_PointerStructInput_UsesFlatSchema` (black-box): a `*struct` handler accepts flat arguments. It fails before this change (schema validation rejects the flat args) and passes after.