### PR TITLE
Clone anthropic MessageNewParams slices to avoid mutating caller state

### DIFF
--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -288,6 +288,11 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 	var params anthropic.MessageNewParams
 	if p, ok := agent.GetOption(opts, MessageNewParams); ok {
 		params = p
+		// Clone the mutable slice fields appended to below so we never mutate
+		// the caller's backing arrays (the option stores a shallow copy of the
+		// struct); the gemini provider clones for the same reason.
+		params.System = slices.Clone(params.System)
+		params.Messages = slices.Clone(params.Messages)
 	}
 	params.Model = cmp.Or(params.Model, a.config.Model)
 	params.MaxTokens = cmp.Or(params.MaxTokens, 4096)

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -34,7 +34,8 @@ func newTestClient(t *testing.T, server *httptest.Server) *agent.Agent {
 		anthropicprovider.AgentConfig{
 			Model:  "claude-3-5-sonnet-20241022",
 			Config: agent.Config{DisableFuncAutoCall: true},
-		})
+		},
+	)
 }
 
 // nestedKey traverses a decoded JSON map following the given path of keys and
@@ -197,7 +198,8 @@ func TestConfigInstructions(t *testing.T) {
 			Config: agent.Config{
 				DisableFuncAutoCall: true,
 			},
-		})
+		},
+	)
 
 	if _, err := a.RunText(t.Context(), "hi").Collect(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -453,5 +455,29 @@ func TestStreamingToolCallsSupportInterleavedDeltas(t *testing.T) {
 		if call.Arguments != want[call.CallID] {
 			t.Errorf("call %q arguments = %q, want %q", call.CallID, call.Arguments, want[call.CallID])
 		}
+	}
+}
+
+// Building the request must not mutate the caller's MessageNewParams slices.
+// The provider appends system instructions to params.System; if it shares the
+// caller's backing array (spare capacity), the append corrupts the caller's data.
+func TestBuildMessageParams_DoesNotMutateCallerSystemSlice(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"m","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer server.Close()
+	a := newTestClient(t, server)
+
+	// Caller-supplied System slice with spare capacity.
+	system := make([]anthropic.TextBlockParam, 1, 4)
+	system[0] = anthropic.TextBlockParam{Text: "s0"}
+	opt := anthropicprovider.MessageNewParams(anthropic.MessageNewParams{System: system})
+
+	if _, err := a.RunText(t.Context(), "hi", agent.WithInstructions("added"), opt).Collect(); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if full := system[:cap(system)]; full[1].Text != "" {
+		t.Errorf("provider mutated the caller's System backing array: spare slot = %q", full[1].Text)
 	}
 }

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -481,3 +481,26 @@ func TestBuildMessageParams_DoesNotMutateCallerSystemSlice(t *testing.T) {
 		t.Errorf("provider mutated the caller's System backing array: spare slot = %q", full[1].Text)
 	}
 }
+
+func TestBuildMessageParams_DoesNotMutateCallerMessagesSlice(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"m","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer server.Close()
+	a := newTestClient(t, server)
+
+	// Caller-supplied Messages slice with spare capacity. The provider appends
+	// the run's messages to params.Messages; with aliasing that append lands in
+	// the caller's spare slot instead of a cloned slice.
+	messages := make([]anthropic.MessageParam, 1, 4)
+	messages[0] = anthropic.NewUserMessage(anthropic.NewTextBlock("seeded"))
+	opt := anthropicprovider.MessageNewParams(anthropic.MessageNewParams{Messages: messages})
+
+	if _, err := a.RunText(t.Context(), "hi", opt).Collect(); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if full := messages[:cap(messages)]; len(full[1].Content) != 0 {
+		t.Errorf("provider mutated the caller's Messages backing array: spare slot has %d content block(s)", len(full[1].Content))
+	}
+}


### PR DESCRIPTION
## Problem

`buildMessageParams` adopts the caller-provided `MessageNewParams` option by struct copy:

```go
if p, ok := agent.GetOption(opts, MessageNewParams); ok {
    params = p
}
```

It then appends to `params.System` (system instructions) and `params.Messages`. A struct copy shares the slice **backing arrays** with the caller's value, so:

- If the caller's slice has spare capacity, the append writes into the caller's spare slots — silently corrupting their data.
- A caller that reuses the same `MessageNewParams` across runs accumulates duplicated system blocks.

The **gemini provider already clones for exactly this reason** (`provider/geminiprovider/agent.go`), so this also aligns the two providers.

## Fix

Clone the two mutated slice fields right after adopting the option:

```go
params = p
params.System = slices.Clone(params.System)
params.Messages = slices.Clone(params.Messages)
```

## Test

`TestBuildMessageParams_DoesNotMutateCallerSystemSlice` (black-box, in `agent_test.go`) passes a `System` slice with spare capacity and asserts the caller's backing array is untouched after a run. It fails on `main` (`spare slot = "added"`) and passes with the fix.