### PR TITLE
[dotnet-code] Consolidate todo remaining item filtering

### DIFF
--- a/agent/harness/todo/todo.go
+++ b/agent/harness/todo/todo.go
@@ -137,13 +137,7 @@ func (p *Provider) GetRemainingItems(opts ...agent.Option) []Item {
 	mu.Lock()
 	defer mu.Unlock()
 	st := p.loadState(opts)
-	var remaining []Item
-	for _, item := range st.Items {
-		if !item.IsComplete {
-			remaining = append(remaining, item)
-		}
-	}
-	return remaining
+	return remainingItems(st.Items)
 }
 
 func (p *Provider) loadState(opts []agent.Option) *state {
@@ -313,13 +307,7 @@ func (p *Provider) createTools(opts []agent.Option) []tool.FuncTool {
 			mu.Lock()
 			defer mu.Unlock()
 			st := p.loadState(opts)
-			var remaining []Item
-			for _, item := range st.Items {
-				if !item.IsComplete {
-					remaining = append(remaining, item)
-				}
-			}
-			return remaining, nil
+			return remainingItems(st.Items), nil
 		},
 	)
 
@@ -338,6 +326,16 @@ func (p *Provider) createTools(opts []agent.Option) []tool.FuncTool {
 	)
 
 	return []tool.FuncTool{addTool, completeTool, removeTool, getRemainingTool, getAllTool}
+}
+
+func remainingItems(items []Item) []Item {
+	var remaining []Item
+	for _, item := range items {
+		if !item.IsComplete {
+			remaining = append(remaining, item)
+		}
+	}
+	return remaining
 }
 
 func formatTodoListMessage(items []Item) string {


### PR DESCRIPTION
## Summary

Consolidates the todo provider's incomplete-item filtering into a single unexported helper used by both `GetRemainingItems` and the `todos_get_remaining` tool. This keeps the Go internals closer to the .NET TodoProvider shape, where remaining todos are computed consistently with the same `Where(t => !t.IsComplete).ToList()` query pattern.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProvider.cs` - `GetRemainingTodosAsync` and the `todos_get_remaining` tool both return incomplete todo items using the same filtering expression.
- `dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/Todo/TodoProviderTests.cs` - sampled tests covering remaining todo behavior.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/harness/todo`

## Notes

Rejected sampled candidates:
- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/IRunEventStream.cs` versus `workflow/internal/execution/eventstream.go`: corresponding Go event stream logic is concurrency-sensitive, so helper extraction there was riskier for a nightly portability cleanup.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/DirectEdgeInfo.cs` versus `workflow/internal/checkpoint/info.go` and `workflow/info.go`: Go checkpoint and edge matching already have focused tests and no obvious tiny structural cleanup from this sample.
- `dotnet/src/Microsoft.Agents.AI/AnonymousDelegatingAIAgent.cs` versus `agent/agent.go`: no small equivalent internal delegate-agent cleanup was found without touching broader agent construction behavior.

Open `[dotnet-code]` PR checks via the GitHub read tool returned HTTP 503 during this run, including candidate-specific todo searches, so this PR was kept narrowly scoped to reduce overlap risk.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29540043063) · 414.8 AIC · ⌖ 44.2 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29540043063, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29540043063 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #514