### PR TITLE
[dotnet-code] Clarify file script run internals

### DIFF
--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -540,20 +540,31 @@ func newScript(name string, fsys fs.FS, runner skills.ScriptRunner) skills.Scrip
 	return skills.Script{
 		Name:             name,
 		ParametersSchema: defaultFileScriptSchema,
-		Run: func(ctx context.Context, owner *skills.Skill, arguments []string) (any, error) {
-			if _, err := FSFromSkill(owner); err != nil {
-				return nil, fmt.Errorf("file-based script %q requires a skill with a backing fs.FS: %w", name, err)
-			}
-			if runner == nil {
-				return nil, fmt.Errorf("script %q cannot be executed because no file script runner was provided", name)
-			}
-			script := &skills.Script{Name: name}
-			return runner(ctx, owner, script, arguments)
-		},
+		Run:              newFileScriptRunFunc(name, runner),
 		AdditionalProperties: map[string]any{
 			"fsskills.scriptFS": fsys,
 		},
 	}
+}
+
+func newFileScriptRunFunc(name string, runner skills.ScriptRunner) func(context.Context, *skills.Skill, []string) (any, error) {
+	return func(ctx context.Context, owner *skills.Skill, arguments []string) (any, error) {
+		if err := requireFileSkill(name, owner); err != nil {
+			return nil, err
+		}
+		if runner == nil {
+			return nil, fmt.Errorf("script %q cannot be executed because no file script runner was provided", name)
+		}
+		script := &skills.Script{Name: name}
+		return runner(ctx, owner, script, arguments)
+	}
+}
+
+func requireFileSkill(scriptName string, skill *skills.Skill) error {
+	if _, err := FSFromSkill(skill); err != nil {
+		return fmt.Errorf("file-based script %q requires a skill with a backing fs.FS: %w", scriptName, err)
+	}
+	return nil
 }
 
 type discoveredSkillDir struct {


### PR DESCRIPTION
## Summary

Extracted the file-backed script run closure into small unexported helpers. This keeps the Go file-skill script execution shape closer to the .NET `AgentFileSkillScript.RunAsync` guard sequence while preserving the existing public API and behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillScript.cs` - validates the owning file skill, checks for a configured runner, then invokes the file script runner.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/skills/...`
- `gofmt -w agent/skills/fsskills/source.go`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillResource.cs` - Go inline skills are represented directly by `skills.Skill` values and test helpers rather than a corresponding internal resource type, so there was no narrow production cleanup to make.
- `dotnet/src/Microsoft.Agents.AI/Evaluation/ExpectedToolCall.cs` - no matching Go evaluation surface was present in the sampled implementation, so changing Go would risk adding a missing feature rather than refactoring existing internals.
- `dotnet/src/Microsoft.Agents.AI.Workflows/ExternalResponse.cs` - the close Go equivalent would require adding exported convenience methods to `workflow.ExternalResponse`, which would change the public Go API and violate the task constraints.

Open `[dotnet-code]` PRs were checked before editing; the existing workflow edge PR does not cover this file-skill script candidate.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29456032149) · 277 AIC · ⌖ 41.7 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29456032149, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29456032149 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #499