### PR TITLE
[dotnet-code] Consolidate OpenAI tool schema conversion

### DIFF
--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -308,21 +308,10 @@ func buildCompletionParams(model string, messages []*message.Message, opts []age
 			}
 		case tool.FuncTool:
 			name, description := tl.Name(), tl.Description()
-			var funcParams map[string]any
-			switch schema := tl.Schema().(type) {
-			case map[string]any:
-				funcParams = schema
-			default:
-				if schema == nil {
-					break
-				}
-				data, err := json.Marshal(schema)
-				if err == nil {
-					err = json.Unmarshal(data, &funcParams)
-				}
-				if err != nil {
-					return openai.ChatCompletionNewParams{}, fmt.Errorf("failed to convert function tool schema to JSON format: %w", err)
-				}
+			schema := tl.Schema()
+			funcParams, err := schemaToMap(schema)
+			if err != nil {
+				return openai.ChatCompletionNewParams{}, fmt.Errorf("failed to convert function tool schema to JSON format: %w", err)
 			}
 			params.Tools = append(params.Tools, openai.ChatCompletionToolUnionParam{
 				OfFunction: &openai.ChatCompletionFunctionToolParam{

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -760,6 +760,9 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 }
 
 func schemaToMap(schema any) (map[string]any, error) {
+	if schema == nil {
+		return nil, nil
+	}
 	if schemaMap, ok := schema.(map[string]any); ok {
 		return schemaMap, nil
 	}

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -327,21 +327,10 @@ func responsesBuildCompletionParams(config AgentConfig, messages []*message.Mess
 		switch tl := tl.(type) {
 		case tool.FuncTool:
 			name, description := tl.Name(), tl.Description()
-			var funcParams map[string]any
-			switch schema := tl.Schema().(type) {
-			case map[string]any:
-				funcParams = schema
-			default:
-				if schema == nil {
-					break
-				}
-				data, err := json.Marshal(schema)
-				if err == nil {
-					err = json.Unmarshal(data, &funcParams)
-				}
-				if err != nil {
-					return responses.ResponseNewParams{}, fmt.Errorf("failed to convert schema for function tool %q (type %T) to JSON format: %w", name, schema, err)
-				}
+			schema := tl.Schema()
+			funcParams, err := schemaToMap(schema)
+			if err != nil {
+				return responses.ResponseNewParams{}, fmt.Errorf("failed to convert schema for function tool %q (type %T) to JSON format: %w", name, schema, err)
 			}
 			params.Tools = append(params.Tools, responses.ToolUnionParam{
 				OfFunction: &responses.FunctionToolParam{


### PR DESCRIPTION
## Summary

Consolidated the duplicated function-tool schema conversion in the OpenAI chat completions and responses request builders through the existing unexported `schemaToMap` helper. This keeps the Go provider internals closer to the .NET provider's central `FunctionDefinition` shape while preserving the generated request payloads.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Models/Tool.cs` - central tool/function definition model used when constructing OpenAI tool payloads.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w provider/openaiprovider/chat.go provider/openaiprovider/responses.go`
- `go test ./provider/openaiprovider`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI/Skills/Decorators/FilteringAgentSkillsSource.cs` - Go already exposes skill filtering through `ContextProviderOptions.SkillFilter`; adding a .NET-style source decorator would add new public API, so it was rejected.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/JsonConverterDictionarySupportBase.cs` - Go checkpoint JSON uses explicit entry structs rather than dictionary-key converters, so there was no narrow structural cleanup that would improve parity without churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticConstants.cs` - no corresponding Go Magentic internals exist in the current sampled surface, so adding constants would be placeholder feature shape rather than portability cleanup.

Open `[dotnet-code]` PR https://github.com/microsoft/agent-framework-go/pull/484 already covers workflow edge construction, so adjacent workflow-edge work was avoided.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29373591915) · 521.9 AIC · ⌖ 54.5 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29373591915, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29373591915 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #498