### PR TITLE
[dotnet-code] Consolidate shell argv helper

### DIFF
--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -594,37 +593,42 @@ func shellKindDescription(shell resolvedShell) string {
 }
 
 func (s resolvedShell) statelessArgvForCommand(command string) []string {
-	var suffix []string
 	switch s.kind {
 	case shellKindPowerShell:
-		suffix = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-Command", command}
+		return s.argvWithExtra([]string{"-NoProfile", "-NoLogo", "-NonInteractive", "-Command", command})
 	case shellKindCmd:
-		suffix = []string{"/d", "/c", command}
+		return s.argvWithExtra([]string{"/d", "/c", command})
 	case shellKindBash:
-		suffix = []string{"--noprofile", "--norc", "-c", command}
+		return s.argvWithExtra([]string{"--noprofile", "--norc", "-c", command})
 	default:
-		suffix = []string{"-c", command}
+		return s.argvWithExtra([]string{"-c", command})
 	}
-	return combineArgv(s.extraArgv, suffix)
 }
 
 func (s resolvedShell) persistentArgv() ([]string, error) {
-	var suffix []string
 	switch s.kind {
 	case shellKindPowerShell:
-		suffix = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-Command", "-"}
+		return s.launchArgv([]string{"-NoProfile", "-NoLogo", "-NonInteractive", "-Command", "-"}), nil
 	case shellKindCmd:
 		return nil, fmt.Errorf("persistent mode is not supported for cmd.exe; use pwsh, powershell, or a POSIX shell")
 	case shellKindBash:
-		suffix = []string{"--noprofile", "--norc"}
+		return s.launchArgv([]string{"--noprofile", "--norc"}), nil
 	default:
-		suffix = nil
+		return s.launchArgv(nil), nil
 	}
-	return append([]string{s.binary}, combineArgv(s.extraArgv, suffix)...), nil
 }
 
-func combineArgv(extra, suffix []string) []string {
-	return slices.Concat(extra, suffix)
+func (s resolvedShell) launchArgv(suffix []string) []string {
+	return append([]string{s.binary}, s.argvWithExtra(suffix)...)
+}
+
+func (s resolvedShell) argvWithExtra(suffix []string) []string {
+	if len(s.extraArgv) == 0 {
+		return suffix
+	}
+	argv := make([]string, 0, len(s.extraArgv)+len(suffix))
+	argv = append(argv, s.extraArgv...)
+	return append(argv, suffix...)
 }
 
 func classifyShellKind(shell string) shellKind {

--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -626,7 +627,7 @@ func (s resolvedShell) argvWithExtra(suffix []string) []string {
 	if len(s.extraArgv) == 0 {
 		return suffix
 	}
-	return append(append([]string{}, s.extraArgv...), suffix...)
+	return append(slices.Clone(s.extraArgv), suffix...)
 }
 
 func classifyShellKind(shell string) shellKind {

--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -626,9 +626,7 @@ func (s resolvedShell) argvWithExtra(suffix []string) []string {
 	if len(s.extraArgv) == 0 {
 		return suffix
 	}
-	argv := make([]string, 0, len(s.extraArgv)+len(suffix))
-	argv = append(argv, s.extraArgv...)
-	return append(argv, suffix...)
+	return append(append([]string{}, s.extraArgv...), suffix...)
 }
 
 func classifyShellKind(shell string) shellKind {

--- a/tool/shelltool/localshell_internal_test.go
+++ b/tool/shelltool/localshell_internal_test.go
@@ -2,7 +2,10 @@
 
 package shelltool
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestPreserveEnvironmentValuesKeepsOnlyAllowlist(t *testing.T) {
 	source := []string{
@@ -11,6 +14,7 @@ func TestPreserveEnvironmentValuesKeepsOnlyAllowlist(t *testing.T) {
 		"AF_SHELL_PARENT_VAR=should-not-leak",
 		"tmp=/tmp/test",
 	}
+
 	env := make(map[string]string)
 
 	preserveEnvironmentValues(env, source)
@@ -26,5 +30,25 @@ func TestPreserveEnvironmentValuesKeepsOnlyAllowlist(t *testing.T) {
 	}
 	if _, ok := env["AF_SHELL_PARENT_VAR"]; ok {
 		t.Fatal("unexpected non-preserved variable copied")
+	}
+}
+
+func TestResolvedShellArgvIncludesExtraArgv(t *testing.T) {
+	shell := resolvedShell{
+		binary:    "/custom/bash",
+		kind:      shellKindBash,
+		extraArgv: []string{"--login"},
+	}
+
+	if got, want := shell.statelessArgvForCommand("echo hi"), []string{"--login", "--noprofile", "--norc", "-c", "echo hi"}; !slices.Equal(got, want) {
+		t.Fatalf("statelessArgvForCommand = %v, want %v", got, want)
+	}
+
+	got, err := shell.persistentArgv()
+	if err != nil {
+		t.Fatalf("persistentArgv: %v", err)
+	}
+	if want := []string{"/custom/bash", "--login", "--noprofile", "--norc"}; !slices.Equal(got, want) {
+		t.Fatalf("persistentArgv = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Consolidated shell argv assembly through small unexported helpers so stateless and persistent shell launch paths share the same extra-argv composition logic. This keeps the Go shell internals closer to the .NET `ResolvedShell` shape, where shell-specific suffixes are selected separately from combining constructor-provided extra argv.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellResolver.cs` - resolves shell kind and combines optional extra argv with stateless/persistent shell suffixes.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- Added `TestResolvedShellArgvIncludesExtraArgv` to preserve existing stateless and persistent argv shapes with `ShellArgv` extras.
- `gofmt -w tool/shelltool/localshell.go tool/shelltool/localshell_internal_test.go`
- `go test ./tool/shelltool`

## Notes

Rejected sampled candidates:

- `dotnet/src/Microsoft.Agents.AI.Workflows/HandoffWorkflowBuilder.cs` - Go handoff-related workflow builder changes would touch public/broader workflow behavior, and existing open `[dotnet-code]` workflow PRs already cover nearby workflow internals.
- `dotnet/src/Microsoft.Agents.AI.Workflows/IExternalRequestContext.cs` - the Go external request area already has direct behavior coverage, and the sampled .NET interface did not suggest a narrow production cleanup without churn.
- `dotnet/src/Microsoft.Agents.AI.Mcp/Skills/McpJsonContext.cs` - the .NET file is source-generated JSON context plumbing, with no useful direct Go equivalent beyond existing MCP JSON helpers.

Checked for open shelltool/ShellResolver `[dotnet-code]` PR overlap and found none before editing.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29290442149) · 520.7 AIC · ⌖ 31.4 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29290442149, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29290442149 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #486