### PR TITLE
[dotnet-port-fixes] Align compaction summary marker handling

### DIFF
--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -67,6 +67,42 @@ func TestMessageIndex_GroupsToolCallsAtomically(t *testing.T) {
 	}
 }
 
+func TestMessageIndex_SummaryPropertyKeyIsRespected(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected compaction.GroupKind
+	}{
+		{name: "missing", expected: compaction.GroupKindAssistantText},
+		{name: "bool false", value: false, expected: compaction.GroupKindAssistantText},
+		{name: "raw false", value: json.RawMessage(`false`), expected: compaction.GroupKindAssistantText},
+		{name: "raw null", value: json.RawMessage(`null`), expected: compaction.GroupKindAssistantText},
+		{name: "raw string", value: json.RawMessage(`"Unexpected string"`), expected: compaction.GroupKindAssistantText},
+		{name: "bool true", value: true, expected: compaction.GroupKindSummary},
+		{name: "raw true", value: json.RawMessage(`true`), expected: compaction.GroupKindSummary},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := textMessage(message.RoleAssistant, "Hello")
+			if tt.name != "missing" {
+				msg.AdditionalProperties = map[string]any{
+					"_is_summary": tt.value,
+				}
+			}
+
+			index := compaction.CreateMessageIndex([]*message.Message{msg}, nil)
+
+			if len(index.Groups) != 1 {
+				t.Fatalf("expected one group, got %d", len(index.Groups))
+			}
+			if got := index.Groups[0].Kind; got != tt.expected {
+				t.Fatalf("group kind = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestTruncationStrategy_ExcludesOldestGroups(t *testing.T) {
 	index := compaction.CreateMessageIndex(turnMessages(3), nil)
 	strategy := &compaction.TruncationStrategy{

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -67,7 +67,9 @@ func TestMessageIndex_GroupsToolCallsAtomically(t *testing.T) {
 	}
 }
 
-func TestMessageIndex_SummaryPropertyKeyIsRespected(t *testing.T) {
+func TestMessageIndex_SummaryPropertyValueParsing(t *testing.T) {
+	rawFalse := json.RawMessage(`false`)
+	rawTrue := json.RawMessage(`true`)
 	tests := []struct {
 		name     string
 		value    any
@@ -80,6 +82,12 @@ func TestMessageIndex_SummaryPropertyKeyIsRespected(t *testing.T) {
 		{name: "raw string", value: json.RawMessage(`"Unexpected string"`), expected: compaction.GroupKindAssistantText},
 		{name: "bool true", value: true, expected: compaction.GroupKindSummary},
 		{name: "raw true", value: json.RawMessage(`true`), expected: compaction.GroupKindSummary},
+		{name: "ptr raw nil", value: (*json.RawMessage)(nil), expected: compaction.GroupKindAssistantText},
+		{name: "ptr raw false", value: &rawFalse, expected: compaction.GroupKindAssistantText},
+		{name: "ptr raw true", value: &rawTrue, expected: compaction.GroupKindSummary},
+		{name: "bytes false", value: []byte(`false`), expected: compaction.GroupKindAssistantText},
+		{name: "bytes null", value: []byte(`null`), expected: compaction.GroupKindAssistantText},
+		{name: "bytes true", value: []byte(`true`), expected: compaction.GroupKindSummary},
 	}
 
 	for _, tt := range tests {

--- a/agent/compaction/index.go
+++ b/agent/compaction/index.go
@@ -3,6 +3,7 @@
 package compaction
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -421,8 +422,24 @@ func isSummaryMessage(msg *message.Message) bool {
 	if !ok {
 		return false
 	}
-	if boolValue, ok := value.(bool); ok {
-		return boolValue
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case json.RawMessage:
+		return rawSummaryMessageValue(typed)
+	case *json.RawMessage:
+		return typed != nil && rawSummaryMessageValue(*typed)
+	case []byte:
+		return rawSummaryMessageValue(typed)
+	default:
+		return false
 	}
-	return false
+}
+
+func rawSummaryMessageValue(value []byte) bool {
+	var boolValue bool
+	if err := json.Unmarshal(value, &boolValue); err != nil {
+		return false
+	}
+	return boolValue
 }


### PR DESCRIPTION
## Summary

Align Go compaction summary detection with the upstream .NET fix for `_is_summary` metadata by accepting both native `bool` values and raw JSON boolean tokens when grouping assistant messages. Added parity tests that keep missing, false, null, and string token values as assistant text while recognizing `true` in both native and raw-token forms.

Upstream reference:
- microsoft/agent-framework@e677ccc3b17c488b40f6b6d9d274f3b64797ea0c — Fix CompactionMessageIndex.IsSummaryMessage
  https://github.com/microsoft/agent-framework/commit/e677ccc3b17c488b40f6b6d9d274f3b64797ea0c

## Ported .NET PRs

- microsoft/agent-framework#7042 - Fix `CompactionMessageIndex.IsSummaryMessage` for deserialized JSON token values

## Breaking Changes

No.

## Tests and Examples

- `go test ./agent/compaction`
- Added `TestMessageIndex_SummaryPropertyKeyIsRespected`
- No examples changed

## Notes

Skipped broader recent upstream compaction/workflow changes because they were either already tracked in Go porting work or were larger than the narrow nightly PR target. This change is internal-only and does not modify exported Go symbols.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29303564072) · 939.3 AIC · ⌖ 31.2 AIC · ⊞ 21.7K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.60, model: gpt-5.4, id: 29303564072, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29303564072 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #487