### PR TITLE
Account for Copilot reasoning tokens in usage details

### DIFF
--- a/provider/copilotprovider/copilot.go
+++ b/provider/copilotprovider/copilot.go
@@ -587,6 +587,7 @@ func (p *provider) assistantUsageUpdate(event copilot.SessionEvent, data *copilo
 		OutputTokenCount:      outputTokens,
 		TotalTokenCount:       inputTokens + outputTokens,
 		CachedInputTokenCount: int64Value(data.CacheReadTokens),
+		ReasoningTokenCount:   int64Value(data.ReasoningTokens),
 		AdditionalCounts:      additionalUsageCounts(data),
 	}
 	update := &agent.ResponseUpdate{

--- a/provider/copilotprovider/copilot_test.go
+++ b/provider/copilotprovider/copilot_test.go
@@ -336,6 +336,31 @@ func TestConvertToAgentResponseUpdate_ToolExecutionStartEvent_WithNullArguments_
 	}
 }
 
+func TestConvertToAgentResponseUpdate_UsageEvent_SurfacesReasoningTokens(t *testing.T) {
+	runtime := newFakeRuntime(t,
+		sessionEvent("assistant.usage", map[string]any{
+			"model":           "gpt-5",
+			"inputTokens":     10,
+			"outputTokens":    20,
+			"reasoningTokens": 8,
+		}),
+		idleEvent(),
+	)
+	agent := copilotprovider.NewAgent(runtime.client(), copilotprovider.AgentConfig{})
+
+	response, err := runText(t, agent, "hello")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	usage := firstContent[*message.UsageContent](t, response)
+	if usage.Details.ReasoningTokenCount != 8 {
+		t.Fatalf("ReasoningTokenCount = %d, want 8", usage.Details.ReasoningTokenCount)
+	}
+	if usage.Details.OutputTokenCount != 20 {
+		t.Fatalf("OutputTokenCount = %d, want 20", usage.Details.OutputTokenCount)
+	}
+}
+
 func TestConvertToAgentResponseUpdate_ToolExecutionStartEvent_WithNullData_ProducesEmptyFunctionCall(t *testing.T) {
 	runtime := newFakeRuntime(t,
 		sessionEvent("tool.execution_start", nil),


### PR DESCRIPTION
When converting a Copilot `assistant.usage` event, `assistantUsageUpdate` mapped input, output, total, and cache-read tokens but never read `AssistantUsageData.ReasoningTokens`:

```go
details := message.UsageDetails{
    InputTokenCount:       inputTokens,
    OutputTokenCount:      outputTokens,
    TotalTokenCount:       inputTokens + outputTokens,
    CachedInputTokenCount: int64Value(data.CacheReadTokens),
    AdditionalCounts:      additionalUsageCounts(data),
}
```

The SDK documents `ReasoningTokens` as *"Number of output tokens used for reasoning (e.g., chain-of-thought)."* For a reasoning model those tokens were silently dropped: the framework’s dedicated `UsageDetails.ReasoningTokenCount` field (populated by the OpenAI and Gemini providers, summed by `UsageDetails.Add`) stayed `0`, so callers had no reasoning-token breakdown from Copilot.

## Fix

```go
    CachedInputTokenCount: int64Value(data.CacheReadTokens),
    ReasoningTokenCount:   int64Value(data.ReasoningTokens),
```

`ReasoningTokens` is a subset of the output tokens, so `TotalTokenCount` (input + output) already accounts for it and is left unchanged — only the missing breakdown field is added, consistent with the OpenAI providers.

## Test

`TestConvertToAgentResponseUpdate_UsageEvent_SurfacesReasoningTokens` drives an `assistant.usage` event with `reasoningTokens: 8` and asserts `ReasoningTokenCount == 8`. It fails on the old code (`0`) and passes with the fix.