### PR TITLE
Surface streamed chat-completion refusals as ErrorContent

### DIFF
--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -174,6 +174,9 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 					Arguments: tc.Arguments,
 				})
 			}
+			if refusal, ok := acc.JustFinishedRefusal(); ok {
+				contents = append(contents, &message.ErrorContent{Message: refusal})
+			}
 			role := message.RoleAssistant
 			if len(chunk.Choices) > 0 {
 				choice := chunk.Choices[0]

--- a/provider/openaiprovider/chat_test.go
+++ b/provider/openaiprovider/chat_test.go
@@ -334,6 +334,50 @@ data: [DONE]
 	}
 }
 
+// TestChatStreamingRefusal_SurfacesErrorContent verifies that a refusal streamed
+// via delta.refusal is surfaced as ErrorContent, matching the non-streaming path
+// (which converts choice.Message.Refusal to ErrorContent).
+func TestChatStreamingRefusal_SurfacesErrorContent(t *testing.T) {
+	const input = `
+            {
+                "messages":[{"role":"user","content":"do something disallowed"}],
+                "model":"gpt-4o-mini",
+                "stream":true
+            }
+            `
+	const output = `data: {"id":"chatcmpl-refusal01","object":"chat.completion.chunk","created":1727889370,"model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"role":"assistant","refusal":"I'm sorry, I can't "},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-refusal01","object":"chat.completion.chunk","created":1727889370,"model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"refusal":"help with that."},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-refusal01","object":"chat.completion.chunk","created":1727889370,"model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null}
+
+data: [DONE]
+
+`
+	server := newTestServerStreaming(t, input, output)
+	defer server.Close()
+
+	a := newTestClient(server)
+
+	var refusal *message.ErrorContent
+	for update, err := range a.RunText(t.Context(), "do something disallowed", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		for _, c := range update.Contents {
+			if ec, ok := c.(*message.ErrorContent); ok {
+				refusal = ec
+			}
+		}
+	}
+	if refusal == nil {
+		t.Fatal("expected ErrorContent for streamed refusal, got none")
+	}
+	if refusal.Message != "I'm sorry, I can't help with that." {
+		t.Errorf("refusal message = %q, want full accumulated refusal", refusal.Message)
+	}
+}
+
 func TestChatMultipleMessages_NonStreaming(t *testing.T) {
 	const input = `
             {


### PR DESCRIPTION
The non-streaming Chat Completions path surfaces a model refusal to the caller:

```go
if choice.Message.Refusal != "" {
    contents = append(contents, &message.ErrorContent{Message: choice.Message.Refusal})
}
```

But the streaming loop only ever inspected `JustFinishedToolCall()`, `choice.Delta.Content`, usage, and `FinishReason` — it never read the refusal. OpenAI streams refusals token-by-token via `delta.refusal`, and the SDK accumulator exposes `JustFinishedRefusal()` (right alongside the `JustFinishedToolCall()` the loop already uses), but it was never consulted.

Result: a refused **streamed** request degraded to a silent empty assistant message — no text, no error — leaving the caller with no indication the model refused or why. The same request over the non-streaming path returns an `ErrorContent`. A streaming-vs-non-streaming parity gap.

## Fix

```go
if refusal, ok := acc.JustFinishedRefusal(); ok {
    contents = append(contents, &message.ErrorContent{Message: refusal})
}
```

## Test

`TestChatStreamingRefusal_SurfacesErrorContent` streams a two-chunk `delta.refusal` followed by a stop chunk and asserts the accumulated refusal is emitted as `ErrorContent`. It fails on the old code (no `ErrorContent`) and passes with the fix.