### PR TITLE
Document exported constructors on the A2A, AG-UI, and Anthropic providers

### DIFF
--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -20,6 +20,7 @@ import (
 	"github.com/microsoft/agent-framework-go/message"
 )
 
+// AgentConfig contains configuration for [NewAgent].
 type AgentConfig struct {
 	agent.Config
 }
@@ -28,6 +29,8 @@ type taskIDOpt struct{ string }
 
 func (o taskIDOpt) Value() any { return o.string }
 
+// TaskID returns an [agent.Option] that associates the run with an existing A2A
+// task, so the request continues that task rather than starting a new one.
 func TaskID(taskID string) agent.Option {
 	return taskIDOpt{taskID}
 }
@@ -37,6 +40,9 @@ type a2aProvider struct {
 	cfg    AgentConfig
 }
 
+// NewAgent creates a new [agent.Agent] that delegates runs to a remote agent
+// over the A2A (Agent-to-Agent) protocol via the a2a client. It panics if
+// aclient is nil.
 func NewAgent(aclient *a2aclient.Client, config AgentConfig) *agent.Agent {
 	if aclient == nil {
 		panic("a2aprovider: client cannot be nil")

--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -22,12 +22,14 @@ import (
 	"github.com/microsoft/agent-framework-go/tool"
 )
 
+// AgentConfig contains configuration for [NewAgent].
 type AgentConfig struct {
 	agent.Config
 
 	// Instructions are sent to AG-UI as a leading system message for each run.
 	Instructions string
 
+	// Decoder decodes the AG-UI event stream. When nil, a default decoder is used.
 	Decoder *aguiEvents.EventDecoder
 }
 
@@ -37,6 +39,8 @@ type provider struct {
 	cfg     AgentConfig
 }
 
+// NewAgent creates a new [agent.Agent] backed by a remote agent that speaks the
+// AG-UI protocol over Server-Sent Events via the AG-UI client.
 func NewAgent(aclient *aguiSSEClient.Client, config AgentConfig) *agent.Agent {
 	p := &provider{
 		cfg:    config,

--- a/provider/aguiprovider/hosting.go
+++ b/provider/aguiprovider/hosting.go
@@ -16,10 +16,15 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 )
 
+// HandlerConfig contains configuration for [NewJSONHTTPHandler].
 type HandlerConfig struct {
+	// Logger receives handler diagnostics. When nil, logs are discarded.
 	Logger *slog.Logger
 }
 
+// NewJSONHTTPHandler returns an [http.Handler] that hosts hostedAgent behind the
+// AG-UI protocol: it accepts POSTed AG-UI run input and streams the agent's
+// response back as AG-UI Server-Sent Events. It panics if hostedAgent is nil.
 func NewJSONHTTPHandler(hostedAgent *agent.Agent, cfg HandlerConfig) http.Handler {
 	if hostedAgent == nil {
 		panic("agent is required")

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -46,6 +46,7 @@ type AgentConfig struct {
 	Model string
 }
 
+// NewAgent creates a new [agent.Agent] backed by the Anthropic Messages API via the anthropic client.
 func NewAgent(aclient anthropic.Client, config AgentConfig) *agent.Agent {
 	c := &client{
 		client: aclient,


### PR DESCRIPTION
The OpenAI, Gemini, and Copilot providers document their `NewAgent` constructors; the A2A, AG-UI, and Anthropic providers did not. This closes that consistency gap by adding godoc to the undocumented exported symbols on those three providers, matching the existing style (e.g. Gemini’s *"NewAgent creates a new [agent.Agent] backed by …"*).

Documented:
- `anthropicprovider.NewAgent`
- `a2aprovider.NewAgent`, `a2aprovider.AgentConfig`, `a2aprovider.TaskID`
- `aguiprovider.NewAgent`, `aguiprovider.AgentConfig` (+ the `Decoder` field), `aguiprovider.HandlerConfig` (+ `Logger`), `aguiprovider.NewJSONHTTPHandler`

Docs-only; no behavior change. `go build ./...`, `go vet`, and `gofmt` are clean, and the comments render under `go doc`.