### PR TITLE
[dotnet-code] Consolidate file skill filter context construction

### DIFF
--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -52,6 +52,13 @@ type FilterContext struct {
 	RelativeFilePath string
 }
 
+func newFilterContext(skillName, relativeFilePath string) FilterContext {
+	return FilterContext{
+		SkillName:        skillName,
+		RelativeFilePath: relativeFilePath,
+	}
+}
+
 // SourceOptions configures file-based skill discovery.
 //
 // Use this struct to configure discovery without relying on positional
@@ -519,7 +526,7 @@ func (s *Source) scanForFiles(
 
 		relativePath := entryPath
 
-		if filter != nil && !filter(FilterContext{SkillName: skillName, RelativeFilePath: relativePath}) {
+		if filter != nil && !filter(newFilterContext(skillName, relativePath)) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Consolidated file skill filter context construction behind a small unexported `newFilterContext` helper. This keeps the Go file-skill discovery internals closer to the .NET `AgentFileSkillFilterContext` construction shape while preserving the exported `FilterContext` struct and current predicate behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillFilterContext.cs` - contextual object constructed for script and resource filter predicates.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w agent/skills/fsskills/source.go`
- `go test ./agent/skills/fsskills`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI.Workflows/Run.cs` - workflow edge internals are already covered by open PR https://github.com/microsoft/agent-framework-go/pull/484, and the sampled run/event shape did not present a smaller unclaimed cleanup.
- `dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentSession.cs` - Go provider session handling is spread across provider-specific implementations, so matching this shape would risk broader behavior churn.
- `dotnet/src/Microsoft.Agents.AI/Compaction/CompactionMessageGroup.cs` - no corresponding Go compaction message group implementation was found in the sampled area, so adding one would be new feature shape.
- `dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateEntry.cs` and `DurableAgentStateUsageContent.cs` - the closest Go usage/state serialization paths are not a narrow durable-state counterpart suitable for a small portability cleanup.

Open `[dotnet-code]` PR https://github.com/microsoft/agent-framework-go/pull/535 already covers adjacent OpenAI provider conversion work, so OpenAI candidates from the random sample were skipped.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29784506579) · 275.6 AIC · ⌖ 28.5 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29784506579, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29784506579 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #573