### PR TITLE
[dotnet-code] Consolidate agent workflow binding setup

### DIFF
--- a/workflow/agentworkflow/builders.go
+++ b/workflow/agentworkflow/builders.go
@@ -22,6 +22,17 @@ func validateBuilderAgents(builderName string, agents []*agent.Agent) error {
 	return nil
 }
 
+func newAgentBindings(agents []*agent.Agent, cfg Config) ([]workflow.ExecutorBinding, map[*agent.Agent]workflow.ExecutorBinding) {
+	bindings := make([]workflow.ExecutorBinding, len(agents))
+	bindingsByAgent := make(map[*agent.Agent]workflow.ExecutorBinding, len(agents))
+	for index, currentAgent := range agents {
+		binding := New(currentAgent, cfg)
+		bindings[index] = binding
+		bindingsByAgent[currentAgent] = binding
+	}
+	return bindings, bindingsByAgent
+}
+
 type outputDesignations map[*agent.Agent]map[workflow.OutputTag]struct{}
 
 func (d outputDesignations) explicit() bool {

--- a/workflow/agentworkflow/concurrent.go
+++ b/workflow/agentworkflow/concurrent.go
@@ -95,13 +95,7 @@ func (b *ConcurrentWorkflowBuilder) Build() (*workflow.Workflow, error) {
 	}
 
 	cfg := Config{}
-	bindings := make([]workflow.ExecutorBinding, len(b.agents))
-	bindingsByAgent := make(map[*agent.Agent]workflow.ExecutorBinding, len(b.agents))
-	for index, currentAgent := range b.agents {
-		binding := New(currentAgent, cfg)
-		bindings[index] = binding
-		bindingsByAgent[currentAgent] = binding
-	}
+	bindings, bindingsByAgent := newAgentBindings(b.agents, cfg)
 
 	start := newMessageForwardingBinding("Start")
 	accumulators := make([]workflow.ExecutorBinding, len(bindings))

--- a/workflow/agentworkflow/sequential.go
+++ b/workflow/agentworkflow/sequential.go
@@ -93,13 +93,7 @@ func (b *SequentialWorkflowBuilder) Build() (*workflow.Workflow, error) {
 	}
 
 	cfg := Config{DisableForwardIncomingMessages: b.chainOnlyAgentResponses}
-	bindings := make([]workflow.ExecutorBinding, len(b.agents))
-	bindingsByAgent := make(map[*agent.Agent]workflow.ExecutorBinding, len(b.agents))
-	for index, currentAgent := range b.agents {
-		binding := New(currentAgent, cfg)
-		bindings[index] = binding
-		bindingsByAgent[currentAgent] = binding
-	}
+	bindings, bindingsByAgent := newAgentBindings(b.agents, cfg)
 
 	bld := applyBuilderMetadata(workflow.NewBuilder(bindings[0]), b.name, b.description)
 	previous := bindings[0]


### PR DESCRIPTION
## Summary

Extracted the repeated agent-to-executor-binding construction used by the sequential and concurrent workflow builders into a shared unexported helper. This keeps the Go builder internals closer to the .NET `AgentWorkflowBuilder` core flow, where public overloads funnel into centralized builder construction paths, while preserving behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/AgentWorkflowBuilder.cs` - centralizes sequential and concurrent workflow construction through core builder helpers.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow/agentworkflow`

## Notes

Rejected candidates:
- `dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillFilterContext.cs` / Go file-skill source area: rejected because an open `[dotnet-code]` PR already covers nearby file-skill script internals.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Run.cs` / Go workflow run handle area: rejected because the sampled shape did not reveal a small safe portability cleanup without touching runtime behavior.
- `dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentBuilderExtensionsTests.cs` / Go tool-approval harness tests: rejected because the sampled .NET file was builder API test coverage and did not map to a small internal Go production-code cleanup.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29706408642) · 310 AIC · ⌖ 29.2 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29706408642, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29706408642 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #560