### PR TITLE
[dotnet-code] Consolidate tool approval response collection

### DIFF
--- a/agent/harness/toolapproval/toolapproval.go
+++ b/agent/harness/toolapproval/toolapproval.go
@@ -208,32 +208,8 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 	for i, msg := range messages {
 		var hasApproval bool
 		for _, c := range msg.Contents {
-			switch resp := c.(type) {
-			case *message.AlwaysApproveToolApprovalResponseContent:
+			if collectInboundApproval(&st, c) {
 				hasApproval = true
-				if resp.InnerResponse != nil {
-					if fc, ok := resp.InnerResponse.ToolCall.(*message.FunctionCallContent); ok && fc != nil {
-						if resp.AlwaysApproveTool {
-							addRuleIfNotExists(&st, Rule{ToolName: fc.Name})
-						} else if resp.AlwaysApproveToolWithArguments {
-							args, err := serializeArguments(fc.Arguments)
-							if err != nil {
-								// If we can't parse the arguments, skip adding a rule.
-								break
-							}
-							addRuleIfNotExists(&st, Rule{
-								ToolName:  fc.Name,
-								Arguments: args,
-							})
-						}
-					}
-				}
-				if resp.InnerResponse != nil {
-					st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, resp.InnerResponse)
-				}
-			case *message.ToolApprovalResponseContent:
-				hasApproval = true
-				st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, resp)
 			}
 		}
 		if hasApproval {
@@ -244,10 +220,7 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 			// Strip approval contents from the message, keep the rest.
 			var remaining []message.Content
 			for _, c := range msg.Contents {
-				if _, ok := c.(*message.ToolApprovalResponseContent); ok {
-					continue
-				}
-				if _, ok := c.(*message.AlwaysApproveToolApprovalResponseContent); ok {
+				if isInboundApprovalContent(c) {
 					continue
 				}
 				if c != nil {
@@ -267,6 +240,48 @@ func prepareInbound(messages []*message.Message, st state) ([]*message.Message, 
 		return cleaned, st
 	}
 	return messages, st
+}
+
+func collectInboundApproval(st *state, c message.Content) bool {
+	switch resp := c.(type) {
+	case *message.AlwaysApproveToolApprovalResponseContent:
+		collectAlwaysApproveResponse(st, resp)
+		return true
+	case *message.ToolApprovalResponseContent:
+		st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, resp)
+		return true
+	default:
+		return false
+	}
+}
+
+func collectAlwaysApproveResponse(st *state, resp *message.AlwaysApproveToolApprovalResponseContent) {
+	if resp.InnerResponse == nil {
+		return
+	}
+	if fc, ok := resp.InnerResponse.ToolCall.(*message.FunctionCallContent); ok && fc != nil {
+		if resp.AlwaysApproveTool {
+			addRuleIfNotExists(st, Rule{ToolName: fc.Name})
+		} else if resp.AlwaysApproveToolWithArguments {
+			args, err := serializeArguments(fc.Arguments)
+			if err == nil {
+				addRuleIfNotExists(st, Rule{
+					ToolName:  fc.Name,
+					Arguments: args,
+				})
+			}
+		}
+	}
+	st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, resp.InnerResponse)
+}
+
+func isInboundApprovalContent(c message.Content) bool {
+	switch c.(type) {
+	case *message.AlwaysApproveToolApprovalResponseContent, *message.ToolApprovalResponseContent:
+		return true
+	default:
+		return false
+	}
 }
 
 // drainAutoApprovable removes queued requests that now match a standing rule,

--- a/agent/harness/toolapproval/toolapproval.go
+++ b/agent/harness/toolapproval/toolapproval.go
@@ -264,12 +264,13 @@ func collectAlwaysApproveResponse(st *state, resp *message.AlwaysApproveToolAppr
 			addRuleIfNotExists(st, Rule{ToolName: fc.Name})
 		} else if resp.AlwaysApproveToolWithArguments {
 			args, err := serializeArguments(fc.Arguments)
-			if err == nil {
-				addRuleIfNotExists(st, Rule{
-					ToolName:  fc.Name,
-					Arguments: args,
-				})
+			if err != nil {
+				return
 			}
+			addRuleIfNotExists(st, Rule{
+				ToolName:  fc.Name,
+				Arguments: args,
+			})
 		}
 	}
 	st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, resp.InnerResponse)

--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -380,6 +380,86 @@ func TestToolApproval_AlwaysApproveToolWithArgumentsMatchesByValue(t *testing.T)
 	}
 }
 
+func TestToolApproval_AlwaysApproveToolWithArgumentsDoesNotForwardOnSerializeFailure(t *testing.T) {
+	fcc := &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`}
+
+	var innerCallMessages []*message.Message
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc},
+				},
+			}).
+			NewTurn(func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+				innerCallMessages = messages
+			}).
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc},
+				},
+			}).
+			Build(),
+	}
+
+	mw := toolapproval.New(toolapproval.Config{})
+	session := agenttest.CreateSession()
+	opts := []agent.Option{agent.WithSession(session)}
+
+	turn1 := collectUpdates(
+		t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}}},
+		opts...,
+	)
+
+	var req *message.ToolApprovalRequestContent
+	for _, u := range turn1 {
+		for _, c := range u.Contents {
+			if r, ok := c.(*message.ToolApprovalRequestContent); ok {
+				req = r
+			}
+		}
+	}
+	if req == nil {
+		t.Fatal("expected approval request in turn 1")
+	}
+
+	resp := req.AlwaysApproveToolWithArgumentsResponse()
+	fc, ok := resp.InnerResponse.ToolCall.(*message.FunctionCallContent)
+	if !ok || fc == nil {
+		t.Fatal("expected function call in approval response")
+	}
+	fc.Arguments = "{"
+
+	turn2 := collectUpdates(
+		t, mw, runner.Run,
+		[]*message.Message{{Role: message.RoleUser, Contents: []message.Content{resp}}},
+		opts...,
+	)
+
+	for _, msg := range innerCallMessages {
+		for _, c := range msg.Contents {
+			if _, ok := c.(*message.ToolApprovalResponseContent); ok {
+				t.Fatal("expected malformed always-approve response not to be forwarded to inner agent")
+			}
+		}
+	}
+
+	var surfacedReq *message.ToolApprovalRequestContent
+	for _, u := range turn2 {
+		for _, c := range u.Contents {
+			if r, ok := c.(*message.ToolApprovalRequestContent); ok {
+				surfacedReq = r
+			}
+		}
+	}
+	if surfacedReq == nil || surfacedReq.RequestID != "r1" {
+		t.Fatalf("expected original approval request to be surfaced again, got %#v", surfacedReq)
+	}
+}
+
 func TestToolApproval_AlwaysApproveToolWithNoArgumentsDoesNotMatchCallWithArguments(t *testing.T) {
 	runner := &agenttest.Runner{
 		Responses: agenttest.NewResponseBuilder().


### PR DESCRIPTION
## Summary

Extracted inbound tool approval response collection into small unexported helpers so always-approve wrapper unwrapping is separated from message cleanup. This keeps the Go middleware structure closer to the .NET `AlwaysApproveToolApprovalResponseContent` flow, where the wrapper carries approval settings while the inner response is forwarded.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/AlwaysApproveToolApprovalResponseContent.cs` - wraps an inner approval response with always-approve settings that the middleware extracts before forwarding the inner response.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w agent/harness/toolapproval/toolapproval.go`
- `go test ./agent/harness/toolapproval`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Models/Tool.cs` - rejected because open PR https://github.com/microsoft/agent-framework-go/pull/535 already covers OpenAI tool schema conversion internals.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Edge.cs`, `EdgeId.cs`, and `DirectEdgeData.cs` - rejected because open PR https://github.com/microsoft/agent-framework-go/pull/484 already covers adjacent workflow edge construction internals.
- `dotnet/src/Microsoft.Agents.AI.Abstractions/AgentSessionExtensions.cs` - rejected because adding .NET-style chat-history session helpers would change the public Go API rather than refactor existing internals.
- `dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentState.cs` - rejected because no matching Go background-agent state surface exists in the sampled implementation without adding missing feature shape.

Candidate-specific open PR search for tool approval / always-approve overlap found no open `[dotnet-code]` PR before editing.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29663648990) · 429.2 AIC · ⌖ 42.3 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29663648990, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29663648990 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #547