### PR TITLE
[dotnet-code] Extract A2A message creation helper

### DIFF
--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -90,27 +90,7 @@ func (a *a2aProvider) run(ctx context.Context, messages []*message.Message, opti
 				yield(nil, err)
 				return
 			}
-			taskIDs := make([]a2a.TaskID, 0, 1)
-			for _, taskID := range getTaskIDs(session) {
-				taskIDs = append(taskIDs, a2a.TaskID(taskID))
-			}
-			userMsg := a2a.NewMessage(a2a.MessageRoleUser, parts...)
-			if msg.ID != "" {
-				userMsg.ID = msg.ID
-			}
-			userMsg.ContextID = getContextID(session)
-			// When the task is waiting for user input (InputRequired), link the message
-			// directly to the task via TaskId so it is treated as input for that task.
-			// Otherwise, use ReferenceTasks to link as a follow-up.
-			// See: https://github.com/a2aproject/A2A/blob/main/docs/topics/life-of-a-task.md#task-refinements
-			if getLastTaskState(session) == a2a.TaskStateInputRequired && len(taskIDs) > 0 {
-				userMsg.TaskID = taskIDs[len(taskIDs)-1]
-			} else {
-				userMsg.ReferenceTasks = taskIDs
-			}
-			userMsg.Metadata = maps.Clone(msg.AdditionalProperties)
-
-			params := &a2a.SendMessageRequest{Message: userMsg}
+			params := &a2a.SendMessageRequest{Message: createA2AMessage(session, msg, parts)}
 			var seq iter.Seq2[a2a.Event, error]
 			if stream {
 				seq = a.client.SendStreamingMessage(ctx, params)
@@ -123,6 +103,26 @@ func (a *a2aProvider) run(ctx context.Context, messages []*message.Message, opti
 			sendMsg(session, seq, yield)
 		}
 	}
+}
+
+func createA2AMessage(session *agent.Session, msg *message.Message, parts a2a.ContentParts) *a2a.Message {
+	taskIDs := make([]a2a.TaskID, 0, 1)
+	for _, taskID := range getTaskIDs(session) {
+		taskIDs = append(taskIDs, a2a.TaskID(taskID))
+	}
+
+	a2aMessage := a2a.NewMessage(a2a.MessageRoleUser, parts...)
+	if msg.ID != "" {
+		a2aMessage.ID = msg.ID
+	}
+	a2aMessage.ContextID = getContextID(session)
+	if getLastTaskState(session) == a2a.TaskStateInputRequired && len(taskIDs) > 0 {
+		a2aMessage.TaskID = taskIDs[len(taskIDs)-1]
+	} else {
+		a2aMessage.ReferenceTasks = taskIDs
+	}
+	a2aMessage.Metadata = maps.Clone(msg.AdditionalProperties)
+	return a2aMessage
 }
 
 // subscribeToTaskWithFallback resumes a task stream for a continuation token.

--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -116,6 +116,11 @@ func createA2AMessage(session *agent.Session, msg *message.Message, parts a2a.Co
 		a2aMessage.ID = msg.ID
 	}
 	a2aMessage.ContextID = getContextID(session)
+
+	// When the task is waiting for user input (InputRequired), link the message
+	// directly to the task via TaskID so it is treated as input for that task.
+	// Otherwise, use ReferenceTasks to link as a follow-up.
+	// See: https://github.com/a2aproject/A2A/blob/main/docs/topics/life-of-a-task.md#task-refinements
 	if getLastTaskState(session) == a2a.TaskStateInputRequired && len(taskIDs) > 0 {
 		a2aMessage.TaskID = taskIDs[len(taskIDs)-1]
 	} else {


### PR DESCRIPTION
## Summary

Extracted the existing outbound A2A message assembly into a small unexported `createA2AMessage` helper. This keeps the Go A2A provider structure closer to the .NET provider's `CreateA2AMessage` helper while preserving the existing request fields and routing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.A2A/A2AAgent.cs` - uses `CreateA2AMessage` to build outbound A2A messages and attach session context/task routing.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./provider/a2aprovider`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI.Abstractions/AgentSessionStateBagJsonConverter.cs` versus `agent/session.go` and `agent/value.go`: Go already has focused session JSON helpers and preservation tests; extracting another normalization helper would add little parity value.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/InMemoryStorageOptions.cs`: no narrow Go OpenAI hosting storage counterpart exists in the sampled surface; the nearest in-memory history configuration is a public agent feature and was avoided.

Open `[dotnet-code]` PR checks found no A2A or `CreateA2AMessage` overlap before editing.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29618242488) · 528.3 AIC · ⌖ 30.1 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29618242488, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29618242488 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #540