### PR TITLE
[dotnet-port-fixes] Align MessageMerger reasoning folding with .NET

### DIFF
--- a/workflow/agentworkflow/message_merger.go
+++ b/workflow/agentworkflow/message_merger.go
@@ -66,6 +66,7 @@ func (m *messageMerger) ComputeMerged(primaryResponseID string, primaryAgentID s
 	}
 
 	messages = append(messages, m.danglingState.computeFlattened()...)
+	messages = foldIdentifierlessMessages(messages)
 	messages = cleanupMergedMessages(messages)
 
 	response := &agent.Response{
@@ -188,6 +189,32 @@ func messagesWithCreatedAt(response *agent.Response) []*message.Message {
 			clone.CreatedAt = response.CreatedAt
 		}
 		messages = append(messages, clone)
+	}
+	return messages
+}
+
+func foldIdentifierlessMessages(messages []*message.Message) []*message.Message {
+	for i := len(messages) - 1; i > 0; i-- {
+		current := messages[i-1]
+		next := messages[i]
+		if current == nil || next == nil {
+			continue
+		}
+		if current.ID != "" || next.ID == "" || current.Role != next.Role {
+			continue
+		}
+
+		merged := next.Clone()
+		merged.AuthorName = cmp.Or(next.AuthorName, current.AuthorName)
+		if merged.CreatedAt.IsZero() {
+			merged.CreatedAt = current.CreatedAt
+		}
+		merged.Contents = append(slices.Clone(current.Contents), next.Contents...)
+		if merged.Source == (message.Source{}) {
+			merged.Source = current.Source
+		}
+		messages[i] = merged
+		messages = append(messages[:i-1], messages[i:]...)
 	}
 	return messages
 }

--- a/workflow/agentworkflow/message_merger.go
+++ b/workflow/agentworkflow/message_merger.go
@@ -200,12 +200,13 @@ func foldIdentifierlessMessages(messages []*message.Message) []*message.Message 
 		if current == nil || next == nil {
 			continue
 		}
-		if current.ID != "" || next.ID == "" || current.Role != next.Role {
+		if !isIdentifierlessAssistantReasoningMessage(current) || next.ID == "" || current.Role != next.Role {
 			continue
 		}
 
 		merged := next.Clone()
 		merged.AuthorName = cmp.Or(next.AuthorName, current.AuthorName)
+		merged.AdditionalProperties = mergeProperties(current.AdditionalProperties, merged.AdditionalProperties)
 		if merged.CreatedAt.IsZero() {
 			merged.CreatedAt = current.CreatedAt
 		}
@@ -217,6 +218,18 @@ func foldIdentifierlessMessages(messages []*message.Message) []*message.Message 
 		messages = append(messages[:i-1], messages[i:]...)
 	}
 	return messages
+}
+
+func isIdentifierlessAssistantReasoningMessage(msg *message.Message) bool {
+	if msg == nil || msg.ID != "" || msg.Role != message.RoleAssistant || len(msg.Contents) == 0 {
+		return false
+	}
+	for _, content := range msg.Contents {
+		if _, ok := content.(*message.TextReasoningContent); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func mergeProperties(current, incoming map[string]any) map[string]any {

--- a/workflow/agentworkflow/message_merger_test.go
+++ b/workflow/agentworkflow/message_merger_test.go
@@ -237,6 +237,40 @@ func TestMessageMerger_DoesNotFoldIdentifierlessReasoningIntoDifferentRole(t *te
 	}
 }
 
+func TestMessageMerger_DoesNotFoldIdentifierlessAssistantFunctionCallIntoFollowingMessage(t *testing.T) {
+	const (
+		responseID = "response"
+		messageID  = "msg-answer"
+		callID     = "call-1"
+	)
+
+	merger := newMessageMerger()
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.FunctionCallContent{CallID: callID, Name: "handoff"}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		MessageID:  messageID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextContent{Text: "answer"}},
+	})
+
+	response := merger.ComputeMerged(responseID, "", "")
+
+	if len(response.Messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(response.Messages))
+	}
+	if _, ok := response.Messages[0].Contents[0].(*message.FunctionCallContent); !ok {
+		t.Fatalf("first content = %T, want *message.FunctionCallContent", response.Messages[0].Contents[0])
+	}
+	if response.Messages[1].ID != messageID {
+		t.Fatalf("second message ID = %q, want %q", response.Messages[1].ID, messageID)
+	}
+	assertTextContent(t, response.Messages[1].Contents[0], "answer")
+}
+
 func TestMessageMerger_PreservesMessageOrderWhenReasoningLacksCreatedAt(t *testing.T) {
 	responseID := "response"
 	answerTime := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
@@ -311,6 +345,44 @@ func TestMessageMerger_MergesReasoningAndTextIntoSingleMessageWhenReasoningLacks
 	}
 	assertTextReasoningContent(t, msg.Contents[0], "Thinking about the question")
 	assertTextContent(t, msg.Contents[1], "Here is the answer.")
+}
+
+func TestMessageMerger_FoldsIdentifierlessReasoningMergesAdditionalProperties(t *testing.T) {
+	const (
+		responseID = "response"
+		messageID  = "msg-answer"
+	)
+
+	merger := newMessageMerger()
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID:           responseID,
+		Role:                 message.RoleAssistant,
+		AdditionalProperties: map[string]any{"reasoning_key": "reasoning", "shared": "reasoning"},
+		Contents:             []message.Content{&message.TextReasoningContent{Text: "thinking"}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID:           responseID,
+		MessageID:            messageID,
+		Role:                 message.RoleAssistant,
+		AdditionalProperties: map[string]any{"answer_key": "answer", "shared": "answer"},
+		Contents:             []message.Content{&message.TextContent{Text: "final"}},
+	})
+
+	response := merger.ComputeMerged(responseID, "", "")
+
+	if len(response.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(response.Messages))
+	}
+	msg := response.Messages[0]
+	if msg.AdditionalProperties["reasoning_key"] != "reasoning" {
+		t.Fatalf("reasoning additional property = %v, want reasoning", msg.AdditionalProperties["reasoning_key"])
+	}
+	if msg.AdditionalProperties["answer_key"] != "answer" {
+		t.Fatalf("answer additional property = %v, want answer", msg.AdditionalProperties["answer_key"])
+	}
+	if msg.AdditionalProperties["shared"] != "answer" {
+		t.Fatalf("shared additional property = %v, want answer", msg.AdditionalProperties["shared"])
+	}
 }
 
 func TestMessageMerger_FoldsIdentifierlessReasoningIntoFollowingMessageAcrossResponseBuckets(t *testing.T) {

--- a/workflow/agentworkflow/message_merger_test.go
+++ b/workflow/agentworkflow/message_merger_test.go
@@ -165,6 +165,190 @@ func TestMessageMerger_SeparatesIdentifierlessSegments(t *testing.T) {
 	assertMessageTexts(t, response.Messages, "AB", "X", "Y")
 }
 
+func TestMessageMerger_FoldsIdentifierlessReasoningIntoFollowingMessage(t *testing.T) {
+	const (
+		responseID = "response"
+		messageID  = "msg-answer"
+	)
+
+	merger := newMessageMerger()
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextReasoningContent{Text: "thinking about the question"}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		MessageID:  messageID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextContent{Text: "The reformulated question."}},
+	})
+
+	response := merger.ComputeMerged(responseID, "", "")
+
+	if len(response.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(response.Messages))
+	}
+	msg := response.Messages[0]
+	if msg.Role != message.RoleAssistant {
+		t.Fatalf("role = %q, want %q", msg.Role, message.RoleAssistant)
+	}
+	if msg.ID != messageID {
+		t.Fatalf("message ID = %q, want %q", msg.ID, messageID)
+	}
+	assertMessageContentTexts(t, msg, "thinking about the question", "The reformulated question.")
+	assertTextReasoningContent(t, msg.Contents[0], "thinking about the question")
+	assertTextContent(t, msg.Contents[1], "The reformulated question.")
+}
+
+func TestMessageMerger_DoesNotFoldIdentifierlessReasoningIntoDifferentRole(t *testing.T) {
+	const (
+		responseID = "response"
+		messageID  = "msg-tool"
+	)
+
+	merger := newMessageMerger()
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextReasoningContent{Text: "thinking"}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		MessageID:  messageID,
+		Role:       message.RoleTool,
+		Contents:   []message.Content{&message.FunctionResultContent{CallID: "call", Result: "done"}},
+	})
+
+	response := merger.ComputeMerged(responseID, "", "")
+
+	if len(response.Messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(response.Messages))
+	}
+	if response.Messages[0].Role != message.RoleAssistant {
+		t.Fatalf("first role = %q, want %q", response.Messages[0].Role, message.RoleAssistant)
+	}
+	assertTextReasoningContent(t, response.Messages[0].Contents[0], "thinking")
+	if response.Messages[1].Role != message.RoleTool {
+		t.Fatalf("second role = %q, want %q", response.Messages[1].Role, message.RoleTool)
+	}
+	if _, ok := response.Messages[1].Contents[0].(*message.FunctionResultContent); !ok {
+		t.Fatalf("second content = %T, want *message.FunctionResultContent", response.Messages[1].Contents[0])
+	}
+}
+
+func TestMessageMerger_PreservesMessageOrderWhenReasoningLacksCreatedAt(t *testing.T) {
+	responseID := "response"
+	answerTime := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+
+	merger := newMessageMerger()
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		MessageID:  "reasoning-message",
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextReasoningContent{Text: "Thinking about the question"}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		MessageID:  "text-message",
+		Role:       message.RoleAssistant,
+		CreatedAt:  answerTime,
+		Contents:   []message.Content{&message.TextContent{Text: "Here is the answer."}},
+	})
+
+	response := merger.ComputeMerged(responseID, "", "")
+
+	if len(response.Messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(response.Messages))
+	}
+	assertTextReasoningContent(t, response.Messages[0].Contents[0], "Thinking about the question")
+	assertTextContent(t, response.Messages[1].Contents[0], "Here is the answer.")
+}
+
+func TestMessageMerger_MergesReasoningAndTextIntoSingleMessageWhenReasoningLacksMessageID(t *testing.T) {
+	const (
+		responseID = "response"
+		messageID  = "msg-answer"
+	)
+
+	merger := newMessageMerger()
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextReasoningContent{Text: "Thinking "}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextReasoningContent{Text: "about the question"}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		MessageID:  messageID,
+		Role:       message.RoleAssistant,
+		CreatedAt:  time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+		Contents:   []message.Content{&message.TextContent{Text: "Here is "}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: responseID,
+		MessageID:  messageID,
+		Role:       message.RoleAssistant,
+		CreatedAt:  time.Date(2026, 7, 15, 12, 0, 1, 0, time.UTC),
+		Contents:   []message.Content{&message.TextContent{Text: "the answer."}},
+	})
+
+	response := merger.ComputeMerged(responseID, "", "")
+
+	if len(response.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(response.Messages))
+	}
+	msg := response.Messages[0]
+	if msg.ID != messageID {
+		t.Fatalf("message ID = %q, want %q", msg.ID, messageID)
+	}
+	if len(msg.Contents) != 2 {
+		t.Fatalf("content count = %d, want 2", len(msg.Contents))
+	}
+	assertTextReasoningContent(t, msg.Contents[0], "Thinking about the question")
+	assertTextContent(t, msg.Contents[1], "Here is the answer.")
+}
+
+func TestMessageMerger_FoldsIdentifierlessReasoningIntoFollowingMessageAcrossResponseBuckets(t *testing.T) {
+	const (
+		reasoningResponseID = "resp-reasoning"
+		textResponseID      = "resp-text"
+		messageID           = "msg-answer"
+	)
+
+	merger := newMessageMerger()
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: reasoningResponseID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextReasoningContent{Text: "thinking about the question"}},
+	})
+	merger.AddUpdate(&agent.ResponseUpdate{
+		ResponseID: textResponseID,
+		MessageID:  messageID,
+		Role:       message.RoleAssistant,
+		Contents:   []message.Content{&message.TextContent{Text: "The reformulated question."}},
+	})
+
+	response := merger.ComputeMerged(textResponseID, "", "")
+
+	if len(response.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(response.Messages))
+	}
+	msg := response.Messages[0]
+	if msg.ID != messageID {
+		t.Fatalf("message ID = %q, want %q", msg.ID, messageID)
+	}
+	if msg.Role != message.RoleAssistant {
+		t.Fatalf("role = %q, want %q", msg.Role, message.RoleAssistant)
+	}
+	assertTextReasoningContent(t, msg.Contents[0], "thinking about the question")
+	assertTextContent(t, msg.Contents[1], "The reformulated question.")
+}
+
 func addTextUpdate(merger *messageMerger, responseID string, text string, messageID string, createdAt time.Time) {
 	merger.AddUpdate(&agent.ResponseUpdate{
 		ResponseID: responseID,
@@ -184,5 +368,48 @@ func assertMessageTexts(t *testing.T, messages []*message.Message, want ...strin
 		if got := msg.String(); got != want[i] {
 			t.Fatalf("message[%d] = %q, want %q", i, got, want[i])
 		}
+	}
+}
+
+func assertMessageContentTexts(t *testing.T, msg *message.Message, want ...string) {
+	t.Helper()
+	if len(msg.Contents) != len(want) {
+		t.Fatalf("content count = %d, want %d", len(msg.Contents), len(want))
+	}
+	for i, content := range msg.Contents {
+		var got string
+		switch v := content.(type) {
+		case *message.TextContent:
+			got = v.Text
+		case *message.TextReasoningContent:
+			got = v.Text
+		default:
+			t.Fatalf("content[%d] = %T, want text or reasoning content", i, content)
+		}
+		if got != want[i] {
+			t.Fatalf("content[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func assertTextReasoningContent(t *testing.T, content message.Content, want string) {
+	t.Helper()
+	reasoning, ok := content.(*message.TextReasoningContent)
+	if !ok {
+		t.Fatalf("content = %T, want *message.TextReasoningContent", content)
+	}
+	if reasoning.Text != want {
+		t.Fatalf("reasoning text = %q, want %q", reasoning.Text, want)
+	}
+}
+
+func assertTextContent(t *testing.T, content message.Content, want string) {
+	t.Helper()
+	text, ok := content.(*message.TextContent)
+	if !ok {
+		t.Fatalf("content = %T, want *message.TextContent", content)
+	}
+	if text.Text != want {
+		t.Fatalf("text = %q, want %q", text.Text, want)
 	}
 }


### PR DESCRIPTION
## Summary

Port the remaining internal `MessageMerger` behavior from upstream .NET PR `microsoft/agent-framework#6826` so identifierless assistant reasoning is folded into the following identified assistant message, including when the reasoning and final answer arrive in different response buckets.

The Go change adds the missing backward fold pass in `workflow/agentworkflow/message_merger.go` and ports focused parity tests in `workflow/agentworkflow/message_merger_test.go` for same-role folding, different-role non-folding, preserved ordering when reasoning lacks `CreatedAt`, same-bucket reasoning+text merging, and cross-bucket reasoning+text merging.

Relevant upstream commit: `3ab263024381fe726da818d7644aed2238b8ff67` on top of inspected upstream head `9cf514332186db190d1f24d37723f7447a3cc05a`.

## Ported .NET PRs

- microsoft/agent-framework#6826 - Refactor workflow `MessageMerger` to preserve message order and fold identifierless reasoning into the following same-role identified message

## Breaking Changes

No.

## Tests and Examples

- `go test ./workflow/agentworkflow`
- `go test ./workflow/...`
- Added `MessageMerger` parity tests for reasoning folding and ordering behavior

## Notes

- This PR intentionally ports only the remaining identifierless-reasoning fold behavior from `#6826`; nearby ordering-related changes had already been covered by earlier Go parity work.
- No public Go API was changed.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29798723391) · 744.2 AIC · ⌖ 26 AIC · ⊞ 21.7K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.60, model: gpt-5.4, id: 29798723391, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29798723391 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #574