### PR TITLE
Populate ResponseUpdate.FinishReason for the Anthropic provider from stop_reason

### DIFF
--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -117,6 +117,7 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				MessageID:         resp.ID,
 				ResponseID:        resp.ID,
 				CreatedAt:         time.Now(),
+				FinishReason:      mapStopReason(resp.StopReason),
 				RawRepresentation: resp,
 			}, nil)
 		}
@@ -125,6 +126,7 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 		stream := a.client.Messages.NewStreaming(ctx, params)
 
 		var messageID string
+		var finishReason string
 		var usage message.UsageDetails
 		var accumulated anthropic.Message
 
@@ -142,6 +144,11 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				usage.Add(toUsageDetails(event.Message.Usage))
 			case anthropic.MessageDeltaEvent:
 				usage.Add(toUsageDetailsDelta(event.Usage))
+				// Later chunks may carry an empty stop_reason; don't clobber a
+				// value we already captured.
+				if fr := mapStopReason(event.Delta.StopReason); fr != "" {
+					finishReason = fr
+				}
 			case anthropic.ContentBlockStartEvent:
 				block := event.ContentBlock.AsAny()
 				if _, isToolUse := block.(anthropic.ToolUseBlock); !isToolUse {
@@ -171,9 +178,10 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 			}
 		}
 		if !yield(&agent.ResponseUpdate{
-			CreatedAt: time.Now(),
-			Role:      message.RoleAssistant,
-			MessageID: messageID,
+			CreatedAt:    time.Now(),
+			Role:         message.RoleAssistant,
+			MessageID:    messageID,
+			FinishReason: finishReason,
 			Contents: []message.Content{
 				&message.UsageContent{
 					Details: usage,
@@ -185,6 +193,24 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 		if err := stream.Err(); err != nil {
 			yield(nil, err)
 		}
+	}
+}
+
+// mapStopReason maps an Anthropic stop_reason to the canonical FinishReason
+// values shared across providers (mirroring the OpenAI/Copilot providers). It
+// returns "" for empty or unrecognized reasons so callers can fall through.
+func mapStopReason(reason anthropic.StopReason) string {
+	switch reason {
+	case anthropic.StopReasonEndTurn, anthropic.StopReasonStopSequence, anthropic.StopReasonPauseTurn:
+		return "stop"
+	case anthropic.StopReasonMaxTokens:
+		return "length"
+	case anthropic.StopReasonToolUse:
+		return "tool_calls"
+	case anthropic.StopReasonRefusal:
+		return "content_filter"
+	default:
+		return ""
 	}
 }
 

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -172,6 +172,90 @@ func collectStreamingToolCalls(t *testing.T, events string) []*message.FunctionC
 	return calls
 }
 
+// finishReasonCases enumerates every Anthropic stop_reason the provider maps to
+// a canonical FinishReason, exercising the unexported mapStopReason helper end
+// to end through the public API.
+var finishReasonCases = []struct {
+	stopReason string
+	want       string
+}{
+	{"end_turn", "stop"},
+	{"stop_sequence", "stop"},
+	{"pause_turn", "stop"},
+	{"max_tokens", "length"},
+	{"tool_use", "tool_calls"},
+	{"refusal", "content_filter"},
+}
+
+// TestNonStreamingFinishReason verifies the provider maps the Anthropic
+// stop_reason on a non-streaming response to the canonical FinishReason.
+func TestNonStreamingFinishReason(t *testing.T) {
+	for _, tc := range finishReasonCases {
+		t.Run(tc.stopReason, func(t *testing.T) {
+			body := fmt.Sprintf(`{
+				"id":"msg_finish",
+				"type":"message",
+				"role":"assistant",
+				"model":"claude-3-5-sonnet-20241022",
+				"stop_reason":%q,
+				"stop_sequence":null,
+				"content":[{"type":"text","text":"hello"}],
+				"usage":{"input_tokens":10,"output_tokens":5}
+			}`, tc.stopReason)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, body)
+			}))
+			defer server.Close()
+
+			resp, err := newTestClient(t, server).RunText(t.Context(), "hi").Collect()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.FinishReason != tc.want {
+				t.Errorf("FinishReason = %q, want %q", resp.FinishReason, tc.want)
+			}
+		})
+	}
+}
+
+// TestStreamingFinishReason verifies the provider captures the stop_reason from
+// the streaming message_delta event and reports it as the canonical
+// FinishReason on the collected response.
+func TestStreamingFinishReason(t *testing.T) {
+	for _, tc := range finishReasonCases {
+		t.Run(tc.stopReason, func(t *testing.T) {
+			stream := "" +
+				"event: message_start\n" +
+				`data: {"type":"message_start","message":{"id":"msg_stream_finish","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}` + "\n\n" +
+				"event: content_block_start\n" +
+				`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+				"event: content_block_delta\n" +
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}` + "\n\n" +
+				"event: content_block_stop\n" +
+				`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+				"event: message_delta\n" +
+				fmt.Sprintf(`data: {"type":"message_delta","delta":{"stop_reason":%q,"stop_sequence":null},"usage":{"output_tokens":5}}`, tc.stopReason) + "\n\n" +
+				"event: message_stop\n" +
+				`data: {"type":"message_stop"}` + "\n\n"
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w, stream)
+			}))
+			defer server.Close()
+
+			resp, err := newTestClient(t, server).RunText(t.Context(), "hi", agent.Stream(true)).Collect()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.FinishReason != tc.want {
+				t.Errorf("FinishReason = %q, want %q", resp.FinishReason, tc.want)
+			}
+		})
+	}
+}
+
 func TestConfigInstructions(t *testing.T) {
 	bodyCh := make(chan []byte, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -256,6 +256,42 @@ func TestStreamingFinishReason(t *testing.T) {
 	}
 }
 
+// TestStreamingFinishReasonNotClobbered verifies that once a non-empty
+// stop_reason has been captured from a message_delta, a later message_delta
+// carrying an empty stop_reason does not overwrite it. This exercises the guard
+// in the streaming path that skips empty stop_reason chunks.
+func TestStreamingFinishReasonNotClobbered(t *testing.T) {
+	stream := "" +
+		"event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_stream_finish","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":5}}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":null,"stop_sequence":null},"usage":{"output_tokens":1}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, stream)
+	}))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "hi", agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.FinishReason != "length" {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, "length")
+	}
+}
+
 func TestConfigInstructions(t *testing.T) {
 	bodyCh := make(chan []byte, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

The Anthropic provider never populated `ResponseUpdate.FinishReason`, so collected responses had an empty `FinishReason` even though the Messages API returns `stop_reason` on both the non-streaming response and the streaming `message_delta` event.

This adds a package-level `mapStopReason` helper that maps the SDK `stop_reason` to the canonical `FinishReason` values shared across providers:

- `end_turn`, `stop_sequence`, `pause_turn` -> `stop`
- `max_tokens` -> `length`
- `tool_use` -> `tool_calls`
- `refusal` -> `content_filter`
- empty / unknown -> `""`

- Non-streaming: sets `FinishReason: mapStopReason(resp.StopReason)` on the update.
- Streaming: captures the stop reason from `MessageDeltaEvent` and sets it on the terminal update, guarding against a later empty chunk overwriting a value already captured.

## Why

Brings the Anthropic provider to parity with the other providers, which already surface a finish reason: `openaiprovider/chat.go` sets `finishReason = choice.FinishReason` and `copilotprovider/copilot.go` sets `update.FinishReason`. This mirrors the .NET `ChatFinishReason` semantics so downstream consumers can reason about why generation stopped regardless of provider.

## Tests

- `TestMapStopReason`: table test asserting each SDK `stop_reason` constant maps to the expected canonical string (including empty/unknown -> `""`).
- `TestNonStreamingFinishReason`: fake-transport run returning `stop_reason: tool_use` asserts the collected `Response.FinishReason == tool_calls`.
- `TestStreamingFinishReason`: streaming run emitting a `message_delta` with `stop_reason: max_tokens` asserts `Response.FinishReason == length`.

`go build ./...`, `go vet ./provider/anthropicprovider/...`, and `go test ./provider/anthropicprovider/...` all pass.