### PR TITLE
Zero the vacated head slot in concurrent.Queue.Dequeue to release dead references

### DIFF
--- a/internal/concurrent/queue.go
+++ b/internal/concurrent/queue.go
@@ -27,7 +27,15 @@ func (q *Queue[T]) Dequeue() (T, bool) {
 	}
 
 	item := q.items[0]
+	// Zero the vacated head slot so the backing array no longer pins the
+	// dequeued value; drop the array entirely once the queue empties. This
+	// matches slices.Delete semantics and lets dead references be collected.
+	var zero T
+	q.items[0] = zero
 	q.items = q.items[1:]
+	if len(q.items) == 0 {
+		q.items = nil
+	}
 	return item, true
 }
 

--- a/internal/concurrent/queue_test.go
+++ b/internal/concurrent/queue_test.go
@@ -114,6 +114,60 @@ func TestQueue_Len(t *testing.T) {
 	}
 }
 
+// TestQueue_DequeueZeroesVacatedSlot verifies that Dequeue clears the vacated
+// head slot in the backing array so it no longer pins the dequeued reference.
+// The queue keeps later elements, so the backing array stays alive; the test
+// inspects the shared backing array directly to confirm the head slot was
+// zeroed rather than left holding the dead reference until reallocation.
+func TestQueue_DequeueZeroesVacatedSlot(t *testing.T) {
+	q := &Queue[*int]{}
+
+	head := new(int)
+	*head = 42
+	q.Enqueue(head)
+	for i := range 4 {
+		v := i
+		q.Enqueue(&v)
+	}
+
+	// A full-capacity view over the same backing array lets the test observe
+	// the physical head slot after it has been advanced past by Dequeue.
+	backing := q.items[:cap(q.items)]
+	if backing[0] != head {
+		t.Fatalf("expected head at slot 0, got %v", backing[0])
+	}
+
+	got, ok := q.Dequeue()
+	if !ok || got != head {
+		t.Fatalf("expected to dequeue head, got %v (ok=%v)", got, ok)
+	}
+
+	if backing[0] != nil {
+		t.Errorf("expected vacated head slot to be zeroed, still holds %v", backing[0])
+	}
+}
+
+// TestQueue_DequeueDropsEmptyBackingArray verifies that draining the queue
+// releases the backing array entirely so no residual references are retained.
+func TestQueue_DequeueDropsEmptyBackingArray(t *testing.T) {
+	q := &Queue[*int]{}
+
+	head := new(int)
+	q.Enqueue(head)
+	q.Enqueue(new(int))
+
+	if _, ok := q.Dequeue(); !ok {
+		t.Fatal("expected first dequeue to succeed")
+	}
+	if _, ok := q.Dequeue(); !ok {
+		t.Fatal("expected second dequeue to succeed")
+	}
+
+	if q.items != nil {
+		t.Errorf("expected backing array to be released on empty, got %v", q.items)
+	}
+}
+
 func TestQueue_All(t *testing.T) {
 	q := &Queue[int]{}
 


### PR DESCRIPTION
## What

`Queue.Dequeue` advanced the internal slice with `q.items = q.items[1:]` but never cleared the old head slot. The backing array therefore kept a live pointer to the dequeued value at the vacated index until the array eventually reallocated.

This change zeroes the head slot before re-slicing and drops the backing array once the queue empties:

```go
item := q.items[0]
var zero T
q.items[0] = zero
q.items = q.items[1:]
if len(q.items) == 0 {
    q.items = nil
}
return item, true
```

## Why

The queue is instantiated with reference element types that are long-lived and cycle steadily, e.g. `Queue[*execution.MessageEnvelope]` (workflow/inproc/runner.go), `Queue[workflow.Event]` (workflow/internal/execution/eventstream.go), and `Queue[func(context.Context) error]` (workflow/inproc/context.go). Because the head slot was never cleared, a dequeued value stayed GC-reachable through the backing array long after it was logically removed, retaining whatever object graph it pointed at until the slice happened to reallocate.

Clearing the vacated element mirrors Go's own `slices.Delete` semantics, which zero removed slots precisely so dead references can be collected promptly.

## How it is tested

Two deterministic tests in `internal/concurrent/queue_test.go`:
- `TestQueue_DequeueZeroesVacatedSlot` inspects the shared backing array through a full-capacity view and asserts the head slot is `nil` after `Dequeue` (while later elements keep the array alive).
- `TestQueue_DequeueDropsEmptyBackingArray` asserts `items` is released to `nil` once the queue drains.

Both fail before the change and pass after. `go build ./...`, `go vet ./internal/concurrent/...`, and `go test ./internal/concurrent/...` all pass.