### PR TITLE
Tolerate empty context IDs when updating A2A session state

### DIFF
--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -285,7 +285,7 @@ func updateSessionContextID(session *agent.Session, contextID, taskID string, ta
 	// Surface cases where the A2A agent responds with a response that
 	// has a different context ID than the session's context ID.
 	currentContextID := getContextID(session)
-	if currentContextID != "" && currentContextID != contextID {
+	if currentContextID != "" && contextID != "" && currentContextID != contextID {
 		return fmt.Errorf("mismatched context ID: session has %q but A2A response has %q", currentContextID, contextID)
 	}
 	setContextID(session, contextID)

--- a/provider/a2aprovider/a2a_test.go
+++ b/provider/a2aprovider/a2a_test.go
@@ -30,6 +30,10 @@ type mockA2ATransport struct {
 	sendStreamingMessageCalled bool
 	subscribeToTaskCalled      bool
 	getTaskCalled              bool
+	// rawStreamingResponse yields streamingResponseToReturn verbatim, without
+	// backfilling an empty ContextID from the request. It lets tests exercise
+	// bare streamed messages that carry no context ID.
+	rawStreamingResponse bool
 }
 
 func (m *mockA2ATransport) SendMessage(ctx context.Context, _ a2aclient.ServiceParams, params *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
@@ -50,6 +54,11 @@ func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, _ a2aclient
 	m.sendStreamingMessageCalled = true
 	m.capturedMessageSendParams = params
 	responseToYield := m.streamingResponseToReturn
+	if m.rawStreamingResponse {
+		return func(yield func(a2a.Event, error) bool) {
+			yield(responseToYield, nil)
+		}
+	}
 	if responseToYield == nil {
 		// Return default empty message with context ID from request
 		responseToYield = &a2a.Message{
@@ -544,6 +553,69 @@ func TestRunStreamingWithSessionHavingDifferentContextID(t *testing.T) {
 
 	if !gotError {
 		t.Error("expected error, got nil")
+	}
+}
+
+// TestRunStreamingWithEmptyContextIDKeepsSessionContext verifies that a bare
+// streamed message carrying an empty context ID neither errors the run nor
+// clobbers the context ID already stored in the session. This mirrors the .NET
+// behavior where ContextId is only assigned when currently unset
+// (ContextId ??= contextId).
+func TestRunStreamingWithEmptyContextIDKeepsSessionContext(t *testing.T) {
+	transport := &mockA2ATransport{
+		rawStreamingResponse: true,
+		streamingResponseToReturn: &a2a.Message{
+			ID:    "stream-1",
+			Role:  a2a.MessageRoleAgent,
+			Parts: a2a.ContentParts{a2a.NewTextPart("Response")},
+			// No ContextID: a bare streamed message chunk.
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context(), agent.WithServiceID("ctx-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range a.RunText(t.Context(), "Test streaming", agent.WithSession(session), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+	}
+
+	if got := session.ServiceID(); got != "ctx-1" {
+		t.Errorf("session.ServiceID = %q, want %q", got, "ctx-1")
+	}
+}
+
+// TestRunStreamingWithEmptyInitialContextStoresResponseContext verifies that when
+// the session has no context ID yet, the first streamed event's context ID is stored.
+func TestRunStreamingWithEmptyInitialContextStoresResponseContext(t *testing.T) {
+	transport := &mockA2ATransport{
+		rawStreamingResponse: true,
+		streamingResponseToReturn: &a2a.Message{
+			ID:        "stream-1",
+			Role:      a2a.MessageRoleAgent,
+			Parts:     a2a.ContentParts{a2a.NewTextPart("Response")},
+			ContextID: "ctx-1",
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range a.RunText(t.Context(), "Test streaming", agent.WithSession(session), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+	}
+
+	if got := session.ServiceID(); got != "ctx-1" {
+		t.Errorf("session.ServiceID = %q, want %q", got, "ctx-1")
 	}
 }
 

--- a/provider/a2aprovider/a2a_test.go
+++ b/provider/a2aprovider/a2a_test.go
@@ -55,6 +55,17 @@ func (m *mockA2ATransport) SendStreamingMessage(ctx context.Context, _ a2aclient
 	m.capturedMessageSendParams = params
 	responseToYield := m.streamingResponseToReturn
 	if m.rawStreamingResponse {
+		if responseToYield == nil {
+			// Default to a non-nil event so a raw test that forgets to set
+			// streamingResponseToReturn doesn't yield a nil event (which would
+			// panic when production code calls TaskInfo()). Deliberately leave
+			// ContextID empty — the "raw" mode exists to exercise bare messages
+			// that carry no context ID.
+			responseToYield = &a2a.Message{
+				ID:   "default-stream-id",
+				Role: a2a.MessageRoleAgent,
+			}
+		}
 		return func(yield func(a2a.Event, error) bool) {
 			yield(responseToYield, nil)
 		}

--- a/provider/a2aprovider/session.go
+++ b/provider/a2aprovider/session.go
@@ -15,6 +15,9 @@ const (
 )
 
 func setContextID(session *agent.Session, contextID string) {
+	if contextID == "" {
+		return
+	}
 	session.SetServiceID(contextID)
 }
 


### PR DESCRIPTION
## What

`updateSessionContextID` in `provider/a2aprovider/a2a.go` reconciles the A2A response's context ID with the one stored in the session. Two problems when the incoming context ID is empty:

1. The mismatch guard (`currentContextID != "" && currentContextID != contextID`) fires whenever the session already holds a context ID and the incoming one is empty, returning `mismatched context ID` and erroring the whole run.
2. Even past the guard, `setContextID` unconditionally overwrote the stored context ID with the empty string.

A bare streamed `Message` legitimately carries an empty `ContextID` (`sendMsg` reads `taskInfo.ContextID`), so both paths are reachable in normal streaming.

This is fixed by adding `contextID != ""` to the mismatch condition and adding an early `if contextID == "" { return }` guard inside `setContextID`, so empty streamed values neither error nor clobber the stored context ID.

## Why

This aligns with .NET, where the context ID is only assigned when currently unset (`ContextId ??= contextId`), and restores internal consistency: `setTaskID` already guards `if taskID == "" { return }`, while `setContextID` did not. The asymmetry is what let the empty case slip through.

## Testing

Added two black-box tests in `a2a_test.go` driven through the existing streaming harness (extended the shared mock with a `rawStreamingResponse` flag so a bare message's empty context ID is not backfilled from the request):

- `TestRunStreamingWithEmptyContextIDKeepsSessionContext`: session holds `ctx-1`, a streamed message with empty `ContextID` produces no error and leaves `ServiceID()` as `ctx-1`. Fails before the fix (`mismatched context ID: session has "ctx-1" but A2A response has ""`), passes after.
- `TestRunStreamingWithEmptyInitialContextStoresResponseContext`: session starts with no context ID, first event carries `ctx-1`, which is stored.

`go build ./...`, `go vet ./provider/a2aprovider/...`, and `go test ./provider/a2aprovider/...` all pass.