### PR TITLE
Forward provider updates in the structured-output middleware so the response is not empty

### DIFF
--- a/agent/structuredoutput.go
+++ b/agent/structuredoutput.go
@@ -54,6 +54,9 @@ func (m *structuredOutputMiddleware) Run(next RunFunc, ctx context.Context, mess
 			}
 			data = append(data, update.String()...)
 			current.update(update)
+			if !yield(update, nil) {
+				return
+			}
 		}
 		if err := m.unmarshal(format, data, v); err != nil {
 			yield(nil, err)

--- a/agent/structuredoutput_test.go
+++ b/agent/structuredoutput_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/internal/agenttest"
 	"github.com/microsoft/agent-framework-go/message"
 )
 
@@ -162,7 +163,7 @@ func TestAgent_StructuredOutput_SuccessfulUnmarshal(t *testing.T) {
 		Name string `json:"name"`
 		Age  int    `json:"age"`
 	}{}
-	_, err := a.Run(context.Background(), nil, agent.WithStructuredOutput(output)).Collect()
+	resp, err := a.Run(context.Background(), nil, agent.WithStructuredOutput(output)).Collect()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -171,6 +172,12 @@ func TestAgent_StructuredOutput_SuccessfulUnmarshal(t *testing.T) {
 	}
 	if output.Age != 30 {
 		t.Fatalf("expected Age 30, got %d", output.Age)
+	}
+	// The middleware must forward the provider updates so the assistant response is
+	// surfaced alongside the deserialized value, matching .NET AgentRunResponse<T>
+	// which keeps Messages/Text next to the parsed Result.
+	if got := resp.String(); got != `{"name":"Alice","age":30}` {
+		t.Fatalf("expected response text to equal the JSON payload, got %q", got)
 	}
 }
 
@@ -448,6 +455,54 @@ func TestAgent_StructuredOutput_MultipleContentTypes(t *testing.T) {
 	}
 	if output.Name != "Charlie" {
 		t.Fatalf("expected Name Charlie, got %q", output.Name)
+	}
+}
+
+func TestAgent_StructuredOutput_StoresAssistantMessages(t *testing.T) {
+	var stored []*message.Message
+	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
+		SourceID: "structured-output-history",
+		Store: func(ctx context.Context, invoked agent.InvokedContext) error {
+			stored = append(stored, invoked.ResponseMessages...)
+			return nil
+		},
+	})
+	a := agent.New(agent.ProviderConfig{
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return singleStructuredOutputTestUpdate(`{"name":"Ivy"}`)
+		},
+		Format: func(v any) (agent.ResponseFormat, error) {
+			return agent.ResponseFormat{Kind: "json"}, nil
+		},
+		Unmarshal: func(format agent.ResponseFormat, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+	}, agent.Config{ID: "structured-output-store-agent", HistoryProvider: historyProvider})
+
+	output := &struct {
+		Name string `json:"name"`
+	}{}
+	_, err := a.Run(context.Background(), nil,
+		agent.WithStructuredOutput(output),
+		agent.WithSession(agenttest.CreateSession()),
+	).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.Name != "Ivy" {
+		t.Fatalf("expected Name Ivy, got %q", output.Name)
+	}
+	// The middleware must forward provider updates so the run persists the assistant
+	// response. Without forwarding, historyResponse stays empty and nothing is stored.
+	if len(stored) == 0 {
+		t.Fatal("expected assistant response messages to be stored, got none")
+	}
+	var text string
+	for _, msg := range stored {
+		text += msg.String()
+	}
+	if text != `{"name":"Ivy"}` {
+		t.Fatalf("expected stored assistant text to equal the JSON payload, got %q", text)
 	}
 }
 


### PR DESCRIPTION
## What

The structured-output middleware's happy-path loop accumulates provider updates to assemble the JSON payload for unmarshalling, but it never yields any update downstream. The only success exit yields nothing.

Because this is a provider middleware and `agent.invoke` builds the response by consuming the provider-middleware chain (`historyResponse.Update(update)` per yielded update), emitting zero updates leaves `historyResponse` empty. The consequence: the collected `Response` has empty text, and the history provider persists an empty assistant message even though the structured value was deserialized correctly.

## Fix

After appending the update text to the accumulation buffer and updating the message key, forward the update downstream and stop if the consumer stops:

```go
data = append(data, update.String()...)
current.update(update)
if !yield(update, nil) {
    return
}
```

This preserves the existing per-message reset logic and the final unmarshal, while surfacing the assistant response so `agent.invoke` populates and persists `historyResponse`.

## Parity

This matches .NET `AgentRunResponse<T>`, which keeps `Messages`/`Text` alongside the deserialized `Result` rather than discarding the raw assistant response once the value is parsed.

## Tests

- Extended `TestAgent_StructuredOutput_SuccessfulUnmarshal` to assert the returned `Response.String()` equals the streamed JSON payload (previously discarded).
- Added `TestAgent_StructuredOutput_StoresAssistantMessages`, which runs with an explicit history provider and a session and asserts the stored assistant messages are non-empty and contain the JSON payload.

Both tests fail before the change and pass after. `go build ./...`, `go vet ./agent/...`, and `go test ./agent/...` are green.