### PR TITLE
Preserve full citation annotation data in Responses API populateAnnotations

### DIFF
--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -1205,11 +1205,27 @@ func populateAnnotations(anns []responses.ResponseOutputTextAnnotationUnion, con
 		case responses.ResponseOutputTextAnnotationFileCitation:
 			content.Annotations = append(content.Annotations, &message.CitationAnnotation{
 				FileID:            a.FileID,
+				Title:             a.Filename,
 				RawRepresentation: a,
 			})
 		case responses.ResponseOutputTextAnnotationURLCitation:
 			content.Annotations = append(content.Annotations, &message.CitationAnnotation{
+				Title:             a.Title,
 				URL:               a.URL,
+				AnnotatedRegions:  message.AnnotatedRegions{&message.TextSpanAnnotatedRegion{Start: int(a.StartIndex), End: int(a.EndIndex)}},
+				RawRepresentation: a,
+			})
+		case responses.ResponseOutputTextAnnotationContainerFileCitation:
+			content.Annotations = append(content.Annotations, &message.CitationAnnotation{
+				FileID:               a.FileID,
+				Title:                a.Filename,
+				AnnotatedRegions:     message.AnnotatedRegions{&message.TextSpanAnnotatedRegion{Start: int(a.StartIndex), End: int(a.EndIndex)}},
+				AdditionalProperties: map[string]any{"ContainerId": a.ContainerID},
+				RawRepresentation:    a,
+			})
+		case responses.ResponseOutputTextAnnotationFilePath:
+			content.Annotations = append(content.Annotations, &message.CitationAnnotation{
+				FileID:            a.FileID,
 				RawRepresentation: a,
 			})
 		}

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -2859,6 +2859,104 @@ data: {"type":"response.completed","response":{"id":"resp_001","object":"respons
 	}
 }
 
+func TestResponsesAnnotations_NonStreaming_PreservesFidelity(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]
+            }
+            `
+
+	const output = `
+            {
+                "id":"resp_001",
+                "object":"response",
+                "created_at":1741892091,
+                "status":"completed",
+                "error":null,
+                "incomplete_details":null,
+                "model":"gpt-4o-mini",
+                "output":[{
+                    "type":"message",
+                    "id":"msg_001",
+                    "status":"completed",
+                    "role":"assistant",
+                    "content":[{"type":"output_text","text":"Annotated text","annotations":[
+                        {"type":"url_citation","title":"Example","url":"https://example.com","start_index":0,"end_index":9},
+                        {"type":"file_citation","file_id":"file_123","filename":"doc.pdf","index":0},
+                        {"type":"container_file_citation","container_id":"cntr_1","file_id":"file_456","filename":"out.txt","start_index":2,"end_index":8}
+                    ]}]
+                }]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+
+	resp, err := a.RunText(t.Context(), "hello").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(resp.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(resp.Messages))
+	}
+
+	var annotations []message.Annotation
+	for _, content := range resp.Messages[0].Contents {
+		if tc, ok := content.(*message.TextContent); ok {
+			annotations = tc.Annotations
+		}
+	}
+	if len(annotations) != 3 {
+		t.Fatalf("expected 3 annotations, got %d", len(annotations))
+	}
+
+	url, ok := annotations[0].(*message.CitationAnnotation)
+	if !ok {
+		t.Fatalf("annotation[0] type = %T, want *CitationAnnotation", annotations[0])
+	}
+	if url.Title != "Example" || url.URL != "https://example.com" {
+		t.Errorf("url citation = %+v, want Title=Example URL=https://example.com", url)
+	}
+	if len(url.AnnotatedRegions) != 1 {
+		t.Fatalf("url citation regions = %d, want 1", len(url.AnnotatedRegions))
+	}
+	if span, ok := url.AnnotatedRegions[0].(*message.TextSpanAnnotatedRegion); !ok {
+		t.Errorf("url region type = %T, want *TextSpanAnnotatedRegion", url.AnnotatedRegions[0])
+	} else if span.Start != 0 || span.End != 9 {
+		t.Errorf("url span = {%d,%d}, want {0,9}", span.Start, span.End)
+	}
+
+	file, ok := annotations[1].(*message.CitationAnnotation)
+	if !ok {
+		t.Fatalf("annotation[1] type = %T, want *CitationAnnotation", annotations[1])
+	}
+	if file.FileID != "file_123" || file.Title != "doc.pdf" {
+		t.Errorf("file citation = %+v, want FileID=file_123 Title=doc.pdf", file)
+	}
+
+	container, ok := annotations[2].(*message.CitationAnnotation)
+	if !ok {
+		t.Fatalf("annotation[2] type = %T, want *CitationAnnotation", annotations[2])
+	}
+	if container.FileID != "file_456" || container.Title != "out.txt" {
+		t.Errorf("container citation = %+v, want FileID=file_456 Title=out.txt", container)
+	}
+	if container.AdditionalProperties["ContainerId"] != "cntr_1" {
+		t.Errorf("container id = %v, want cntr_1", container.AdditionalProperties["ContainerId"])
+	}
+	if len(container.AnnotatedRegions) != 1 {
+		t.Fatalf("container regions = %d, want 1", len(container.AnnotatedRegions))
+	}
+	if span, ok := container.AnnotatedRegions[0].(*message.TextSpanAnnotatedRegion); !ok {
+		t.Errorf("container region type = %T, want *TextSpanAnnotatedRegion", container.AnnotatedRegions[0])
+	} else if span.Start != 2 || span.End != 8 {
+		t.Errorf("container span = {%d,%d}, want {2,8}", span.Start, span.End)
+	}
+}
+
 func TestResponsesResponseWithInputImageHttpUrl_ParsesAsUriContent(t *testing.T) {
 	t.Skip("Skipping: input_image in output messages not yet supported by SDK")
 	const input = `


### PR DESCRIPTION
## What

`populateAnnotations` in `provider/openaiprovider/responses.go` mapped only a fraction of the data the Responses SDK exposes on text annotations:

- **URL citation**: only `URL` was copied — `Title`, `StartIndex`, `EndIndex` were dropped.
- **File citation**: only `FileID` was copied — `Filename` was dropped.
- **container_file_citation** and **file_path** annotations were not handled at all.

This change:

- Sets `Title` on URL citations (from `a.Title`) and file citations (from `a.Filename`).
- Populates `AnnotatedRegions` with a `TextSpanAnnotatedRegion{Start, End}` built from the SDK's `StartIndex`/`EndIndex` (cast from `int64`).
- Adds a case for `ResponseOutputTextAnnotationContainerFileCitation` (FileID, title, text-span region, and container id via `AdditionalProperties`).
- Adds a case for `ResponseOutputTextAnnotationFilePath` (FileID).

## Why

The target `message.CitationAnnotation` already carries `Title`, `Snippet`, `URL`, `FileID`, and `AnnotatedRegions`, and the sibling Anthropic provider populates `Title` (`cmp.Or(DocumentTitle, Title)`), `Snippet`, `URL`, proving the intended fidelity. This aligns the OpenAI Responses provider with the same cross-SDK behavior (.NET/Python), where citation title and annotated text-span regions are surfaced on the returned annotation rather than being silently discarded.

## Testing

Added `TestResponsesAnnotations_NonStreaming_PreservesFidelity` in `responses_test.go`, a black-box test driving `RunText().Collect()` through the existing fake-server harness. It returns `url_citation`, `file_citation`, and `container_file_citation` annotations and asserts that `Title` is set and that `AnnotatedRegions` contains a `TextSpanAnnotatedRegion` with the expected `Start`/`End`, plus the container id. The test fails before the fix (2 annotations, missing title/regions) and passes after.

`go build ./...`, `go vet ./provider/openaiprovider/...`, and `go test ./provider/openaiprovider/...` all pass.