### PR TITLE
Foundry memory items emit assistant content as input_text instead of output_text

### DIFF
--- a/provider/foundryprovider/memory.go
+++ b/provider/foundryprovider/memory.go
@@ -223,11 +223,15 @@ func toResponseItem(role message.Role, text string) map[string]any {
 	default:
 		role = message.RoleUser
 	}
+	contentType := "input_text"
+	if role == message.RoleAssistant {
+		contentType = "output_text"
+	}
 	return map[string]any{
 		"type": "message",
 		"role": string(role),
 		"content": []map[string]any{{
-			"type": "input_text",
+			"type": contentType,
 			"text": text,
 		}},
 	}

--- a/provider/foundryprovider/memory_test.go
+++ b/provider/foundryprovider/memory_test.go
@@ -235,6 +235,22 @@ func TestMemoryProviderInvokedUpdatesMemories(t *testing.T) {
 	if items[0].(map[string]any)["role"] != "user" || items[1].(map[string]any)["role"] != "assistant" {
 		t.Fatalf("items = %#v", items)
 	}
+	if got := contentPartType(t, items[0]); got != "input_text" {
+		t.Fatalf("user content type = %q, want input_text", got)
+	}
+	if got := contentPartType(t, items[1]); got != "output_text" {
+		t.Fatalf("assistant content type = %q, want output_text", got)
+	}
+}
+
+func contentPartType(t *testing.T, item any) string {
+	t.Helper()
+	content, ok := item.(map[string]any)["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("item content = %#v", item)
+	}
+	partType, _ := content[0].(map[string]any)["type"].(string)
+	return partType
 }
 
 func TestMemoryProviderInvokedSkipsStoreWhenInvocationFailed(t *testing.T) {


### PR DESCRIPTION
## What

`toResponseItem` in `provider/foundryprovider/memory.go` selected the message
role among assistant/system/user but always emitted the content part with type
`input_text`. As a result, an assistant memory item was serialized with
`input_text` rather than `output_text`.

This selects the content-part type by role: assistant items now emit
`output_text`, while user and system items keep `input_text`.

## Why

This aligns with the repo's Responses convention and .NET/Python parity. In
`provider/openaiprovider/responses.go`, assistant turns are output messages
built with `OfOutputText` (`output_text`), while user/system turns use
`OfInputText` (`input_text`). Foundry memory items should follow the same
input/output distinction so the assistant turn is represented as model output,
not user input.

## Tests

Extended `TestMemoryProviderInvokedUpdatesMemories` to decode the serialized
items and assert the content-part type: the user item is `input_text` and the
assistant item is `output_text`. The test fails before the fix (assistant part
was `input_text`) and passes after.