### PR TITLE
Add EnsureStoredMemoriesDeleted to Foundry MemoryProvider to expose scope deletion

### DIFF
--- a/provider/foundryprovider/memory.go
+++ b/provider/foundryprovider/memory.go
@@ -5,7 +5,9 @@ package foundryprovider
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -122,6 +124,26 @@ func (p *MemoryProvider) Invoking(ctx context.Context, invoking agent.InvokingCo
 
 func (p *MemoryProvider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
+}
+
+// EnsureStoredMemoriesDeleted deletes every memory stored for the session's scope in the
+// backing Foundry memory store. The scope is resolved with the provider's scope callback,
+// so a blank scope is treated as a configuration error and panics, matching the contract
+// documented on [NewMemoryProvider]. A store that holds no memories for the scope responds
+// with HTTP 404, which is treated as success. Any other error is returned to the caller.
+func (p *MemoryProvider) EnsureStoredMemoriesDeleted(ctx context.Context, session *agent.Session) error {
+	scope := p.scope(session)
+	if _, err := p.client.DeleteScope(ctx, p.memoryStoreName, scope, nil); err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+			p.log(ctx, slog.LevelInfo, "foundrymemory: no stored memories to delete", "memory_store", p.memoryStoreName)
+			return nil
+		}
+		p.log(ctx, slog.LevelError, "foundrymemory: failed to delete stored memories", "memory_store", p.memoryStoreName, "error", err)
+		return err
+	}
+	p.log(ctx, slog.LevelInfo, "foundrymemory: deleted stored memories", "memory_store", p.memoryStoreName)
+	return nil
 }
 
 func (p *MemoryProvider) provide(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {

--- a/provider/foundryprovider/memory_test.go
+++ b/provider/foundryprovider/memory_test.go
@@ -316,6 +316,21 @@ func TestMemoryProviderEnsureStoredMemoriesDeletedTreatsNotFoundAsSuccess(t *tes
 	if err := provider.EnsureStoredMemoriesDeleted(t.Context(), nil); err != nil {
 		t.Fatalf("EnsureStoredMemoriesDeleted error = %v", err)
 	}
+
+	requests := transport.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(requests))
+	}
+	req := requests[0]
+	if req.Method != http.MethodPost || req.Path != "/memory_stores/memory:delete_scope" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	if got := req.Header.Get("Foundry-Features"); got != "MemoryStores=V1Preview" {
+		t.Fatalf("Foundry-Features = %q", got)
+	}
+	if body := jsonMap(t, req.Body); body["scope"] != "user-456" {
+		t.Fatalf("scope = %#v", body["scope"])
+	}
 }
 
 func TestMemoryProviderEnsureStoredMemoriesDeletedSurfacesOtherErrors(t *testing.T) {

--- a/provider/foundryprovider/memory_test.go
+++ b/provider/foundryprovider/memory_test.go
@@ -277,4 +277,70 @@ func TestMemoryProviderInvokedLogsUpdateFailureAndDoesNotReturnError(t *testing.
 	}
 }
 
+func TestMemoryProviderEnsureStoredMemoriesDeletedDeletesScope(t *testing.T) {
+	transport := &recordingTransport{handle: func(req *http.Request, _ string) (*http.Response, error) {
+		return jsonResponse(req, http.StatusOK, `{"deleted_count":3}`), nil
+	}}
+	provider := foundryprovider.NewMemoryProvider(validEndpoint, validCredential, "memory", validScope, foundryprovider.MemoryProviderConfig{
+		ClientOptions: azcore.ClientOptions{Transport: transport},
+	})
+
+	if err := provider.EnsureStoredMemoriesDeleted(t.Context(), nil); err != nil {
+		t.Fatalf("EnsureStoredMemoriesDeleted error = %v", err)
+	}
+
+	requests := transport.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(requests))
+	}
+	req := requests[0]
+	if req.Method != http.MethodPost || req.Path != "/memory_stores/memory:delete_scope" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	if got := req.Header.Get("Foundry-Features"); got != "MemoryStores=V1Preview" {
+		t.Fatalf("Foundry-Features = %q", got)
+	}
+	if body := jsonMap(t, req.Body); body["scope"] != "user-456" {
+		t.Fatalf("scope = %#v", body["scope"])
+	}
+}
+
+func TestMemoryProviderEnsureStoredMemoriesDeletedTreatsNotFoundAsSuccess(t *testing.T) {
+	transport := &recordingTransport{handle: func(req *http.Request, _ string) (*http.Response, error) {
+		return jsonResponse(req, http.StatusNotFound, `{"error":{"code":"NotFound","message":"scope not found"}}`), nil
+	}}
+	provider := foundryprovider.NewMemoryProvider(validEndpoint, validCredential, "memory", validScope, foundryprovider.MemoryProviderConfig{
+		ClientOptions: azcore.ClientOptions{Transport: transport},
+	})
+
+	if err := provider.EnsureStoredMemoriesDeleted(t.Context(), nil); err != nil {
+		t.Fatalf("EnsureStoredMemoriesDeleted error = %v", err)
+	}
+}
+
+func TestMemoryProviderEnsureStoredMemoriesDeletedSurfacesOtherErrors(t *testing.T) {
+	transport := &recordingTransport{handle: func(req *http.Request, _ string) (*http.Response, error) {
+		return jsonResponse(req, http.StatusInternalServerError, `{"error":{"code":"InternalError","message":"boom"}}`), nil
+	}}
+	provider := foundryprovider.NewMemoryProvider(validEndpoint, validCredential, "memory", validScope, foundryprovider.MemoryProviderConfig{
+		ClientOptions: azcore.ClientOptions{Transport: transport},
+	})
+
+	err := provider.EnsureStoredMemoriesDeleted(t.Context(), nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestMemoryProviderEnsureStoredMemoriesDeletedPanicsWhenScopeIsEmpty(t *testing.T) {
+	provider := foundryprovider.NewMemoryProvider(validEndpoint, validCredential, "memory", func(*agent.Session) string { return " " }, foundryprovider.MemoryProviderConfig{})
+	assertPanics(t, func() {
+		_ = provider.EnsureStoredMemoriesDeleted(t.Context(), nil)
+	})
+}
+
 func validScope(*agent.Session) string { return "user-456" }


### PR DESCRIPTION
## What

Adds an exported `EnsureStoredMemoriesDeleted(ctx, session)` method to the Foundry `MemoryProvider`. It resolves the session scope with the provider's scope callback and calls `MemoryStoresClient.DeleteScope` to delete all memories stored for that scope in the memory store. A 404 (no memories exist for the scope) is treated as success; any other error is returned to the caller. Success and no-op cases are logged at info, consistent with the existing `provide`/`store` operations.

## Why

`MemoryStoresClient.DeleteScope` lives in the internal `azaiprojects` package and cannot be reached by external callers. The provider previously exposed only `Invoking`/`Invoked`, so there was no way to clear a scope's stored memories through the public API.

This mirrors the memory-provider surface in the .NET and Python Agent Framework, where a memory provider exposes an explicit "delete stored memories for this scope" operation (e.g. the `EnsureStoredMemoriesDeletedAsync`/thread-deletion hooks) so applications can honor data-deletion requests per user/tenant scope. Adding it keeps the Go provider aligned with the other SDKs.

## Tests

Added tests in `memory_test.go` driving the method through the existing fake `MemoryStoresClient` transport:
- successful `DeleteScope` returns nil and issues `POST /memory_stores/memory:delete_scope` with the resolved scope and Foundry-Features header;
- a 404 response is swallowed and returns nil;
- a 500 response is surfaced as an `*azcore.ResponseError`;
- a blank scope panics via the provider's scope contract.

`go build ./...`, `go vet ./provider/foundryprovider/...`, and `go test ./provider/foundryprovider/...` all pass.