### PR TITLE
Complete group chat instead of erroring when manager selects a non-participant agent

### DIFF
--- a/workflow/agentworkflow/groupchat.go
+++ b/workflow/agentworkflow/groupchat.go
@@ -355,7 +355,10 @@ func (host *groupChatHostExecutor) handleTurn(ctx *workflow.Context, token workf
 	}
 	nextBinding, ok := host.bindingForAgent(nextAgent)
 	if !ok {
-		return fmt.Errorf("agentworkflow: group chat manager selected non-participant agent %q", agentNameForError(nextAgent))
+		// Selecting an agent that is not a participant ends the chat and
+		// yields the accumulated conversation, matching .NET GroupChatHost
+		// falling through to CompleteAsync on a lookup miss.
+		return host.complete(ctx)
 	}
 
 	host.iterationCount++

--- a/workflow/agentworkflow/groupchat_test.go
+++ b/workflow/agentworkflow/groupchat_test.go
@@ -302,6 +302,28 @@ func TestGroupChatWorkflowBuilder_UpdateHistoryFiltersBroadcastPayload(t *testin
 	}
 }
 
+func TestGroupChatWorkflowBuilder_NonParticipantSelectionCompletesChat(t *testing.T) {
+	agentA := newGroupChatLabelAgent("a", "A", "from-a")
+	outsider := newGroupChatLabelAgent("outsider", "Outsider", "from-outsider")
+
+	wf, err := newGroupChatWorkflow("", func([]*agent.Agent) *GroupChatManager {
+		return &GroupChatManager{
+			SelectNextAgent: func(context.Context, []*message.Message) (*agent.Agent, error) {
+				return outsider, nil
+			},
+		}
+	}, agentA)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	events := runGroupChatWorkflowTurn(t, wf, "hello")
+	assertNoGroupChatErrors(t, events)
+	if got := collectGroupChatOutputTexts(events); !slices.Equal(got, []string{"hello"}) {
+		t.Fatalf("output transcript = %v, want [hello]", got)
+	}
+}
+
 func TestGroupChatWorkflowBuilder_ToolApprovalCheckpointResumePreservesFunctionCallContent(t *testing.T) {
 	approvalAgent := newGroupChatApprovalAgent("approval-agent")
 	wf, err := newGroupChatWorkflow("", func(agents []*agent.Agent) *GroupChatManager {


### PR DESCRIPTION
## What

In `workflow/agentworkflow/groupchat.go`, when a `GroupChatManager.SelectNextAgent` returns an agent that is not one of the workflow's participants, `handleTurn` returned an error (`group chat manager selected non-participant agent`). That error propagates as a workflow `ErrorEvent` and aborts the run, discarding the accumulated conversation.

This changes the map-miss branch to `return host.complete(ctx)`, so a non-participant selection terminates the chat and yields the accumulated conversation, exactly like the already-handled `nextAgent == nil` case just above it.

## Why (.NET parity)

This aligns Go with .NET `GroupChatHost.TakeTurnAsync`: on a `TryGetValue` miss for the selected agent, the compound condition is false, the success/send branch (which ends in `return`) is skipped, and control falls through to `CompleteAsync` - the chat ends gracefully rather than throwing. The Go nil-selection case already matched (`host.complete`); only the map-miss case diverged by erroring.

## Tests

Added `TestGroupChatWorkflowBuilder_NonParticipantSelectionCompletesChat`: a custom manager whose `SelectNextAgent` returns an agent that is not a participant. The test asserts the workflow completes and yields the accumulated conversation with no `ErrorEvent`/`ExecutorFailedEvent`. It fails before the change (executor failure) and passes after.

`go build ./...`, `go vet ./workflow/agentworkflow/...`, and `go test ./workflow/agentworkflow/...` all pass.