### PR TITLE
Remove extra hardcoded bullet from agentmode defaultInstructions to match .NET

### DIFF
--- a/agent/harness/agentmode/agentmode.go
+++ b/agent/harness/agentmode/agentmode.go
@@ -28,8 +28,6 @@ const stateKey = "agentModeState"
 const defaultInstructions = `## Agent Mode
 
 - You can operate in different modes. Depending on the mode you are in, you will be required to follow different processes.
-- You must check the current mode after any user input, since the user may have changed the mode themselves,
-  e.g. the user may have switched to 'plan' mode after a previous research task finished in 'execute' mode, meaning they want to review a plan first before execution.
 
 Use the mode_get tool to check your current operating mode.
 Use the mode_set tool to switch between modes as your work progresses. Only use mode_set if the user explicitly instructs/allows you to change modes.

--- a/agent/harness/agentmode/agentmode_test.go
+++ b/agent/harness/agentmode/agentmode_test.go
@@ -577,10 +577,29 @@ func TestDefaultInstructions_ContainToolNamesAndModeCheckGuidance(t *testing.T) 
 	}
 
 	instructions := collectInstructions(outOpts)
-	for _, want := range []string{"mode_get", "mode_set", "check the current mode", "Mandatory Mode based Workflow"} {
+	for _, want := range []string{"mode_get", "mode_set", "check your current operating mode", "Mandatory Mode based Workflow"} {
 		if !strings.Contains(instructions, want) {
 			t.Errorf("expected instructions to contain %q", want)
 		}
+	}
+}
+
+// Verify the default instructions omit the extra hardcoded bullet that is not
+// present in the .NET AgentModeProvider default instructions. That bullet baked
+// the built-in 'plan'/'execute' names into the prose, which misleads when custom
+// modes are configured.
+func TestDefaultInstructions_OmitExtraHardcodedBullet(t *testing.T) {
+	p := agentmode.New(agentmode.Config{})
+	opts := sessionOpts()
+
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instructions := collectInstructions(outOpts)
+	if strings.Contains(instructions, "You must check the current mode after any user input") {
+		t.Error("expected default instructions to omit the extra hardcoded bullet")
 	}
 }
 


### PR DESCRIPTION
## What

Removes the second bullet from `defaultInstructions` in `agent/harness/agentmode/agentmode.go`:

> - You must check the current mode after any user input, since the user may have changed the mode themselves, e.g. the user may have switched to 'plan' mode after a previous research task finished in 'execute' mode, meaning they want to review a plan first before execution.

After the change the first bullet is immediately followed by `Use the mode_get tool to check your current operating mode.`, matching the .NET template verbatim.

## Why

The .NET `AgentModeProvider` `DefaultInstructions` contains only the first bullet, then `Use the mode_get tool to check your current operating mode.` The Go port had an additional bullet that is not present in .NET. Beyond the parity gap, that bullet baked the built-in `plan`/`execute` mode names into the prose, which is misleading when custom Modes are configured via `Config.Modes`. The rest of the Go template already matches .NET, so this brings the default instructions back in line.

## Testing

- Updated `TestDefaultInstructions_ContainToolNamesAndModeCheckGuidance` to assert on `check your current operating mode` (the surviving mode-check guidance from the first-bullet/mode_get line).
- Added `TestDefaultInstructions_OmitExtraHardcodedBullet` asserting the rendered default instructions no longer contain `You must check the current mode after any user input`.
- `go build ./...`, `go vet ./agent/harness/agentmode/...`, `go test ./agent/harness/agentmode/...` all pass.