### PR TITLE
Deduplicate A2A task IDs accumulated per streaming event in setTaskID

### DIFF
--- a/provider/a2aprovider/a2a_test.go
+++ b/provider/a2aprovider/a2a_test.go
@@ -707,6 +707,72 @@ func TestRunWithMultipleTaskIDsInSessionAndMessage(t *testing.T) {
 	}
 }
 
+// TestRunDeduplicatesTaskIDsAcrossTurns tests that repeating the same task ID
+// across turns (as happens when every streamed event carries the same task ID)
+// stores it only once, so follow-up requests do not accumulate duplicates.
+func TestRunDeduplicatesTaskIDsAcrossTurns(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-123"),
+			ContextID: "ctx-123",
+			Status:    a2a.TaskStatus{State: a2a.TaskStateCompleted},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := a.RunText(t.Context(), "Do something", agent.WithSession(session)).Collect(); err != nil {
+			t.Fatalf("run %d error = %v, want nil", i, err)
+		}
+	}
+
+	taskIDs := a2a1.TaskIDsFromSession(session)
+	if len(taskIDs) != 1 || taskIDs[0] != "task-123" {
+		t.Fatalf("TaskIDsFromSession = %v, want [task-123]", taskIDs)
+	}
+}
+
+// TestRunKeepsDistinctTaskIDs tests that dedup does not collapse distinct task IDs.
+func TestRunKeepsDistinctTaskIDs(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-123"),
+			ContextID: "ctx-123",
+			Status:    a2a.TaskStatus{State: a2a.TaskStateCompleted},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.RunText(t.Context(), "Do something", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("first run error = %v, want nil", err)
+	}
+
+	transport.responseToReturn = &a2a.Task{
+		ID:        a2a.TaskID("task-456"),
+		ContextID: "ctx-123",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateCompleted},
+	}
+	if _, err := a.RunText(t.Context(), "Do something else", agent.WithSession(session)).Collect(); err != nil {
+		t.Fatalf("second run error = %v, want nil", err)
+	}
+
+	taskIDs := a2a1.TaskIDsFromSession(session)
+	want := []string{"task-123", "task-456"}
+	if len(taskIDs) != len(want) || taskIDs[0] != want[0] || taskIDs[1] != want[1] {
+		t.Fatalf("TaskIDsFromSession = %v, want %v", taskIDs, want)
+	}
+}
+
 func assertTaskRoutingAfterFollowUp(t *testing.T, initialTaskID string, initialTaskState a2a.TaskState, wantTaskID string, wantReferenceTask string) {
 	transport := &mockA2ATransport{
 		responseToReturn: &a2a.Task{

--- a/provider/a2aprovider/session.go
+++ b/provider/a2aprovider/session.go
@@ -3,6 +3,8 @@
 package a2aprovider
 
 import (
+	"slices"
+
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/microsoft/agent-framework-go/agent"
 )
@@ -24,7 +26,14 @@ func setTaskID(session *agent.Session, taskID string) {
 	if taskID == "" {
 		return
 	}
-	setTaskIDs(session, append(getTaskIDs(session), taskID))
+	existing := getTaskIDs(session)
+	// The same task ID is reported on every streamed event for a task, so guard
+	// against re-adding an ID that is already stored. slices.Contains keeps
+	// interleaved distinct task IDs working.
+	if slices.Contains(existing, taskID) {
+		return
+	}
+	setTaskIDs(session, append(existing, taskID))
 }
 
 func setTaskIDs(session *agent.Session, taskIDs []string) {


### PR DESCRIPTION
## What

`setTaskID` in `provider/a2aprovider/session.go` appended the task ID to session state unconditionally. Guard the append with `slices.Contains` so an already-stored ID is not re-added.

## Why

`updateSessionContextID` is invoked once per event in the `sendMsg` loop, and every streamed event for a task carries the same `TaskInfo.TaskID`. As a result the same ID was appended dozens of times within a single turn. The next turn builds `taskIDs` from `getTaskIDs` and assigns them to `userMsg.ReferenceTasks`, so follow-up requests carried duplicate task references and the accumulation compounded across turns.

This mirrors the .NET/Python A2A providers, which track a task's identifier once per session rather than once per streamed update — a session should reference each linked task a single time. Using `slices.Contains` keeps interleaved distinct task IDs working, so multi-task sessions still record every task.

## Tests

Added two black-box tests in the canonical `a2a_test.go` using the existing mock transport harness:
- `TestRunDeduplicatesTaskIDsAcrossTurns` runs the agent three turns with the same completed task and asserts `TaskIDsFromSession` returns exactly one entry. Fails before the fix (`[task-123 task-123 task-123]`), passes after.
- `TestRunKeepsDistinctTaskIDs` confirms two distinct task IDs are both retained.

`go build ./...`, `go vet ./provider/a2aprovider/...`, and `go test ./provider/a2aprovider/...` all pass.