### PR TITLE
Degrade on unknown annotation/region discriminators instead of aborting the message parse

### DIFF
--- a/message/annotation.go
+++ b/message/annotation.go
@@ -37,15 +37,39 @@ type annotationKind string
 type Annotations []Annotation
 
 func (as *Annotations) UnmarshalJSON(data []byte) error {
-	var err error
-	*as, err = jsonx.UnmarshalDiscriminatedUnionSlice[Annotation](data, supportedAnnotations)
-	return err
+	out, err := jsonx.UnmarshalDiscriminatedUnionSliceWithFallback(data, supportedAnnotations, unmarshalRawAnnotation)
+	if err != nil {
+		return err
+	}
+	*as = out
+	return nil
+}
+
+func unmarshalRawAnnotation(data json.RawMessage) (Annotation, error) {
+	return &RawAnnotation{RawRepresentation: append(json.RawMessage(nil), data...)}, nil
 }
 
 // Annotation represents an annotation on content.
 type Annotation interface {
 	kind() annotationKind
 }
+
+// RawAnnotation represents a provider-specific annotation that does not fit one
+// of the structured annotation types. The original JSON is preserved in
+// RawRepresentation and round-tripped on marshal so that newer provider-emitted
+// annotation subtypes do not fail the enclosing deserialization.
+type RawAnnotation struct {
+	RawRepresentation json.RawMessage
+}
+
+func (t *RawAnnotation) MarshalJSON() ([]byte, error) {
+	if len(t.RawRepresentation) > 0 {
+		return t.RawRepresentation, nil
+	}
+	return []byte("{}"), nil
+}
+
+func (t *RawAnnotation) kind() annotationKind { return "" }
 
 // CitationAnnotation represents an annotation that links content to source references,
 // such as documents, URLs, files, or tool outputs.
@@ -80,9 +104,16 @@ type annotatedRegionKind string
 type AnnotatedRegions []AnnotatedRegion
 
 func (as *AnnotatedRegions) UnmarshalJSON(data []byte) error {
-	var err error
-	*as, err = jsonx.UnmarshalDiscriminatedUnionSlice[AnnotatedRegion](data, supportedAnnotatedRegions)
-	return err
+	out, err := jsonx.UnmarshalDiscriminatedUnionSliceWithFallback(data, supportedAnnotatedRegions, unmarshalRawAnnotatedRegion)
+	if err != nil {
+		return err
+	}
+	*as = out
+	return nil
+}
+
+func unmarshalRawAnnotatedRegion(data json.RawMessage) (AnnotatedRegion, error) {
+	return &RawAnnotatedRegion{RawRepresentation: append(json.RawMessage(nil), data...)}, nil
 }
 
 // AnnotatedRegion describes the portion of an associated [Content]
@@ -90,6 +121,23 @@ func (as *AnnotatedRegions) UnmarshalJSON(data []byte) error {
 type AnnotatedRegion interface {
 	kind() annotatedRegionKind
 }
+
+// RawAnnotatedRegion represents a provider-specific annotated region that does
+// not fit one of the structured region types. The original JSON is preserved in
+// RawRepresentation and round-tripped on marshal so that newer provider-emitted
+// region subtypes do not fail the enclosing deserialization.
+type RawAnnotatedRegion struct {
+	RawRepresentation json.RawMessage
+}
+
+func (t *RawAnnotatedRegion) MarshalJSON() ([]byte, error) {
+	if len(t.RawRepresentation) > 0 {
+		return t.RawRepresentation, nil
+	}
+	return []byte("{}"), nil
+}
+
+func (t *RawAnnotatedRegion) kind() annotatedRegionKind { return "" }
 
 // TextSpanAnnotatedRegion describes a location in the associated [Content]
 // based on starting and ending character indices.

--- a/message/annotation_test.go
+++ b/message/annotation_test.go
@@ -38,6 +38,54 @@ func TestAnnotationEncoding_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestAnnotationEncoding_UnknownTypesPreservedAsRaw(t *testing.T) {
+	const rawRegion = `{"Type":"futureRegion","Start":1,"End":2}`
+	const rawAnnotation = `{"Type":"futureAnnotation","Value":42}`
+	data := []byte(`[` +
+		`{"Type":"citation","AnnotatedRegions":[` + rawRegion + `]},` +
+		rawAnnotation +
+		`]`)
+
+	var annotations message.Annotations
+	if err := json.Unmarshal(data, &annotations); err != nil {
+		t.Fatal(err)
+	}
+	if len(annotations) != 2 {
+		t.Fatalf("expected 2 annotations, got %d", len(annotations))
+	}
+
+	citation, ok := annotations[0].(*message.CitationAnnotation)
+	if !ok {
+		t.Fatalf("annotations[0] = %T, want *message.CitationAnnotation", annotations[0])
+	}
+	if len(citation.AnnotatedRegions) != 1 {
+		t.Fatalf("expected 1 annotated region, got %d", len(citation.AnnotatedRegions))
+	}
+	rawRegionVal, ok := citation.AnnotatedRegions[0].(*message.RawAnnotatedRegion)
+	if !ok {
+		t.Fatalf("region = %T, want *message.RawAnnotatedRegion", citation.AnnotatedRegions[0])
+	}
+	if got := string(rawRegionVal.RawRepresentation); got != rawRegion {
+		t.Fatalf("region raw = %s, want %s", got, rawRegion)
+	}
+
+	rawAnnotationVal, ok := annotations[1].(*message.RawAnnotation)
+	if !ok {
+		t.Fatalf("annotations[1] = %T, want *message.RawAnnotation", annotations[1])
+	}
+	if got := string(rawAnnotationVal.RawRepresentation); got != rawAnnotation {
+		t.Fatalf("annotation raw = %s, want %s", got, rawAnnotation)
+	}
+
+	// The unknown entries round-trip back to their original JSON.
+	if b, err := json.Marshal(citation.AnnotatedRegions[0]); err != nil || string(b) != rawRegion {
+		t.Fatalf("region remarshal = %s (err %v), want %s", b, err, rawRegion)
+	}
+	if b, err := json.Marshal(annotations[1]); err != nil || string(b) != rawAnnotation {
+		t.Fatalf("annotation remarshal = %s (err %v), want %s", b, err, rawAnnotation)
+	}
+}
+
 func TestAnnotatedRegionEncoding_Roundtrip(t *testing.T) {
 	regions := message.AnnotatedRegions{
 		&message.TextSpanAnnotatedRegion{

--- a/message/annotation_test.go
+++ b/message/annotation_test.go
@@ -86,6 +86,20 @@ func TestAnnotationEncoding_UnknownTypesPreservedAsRaw(t *testing.T) {
 	}
 }
 
+func TestAnnotationEncoding_KnownTypeInvalidPayloadReturnsError(t *testing.T) {
+	// A known discriminator ("citation") with a payload that does not match the
+	// structured type must surface a decode error rather than being silently
+	// downgraded to a RawAnnotation.
+	if err := json.Unmarshal([]byte(`[{"Type":"citation","URL":123}]`), new(message.Annotations)); err == nil {
+		t.Fatal("expected error decoding known annotation with invalid payload, got nil")
+	}
+
+	// Likewise for a known annotated region type ("text_span").
+	if err := json.Unmarshal([]byte(`[{"Type":"text_span","Start":"nope"}]`), new(message.AnnotatedRegions)); err == nil {
+		t.Fatal("expected error decoding known region with invalid payload, got nil")
+	}
+}
+
 func TestAnnotatedRegionEncoding_Roundtrip(t *testing.T) {
 	regions := message.AnnotatedRegions{
 		&message.TextSpanAnnotatedRegion{


### PR DESCRIPTION
## What

`Annotations.UnmarshalJSON` and `AnnotatedRegions.UnmarshalJSON` called `jsonx.UnmarshalDiscriminatedUnionSlice` (the no-fallback variant). With a nil fallback, an unrecognized discriminator returns an error, which fails the entire enclosing message deserialization. Only `citation` / `text_span` are registered, so any newer provider-emitted annotation or region subtype is fatal.

This switches both to `UnmarshalDiscriminatedUnionSliceWithFallback`, adding package-internal `RawAnnotation` and `RawAnnotatedRegion` types that preserve the original JSON and round-trip it on marshal (returning empty `kind()`), mirroring how `Contents` already preserves unknown content via `RawContent`.

## Why

`message/content.go` already tolerates unknown content kinds through `RawContent` via `unmarshalRawContent`, but annotations did not — an inconsistency that makes forward-compatibility depend on which field a new subtype lands in. Aligning annotations with content matches the .NET/Python SDK semantics of gracefully degrading on unrecognized union members rather than dropping or rejecting them, preserving the raw payload for downstream inspection and faithful re-serialization.

## Testing

Added `TestAnnotationEncoding_UnknownTypesPreservedAsRaw` in `message/annotation_test.go`: unmarshals a `citation` annotation whose `AnnotatedRegions` holds an unknown region type, alongside an unknown top-level annotation type. It asserts no error, that both unknowns are preserved as `RawAnnotatedRegion` / `RawAnnotation`, and that they round-trip back to the original JSON. `go build ./...`, `go vet ./message/...`, and `go test ./message/...` all pass.