### PR TITLE
Do not emit trailing UsageContent when the Anthropic stream faults

### DIFF
--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -170,6 +170,10 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				return
 			}
 		}
+		if err := stream.Err(); err != nil {
+			yield(nil, err)
+			return
+		}
 		if !yield(&agent.ResponseUpdate{
 			CreatedAt: time.Now(),
 			Role:      message.RoleAssistant,
@@ -181,9 +185,6 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 			},
 		}, nil) {
 			return
-		}
-		if err := stream.Err(); err != nil {
-			yield(nil, err)
 		}
 	}
 }

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -458,6 +458,39 @@ func TestStreamingToolCallsSupportInterleavedDeltas(t *testing.T) {
 	}
 }
 
+// When the streaming request faults (here, an immediate HTTP 500 before any
+// SSE event) the provider must surface only the error and emit no trailing
+// UsageContent update. This matches openaiprovider chat streaming, which yields
+// stream.Err() alone on failure; an aggregator/otel middleware counting
+// UsageContent would otherwise record phantom usage for a call that never ran.
+func TestStreamingFaultEmitsNoUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	var gotErr error
+	var updates int
+	for update, err := range newTestClient(t, server).RunText(t.Context(), "hi", agent.Stream(true)) {
+		if err != nil {
+			gotErr = err
+			continue
+		}
+		updates++
+		for _, c := range update.Contents {
+			if _, ok := c.(*message.UsageContent); ok {
+				t.Error("streaming fault emitted a UsageContent update; want none")
+			}
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected a terminal error from the faulted stream, got nil")
+	}
+	if updates != 0 {
+		t.Errorf("got %d non-error updates, want 0 before the fault", updates)
+	}
+}
+
 // Building the request must not mutate the caller's MessageNewParams slices.
 // The provider appends system instructions to params.System; if it shares the
 // caller's backing array (spare capacity), the append corrupts the caller's data.


### PR DESCRIPTION
## What

The Anthropic streaming path unconditionally yielded a terminal `ResponseUpdate` carrying a `UsageContent` and only then checked `stream.Err()`. When the SSE stream faults — an immediate auth/HTTP error before any `message_start`, a mid-stream drop, or a context cancel — `stream.Next()` returns false and that usage update is still emitted (zero usage + empty messageID on an immediate error, or partial usage on a mid-stream drop) before the error is surfaced.

This reorders the terminal handling so the error is surfaced first (`yield(nil, err); return`) and the `UsageContent` update is emitted only on successful completion.

## Why

`openaiprovider/chat.go` yields `stream.Err()` alone on failure and emits no trailing usage; Anthropic was the outlier. The same error-only-on-fault semantics also match the .NET/Python SDKs, where usage is reported only for a completed response. With the old behavior an aggregator or OpenTelemetry middleware counting `UsageContent` records phantom or partial usage for a call that never produced a result. Aligning the providers keeps usage accounting consistent across SDKs.

## Tests

Adds `TestStreamingFaultEmitsNoUsage` to `agent_test.go`: it points the client Base URL at an `httptest.Server` returning HTTP 500 for the messages endpoint, runs the agent with `agent.Stream(true)`, and asserts the sequence contains no `UsageContent` update and terminates with a single terminal error. The test fails before the fix (observes a `UsageContent` update immediately preceding the error) and passes after. `go build ./...`, `go vet`, and `go test` for the package all pass.