### PR TITLE
Preserve assistant text and reasoning when the autocall loop rebuilds the tool-call turn

### DIFF
--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -338,22 +338,31 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 
 			// Coalesce the buffered updates for this iteration so streamed text/reasoning
 			// fragments merge, then carry the text and reasoning over alongside the
-			// processed (non-informational) function calls, preserving the natural
-			// assistant order of reasoning → text → tool_calls.
+			// processed (non-informational) function calls, preserving the exact
+			// assistant content order the model emitted (e.g. reasoning → text →
+			// tool_calls, or text following a tool_call).
+			processedFCCSet := make(map[*message.FunctionCallContent]struct{}, len(processedFunctionCalls))
+			for _, fcc := range processedFunctionCalls {
+				processedFCCSet[fcc] = struct{}{}
+			}
 			var iterationContents []message.Content
 			for _, u := range updates {
 				iterationContents = append(iterationContents, u.Contents...)
 			}
 			iterationContents = message.CoalesceContents(iterationContents)
-			assistantContents := make([]message.Content, 0, len(iterationContents)+len(processedFunctionCalls))
+			assistantContents := make([]message.Content, 0, len(iterationContents))
 			for _, c := range iterationContents {
-				switch c.(type) {
+				switch v := c.(type) {
 				case *message.TextContent, *message.TextReasoningContent:
 					assistantContents = append(assistantContents, c)
+				case *message.FunctionCallContent:
+					// Only carry over the non-informational function calls that were
+					// actually processed this iteration, keeping them in their original
+					// position relative to the surrounding text/reasoning.
+					if _, ok := processedFCCSet[v]; ok {
+						assistantContents = append(assistantContents, c)
+					}
 				}
-			}
-			for _, fcc := range processedFunctionCalls {
-				assistantContents = append(assistantContents, fcc)
 			}
 
 			// Use the augmented history as the new set of messages to send.

--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -326,13 +326,34 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 				return
 			}
 
-			// Build an assistant message containing the function calls that were processed.
-			// This is needed because chat APIs (e.g. OpenAI) require tool result messages
-			// to be preceded by an assistant message containing the corresponding tool_calls.
+			// Build an assistant message containing the text, reasoning, and function
+			// calls that were produced this iteration. This is needed because chat APIs
+			// (e.g. OpenAI) require tool result messages to be preceded by an assistant
+			// message containing the corresponding tool_calls. Preserving the assistant's
+			// text and reasoning content keeps the turn intact for the next provider call,
+			// matching .NET's FunctionInvokingChatClient, which does
+			// augmentedHistory.AddMessages(response) rather than reconstructing from the
+			// function calls alone.
 			processedFunctionCalls := functionCallContents[:len(newMsg.Contents)]
-			assistantContents := make([]message.Content, len(processedFunctionCalls))
-			for i, fcc := range processedFunctionCalls {
-				assistantContents[i] = fcc
+
+			// Coalesce the buffered updates for this iteration so streamed text/reasoning
+			// fragments merge, then carry the text and reasoning over alongside the
+			// processed (non-informational) function calls, preserving the natural
+			// assistant order of reasoning → text → tool_calls.
+			var iterationContents []message.Content
+			for _, u := range updates {
+				iterationContents = append(iterationContents, u.Contents...)
+			}
+			iterationContents = message.CoalesceContents(iterationContents)
+			assistantContents := make([]message.Content, 0, len(iterationContents)+len(processedFunctionCalls))
+			for _, c := range iterationContents {
+				switch c.(type) {
+				case *message.TextContent, *message.TextReasoningContent:
+					assistantContents = append(assistantContents, c)
+				}
+			}
+			for _, fcc := range processedFunctionCalls {
+				assistantContents = append(assistantContents, fcc)
 			}
 
 			// Use the augmented history as the new set of messages to send.

--- a/agent/harness/toolautocall/autocall_test.go
+++ b/agent/harness/toolautocall/autocall_test.go
@@ -1473,10 +1473,15 @@ func TestFunctionInvoking_NextIterationIncludesAssistantFunctionCallMessage(t *t
 	}
 
 	rb := agenttest.NewResponseBuilder()
-	// First turn: model calls a function.
+	// First turn: model emits reasoning and text alongside the function call in a
+	// single assistant update.
 	rb.Add(&agent.ResponseUpdate{
-		Role:     message.RoleAssistant,
-		Contents: []message.Content{&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`}},
+		Role: message.RoleAssistant,
+		Contents: []message.Content{
+			&message.TextReasoningContent{Text: "thinking about it"},
+			&message.TextContent{Text: "let me look that up"},
+			&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`},
+		},
 	})
 	// Second turn: verify messages, then return final text.
 	rb.NewTurn(func(ctx context.Context, messages []*message.Message, opts ...agent.Option) {
@@ -1493,13 +1498,34 @@ func TestFunctionInvoking_NextIterationIncludesAssistantFunctionCallMessage(t *t
 			t.Errorf("expected second-to-last message to be assistant role, got %s", messages[len(messages)-2].Role)
 		}
 		hasFCC := false
+		hasText := false
+		hasReasoning := false
 		for _, c := range messages[len(messages)-2].Contents {
-			if fcc, ok := c.(*message.FunctionCallContent); ok && fcc.CallID == "callId1" {
-				hasFCC = true
+			switch c := c.(type) {
+			case *message.FunctionCallContent:
+				if c.CallID == "callId1" {
+					hasFCC = true
+				}
+			case *message.TextContent:
+				if c.Text == "let me look that up" {
+					hasText = true
+				}
+			case *message.TextReasoningContent:
+				if c.Text == "thinking about it" {
+					hasReasoning = true
+				}
 			}
 		}
 		if !hasFCC {
 			t.Error("expected assistant message to contain FunctionCallContent with callId1")
+		}
+		// The assistant text and reasoning emitted with the tool call must survive into
+		// the reconstructed turn (parity with .NET augmentedHistory.AddMessages(response)).
+		if !hasText {
+			t.Error("expected assistant message to preserve the emitted TextContent")
+		}
+		if !hasReasoning {
+			t.Error("expected assistant message to preserve the emitted TextReasoningContent")
 		}
 		// Last message should be tool result.
 		if messages[len(messages)-1].Role != message.RoleTool {


### PR DESCRIPTION
## What

When the auto tool-call loop invokes functions and prepares the conversation for the next provider iteration, it reconstructs the assistant turn that must precede the tool result messages. That reconstruction was built solely from the `FunctionCallContent`s:

```go
processedFunctionCalls := functionCallContents[:len(newMsg.Contents)]
assistantContents := make([]message.Content, len(processedFunctionCalls))
for i, fcc := range processedFunctionCalls {
    assistantContents[i] = fcc
}
```

Any `TextContent` and `TextReasoningContent` the model emitted alongside the tool call were yielded to the caller but never carried into the `messages` slice passed to the next provider call, so the assistant's text and reasoning were dropped before they could reach the provider.

This change coalesces the buffered updates for the iteration and carries the assistant's text and reasoning over alongside the processed function calls, preserving the natural `reasoning -> text -> tool_calls` order. Server-handled / informational-only function calls remain excluded exactly as before.

## Why

Parity with .NET's `FunctionInvokingChatClient`, which appends the whole assistant response via `augmentedHistory.AddMessages(response)` instead of rebuilding it from the function calls alone. This is complementary to the merged Anthropic thinking-block fix: that converts reasoning if it reaches the provider, whereas this harness was discarding it before it ever got there.

## Testing

Extended `TestFunctionInvoking_NextIterationIncludesAssistantFunctionCallMessage`: the first provider turn now emits a `TextReasoningContent` + `TextContent` + `FunctionCallContent` in one assistant update, and the test asserts the reconstructed assistant turn (`messages[len-2]`) contains the reasoning and text, not just the function call. The new assertions fail before the fix and pass after. `go build ./...`, `go vet ./agent/harness/toolautocall/...`, and `go test ./agent/harness/toolautocall/...` all pass.