### PR TITLE
Fix stale Contents.Text doc comment: it concatenates all TextContent, not the first

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -90,8 +90,8 @@ func unmarshalRawContent(data json.RawMessage) (Content, error) {
 	return &raw, nil
 }
 
-// Text returns the concatenation of the Text of all TextContent items in cs,
-// or the empty string if there are none.
+// Text returns the concatenation of the Text of all [TextContent] items in the
+// Contents, or the empty string if there are none.
 func (cs Contents) Text() string {
 	var sb strings.Builder
 	for _, c := range cs {

--- a/message/content.go
+++ b/message/content.go
@@ -90,7 +90,8 @@ func unmarshalRawContent(data json.RawMessage) (Content, error) {
 	return &raw, nil
 }
 
-// Text returns the first text content in the response, or empty string.
+// Text returns the concatenation of the Text of all TextContent items in cs,
+// or the empty string if there are none.
 func (cs Contents) Text() string {
 	var sb strings.Builder
 	for _, c := range cs {

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -20,6 +20,36 @@ func TestTextContent_String(t *testing.T) {
 	}
 }
 
+func TestContentsText(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents message.Contents
+		want     string
+	}{
+		{
+			name:     "empty",
+			contents: message.Contents{},
+			want:     "",
+		},
+		{
+			name: "concatenates all text contents in order",
+			contents: message.Contents{
+				&message.TextContent{Text: "foo"},
+				&message.TextReasoningContent{Text: "ignored"},
+				&message.TextContent{Text: "bar"},
+			},
+			want: "foobar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.contents.Text(); got != tt.want {
+				t.Errorf("Text() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // Test TextReasoningContent
 func TestTextReasoningContent_String(t *testing.T) {
 	trc := &message.TextReasoningContent{Text: "reasoning text"}


### PR DESCRIPTION
## What

Corrects the doc comment on `Contents.Text()` in `message/content.go`. The comment read:

> Text returns the first text content in the response, or empty string.

But the implementation loops over every element of `cs` and, for each `*TextContent`, appends its `Text` to a `strings.Builder`, returning the concatenation of *all* text contents (no separator) — not just the first. Updated the comment to describe the actual behavior. No code change.

## Why

The no-separator concatenation is the correct, intended behavior: it matches .NET `ChatMessage.Text`, which uses `string.Concat` over all `TextContent` items. So only the comment was stale, not the code. This keeps the Go doc aligned with the .NET semantics.

## Testing

Added `TestContentsText` (black-box, `package message_test`) with a table covering:
- an empty `Contents` returns `""`
- two `TextContent` items (`foo`, `bar`) interleaved with a non-text content aggregate to `foobar`, proving it concatenates all text contents rather than returning only the first.

`go build ./...`, `go vet ./message/...`, and `go test ./message/...` all pass.