### PR TITLE
Emit RUN_ERROR terminal event instead of a non-standard CUSTOM error event on AG-UI host mid-stream failure

### DIFF
--- a/provider/aguiprovider/hosting.go
+++ b/provider/aguiprovider/hosting.go
@@ -102,7 +102,16 @@ func streamEvents(
 ) error {
 	for evt, err := range events {
 		if err != nil {
-			_ = writer.WriteErrorEvent(ctx, w, err, "")
+			// updatesToAGUIEvents yields a proper RUN_ERROR terminal event
+			// (carrying the runID) alongside the error on every failure path.
+			// Prefer emitting that so consumers see a standard RUN_ERROR frame;
+			// WriteErrorEvent would instead write a non-standard CUSTOM event
+			// with no runID that the AG-UI client accumulator silently drops.
+			if evt != nil {
+				_ = writer.WriteEvent(ctx, w, evt)
+			} else {
+				_ = writer.WriteErrorEvent(ctx, w, err, "")
+			}
 			return err
 		}
 		if evt == nil {

--- a/provider/aguiprovider/hosting.go
+++ b/provider/aguiprovider/hosting.go
@@ -107,12 +107,17 @@ func streamEvents(
 			// Prefer emitting that so consumers see a standard RUN_ERROR frame;
 			// WriteErrorEvent would instead write a non-standard CUSTOM event
 			// with no runID that the AG-UI client accumulator silently drops.
+			var writeErr error
 			if evt != nil {
-				_ = writer.WriteEvent(ctx, w, evt)
+				writeErr = writer.WriteEvent(ctx, w, evt)
 			} else {
-				_ = writer.WriteErrorEvent(ctx, w, err, "")
+				writeErr = writer.WriteErrorEvent(ctx, w, err, "")
 			}
-			return err
+			// Return the original agent error, but also surface any failure to
+			// deliver the terminal frame (e.g. client disconnect/broken pipe)
+			// so stream delivery failures are not silently dropped. This mirrors
+			// the non-error path below, which returns WriteEvent errors.
+			return errors.Join(err, writeErr)
 		}
 		if evt == nil {
 			continue

--- a/provider/aguiprovider/hosting_test.go
+++ b/provider/aguiprovider/hosting_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"iter"
 	"net/http"
 	"net/http/httptest"
@@ -468,5 +469,95 @@ func TestHandler_ConsecutiveAssistantToolCallMessages_Coalesced(t *testing.T) {
 	}
 	if callIDs[0] != "c1" || callIDs[1] != "c2" {
 		t.Errorf("coalesced tool call IDs = %v, want [c1 c2]", callIDs)
+	}
+}
+
+// TestHandler_MidStreamError_EmitsRunErrorEvent verifies that when the hosted agent
+// fails mid-stream, the handler emits the standard RUN_ERROR terminal event (carrying
+// the runID) that updatesToAGUIEvents already built, rather than a non-standard CUSTOM
+// error event. The AG-UI client accumulator has no CUSTOM-event case, so a CUSTOM error
+// frame would be silently dropped and the consumer would see no error. This mirrors the
+// AG-UI protocol semantics used by the .NET/Python SDKs, where run failures terminate
+// the stream with RUN_ERROR.
+func TestHandler_MidStreamError_EmitsRunErrorEvent(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				MessageID: "msg-1",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.TextContent{Text: "partial"}},
+			}, nil)
+			yield(nil, errors.New("boom"))
+		}
+	})
+	h := aguiprovider.NewJSONHTTPHandler(a, aguiprovider.HandlerConfig{})
+
+	body := `{"threadId":"thread-1","runId":"run-err-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	content := rr.Body.String()
+
+	var sawRunError bool
+	var runErrorRunID string
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		var evt map[string]any
+		if err := json.Unmarshal([]byte(data), &evt); err != nil {
+			continue
+		}
+		if evt["type"] == "RUN_ERROR" {
+			sawRunError = true
+			runErrorRunID, _ = evt["runId"].(string)
+		}
+	}
+
+	if !sawRunError {
+		t.Fatalf("expected a RUN_ERROR frame on mid-stream failure, got %q", content)
+	}
+	if runErrorRunID != "run-err-1" {
+		t.Fatalf("RUN_ERROR runId = %q, want %q", runErrorRunID, "run-err-1")
+	}
+	if strings.Contains(content, "CUSTOM") {
+		t.Fatalf("did not expect a non-standard CUSTOM error event, got %q", content)
+	}
+}
+
+// TestHandler_MidStreamError_ClientObservesErrorContent verifies the end-to-end contract:
+// a RUN_ERROR frame emitted by the host is decoded by the AG-UI client accumulator into a
+// message.ErrorContent. A CUSTOM error frame (the pre-fix behavior) would be swallowed and
+// the client would observe a clean stream end with no error surfaced.
+func TestHandler_MidStreamError_ClientObservesErrorContent(t *testing.T) {
+	hosted := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(nil, errors.New("boom"))
+		}
+	})
+	server := httptest.NewServer(aguiprovider.NewJSONHTTPHandler(hosted, aguiprovider.HandlerConfig{}))
+	defer server.Close()
+
+	client := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := client.RunText(context.Background(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	var sawErrorContent bool
+	for _, msg := range resp.Messages {
+		for _, c := range msg.Contents {
+			if ec, ok := c.(*message.ErrorContent); ok {
+				sawErrorContent = true
+				if ec.Message != "boom" {
+					t.Fatalf("error content message = %q, want %q", ec.Message, "boom")
+				}
+			}
+		}
+	}
+	if !sawErrorContent {
+		t.Fatalf("expected client to observe an *message.ErrorContent from RUN_ERROR, got messages %#v", resp.Messages)
 	}
 }

--- a/provider/aguiprovider/hosting_test.go
+++ b/provider/aguiprovider/hosting_test.go
@@ -3,11 +3,13 @@
 package aguiprovider_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"iter"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -524,6 +526,60 @@ func TestHandler_MidStreamError_EmitsRunErrorEvent(t *testing.T) {
 	}
 	if strings.Contains(content, "CUSTOM") {
 		t.Fatalf("did not expect a non-standard CUSTOM error event, got %q", content)
+	}
+}
+
+// failOnMatchResponseWriter fails Write calls whose payload contains a sentinel,
+// simulating a client disconnect/broken pipe partway through the SSE stream.
+type failOnMatchResponseWriter struct {
+	*httptest.ResponseRecorder
+	sentinel string
+	writeErr error
+}
+
+func (w *failOnMatchResponseWriter) Write(b []byte) (int, error) {
+	if strings.Contains(string(b), w.sentinel) {
+		return 0, w.writeErr
+	}
+	return w.ResponseRecorder.Write(b)
+}
+
+func (w *failOnMatchResponseWriter) Flush() { w.ResponseRecorder.Flush() }
+
+// TestHandler_MidStreamError_TerminalWriteFailureSurfaced verifies that when the hosted
+// agent fails mid-stream AND writing the terminal RUN_ERROR frame also fails (e.g. client
+// disconnect/broken pipe), the delivery failure is surfaced to the handler alongside the
+// original agent error rather than silently dropped. The handler logs the returned error,
+// so the captured log must reference both the agent error and the write failure.
+func TestHandler_MidStreamError_TerminalWriteFailureSurfaced(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(nil, errors.New("boom"))
+		}
+	})
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	h := aguiprovider.NewJSONHTTPHandler(a, aguiprovider.HandlerConfig{Logger: logger})
+
+	body := `{"threadId":"thread-1","runId":"run-err-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rr := &failOnMatchResponseWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		sentinel:         "RUN_ERROR",
+		writeErr:         errors.New("broken pipe"),
+	}
+	h.ServeHTTP(rr, req)
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "agui stream failed") {
+		t.Fatalf("expected stream failure to be logged, got %q", logged)
+	}
+	if !strings.Contains(logged, "broken pipe") {
+		t.Fatalf("expected terminal-write failure to be surfaced, got %q", logged)
+	}
+	if !strings.Contains(logged, "boom") {
+		t.Fatalf("expected original agent error to be preserved, got %q", logged)
 	}
 }
 


### PR DESCRIPTION
## What

When a hosted agent fails mid-stream, the AG-UI JSON HTTP handler now emits the standard `RUN_ERROR` terminal event (carrying the `runId`) instead of a non-standard `CUSTOM` error event.

`updatesToAGUIEvents` already builds a proper `RUN_ERROR` event on every failure path (agent error, `ctx.Err()`, and content-conversion errors), yielding it alongside the error. But `streamEvents` ignored the yielded event whenever `err != nil` and instead called `writer.WriteErrorEvent`, which constructs a `CustomEvent` (`EventTypeCustom`) with payload `{error:true,message,request_id:""}` written as `event: error` — a `CUSTOM` frame, not `RUN_ERROR`, carrying no `runId`.

The client accumulator (`toolCallAccumulator.onEvent`) has a `*RunErrorEvent` case that yields `ErrorContent`, but no `*CustomEvent` case, so the `CUSTOM` frame hit `default` and was silently swallowed: the consumer saw the stream end with no error and no `ErrorContent`. The `RUN_ERROR` event the code had already built was never emitted.

## Fix

In `streamEvents`, on the error branch prefer the yielded event: write it with `writer.WriteEvent` (a real `RUN_ERROR` with `runId`) and only fall back to `writer.WriteErrorEvent` when no event was produced.

## Why (cross-SDK parity)

This aligns with the AG-UI protocol semantics used by the .NET and Python SDKs, where a run failure terminates the stream with a `RUN_ERROR` event so clients can surface the error, rather than a provider-specific custom frame that non-.NET/Python consumers cannot interpret.

## Tests

Two tests added to the canonical `hosting_test.go`:

- `TestHandler_MidStreamError_EmitsRunErrorEvent` — hosts an agent that fails mid-stream, POSTs to the JSON handler, and asserts the raw SSE body contains a `RUN_ERROR` frame carrying the `runId` (and no `CUSTOM` frame).
- `TestHandler_MidStreamError_ClientObservesErrorContent` — round-trips the produced stream through the AG-UI client accumulator via `NewAgent` and asserts the collected response contains a `*message.ErrorContent`.

Both fail before the change (the pre-fix output emits `event: error` / `CUSTOM`) and pass after. `go build ./...`, `go vet ./provider/aguiprovider/...`, and `go test ./provider/aguiprovider/...` all pass.