### PR TITLE
Surface A2A artifact-level metadata when converting task artifacts and artifact-update events

### DIFF
--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -215,7 +215,11 @@ func sendMsg(session *agent.Session, seq iter.Seq2[a2a.Event, error], yield func
 				yield(nil, err)
 				return
 			}
-			update := newResponseUpdate(e, e.Metadata, string(e.TaskID), string(e.Artifact.ID), message.RoleAssistant, contents, time.Now())
+			// Surface the artifact's own metadata alongside the event-level
+			// metadata, matching .NET's A2A conversion which folds artifact
+			// metadata into the resulting message.
+			metadata := mergeMetadata(e.Metadata, e.Artifact.Metadata)
+			update := newResponseUpdate(e, metadata, string(e.TaskID), string(e.Artifact.ID), message.RoleAssistant, contents, time.Now())
 			if !yield(update, nil) {
 				return
 			}
@@ -252,6 +256,24 @@ func newResponseUpdate(raw any, additionalProperties map[string]any, responseID,
 	}
 }
 
+// mergeMetadata combines a base metadata map with additional maps into a new
+// map, cloning so the inputs are never mutated. Keys from later maps take
+// precedence over earlier ones. It returns nil when every source is empty,
+// preserving the previous behavior of forwarding the base map unchanged.
+func mergeMetadata(base map[string]any, extra ...map[string]any) map[string]any {
+	merged := maps.Clone(base)
+	for _, m := range extra {
+		if len(m) == 0 {
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string]any, len(m))
+		}
+		maps.Copy(merged, m)
+	}
+	return merged
+}
+
 func yieldTask(yield func(*agent.ResponseUpdate, error) bool, task *a2a.Task) bool {
 	now := time.Now()
 	var continuationToken string
@@ -264,6 +286,7 @@ func yieldTask(yield func(*agent.ResponseUpdate, error) bool, task *a2a.Task) bo
 		timestamp = *task.Status.Timestamp
 	}
 	var contents []message.Content
+	artifactMetadata := make([]map[string]any, 0, len(task.Artifacts))
 	for _, artifact := range task.Artifacts {
 		var err error
 		contents, err = partsToContents(artifact.Parts, contents)
@@ -271,9 +294,14 @@ func yieldTask(yield func(*agent.ResponseUpdate, error) bool, task *a2a.Task) bo
 			yield(nil, err)
 			return false
 		}
+		artifactMetadata = append(artifactMetadata, artifact.Metadata)
 	}
 
-	update := newResponseUpdate(task, task.Metadata, string(task.ID), "", message.RoleAssistant, contents, timestamp)
+	// Fold each artifact's own metadata into the update alongside the
+	// task-level metadata, matching .NET's A2A conversion which preserves
+	// artifact metadata rather than dropping it.
+	metadata := mergeMetadata(task.Metadata, artifactMetadata...)
+	update := newResponseUpdate(task, metadata, string(task.ID), "", message.RoleAssistant, contents, timestamp)
 	update.ContinuationToken = continuationToken
 	return yield(update, nil)
 }

--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -258,10 +258,13 @@ func newResponseUpdate(raw any, additionalProperties map[string]any, responseID,
 
 // mergeMetadata combines a base metadata map with additional maps into a new
 // map, cloning so the inputs are never mutated. Keys from later maps take
-// precedence over earlier ones. It returns nil when every source is empty,
-// preserving the previous behavior of forwarding the base map unchanged.
+// precedence over earlier ones. It returns nil when every source is empty, so a
+// task with no metadata yields no metadata map rather than an empty one.
 func mergeMetadata(base map[string]any, extra ...map[string]any) map[string]any {
-	merged := maps.Clone(base)
+	var merged map[string]any
+	if len(base) > 0 {
+		merged = maps.Clone(base)
+	}
 	for _, m := range extra {
 		if len(m) == 0 {
 			continue

--- a/provider/a2aprovider/a2a_test.go
+++ b/provider/a2aprovider/a2a_test.go
@@ -1513,6 +1513,93 @@ func TestRunStreamingWithTaskStatusUpdateEvent_WithMessage(t *testing.T) {
 	})
 }
 
+// TestRunWithAgentTaskResponse_SurfacesArtifactMetadata asserts that an
+// artifact's own Metadata is surfaced in the response update's
+// AdditionalProperties, matching .NET's A2A conversion which preserves
+// artifact-level metadata rather than dropping it.
+func TestRunWithAgentTaskResponse_SurfacesArtifactMetadata(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-meta"),
+			ContextID: "context-meta",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+			},
+			Metadata: map[string]any{"task-key": "task-value"},
+			Artifacts: []*a2a.Artifact{
+				{
+					ID:       a2a.ArtifactID("art-1"),
+					Metadata: map[string]any{"ext": "v"},
+					Parts:    a2a.ContentParts{a2a.NewTextPart("Artifact content")},
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var updates []*agent.ResponseUpdate
+	for update, err := range a.RunText(t.Context(), "Start a task") {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+	props := updates[0].AdditionalProperties
+	if got, ok := props["ext"]; !ok || got != "v" {
+		t.Errorf("AdditionalProperties[ext] = %v (ok=%v), want %q", got, ok, "v")
+	}
+	if got, ok := props["task-key"]; !ok || got != "task-value" {
+		t.Errorf("AdditionalProperties[task-key] = %v (ok=%v), want %q", got, ok, "task-value")
+	}
+}
+
+// TestRunStreamingWithTaskArtifactUpdateEvent_SurfacesArtifactMetadata asserts
+// that the artifact's Metadata carried by a TaskArtifactUpdateEvent is folded
+// into the update's AdditionalProperties alongside the event-level metadata.
+func TestRunStreamingWithTaskArtifactUpdateEvent_SurfacesArtifactMetadata(t *testing.T) {
+	transport := &mockA2ATransport{
+		streamingResponseToReturn: &a2a.TaskArtifactUpdateEvent{
+			TaskID:    a2a.TaskID("task-artifact-meta"),
+			ContextID: "ctx-artifact-meta",
+			Metadata:  map[string]any{"event-key": "event-value"},
+			Artifact: &a2a.Artifact{
+				ID:       a2a.ArtifactID("artifact-meta"),
+				Metadata: map[string]any{"ext": "v"},
+				Parts:    a2a.ContentParts{a2a.NewTextPart("Artifact data")},
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	session, err := a.CreateSession(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var updates []*agent.ResponseUpdate
+	for update, err := range a.RunText(t.Context(), "Process artifact", agent.WithSession(session), agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+	props := updates[0].AdditionalProperties
+	if got, ok := props["ext"]; !ok || got != "v" {
+		t.Errorf("AdditionalProperties[ext] = %v (ok=%v), want %q", got, ok, "v")
+	}
+	if got, ok := props["event-key"]; !ok || got != "event-value" {
+		t.Errorf("AdditionalProperties[event-key] = %v (ok=%v), want %q", got, ok, "event-value")
+	}
+}
+
 // TestRunStreamingWithTaskArtifactUpdateEvent tests handling of TaskArtifactUpdateEvent
 func TestRunStreamingWithTaskArtifactUpdateEvent(t *testing.T) {
 	const taskID = "task-artifact-123"

--- a/provider/a2aprovider/a2a_test.go
+++ b/provider/a2aprovider/a2a_test.go
@@ -1557,6 +1557,45 @@ func TestRunWithAgentTaskResponse_SurfacesArtifactMetadata(t *testing.T) {
 	}
 }
 
+// TestRunWithAgentTaskResponse_NoMetadataYieldsNilProperties asserts that a task
+// with no task-level or artifact-level metadata produces an update with nil
+// AdditionalProperties rather than a non-nil empty map.
+func TestRunWithAgentTaskResponse_NoMetadataYieldsNilProperties(t *testing.T) {
+	transport := &mockA2ATransport{
+		responseToReturn: &a2a.Task{
+			ID:        a2a.TaskID("task-nometa"),
+			ContextID: "context-nometa",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+			},
+			Metadata: map[string]any{},
+			Artifacts: []*a2a.Artifact{
+				{
+					ID:       a2a.ArtifactID("art-1"),
+					Metadata: map[string]any{},
+					Parts:    a2a.ContentParts{a2a.NewTextPart("Artifact content")},
+				},
+			},
+		},
+	}
+	a := newTestAgent(transport, agent.Config{})
+
+	var updates []*agent.ResponseUpdate
+	for update, err := range a.RunText(t.Context(), "Start a task") {
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		updates = append(updates, update)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1", len(updates))
+	}
+	if props := updates[0].AdditionalProperties; props != nil {
+		t.Errorf("AdditionalProperties = %v, want nil", props)
+	}
+}
+
 // TestRunStreamingWithTaskArtifactUpdateEvent_SurfacesArtifactMetadata asserts
 // that the artifact's Metadata carried by a TaskArtifactUpdateEvent is folded
 // into the update's AdditionalProperties alongside the event-level metadata.


### PR DESCRIPTION
## What

`a2a.Artifact` carries its own `Metadata map[string]any`, but the A2A converter dropped it:

- In `yieldTask`, the response update forwarded only `task.Metadata` as `AdditionalProperties`; each artifact's `Metadata` was never surfaced.
- In the `TaskArtifactUpdateEvent` (streaming) case, the update was built from `e.Metadata` (event-level) rather than `e.Artifact.Metadata`, even though the event's artifact carries its own metadata.

Only part-level metadata survived, because `partsToContents` faithfully clones `part.Metadata`.

This change folds each artifact's metadata into the update's `AdditionalProperties` alongside the task/event-level metadata via a small `mergeMetadata` helper. Precedence is defined: artifact keys win on conflict. The helper clones its inputs and returns `nil` when everything is empty, preserving the prior pass-through behavior.

## Why

The .NET A2A conversion (`ToChatMessages`) preserves artifact-level metadata rather than dropping it. This aligns the Go port with that behavior so extension metadata attached at the artifact level (the documented extension point for A2A artifacts) reaches consumers.

## Testing

- `TestRunWithAgentTaskResponse_SurfacesArtifactMetadata` drives a task whose artifact carries `Metadata{ext: v}` and asserts both the artifact and task metadata appear in the update's `AdditionalProperties`.
- `TestRunStreamingWithTaskArtifactUpdateEvent_SurfacesArtifactMetadata` drives a `TaskArtifactUpdateEvent` whose artifact metadata is set and asserts it appears alongside the event-level metadata.

Both tests fail on the previous code and pass with this change. `go build ./...`, `go vet ./provider/a2aprovider/...`, and `go test ./provider/a2aprovider/...` all pass.