### PR TITLE
Surface Copilot model reasoning content as message.TextReasoningContent

### DIFF
--- a/provider/copilotprovider/copilot.go
+++ b/provider/copilotprovider/copilot.go
@@ -144,6 +144,10 @@ func (p *provider) responseUpdateForSessionEvent(event copilot.SessionEvent, isS
 		return p.assistantMessageDeltaUpdate(event, data), false, nil
 	case *copilot.AssistantMessageData:
 		return p.assistantMessageUpdate(event, data, isStreaming), false, nil
+	case *copilot.AssistantReasoningData:
+		return p.assistantReasoningUpdate(event, data), false, nil
+	case *copilot.AssistantReasoningDeltaData:
+		return p.assistantReasoningDeltaUpdate(event, data), false, nil
 	case *copilot.ToolExecutionStartData:
 		return p.toolExecutionStartUpdate(event, data), false, nil
 	case *copilot.ToolExecutionCompleteData:
@@ -528,8 +532,43 @@ func (p *provider) assistantMessageUpdate(event copilot.SessionEvent, data *copi
 			ContentHeader: message.ContentHeader{RawRepresentation: event},
 			Text:          data.Content,
 		}}
+		if data.ReasoningText != nil {
+			update.Contents = append(update.Contents, &message.TextReasoningContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: event},
+				Text:          *data.ReasoningText,
+				ProtectedData: firstNonNilString(data.ReasoningOpaque, data.EncryptedContent),
+			})
+		}
 	}
 	return update
+}
+
+func (p *provider) assistantReasoningUpdate(event copilot.SessionEvent, data *copilot.AssistantReasoningData) *agent.ResponseUpdate {
+	content := &message.TextReasoningContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: event},
+		Text:          data.Content,
+	}
+	return &agent.ResponseUpdate{
+		RawRepresentation: event,
+		Role:              message.RoleAssistant,
+		MessageID:         data.ReasoningID,
+		CreatedAt:         event.Timestamp,
+		Contents:          []message.Content{content},
+	}
+}
+
+func (p *provider) assistantReasoningDeltaUpdate(event copilot.SessionEvent, data *copilot.AssistantReasoningDeltaData) *agent.ResponseUpdate {
+	content := &message.TextReasoningContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: event},
+		Text:          data.DeltaContent,
+	}
+	return &agent.ResponseUpdate{
+		RawRepresentation: event,
+		Role:              message.RoleAssistant,
+		MessageID:         data.ReasoningID,
+		CreatedAt:         event.Timestamp,
+		Contents:          []message.Content{content},
+	}
 }
 
 func (p *provider) toolExecutionStartUpdate(event copilot.SessionEvent, data *copilot.ToolExecutionStartData) *agent.ResponseUpdate {
@@ -627,6 +666,15 @@ func int64Value(value *int64) int64 {
 		return 0
 	}
 	return *value
+}
+
+func firstNonNilString(values ...*string) string {
+	for _, value := range values {
+		if value != nil {
+			return *value
+		}
+	}
+	return ""
 }
 
 func rawEventUpdate(event copilot.SessionEvent) *agent.ResponseUpdate {

--- a/provider/copilotprovider/copilot_test.go
+++ b/provider/copilotprovider/copilot_test.go
@@ -361,6 +361,72 @@ func TestConvertToAgentResponseUpdate_UsageEvent_SurfacesReasoningTokens(t *test
 	}
 }
 
+func TestConvertToAgentResponseUpdate_ReasoningEvent_SurfacesReasoningContent(t *testing.T) {
+	const thinking = "Let me work through this step by step."
+	runtime := newFakeRuntime(t,
+		sessionEvent("assistant.reasoning", map[string]any{"content": thinking, "reasoningId": "r1"}),
+		idleEvent(),
+	)
+	agent := copilotprovider.NewAgent(runtime.client(), copilotprovider.AgentConfig{})
+
+	response, err := runText(t, agent, "hello")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	reasoning := firstContent[*message.TextReasoningContent](t, response)
+	if reasoning.Text != thinking {
+		t.Fatalf("reasoning text = %q, want %q", reasoning.Text, thinking)
+	}
+}
+
+func TestConvertToAgentResponseUpdate_ReasoningDeltaEvent_SurfacesReasoningContent(t *testing.T) {
+	const chunk = "partial thought"
+	runtime := newFakeRuntime(t,
+		sessionEvent("assistant.reasoning_delta", map[string]any{"deltaContent": chunk, "reasoningId": "r1"}),
+		idleEvent(),
+	)
+	agent := copilotprovider.NewAgent(runtime.client(), copilotprovider.AgentConfig{})
+
+	response, err := runText(t, agent, "hello")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	reasoning := firstContent[*message.TextReasoningContent](t, response)
+	if reasoning.Text != chunk {
+		t.Fatalf("reasoning text = %q, want %q", reasoning.Text, chunk)
+	}
+}
+
+func TestConvertToAgentResponseUpdate_AssistantMessageEventWhenNotStreaming_SurfacesReasoningText(t *testing.T) {
+	const expected = "Full response text"
+	const thinking = "internal reasoning"
+	runtime := newFakeRuntime(t,
+		sessionEvent("assistant.message", map[string]any{
+			"messageId":       "msg-r1",
+			"content":         expected,
+			"reasoningText":   thinking,
+			"reasoningOpaque": "opaque-blob",
+		}),
+		idleEvent(),
+	)
+	agent := copilotprovider.NewAgent(runtime.client(), copilotprovider.AgentConfig{})
+
+	response, err := runText(t, agent, "hello", agentpkg.Stream(false))
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if text := firstContent[*message.TextContent](t, response); text.Text != expected {
+		t.Fatalf("text content = %q, want %q", text.Text, expected)
+	}
+	reasoning := firstContent[*message.TextReasoningContent](t, response)
+	if reasoning.Text != thinking {
+		t.Fatalf("reasoning text = %q, want %q", reasoning.Text, thinking)
+	}
+	if reasoning.ProtectedData != "opaque-blob" {
+		t.Fatalf("reasoning protected data = %q, want %q", reasoning.ProtectedData, "opaque-blob")
+	}
+}
+
 func TestConvertToAgentResponseUpdate_ToolExecutionStartEvent_WithNullData_ProducesEmptyFunctionCall(t *testing.T) {
 	runtime := newFakeRuntime(t,
 		sessionEvent("tool.execution_start", nil),


### PR DESCRIPTION
## What

Surface the GitHub Copilot model's extended-thinking output as `message.TextReasoningContent` in `provider/copilotprovider`.

`responseUpdateForSessionEvent` had no case for `*copilot.AssistantReasoningData` or `*copilot.AssistantReasoningDeltaData`, so both fell through to the default branch and were emitted as empty `message.RawContent`. Separately, the non-streaming `assistant.message` path mapped only `data.Content` to `TextContent`, silently dropping `ReasoningText` / `ReasoningOpaque` / `EncryptedContent`.

This change:
- Adds cases for `assistant.reasoning` and `assistant.reasoning_delta` that emit a `TextReasoningContent` carrying the reasoning text and the reasoning block ID as the message ID.
- On the non-streaming `assistant.message` path, appends a `TextReasoningContent` (with `ProtectedData` from `ReasoningOpaque`, falling back to `EncryptedContent`) alongside the existing `TextContent` when `ReasoningText` is present.

## Why

`message.TextReasoningContent` is the canonical type the framework uses to represent model "thinking", distinct from output `TextContent`. The other providers already surface reasoning this way, matching .NET/Python SDK semantics where reasoning content is delivered to callers as a dedicated reasoning content part rather than folded into text or discarded. This aligns the Copilot provider with that cross-SDK behavior.

Note this is distinct from reasoning-*token* usage accounting (already present via the usage event), which only counts tokens and does not surface the reasoning content itself.

## Testing

Added three black-box tests in `copilot_test.go` using the existing fake-runtime harness:
- `assistant.reasoning` event surfaces a `TextReasoningContent` with the thinking text.
- `assistant.reasoning_delta` event surfaces a `TextReasoningContent` with the delta chunk.
- Non-streaming `assistant.message` with `reasoningText`/`reasoningOpaque` emits both a `TextContent` and a `TextReasoningContent` (with `ProtectedData` populated).

All three fail before the change and pass after. `go build ./...`, `go vet ./provider/copilotprovider/...`, and `go test ./provider/copilotprovider/...` are green.