### PR TITLE
Guard contextProviderMiddleware.Run against yielding after the consumer stopped (range-over-func panic)

### DIFF
--- a/agent/context.go
+++ b/agent/context.go
@@ -211,6 +211,7 @@ func (r *contextProviderMiddleware) Run(next RunFunc, ctx context.Context, messa
 		requestMessages := slices.Clone(messages)
 		var resp Response
 		var invokeErr error
+		var stopped bool
 		for update, err := range next(ctx, messages, options...) {
 			if update != nil {
 				resp.Update(update)
@@ -219,13 +220,16 @@ func (r *contextProviderMiddleware) Run(next RunFunc, ctx context.Context, messa
 				invokeErr = err
 			}
 			if !yield(update, err) {
+				stopped = true
 				break
 			}
 		}
 		resp.Coalesce()
 
 		if err := r.provider.Invoked(ctx, InvokedContext{RequestMessages: requestMessages, ResponseMessages: resp.Messages, Options: options, Err: invokeErr}); err != nil {
-			yield(nil, err)
+			if !stopped {
+				yield(nil, err)
+			}
 			return
 		}
 	}

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -229,6 +229,45 @@ func TestContextProviderMiddleware_Run_PassesRunErrorToCustomProvider(t *testing
 	}
 }
 
+func TestContextProviderMiddleware_Run_SuppressesInvokedErrorAfterConsumerStop(t *testing.T) {
+	provider := contextProviderFunc{
+		invoking: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return invoking.Messages, invoking.Options, nil
+		},
+		invoked: func(context.Context, agent.InvokedContext) error {
+			return errors.New("store failed")
+		},
+	}
+
+	seq := agent.ContextProviderMiddleware(provider).Run(
+		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				if !yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "one"}}}, nil) {
+					return
+				}
+				yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "two"}}}, nil)
+			}
+		},
+		context.Background(),
+		[]*message.Message{message.NewText("hello")},
+		agent.WithSession(agenttest.CreateSession()),
+	)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("middleware yielded after consumer stop: %v", r)
+		}
+	}()
+
+	// Abandon the range after the first update. The provider's Invoked hook then
+	// returns an error; the middleware must not yield it because the consumer
+	// already stopped, otherwise Go panics with
+	// "range function continued iteration after loop body returned false".
+	for range seq {
+		break
+	}
+}
+
 func contextProviderMiddlewareSingleUpdate(text string) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: text}}}, nil)


### PR DESCRIPTION
## What

`contextProviderMiddleware.Run` streams updates to the caller via an `iter.Seq2`. When the loop body breaks because the downstream consumer abandoned the range early (`yield` returned false), the adapter still ran `provider.Invoked(...)` and, on error, unconditionally called `yield(nil, err)` again. Yielding after the consumer already returned false violates the `iter.Seq2` contract and triggers Go's runtime panic `range function continued iteration after loop body returned false`.

This tracks consumer stop with a `stopped` flag (set at the break site) and guards the post-loop error yield with `if !stopped`. `provider.Invoked(...)` is still called unconditionally so the desired store side-effect always runs; only the surfaced error yield is suppressed once the consumer has stopped.

## Why

`agent.go` already establishes this exact pattern: it tracks `var stopped bool`, sets it on break, and guards every post-loop error yield with `if !stopped`. The exported `ContextProviderMiddleware` adapter omitted that guard, leaving a panic reachable through the public middleware API. This aligns the adapter with the internal agent lifecycle's stop-tracking discipline (and with the .NET/Python streaming contract where post-cancellation surfacing is suppressed rather than re-raised).

## Testing

Added `TestContextProviderMiddleware_Run_SuppressesInvokedErrorAfterConsumerStop` in the canonical `agent/context_test.go`, reusing the existing `contextProviderFunc` harness. It builds middleware whose `Invoked` returns a non-nil error over a `next` that emits multiple updates, then breaks out of the range after the first update and asserts via `recover()` that no panic occurs. The test panics without the fix and passes with it. `go build ./...`, `go vet ./agent/...`, and `go test ./agent/... -race` all pass.