### PR TITLE
Set ErrorCode Refusal on non-streaming Chat Completions refusals to match the Responses path

### DIFF
--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -136,7 +136,7 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 				contents = append(contents, &message.TextContent{Text: choice.Message.Content})
 			}
 			if choice.Message.Refusal != "" {
-				contents = append(contents, &message.ErrorContent{Message: choice.Message.Refusal})
+				contents = append(contents, &message.ErrorContent{Message: choice.Message.Refusal, ErrorCode: "Refusal"})
 			}
 			finishReason = choice.FinishReason
 		}

--- a/provider/openaiprovider/chat_test.go
+++ b/provider/openaiprovider/chat_test.go
@@ -1595,3 +1595,58 @@ func TestChatEmptyChoices_NonStreaming(t *testing.T) {
 		t.Errorf("expected usage input=12 total=12 to be surfaced, got %+v", usage)
 	}
 }
+
+func TestChatResponseWithRefusalContent_ParsesCorrectly(t *testing.T) {
+	const input = `
+		{
+			"messages":[{"role":"user","content":"harmful request"}],
+			"model":"gpt-4o-mini"
+		}
+		`
+	const output = `
+		{
+			"id":"chatcmpl-refusal",
+			"object":"chat.completion",
+			"created":1727888631,
+			"model":"gpt-4o-mini",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":null,"refusal":"I cannot provide that information"},
+				"finish_reason":"stop"
+			}]
+		}
+		`
+	server := newTestServer(t, input, output)
+	defer server.Close()
+
+	a := newTestClient(server)
+
+	resp, err := a.RunText(t.Context(), "harmful request").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	if len(resp.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(resp.Messages))
+	}
+
+	// Refusal is mapped to ErrorContent.
+	var errorContent *message.ErrorContent
+	for _, content := range resp.Messages[0].Contents {
+		if ec, ok := content.(*message.ErrorContent); ok {
+			errorContent = ec
+			break
+		}
+	}
+
+	if errorContent == nil {
+		t.Fatal("expected ErrorContent in message")
+	}
+
+	if errorContent.Message != "I cannot provide that information" {
+		t.Errorf("expected error message 'I cannot provide that information', got %q", errorContent.Message)
+	}
+	if errorContent.ErrorCode != "Refusal" {
+		t.Errorf("expected error code 'Refusal', got %q", errorContent.ErrorCode)
+	}
+}


### PR DESCRIPTION
## What

The non-streaming Chat Completions path maps a model refusal to a `message.ErrorContent` but leaves `ErrorCode` empty:

```go
contents = append(contents, &message.ErrorContent{Message: choice.Message.Refusal})
```

Every Responses-path refusal (three sites in `responses.go`) tags `ErrorCode: "Refusal"`. This change adds the same tag on the Chat Completions non-streaming path.

## Why

Refusals should be categorizable the same way regardless of which OpenAI surface produced them. Today a consumer routing on `ErrorContent.ErrorCode` classifies Responses refusals but silently drops identical Chat Completions refusals into the empty-code bucket. This mirrors the .NET/Python SDKs, where refusal content carries a consistent, well-known code across the chat and responses clients, and aligns with the existing `"Refusal"` convention already asserted in `responses_test.go`.

Not a duplicate of #556, which concerns the streaming chat refusal path.

## Testing

Added `TestChatResponseWithRefusalContent_ParsesCorrectly` in `chat_test.go` (mirroring `TestResponsesResponseWithRefusalContent_ParsesCorrectly`): it returns a chat completion with `content: null` and a `refusal` string, runs the agent, extracts the `*message.ErrorContent`, and asserts both `Message` and `ErrorCode == "Refusal"`. The test fails before the fix (empty ErrorCode) and passes after. `go build ./...`, `go vet`, and `go test ./provider/openaiprovider/...` all pass.