### PR TITLE
Fix OTel invoke_agent span: prefix the operation name and omit empty agent name/description attributes

### DIFF
--- a/provider/otelprovider/otel.go
+++ b/provider/otelprovider/otel.go
@@ -67,17 +67,18 @@ func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Me
 		a, _ := agent.AgentFromContext(ctx)
 		// GenAI conventions name the span "<operation> <target>", mirroring the sibling
 		// execute_tool span (see startToolSpan). Fall back to the agent id when it has no
-		// name so the span still carries a target, matching .NET/Python.
-		name := opInvoke
-		if n := cmp.Or(a.Name(), a.ID()); n != "" {
-			name += " " + n
-		}
+		// name so the span still carries a target, matching .NET/Python. Default the id to
+		// "unknown" (as with the provider name below) so the span always carries a target
+		// and gen_ai.agent.id is never an empty string, even when the middleware runs
+		// without an agent in context.
+		id := cmp.Or(a.ID(), "unknown")
+		name := opInvoke + " " + cmp.Or(a.Name(), id)
 		// Only include name/description when present: .NET and Python omit these attributes
 		// for an unnamed/undescribed agent rather than emitting empty strings.
 		attrs := []attribute.KeyValue{
 			attribute.String(attrKeyOperationName, opInvoke),
 			attribute.String(attrKeyProviderName, cmp.Or(a.ProviderName(), "unknown")),
-			attribute.String(attrKeyAgentID, a.ID()),
+			attribute.String(attrKeyAgentID, id),
 		}
 		if a.Name() != "" {
 			attrs = append(attrs, attribute.String(attrKeyAgentName, a.Name()))

--- a/provider/otelprovider/otel.go
+++ b/provider/otelprovider/otel.go
@@ -65,13 +65,27 @@ type mw struct {
 func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		a, _ := agent.AgentFromContext(ctx)
-		ctx, span := m.tracer.Start(ctx, a.Name(), trace.WithAttributes(
+		// GenAI conventions name the span "<operation> <target>", mirroring the sibling
+		// execute_tool span (see startToolSpan). Fall back to the agent id when it has no
+		// name so the span still carries a target, matching .NET/Python.
+		name := opInvoke
+		if n := cmp.Or(a.Name(), a.ID()); n != "" {
+			name += " " + n
+		}
+		// Only include name/description when present: .NET and Python omit these attributes
+		// for an unnamed/undescribed agent rather than emitting empty strings.
+		attrs := []attribute.KeyValue{
 			attribute.String(attrKeyOperationName, opInvoke),
 			attribute.String(attrKeyProviderName, cmp.Or(a.ProviderName(), "unknown")),
 			attribute.String(attrKeyAgentID, a.ID()),
-			attribute.String(attrKeyAgentName, a.Name()),
-			attribute.String(attrKeyAgentDesc, a.Description()),
-		))
+		}
+		if a.Name() != "" {
+			attrs = append(attrs, attribute.String(attrKeyAgentName, a.Name()))
+		}
+		if a.Description() != "" {
+			attrs = append(attrs, attribute.String(attrKeyAgentDesc, a.Description()))
+		}
+		ctx, span := m.tracer.Start(ctx, name, trace.WithAttributes(attrs...))
 		ctx = otelx.WithTracer(ctx, m.tracer)
 		defer span.End()
 

--- a/provider/otelprovider/otel_test.go
+++ b/provider/otelprovider/otel_test.go
@@ -160,6 +160,40 @@ func TestOtel_Run_SpanNamePrefixedWithOperation(t *testing.T) {
 	}
 }
 
+func TestOtel_Run_SpanNameFallsBackToAgentID(t *testing.T) {
+	exporter := setupTracer(t)
+
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	// Agent with an id but no name: the span target falls back to the agent id,
+	// matching .NET/Python.
+	a := agent.New(agent.ProviderConfig{
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{MessageID: "test-1"}, nil)
+			}
+		},
+	}, agent.Config{
+		ID:          "agent-123",
+		Middlewares: []agent.Middleware{mw},
+	})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	// With no name, the target is the agent id.
+	if spans[0].Name != "invoke_agent agent-123" {
+		t.Errorf("expected span name %q, got %q", "invoke_agent agent-123", spans[0].Name)
+	}
+	for _, attr := range spans[0].Attributes {
+		if string(attr.Key) == "gen_ai.agent.id" && attr.Value.AsString() != "agent-123" {
+			t.Errorf("expected gen_ai.agent.id %q, got %q", "agent-123", attr.Value.AsString())
+		}
+	}
+}
+
 func TestOtel_Run_OmitsEmptyAgentNameAndDescription(t *testing.T) {
 	exporter := setupTracer(t)
 

--- a/provider/otelprovider/otel_test.go
+++ b/provider/otelprovider/otel_test.go
@@ -104,9 +104,9 @@ func TestOtel_Run_SpanHasCorrectAttributes(t *testing.T) {
 
 	span := spans[len(spans)-1]
 
-	// Check span name matches agent name
-	if span.Name != "test-agent" {
-		t.Errorf("expected span name 'test-agent', got %s", span.Name)
+	// Check span name is "<operation> <target>" per GenAI conventions
+	if span.Name != "invoke_agent test-agent" {
+		t.Errorf("expected span name 'invoke_agent test-agent', got %s", span.Name)
 	}
 
 	// Check attributes
@@ -128,6 +128,63 @@ func TestOtel_Run_SpanHasCorrectAttributes(t *testing.T) {
 			t.Errorf("expected attribute %q to be present", key)
 		} else if got != expected {
 			t.Errorf("expected attribute %q to be %q, got %q", key, expected, got)
+		}
+	}
+}
+
+func TestOtel_Run_SpanNamePrefixedWithOperation(t *testing.T) {
+	exporter := setupTracer(t)
+
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	a := agent.New(agent.ProviderConfig{
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{MessageID: "test-1"}, nil)
+			}
+		},
+	}, agent.Config{
+		Name:        "helper",
+		Middlewares: []agent.Middleware{mw},
+	})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	// GenAI conventions require the span be named "<operation> <target>", matching the
+	// sibling execute_tool span and the .NET/Python SDKs.
+	if spans[0].Name != "invoke_agent helper" {
+		t.Errorf("expected span name %q, got %q", "invoke_agent helper", spans[0].Name)
+	}
+}
+
+func TestOtel_Run_OmitsEmptyAgentNameAndDescription(t *testing.T) {
+	exporter := setupTracer(t)
+
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	// Agent with no name and no description: .NET and Python omit these attributes
+	// rather than emitting empty strings.
+	a := agent.New(agent.ProviderConfig{
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{MessageID: "test-1"}, nil)
+			}
+		},
+	}, agent.Config{
+		Middlewares: []agent.Middleware{mw},
+	})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	for _, attr := range spans[0].Attributes {
+		if key := string(attr.Key); key == "gen_ai.agent.name" || key == "gen_ai.agent.description" {
+			t.Errorf("expected %q to be omitted for an unnamed/undescribed agent", key)
 		}
 	}
 }


### PR DESCRIPTION
## What

Two GenAI-semantic-convention fixes in the `invoke_agent` span setup in `provider/otelprovider/otel.go`:

1. **Span name.** The span was started with the raw agent name (`tracer.Start(ctx, a.Name(), ...)`); `invoke_agent` was only used for the `gen_ai.operation.name` attribute, never the span name. It is now named `<operation> <target>` (e.g. `invoke_agent helper`), falling back to the agent id when the name is empty so the span still carries a target.

2. **Empty attributes.** `gen_ai.agent.name` and `gen_ai.agent.description` were set unconditionally, so an agent with no name/description produced empty-string attributes. They are now appended only when non-empty. The provider name still keeps its `unknown` default (parity with Python).

## Why

The GenAI semantic conventions require the span be named operation + target. The sibling tool span already does this — `startToolSpan` in `toolautocall/autocall.go` builds `execute_tool <tool>` — so the agent span was inconsistent within this repo and diverged from the .NET and Python SDKs. Both .NET and Python also omit `gen_ai.agent.name`/`gen_ai.agent.description` when they are empty rather than emitting empty strings.

## Tests

Extended `provider/otelprovider/otel_test.go` using the existing `tracetest` in-memory exporter harness:
- `TestOtel_Run_SpanNamePrefixedWithOperation` — asserts the span Name is `invoke_agent helper`.
- `TestOtel_Run_OmitsEmptyAgentNameAndDescription` — asserts no `gen_ai.agent.name`/`gen_ai.agent.description` keys for an unnamed/undescribed agent.
- Updated `TestOtel_Run_SpanHasCorrectAttributes` to expect the prefixed span name.

`go build ./...`, `go vet ./provider/otelprovider/...`, and `go test ./provider/otelprovider/...` all pass.