### PR TITLE
Surface hosted MCP tool-call outputs in OpenAI Responses via a new MCPServerToolResultContent

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -311,7 +311,7 @@ type MCPServerToolResultContent struct {
 	ContentHeader
 
 	CallID     string
-	Name       string   `json:",omitempty"`
+	Name       string
 	ServerName string   `json:",omitempty"`
 	Outputs    Contents `json:",omitempty"`
 	Error      string   `json:",omitempty"`

--- a/message/content.go
+++ b/message/content.go
@@ -36,6 +36,7 @@ func init() {
 		&ToolApprovalResponseContent{},
 		&AlwaysApproveToolApprovalResponseContent{},
 		&MCPServerToolCallContent{},
+		&MCPServerToolResultContent{},
 	} {
 		supportedContents[c.kind()] = reflect.TypeOf(c).Elem()
 	}
@@ -291,6 +292,35 @@ func (t *MCPServerToolCallContent) GetCallID() string {
 
 func (t *MCPServerToolCallContent) MarshalJSON() ([]byte, error) {
 	type alias MCPServerToolCallContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+// MCPServerToolResultContent represents the result of a tool call executed by
+// a hosted MCP server.
+//
+// It mirrors MCPServerToolCallContent and conveys the outputs (and any error)
+// produced when a hosted service runs an MCP server tool.
+type MCPServerToolResultContent struct {
+	ContentHeader
+
+	CallID     string
+	Name       string   `json:",omitempty"`
+	ServerName string   `json:",omitempty"`
+	Outputs    Contents `json:",omitempty"`
+	Error      string   `json:",omitempty"`
+}
+
+func (t MCPServerToolResultContent) kind() contentKind { return "mcpServerToolResult" }
+
+func (t *MCPServerToolResultContent) MarshalJSON() ([]byte, error) {
+	type alias MCPServerToolResultContent
 	tmp := struct {
 		*alias
 		Type contentKind

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -164,6 +164,15 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 			Name:       "mcpName",
 			ServerName: "mcpServer",
 		},
+		&message.MCPServerToolResultContent{
+			CallID:     "mcp-call-123",
+			Name:       "mcpName",
+			ServerName: "mcpServer",
+			Outputs: message.Contents{
+				&message.TextContent{Text: "mcp tool output"},
+			},
+			Error: "mcp tool error",
+		},
 	}
 	data, err := json.Marshal(contents)
 	if err != nil {

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -903,6 +903,9 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 		case responses.ResponseOutputItemMcpApprovalRequest:
 			currentUpdate.Contents = append(currentUpdate.Contents, mcpApprovalRequestContent(out))
 
+		case responses.ResponseOutputItemMcpCall:
+			currentUpdate.Contents = append(currentUpdate.Contents, mcpCallContents(out)...)
+
 		case responses.ResponseOutputItemImageGenerationCall:
 			if content := imageGenerationContent(out); content != nil {
 				currentUpdate.Contents = append(currentUpdate.Contents, content)
@@ -1141,6 +1144,8 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 			u.Contents = []message.Content{content}
 		case responses.ResponseOutputItemMcpApprovalRequest:
 			u.Contents = []message.Content{mcpApprovalRequestContent(item)}
+		case responses.ResponseOutputItemMcpCall:
+			u.Contents = mcpCallContents(item)
 		case responses.ResponseOutputItemImageGenerationCall:
 			if content := imageGenerationContent(item); content != nil {
 				u.Contents = []message.Content{content}
@@ -1181,6 +1186,42 @@ func mcpApprovalRequestContent(item responses.ResponseOutputItemMcpApprovalReque
 			ServerName:    item.ServerLabel,
 		},
 	}
+}
+
+// mcpCallContents surfaces a completed hosted MCP tool call, emitting both the
+// call (from its arguments) and its result so the output is not silently
+// dropped. Any tool-call error is surfaced as an ErrorContent.
+func mcpCallContents(item responses.ResponseOutputItemMcpCall) []message.Content {
+	contents := []message.Content{
+		&message.MCPServerToolCallContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: item},
+			Arguments:     item.Arguments,
+			CallID:        item.ID,
+			Name:          item.Name,
+			ServerName:    item.ServerLabel,
+		},
+	}
+
+	result := &message.MCPServerToolResultContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: item},
+		CallID:        item.ID,
+		Name:          item.Name,
+		ServerName:    item.ServerLabel,
+		Error:         item.Error,
+	}
+	if item.Output != "" {
+		result.Outputs = message.Contents{
+			&message.TextContent{Text: item.Output},
+		}
+	}
+	contents = append(contents, result)
+
+	if item.Error != "" {
+		contents = append(contents, &message.ErrorContent{
+			Message: item.Error,
+		})
+	}
+	return contents
 }
 
 func imageGenerationContent(item responses.ResponseOutputItemImageGenerationCall) *message.DataContent {

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -2157,6 +2157,7 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
+	var call *message.MCPServerToolCallContent
 	var result *message.MCPServerToolResultContent
 	var errContent *message.ErrorContent
 	for update, err := range a.RunText(t.Context(), "test", agent.Stream(true)) {
@@ -2165,6 +2166,8 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 		}
 		for _, content := range update.Contents {
 			switch c := content.(type) {
+			case *message.MCPServerToolCallContent:
+				call = c
 			case *message.MCPServerToolResultContent:
 				result = c
 			case *message.ErrorContent:
@@ -2173,6 +2176,12 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 		}
 	}
 
+	if call == nil {
+		t.Fatal("expected MCPServerToolCallContent")
+	}
+	if call.CallID != "mcp_123" || call.ServerName != "github" || call.Name != "create_issue" || call.Arguments != `{"title":"Bug"}` {
+		t.Fatalf("call = %#v", call)
+	}
 	if result == nil {
 		t.Fatal("expected MCPServerToolResultContent")
 	}

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -2056,6 +2056,141 @@ func firstToolApprovalRequest(t *testing.T, resp *agent.Response) *message.ToolA
 	return nil
 }
 
+func TestResponsesNonStreamingMCPCall_MapsResultContent(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}]
+            }
+            `
+
+	const output = `
+            {
+              "id":"resp_001",
+              "object":"response",
+              "created_at":1741892091,
+              "status":"completed",
+              "model":"gpt-4o-mini",
+              "output":[{
+                "type":"mcp_call",
+                "id":"mcp_123",
+                "server_label":"github",
+                "name":"create_issue",
+                "arguments":"{\"title\":\"Bug\"}",
+                "output":"issue #7 created",
+                "error":"rate limited"
+              }]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	resp, err := a.RunText(t.Context(), "test").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	var call *message.MCPServerToolCallContent
+	var result *message.MCPServerToolResultContent
+	var errContent *message.ErrorContent
+	for content := range resp.Contents() {
+		switch c := content.(type) {
+		case *message.MCPServerToolCallContent:
+			call = c
+		case *message.MCPServerToolResultContent:
+			result = c
+		case *message.ErrorContent:
+			errContent = c
+		}
+	}
+
+	if call == nil {
+		t.Fatal("expected MCPServerToolCallContent")
+	}
+	if call.CallID != "mcp_123" || call.Name != "create_issue" || call.ServerName != "github" || call.Arguments != `{"title":"Bug"}` {
+		t.Fatalf("call = %#v", call)
+	}
+	if result == nil {
+		t.Fatal("expected MCPServerToolResultContent")
+	}
+	if result.CallID != "mcp_123" || result.Name != "create_issue" || result.ServerName != "github" {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Error != "rate limited" {
+		t.Errorf("result.Error = %q, want %q", result.Error, "rate limited")
+	}
+	if len(result.Outputs) != 1 {
+		t.Fatalf("Outputs len = %d, want 1", len(result.Outputs))
+	}
+	text, ok := result.Outputs[0].(*message.TextContent)
+	if !ok || text.Text != "issue #7 created" {
+		t.Fatalf("Outputs[0] = %#v", result.Outputs[0])
+	}
+	if errContent == nil || errContent.Message != "rate limited" {
+		t.Fatalf("expected ErrorContent with tool error, got %#v", errContent)
+	}
+}
+
+func TestResponsesStreamingMCPCall_MapsResultContent(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}],
+                "stream":true
+            }
+            `
+
+	const output = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,"item":{"type":"mcp_call","id":"mcp_123","server_label":"github","name":"create_issue","arguments":"{\"title\":\"Bug\"}","output":"issue #7 created","error":"rate limited"}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+
+`
+
+	server := newTestResponsesServerStreaming(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	var result *message.MCPServerToolResultContent
+	var errContent *message.ErrorContent
+	for update, err := range a.RunText(t.Context(), "test", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		for _, content := range update.Contents {
+			switch c := content.(type) {
+			case *message.MCPServerToolResultContent:
+				result = c
+			case *message.ErrorContent:
+				errContent = c
+			}
+		}
+	}
+
+	if result == nil {
+		t.Fatal("expected MCPServerToolResultContent")
+	}
+	if result.CallID != "mcp_123" || result.ServerName != "github" || result.Name != "create_issue" {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(result.Outputs) != 1 {
+		t.Fatalf("Outputs len = %d, want 1", len(result.Outputs))
+	}
+	text, ok := result.Outputs[0].(*message.TextContent)
+	if !ok || text.Text != "issue #7 created" {
+		t.Fatalf("Outputs[0] = %#v", result.Outputs[0])
+	}
+	if errContent == nil || errContent.Message != "rate limited" {
+		t.Fatalf("expected ErrorContent with tool error, got %#v", errContent)
+	}
+}
+
 func TestResponsesResponseFormatSchemaConvertsJSONSchema(t *testing.T) {
 	type payload struct {
 		Name string `json:"name"`


### PR DESCRIPTION
## What

`message` had `MCPServerToolCallContent` but no result counterpart, unlike the `CodeInterpreterToolCallContent`/`CodeInterpreterToolResultContent` pair. As a result, a completed hosted MCP tool call (`responses.ResponseOutputItemMcpCall`, which carries `Output` and `Error`) was silently dropped: neither the non-streaming output loop nor the streaming `ResponseOutputItemDone` switch in the OpenAI Responses provider handled `mcp_call`, so the tool output never reached the caller.

This change:

- Adds `message.MCPServerToolResultContent` (kind `mcpServerToolResult`) with `CallID`, `Name`, `ServerName`, `Outputs Contents`, and optional `Error`, with a `MarshalJSON` that stamps `Type`, mirroring `CodeInterpreterToolResultContent`. It is registered in the `supportedContents` init slice so it round-trips.
- Handles `responses.ResponseOutputItemMcpCall` in both the non-streaming loop and the streaming `ResponseOutputItemDone` switch, emitting the `MCPServerToolCallContent` (from the call arguments) plus the new `MCPServerToolResultContent` (with the `Output` as a `TextContent`), and surfacing a non-empty `Error` as an `ErrorContent` — the same call+result shaping used for code interpreter.

## Why

This aligns the Go SDK with the .NET/Python semantics where a hosted MCP tool invocation produces both the call record and its result content, matching how the code interpreter tool already exposes both its call and its outputs. Without it, hosted MCP tool results are invisible to consumers.

## Tests

- `message`: extended `TestContentEncoding_Roundtrip` to marshal/unmarshal an `MCPServerToolResultContent`, asserting the `mcpServerToolResult` kind and that nested `Outputs`/`Error` are preserved (parity with the code-interpreter result type).
- `provider/openaiprovider`: added non-streaming and streaming tests that feed a `mcp_call` output item carrying `output` and `error`, asserting the resulting update contains an `MCPServerToolResultContent` whose `Outputs` carry the output text and an `ErrorContent` when `error` is set.

`go build ./...`, `go vet`, and `go test` pass for the changed packages.