### PR TITLE
Add godoc for the exported workflow Builder, NewBuilder, Event, and RequestHaltEvent

### DIFF
--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -15,6 +15,8 @@ import (
 	workflowobservability "github.com/microsoft/agent-framework-go/workflow/observability"
 )
 
+// Builder assembles a Workflow graph from executors, edges, and
+// request/response ports, then produces an immutable Workflow via Build.
 type Builder struct {
 	startExecutorId string
 	name            string
@@ -32,6 +34,8 @@ type Builder struct {
 	telemetry                *internalobservability.Context
 }
 
+// NewBuilder returns a Builder rooted at the given start executor binding,
+// which becomes the workflow entry point.
 func NewBuilder(start ExecutorBinding) *Builder {
 	bld := &Builder{
 		startExecutorId: start.ID,

--- a/workflow/event.go
+++ b/workflow/event.go
@@ -4,6 +4,8 @@ package workflow
 
 import "slices"
 
+// Event is implemented by every workflow run event. Data returns the event
+// payload.
 type Event interface {
 	Data() any
 }
@@ -143,6 +145,8 @@ func (e OutputEvent) IsIntermediate() bool {
 
 var _ Event = RequestHaltEvent{}
 
+// RequestHaltEvent signals that the workflow requested a halt, carrying an
+// optional Result payload.
 type RequestHaltEvent struct {
 	Result any
 }


### PR DESCRIPTION
## What

Adds doc comments for four exported symbols in the `workflow` package that were missing them:

- `Builder` (workflow/builder.go) — assembles a Workflow graph from executors, edges, and request/response ports, then produces an immutable Workflow via Build.
- `NewBuilder` (workflow/builder.go) — returns a Builder rooted at the given start executor binding, which becomes the workflow entry point.
- `Event` (workflow/event.go) — implemented by every workflow run event; Data returns the event payload.
- `RequestHaltEvent` (workflow/event.go) — signals that the workflow requested a halt, carrying an optional Result payload.

## Why

These were inconsistent with their neighbors: every sibling event in event.go (`ExecutorInvokedEvent`, `ExecutorCompletedEvent`, `OutputEvent`, etc.) already carries a doc comment, and `RequestHaltEvent` was the lone undocumented one. `Builder`/`NewBuilder` are the primary entry points for constructing a workflow and warrant documentation. The corresponding types in the .NET and Python Agent Framework SDKs are documented; this brings the Go port to parity on public API documentation. All comments follow the Go convention of starting with the symbol name so they render correctly under `go doc`.

## Testing

Pure documentation change (no runtime behavior). Verified with:

```
go build ./...
go vet ./workflow/...
go test ./workflow/...
go doc github.com/microsoft/agent-framework-go/workflow Builder NewBuilder Event RequestHaltEvent
```

Each symbol now prints its description under `go doc`.