### PR TITLE
Correct the IsCheckpointingEnabled doc comment and document the inproc Run/StreamingRun API

### DIFF
--- a/workflow/inproc/run.go
+++ b/workflow/inproc/run.go
@@ -11,6 +11,9 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow/internal/execution"
 )
 
+// Run represents a non-streaming, in-process workflow run. It advances the
+// workflow to the next halt and accumulates the events raised so far so they
+// can be replayed via OutgoingEvents or consumed incrementally via NewEvents.
 type Run struct {
 	runHandle *execution.RunHandle
 	eventSink []workflow.Event
@@ -24,38 +27,49 @@ func newRun(handle *execution.RunHandle) *Run {
 	}
 }
 
+// SessionID returns the unique identifier for this run's session.
 func (run *Run) SessionID() string {
 	return run.runHandle.SessionID()
 }
 
+// IsCheckpointingEnabled reports whether a checkpoint manager is configured for this run.
 func (run *Run) IsCheckpointingEnabled() bool {
 	return run.runHandle.IsCheckpointingEnabled()
 }
 
+// Checkpoints returns the list of created checkpoints.
 func (run *Run) Checkpoints() []workflow.CheckpointInfo {
 	return run.runHandle.Checkpoints()
 }
 
+// LastCheckpoint returns the most recently created checkpoint, or false if no
+// checkpoint has been created yet.
 func (run *Run) LastCheckpoint() (workflow.CheckpointInfo, bool) {
 	return run.runHandle.LastCheckpoint()
 }
 
+// RestoreCheckpoint restores the workflow state from the given checkpoint.
 func (run *Run) RestoreCheckpoint(ctx context.Context, checkpointInfo workflow.CheckpointInfo) error {
 	return run.runHandle.RestoreCheckpoint(ctx, checkpointInfo)
 }
 
+// GetStatus returns the current execution status of the run.
 func (run *Run) GetStatus(ctx context.Context) (RunStatus, error) {
 	return run.runHandle.GetStatus(ctx)
 }
 
+// OutgoingEvents returns an iterator over all events accumulated by the run so far.
 func (run *Run) OutgoingEvents() iter.Seq[workflow.Event] {
 	return slices.Values(run.eventSink)
 }
 
+// NewEventCount returns the number of accumulated events not yet consumed by NewEvents.
 func (run *Run) NewEventCount() int {
 	return len(run.eventSink) - run.lastBookmark
 }
 
+// NewEvents returns an iterator over the events accumulated since the previous
+// call to NewEvents, advancing the internal bookmark as they are consumed.
 func (run *Run) NewEvents() iter.Seq[workflow.Event] {
 	if run.lastBookmark >= len(run.eventSink) {
 		return func(yield func(workflow.Event) bool) {}
@@ -71,6 +85,8 @@ func (run *Run) NewEvents() iter.Seq[workflow.Event] {
 	}
 }
 
+// Resume enqueues the given messages and advances the workflow to the next
+// halt, returning whether any events were raised.
 func (run *Run) Resume(ctx context.Context, messages ...any) (bool, error) {
 	for _, msg := range messages {
 		if err := run.runHandle.EnqueueMessage(ctx, msg); err != nil {
@@ -80,10 +96,13 @@ func (run *Run) Resume(ctx context.Context, messages ...any) (bool, error) {
 	return run.RunToNextHalt(ctx)
 }
 
+// Close ends the run and releases its resources.
 func (run *Run) Close(ctx context.Context) error {
 	return run.runHandle.Close(ctx)
 }
 
+// RunToNextHalt advances the workflow until it halts, appending any raised
+// events to the run and returning whether any events were raised.
 func (run *Run) RunToNextHalt(ctx context.Context) (bool, error) {
 	var hadEvents bool
 	for evt, err := range run.runHandle.TakeEventStream(ctx, false) {
@@ -96,6 +115,9 @@ func (run *Run) RunToNextHalt(ctx context.Context) (bool, error) {
 	return hadEvents, nil
 }
 
+// StreamingRun represents a streaming, in-process workflow run. Events are
+// delivered to the caller as they are raised rather than accumulated, and new
+// messages or responses can be sent to the workflow while it is running.
 type StreamingRun struct {
 	runHandle *execution.RunHandle
 }
@@ -106,59 +128,79 @@ func newStreamingRun(handle *execution.RunHandle) *StreamingRun {
 	}
 }
 
+// SessionID returns the unique identifier for this run's session.
 func (stream *StreamingRun) SessionID() string {
 	return stream.runHandle.SessionID()
 }
 
+// IsCheckpointingEnabled reports whether a checkpoint manager is configured for this run.
 func (stream *StreamingRun) IsCheckpointingEnabled() bool {
 	return stream.runHandle.IsCheckpointingEnabled()
 }
 
+// Checkpoints returns the list of created checkpoints.
 func (stream *StreamingRun) Checkpoints() []workflow.CheckpointInfo {
 	return stream.runHandle.Checkpoints()
 }
 
+// LastCheckpoint returns the most recently created checkpoint, or false if no
+// checkpoint has been created yet.
 func (stream *StreamingRun) LastCheckpoint() (workflow.CheckpointInfo, bool) {
 	return stream.runHandle.LastCheckpoint()
 }
 
+// RestoreCheckpoint restores the workflow state from the given checkpoint.
 func (stream *StreamingRun) RestoreCheckpoint(ctx context.Context, checkpointInfo workflow.CheckpointInfo) error {
 	return stream.runHandle.RestoreCheckpoint(ctx, checkpointInfo)
 }
 
+// GetStatus returns the current execution status of the run.
 func (stream *StreamingRun) GetStatus(ctx context.Context) (RunStatus, error) {
 	return stream.runHandle.GetStatus(ctx)
 }
 
+// SendResponse delivers an external response to a pending request in the workflow.
 func (stream *StreamingRun) SendResponse(ctx context.Context, response *workflow.ExternalResponse) error {
 	return stream.runHandle.EnqueueResponse(ctx, response)
 }
 
+// SendMessage enqueues a message as input to the workflow.
 func (stream *StreamingRun) SendMessage(ctx context.Context, message any) error {
 	return stream.runHandle.EnqueueMessage(ctx, message)
 }
 
+// ResponsePortExecutorID returns the executor that handles responses on the
+// given port, or ("", false) if no such port is registered.
 func (stream *StreamingRun) ResponsePortExecutorID(portID string) (string, bool) {
 	return stream.runHandle.ResponsePortExecutorID(portID)
 }
 
+// WatchStream returns an iterator over the workflow's events, blocking on
+// pending requests so the stream stays open until they are serviced. Only one
+// consumer may watch the stream at a time.
 func (stream *StreamingRun) WatchStream(ctx context.Context) iter.Seq2[workflow.Event, error] {
 	return stream.runHandle.TakeEventStream(ctx, true)
 }
 
+// WatchUntilHalt returns an iterator over the workflow's events that completes
+// once the workflow halts, without blocking on pending requests. Only one
+// consumer may watch the stream at a time.
 func (stream *StreamingRun) WatchUntilHalt(ctx context.Context) iter.Seq2[workflow.Event, error] {
 	return stream.runHandle.TakeEventStream(ctx, false)
 }
 
+// CancelRun cancels the run, stopping event delivery.
 func (stream *StreamingRun) CancelRun() error {
 	stream.runHandle.Cancel()
 	return nil
 }
 
+// Close ends the run and releases its resources.
 func (stream *StreamingRun) Close(ctx context.Context) error {
 	return stream.runHandle.Close(ctx)
 }
 
+// RunStatus describes the current execution state of a [Run] or [StreamingRun].
 type RunStatus = execution.RunStatus
 
 const (
@@ -169,6 +211,8 @@ const (
 	RunStatusRunning         = execution.RunStatusRunning
 )
 
+// ExecutionOption configures an individual run started via the execution
+// environment's Run, RunStreaming, Resume, or ResumeStreaming methods.
 type ExecutionOption func(*executionOptions)
 
 type executionOptions struct {

--- a/workflow/inproc/run.go
+++ b/workflow/inproc/run.go
@@ -69,7 +69,10 @@ func (run *Run) NewEventCount() int {
 }
 
 // NewEvents returns an iterator over the events accumulated since the previous
-// call to NewEvents, advancing the internal bookmark as they are consumed.
+// call to NewEvents. The internal bookmark is advanced to the current end of the
+// event sink as soon as iteration begins, so every event returned here is
+// consumed even if the caller stops iterating early; a subsequent call will only
+// yield events accumulated after this call.
 func (run *Run) NewEvents() iter.Seq[workflow.Event] {
 	if run.lastBookmark >= len(run.eventSink) {
 		return func(yield func(workflow.Event) bool) {}

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -285,11 +285,12 @@ func (r *runner) RequestEndRun(ctx context.Context) error {
 	return r.runContext.endRun(ctx)
 }
 
-// Checkpoints returns the list of created checkpoints.
+// IsCheckpointingEnabled reports whether a checkpoint manager is configured for this run.
 func (r *runner) IsCheckpointingEnabled() bool {
 	return r.checkpointMgr != nil
 }
 
+// Checkpoints returns the list of created checkpoints.
 func (r *runner) Checkpoints() []workflow.CheckpointInfo {
 	r.checkpointMu.Lock()
 	defer r.checkpointMu.Unlock()


### PR DESCRIPTION
## What

- Fix a copy-paste error in `workflow/inproc/runner.go`: the comment `// Checkpoints returns the list of created checkpoints.` sat above `func (r *runner) IsCheckpointingEnabled()`, describing the adjacent `Checkpoints()` method rather than the method it annotated. Restore the correct doc on `IsCheckpointingEnabled` and move the `Checkpoints` doc onto `Checkpoints`.
- Add godoc to the previously undocumented exported `Run`, `StreamingRun`, `RunStatus`, and `ExecutionOption` types and each of their exported methods in `workflow/inproc/run.go`, each comment beginning with the identifier name per Go convention.

## Why

`runner.IsCheckpointingEnabled` is the private counterpart of the public `ExecutionEnvironment.IsCheckpointingEnabled`, which in the sibling `environment.go` is documented correctly ("reports whether checkpointing is configured") - confirming the runner comment was a stray copy of the neighboring `Checkpoints` doc. The new `Run`/`StreamingRun` doc mirrors the semantics already documented on `ExecutionEnvironment` and the underlying `RunHandle`, keeping the in-process runner surface consistent with the checkpointing/streaming vocabulary used across the .NET and Python SDKs (Run vs. streaming run, checkpoint restore, run status).

## Testing

Documentation-only change. Verified mechanically:
- `go build ./...`, `go vet ./workflow/inproc/...`, and `go test ./workflow/inproc/...` all pass.
- `go doc ./workflow/inproc Run` and `go doc ./workflow/inproc StreamingRun` now render doc lines for the types and their methods.
- The `// Checkpoints returns the list of created checkpoints.` line no longer sits above `func (r *runner) IsCheckpointingEnabled`.