### PR TITLE
Forward file_id from image content AdditionalProperties in the OpenAI Responses input-image builder

### DIFF
--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -529,3 +529,15 @@ func imageDetail(props map[string]any) string {
 	}
 	return ""
 }
+
+// imageFileID returns the string value of props["file_id"] or empty. This
+// allows an image referenced by an already-uploaded file to be forwarded to
+// the Responses API, mirroring the Python reference.
+func imageFileID(props map[string]any) string {
+	if id, ok := props["file_id"]; ok {
+		if v, ok := id.(string); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -471,11 +471,15 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 			case *message.URIContent:
 				switch c.TopLevelMediaType() {
 				case "image":
+					img := responses.ResponseInputImageParam{
+						ImageURL: openai.String(c.URI),
+						Detail:   responses.ResponseInputImageDetail(imageDetail(c.AdditionalProperties)),
+					}
+					if id := imageFileID(c.AdditionalProperties); id != "" {
+						img.FileID = openai.String(id)
+					}
 					contents = append(contents, responses.ResponseInputContentUnionParam{
-						OfInputImage: &responses.ResponseInputImageParam{
-							ImageURL: openai.String(c.URI),
-							Detail:   responses.ResponseInputImageDetail(imageDetail(c.AdditionalProperties)),
-						},
+						OfInputImage: &img,
 					})
 				default:
 					contents = append(contents, responses.ResponseInputContentUnionParam{
@@ -487,11 +491,15 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 			case *message.DataContent:
 				switch c.TopLevelMediaType() {
 				case "image":
+					img := responses.ResponseInputImageParam{
+						ImageURL: openai.String(c.URI()),
+						Detail:   responses.ResponseInputImageDetail(imageDetail(c.AdditionalProperties)),
+					}
+					if id := imageFileID(c.AdditionalProperties); id != "" {
+						img.FileID = openai.String(id)
+					}
 					contents = append(contents, responses.ResponseInputContentUnionParam{
-						OfInputImage: &responses.ResponseInputImageParam{
-							ImageURL: openai.String(c.URI()),
-							Detail:   responses.ResponseInputImageDetail(imageDetail(c.AdditionalProperties)),
-						},
+						OfInputImage: &img,
 					})
 				default:
 					file := responses.ResponseInputFileParam{

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -965,6 +965,206 @@ func TestResponsesDataContentMessage_Image_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestResponsesUriContentMessage_Image_ForwardsFileID(t *testing.T) {
+	// An image referenced by an already-uploaded file_id must be forwarded
+	// alongside image_url and detail, matching the Python reference.
+	const input = `
+            {
+              "input": [
+                {
+                  "type": "message",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "input_image",
+                      "image_url": "https://x/img.png",
+                      "detail": "high",
+                      "file_id": "file-abc"
+                    }
+                  ]
+                }
+              ],
+              "model": "gpt-4o-mini"
+            }
+            `
+	const output = `
+            {
+              "id": "resp_img_fileid",
+              "object": "response",
+              "created_at": 1743531271,
+              "status": "completed",
+              "model": "gpt-4o-mini-2024-07-18",
+              "output": [
+                {
+                  "type": "message",
+                  "id": "msg_img_fileid",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [
+                    {"type": "output_text", "text": "ok", "annotations": []}
+                  ]
+                }
+              ]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+
+	uriContent := &message.URIContent{
+		URI:       "https://x/img.png",
+		MediaType: "image/png",
+	}
+	uriContent.AdditionalProperties = map[string]any{
+		"detail":  "high",
+		"file_id": "file-abc",
+	}
+
+	messages := []*message.Message{
+		{
+			Role:     message.RoleUser,
+			Contents: []message.Content{uriContent},
+		},
+	}
+
+	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestResponsesDataContentMessage_Image_ForwardsFileID(t *testing.T) {
+	const input = `
+            {
+              "input": [
+                {
+                  "type": "message",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "input_image",
+                      "image_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+                      "detail": "high",
+                      "file_id": "file-abc"
+                    }
+                  ]
+                }
+              ],
+              "model": "gpt-4o-mini"
+            }
+            `
+	const output = `
+            {
+              "id": "resp_img_fileid",
+              "object": "response",
+              "created_at": 1743531271,
+              "status": "completed",
+              "model": "gpt-4o-mini-2024-07-18",
+              "output": [
+                {
+                  "type": "message",
+                  "id": "msg_img_fileid",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [
+                    {"type": "output_text", "text": "ok", "annotations": []}
+                  ]
+                }
+              ]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+
+	dataContent := &message.DataContent{
+		Data:      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+		MediaType: "image/png",
+	}
+	dataContent.AdditionalProperties = map[string]any{
+		"detail":  "high",
+		"file_id": "file-abc",
+	}
+
+	messages := []*message.Message{
+		{
+			Role:     message.RoleUser,
+			Contents: []message.Content{dataContent},
+		},
+	}
+
+	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestResponsesUriContentMessage_Image_NoFileID_OmitsField(t *testing.T) {
+	// Without a file_id in AdditionalProperties, no file_id field is emitted.
+	const input = `
+            {
+              "input": [
+                {
+                  "type": "message",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "input_image",
+                      "image_url": "https://x/img.png",
+                      "detail": "high"
+                    }
+                  ]
+                }
+              ],
+              "model": "gpt-4o-mini"
+            }
+            `
+	const output = `
+            {
+              "id": "resp_img_nofileid",
+              "object": "response",
+              "created_at": 1743531271,
+              "status": "completed",
+              "model": "gpt-4o-mini-2024-07-18",
+              "output": [
+                {
+                  "type": "message",
+                  "id": "msg_img_nofileid",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [
+                    {"type": "output_text", "text": "ok", "annotations": []}
+                  ]
+                }
+              ]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+
+	uriContent := &message.URIContent{
+		URI:       "https://x/img.png",
+		MediaType: "image/png",
+	}
+	uriContent.AdditionalProperties = map[string]any{"detail": "high"}
+
+	messages := []*message.Message{
+		{
+			Role:     message.RoleUser,
+			Contents: []message.Content{uriContent},
+		},
+	}
+
+	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestResponsesReasoningTextDelta_Streaming(t *testing.T) {
 	const input = `
             {


### PR DESCRIPTION
## What

In `responsesBuildMessageParam` (provider/openaiprovider/responses.go), the `RoleUser` image branches for both `URIContent` and `DataContent` built a `ResponseInputImageParam` with only `ImageURL` and `Detail`. Neither read a `file_id` from `AdditionalProperties`, so an image referenced by an already-uploaded file was silently dropped on the Responses path.

This adds an `imageFileID(props map[string]any) string` helper (mirroring the existing `imageDetail` helper) and sets `ResponseInputImageParam.FileID` when a `file_id` is present, for both image branches. `ImageURL` is left intact so both are sent when both exist.

## Why

Cross-SDK parity: the Python reference forwards `content.additional_properties["file_id"]` alongside `image_url`/`detail` when building the input image. The SDK already supports it (`responses.ResponseInputImageParam.FileID param.Opt[string]`, `json:"file_id,omitzero"`), and the AdditionalProperties-lookup pattern is already used for `detail`. This closes the gap so Go behaves the same as Python/.NET.

## Tests

Added to the canonical `responses_test.go`, reusing the existing fake-transport harness (`newTestResponsesServer` does exact request-body JSON matching):
- `TestResponsesUriContentMessage_Image_ForwardsFileID` — URIContent with `file_id`; asserts the outgoing `input_image` carries both `image_url` and `file_id`.
- `TestResponsesDataContentMessage_Image_ForwardsFileID` — same for DataContent.
- `TestResponsesUriContentMessage_Image_NoFileID_OmitsField` — negative case: no `file_id` in AdditionalProperties emits no `file_id` field.

The two positive tests fail before the fix and pass after. `go build ./...`, `go vet ./provider/openaiprovider/...`, and `go test ./provider/openaiprovider/...` all pass.