### PR TITLE
Fix Response.Update: keep the earliest valid CreatedAt

### DIFF
--- a/agent/response.go
+++ b/agent/response.go
@@ -186,7 +186,7 @@ func (resp *Response) Update(update *ResponseUpdate) {
 	msg.AuthorName = cmp.Or(update.AuthorName, msg.AuthorName)
 	msg.Role = cmp.Or(update.Role, msg.Role)
 	msg.ID = cmp.Or(update.MessageID, msg.ID)
-	if msg.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(msg.CreatedAt)) {
+	if msg.CreatedAt.IsZero() && isValidCreatedAt(update.CreatedAt) {
 		msg.CreatedAt = update.CreatedAt
 	}
 	msg.Contents = append(msg.Contents, update.Contents...)
@@ -214,7 +214,7 @@ func (resp *Response) Update(update *ResponseUpdate) {
 	} else {
 		resp.ContinuationToken = update.ContinuationToken
 	}
-	if resp.CreatedAt.IsZero() || (!update.CreatedAt.IsZero() && update.CreatedAt.After(resp.CreatedAt)) {
+	if resp.CreatedAt.IsZero() && isValidCreatedAt(update.CreatedAt) {
 		resp.CreatedAt = update.CreatedAt
 	}
 	if update.AdditionalProperties != nil {
@@ -223,6 +223,14 @@ func (resp *Response) Update(update *ResponseUpdate) {
 		}
 		maps.Copy(resp.AdditionalProperties, update.AdditionalProperties)
 	}
+}
+
+// isValidCreatedAt reports whether t is a usable creation timestamp. A zero
+// time.Time or an epoch-zero value is treated as unset, mirroring the .NET
+// ProcessUpdate check that keeps the first valid timestamp and ignores
+// default/uninitialized values.
+func isValidCreatedAt(t time.Time) bool {
+	return t.After(time.Unix(0, 0))
 }
 
 func (resp *Response) targetMessage(update *ResponseUpdate) *message.Message {

--- a/agent/response.go
+++ b/agent/response.go
@@ -186,7 +186,7 @@ func (resp *Response) Update(update *ResponseUpdate) {
 	msg.AuthorName = cmp.Or(update.AuthorName, msg.AuthorName)
 	msg.Role = cmp.Or(update.Role, msg.Role)
 	msg.ID = cmp.Or(update.MessageID, msg.ID)
-	if msg.CreatedAt.IsZero() && isValidCreatedAt(update.CreatedAt) {
+	if !isValidCreatedAt(msg.CreatedAt) && isValidCreatedAt(update.CreatedAt) {
 		msg.CreatedAt = update.CreatedAt
 	}
 	msg.Contents = append(msg.Contents, update.Contents...)
@@ -214,7 +214,7 @@ func (resp *Response) Update(update *ResponseUpdate) {
 	} else {
 		resp.ContinuationToken = update.ContinuationToken
 	}
-	if resp.CreatedAt.IsZero() && isValidCreatedAt(update.CreatedAt) {
+	if !isValidCreatedAt(resp.CreatedAt) && isValidCreatedAt(update.CreatedAt) {
 		resp.CreatedAt = update.CreatedAt
 	}
 	if update.AdditionalProperties != nil {

--- a/agent/response_test.go
+++ b/agent/response_test.go
@@ -309,6 +309,34 @@ func TestResponse_Update_CreatedAt_EpochZeroIgnored(t *testing.T) {
 	}
 }
 
+func TestResponse_Update_CreatedAt_PreexistingEpochZeroReplaced(t *testing.T) {
+	// A Response/Message may already carry an epoch-zero CreatedAt (e.g. loaded
+	// from older data or JSON). Because epoch-zero is treated as unset, a later
+	// valid timestamp must still be allowed to replace it.
+	resp := &agent.Response{
+		CreatedAt: time.Unix(0, 0),
+		Messages: []*message.Message{{
+			ID:        "msg1",
+			CreatedAt: time.Unix(0, 0),
+			Contents:  message.Contents{&message.TextContent{Text: "First"}},
+		}},
+	}
+
+	valid := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	resp.Update(&agent.ResponseUpdate{
+		MessageID: "msg1",
+		CreatedAt: valid,
+		Contents:  message.Contents{&message.TextContent{Text: "Second"}},
+	})
+
+	if !resp.Messages[0].CreatedAt.Equal(valid) {
+		t.Errorf("expected message CreatedAt %v, got %v", valid, resp.Messages[0].CreatedAt)
+	}
+	if !resp.CreatedAt.Equal(valid) {
+		t.Errorf("expected response CreatedAt %v, got %v", valid, resp.CreatedAt)
+	}
+}
+
 func TestResponse_Update_ContinuationToken(t *testing.T) {
 	resp := &agent.Response{}
 

--- a/agent/response_test.go
+++ b/agent/response_test.go
@@ -193,7 +193,8 @@ func TestResponse_Update_CreatedAt(t *testing.T) {
 		t.Errorf("expected CreatedAt %v, got %v", time1, resp.Messages[0].CreatedAt)
 	}
 
-	// Second update with later time - should update
+	// Second update with a later time - the first valid timestamp wins, so the
+	// message keeps time1 (matches .NET ProcessUpdate).
 	update2 := &agent.ResponseUpdate{
 		MessageID: "msg1",
 		CreatedAt: time2,
@@ -201,11 +202,11 @@ func TestResponse_Update_CreatedAt(t *testing.T) {
 	}
 	resp.Update(update2)
 
-	if !resp.Messages[0].CreatedAt.Equal(time2) {
-		t.Errorf("expected CreatedAt %v, got %v", time2, resp.Messages[0].CreatedAt)
+	if !resp.Messages[0].CreatedAt.Equal(time1) {
+		t.Errorf("expected CreatedAt to remain %v, got %v", time1, resp.Messages[0].CreatedAt)
 	}
 
-	// Third update with even later time - should update
+	// Third update with an even later time - still keeps time1.
 	update3 := &agent.ResponseUpdate{
 		MessageID: "msg1",
 		CreatedAt: time3,
@@ -213,8 +214,8 @@ func TestResponse_Update_CreatedAt(t *testing.T) {
 	}
 	resp.Update(update3)
 
-	if !resp.Messages[0].CreatedAt.Equal(time3) {
-		t.Errorf("expected CreatedAt %v, got %v", time3, resp.Messages[0].CreatedAt)
+	if !resp.Messages[0].CreatedAt.Equal(time1) {
+		t.Errorf("expected CreatedAt to remain %v, got %v", time1, resp.Messages[0].CreatedAt)
 	}
 }
 
@@ -241,6 +242,70 @@ func TestResponse_Update_CreatedAt_EarlierIgnored(t *testing.T) {
 
 	if !resp.Messages[0].CreatedAt.Equal(time1) {
 		t.Errorf("expected CreatedAt to remain %v, got %v", time1, resp.Messages[0].CreatedAt)
+	}
+}
+
+func TestResponse_Update_CreatedAt_FirstValidWins(t *testing.T) {
+	resp := &agent.Response{}
+
+	time1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	time2 := time1.Add(time.Second) // Later time
+
+	update1 := &agent.ResponseUpdate{
+		MessageID: "msg1",
+		CreatedAt: time1,
+		Contents:  message.Contents{&message.TextContent{Text: "First"}},
+	}
+	resp.Update(update1)
+
+	// Second update with a strictly later time - the first valid timestamp
+	// wins, so both the message and the response keep time1 (matches .NET
+	// ProcessUpdate, which never overwrites an already-set CreatedAt).
+	update2 := &agent.ResponseUpdate{
+		MessageID: "msg1",
+		CreatedAt: time2,
+		Contents:  message.Contents{&message.TextContent{Text: "Second"}},
+	}
+	resp.Update(update2)
+
+	if !resp.Messages[0].CreatedAt.Equal(time1) {
+		t.Errorf("expected message CreatedAt to remain %v, got %v", time1, resp.Messages[0].CreatedAt)
+	}
+	if !resp.CreatedAt.Equal(time1) {
+		t.Errorf("expected response CreatedAt to remain %v, got %v", time1, resp.CreatedAt)
+	}
+}
+
+func TestResponse_Update_CreatedAt_EpochZeroIgnored(t *testing.T) {
+	resp := &agent.Response{}
+
+	// An epoch-zero timestamp is treated as unset, so it does not populate
+	// CreatedAt and a later valid value can still take hold.
+	resp.Update(&agent.ResponseUpdate{
+		MessageID: "msg1",
+		CreatedAt: time.Unix(0, 0),
+		Contents:  message.Contents{&message.TextContent{Text: "First"}},
+	})
+
+	if !resp.Messages[0].CreatedAt.IsZero() {
+		t.Errorf("expected message CreatedAt to remain zero, got %v", resp.Messages[0].CreatedAt)
+	}
+	if !resp.CreatedAt.IsZero() {
+		t.Errorf("expected response CreatedAt to remain zero, got %v", resp.CreatedAt)
+	}
+
+	valid := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	resp.Update(&agent.ResponseUpdate{
+		MessageID: "msg1",
+		CreatedAt: valid,
+		Contents:  message.Contents{&message.TextContent{Text: "Second"}},
+	})
+
+	if !resp.Messages[0].CreatedAt.Equal(valid) {
+		t.Errorf("expected message CreatedAt %v, got %v", valid, resp.Messages[0].CreatedAt)
+	}
+	if !resp.CreatedAt.Equal(valid) {
+		t.Errorf("expected response CreatedAt %v, got %v", valid, resp.CreatedAt)
 	}
 }
 
@@ -336,7 +401,8 @@ func TestResponse_CreatedAt(t *testing.T) {
 		t.Errorf("expected resp.CreatedAt %v, got %v", time1, resp.CreatedAt)
 	}
 
-	// Second update with later time - should update
+	// Second update with a later time - the first valid timestamp wins, so the
+	// response keeps time1 (matches .NET ProcessUpdate).
 	update2 := &agent.ResponseUpdate{
 		MessageID: "msg2",
 		CreatedAt: time2,
@@ -344,11 +410,11 @@ func TestResponse_CreatedAt(t *testing.T) {
 	}
 	resp.Update(update2)
 
-	if !resp.CreatedAt.Equal(time2) {
-		t.Errorf("expected resp.CreatedAt %v, got %v", time2, resp.CreatedAt)
+	if !resp.CreatedAt.Equal(time1) {
+		t.Errorf("expected resp.CreatedAt to remain %v, got %v", time1, resp.CreatedAt)
 	}
 
-	// Third update with earlier time - should NOT update
+	// Third update with an earlier time - still keeps time1.
 	update3 := &agent.ResponseUpdate{
 		MessageID: "msg3",
 		CreatedAt: time3,
@@ -356,8 +422,8 @@ func TestResponse_CreatedAt(t *testing.T) {
 	}
 	resp.Update(update3)
 
-	if !resp.CreatedAt.Equal(time2) {
-		t.Errorf("expected resp.CreatedAt to remain %v, got %v", time2, resp.CreatedAt)
+	if !resp.CreatedAt.Equal(time1) {
+		t.Errorf("expected resp.CreatedAt to remain %v, got %v", time1, resp.CreatedAt)
 	}
 }
 


### PR DESCRIPTION
## Summary

`(*Response).Update` overwrote an already-set `CreatedAt` whenever a later update carried a strictly-later timestamp (the guard used `update.CreatedAt.After(...)`), in both the message-level and response-level branches. As a result a message/response collected from a stream ended up stamped with the **last** streamed chunk's time instead of the first valid one.

## .NET parity

.NET `ChatResponseExtensions.ProcessUpdate` keeps the **first** valid timestamp, not the latest:

```csharp
if (message.CreatedAt is null && IsValidCreatedAt(update.CreatedAt))
{
    message.CreatedAt = update.CreatedAt;
}
...
if (response.CreatedAt is null && IsValidCreatedAt(update.CreatedAt))
{
    response.CreatedAt = update.CreatedAt;
}
```

This PR mirrors that: `CreatedAt` is set only when it is currently zero and the update's value is valid. It also adds `isValidCreatedAt`, mirroring the .NET `IsValidCreatedAt` helper (`t.After(time.Unix(0, 0))`), so a zero or epoch-zero timestamp is treated as unset — it cannot populate `CreatedAt`, and a later valid value can still take hold.

## Tests

`agent/response_test.go`:

- Updated `TestResponse_Update_CreatedAt` and `TestResponse_CreatedAt`, which previously asserted latest-wins, to assert the first valid timestamp is retained.
- Added `TestResponse_Update_CreatedAt_FirstValidWins` (a strictly-later second update keeps the first timestamp on both message and response) and `TestResponse_Update_CreatedAt_EpochZeroIgnored` (an epoch-zero timestamp is treated as unset and a later valid value takes hold).

Both new tests fail against the previous latest-wins logic and pass with the fix.

Verified with `go build ./...`, `go vet ./agent/...`, and `go test ./...` (full suite green).

## Note

The originally-scoped item also proposed scoping `AdditionalProperties` in `Update` by `MessageID` (matching the same .NET `ProcessUpdate`). That change is intentionally left out of this PR: the Go providers currently surface response-level metadata (e.g. foundry `ServedModel`, openai `EndUserId`/`Error`) by stamping it onto message-bearing updates and relying on `Update` merging those properties into the response. Scoping by `MessageID` in isolation would misroute that metadata onto messages and break provider behavior, so it needs a coordinated provider change and is better handled separately.