### PR TITLE
[dotnet-code] Simplify superstep executor tracking

### DIFF
--- a/workflow/inproc/tracer.go
+++ b/workflow/inproc/tracer.go
@@ -97,20 +97,21 @@ func (t *stepTracer) Advance(step *execution.StepContext) workflow.SuperStepStar
 
 // Complete generates a SuperStepCompletedEvent for the current step.
 func (t *stepTracer) Complete(nextStepHasActions, hasPendingRequests bool) workflow.SuperStepCompletedEvent {
-	activated := slices.Collect(t.activated.Keys())
-	slices.Sort(activated)
-	instantiated := slices.Collect(t.instantiated.Keys())
-	slices.Sort(instantiated)
-
 	return workflow.SuperStepCompletedEvent{
 		StepNumber: t.StepNumber(),
 		CompletionInfo: &workflow.SuperStepCompletionInfo{
-			ActivatedExecutors:    activated,
-			InstantiatedExecutors: instantiated,
+			ActivatedExecutors:    sortedTrackedExecutorIDs(&t.activated),
+			InstantiatedExecutors: sortedTrackedExecutorIDs(&t.instantiated),
 			HasPendingMessages:    nextStepHasActions,
 			HasPendingRequests:    hasPendingRequests,
 			StateUpdated:          t.StateUpdated(),
 			CheckpointInfo:        t.checkpointInfo,
 		},
 	}
+}
+
+func sortedTrackedExecutorIDs(executors *concurrent.Map[string, string]) []string {
+	ids := slices.Collect(executors.Keys())
+	slices.Sort(ids)
+	return ids
 }

--- a/workflow/inproc/tracer_test.go
+++ b/workflow/inproc/tracer_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package inproc
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestStepTracer_CompletionExecutorIDsAreUniqueAndSorted(t *testing.T) {
+	tracer := &stepTracer{}
+	tracer.TraceActivated("writer")
+	tracer.TraceActivated("planner")
+	tracer.TraceActivated("writer")
+	tracer.TraceInstantiated("reviewer")
+	tracer.TraceInstantiated("planner")
+	tracer.TraceInstantiated("reviewer")
+
+	event := tracer.Complete(false, false)
+
+	if got, want := event.CompletionInfo.ActivatedExecutors, []string{"planner", "writer"}; !slices.Equal(got, want) {
+		t.Fatalf("ActivatedExecutors = %v, want %v", got, want)
+	}
+	if got, want := event.CompletionInfo.InstantiatedExecutors, []string{"planner", "reviewer"}; !slices.Equal(got, want) {
+		t.Fatalf("InstantiatedExecutors = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Extracted the super-step tracer's tracked executor ID collection into an unexported helper. This keeps activated and instantiated executor assembly in one place, matching the .NET `SuperStepCompletionInfo` shape where these values are represented as unique sets while preserving Go's stable sorted slices for events.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/SuperStepCompletionInfo.cs` - completion metadata stores activated and instantiated executors as unique collections.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- Added `TestStepTracer_CompletionExecutorIDsAreUniqueAndSorted` to preserve unique, sorted executor IDs in completion events.
- Ran `go test ./workflow/inproc`.

## Notes

Rejected sampled candidates: `ICheckpointManager.cs` already has a direct Go checkpoint manager counterpart with no safe tiny structural cleanup identified; `BackgroundTaskStatus.cs` has no corresponding Go background-agent implementation; `IMcpSkillEntryLoader.cs` would imply MCP skill-loading feature work rather than portability cleanup. Open `[dotnet-code]` PR search returned filtered results, so no candidate-specific overlap details were available.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30050577500) · 433.2 AIC · ⌖ 41.3 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 30050577500, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30050577500 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #673