### PR TITLE
[dotnet-code] Extract message merger fold helper

### DIFF
--- a/workflow/agentworkflow/message_merger.go
+++ b/workflow/agentworkflow/message_merger.go
@@ -235,20 +235,24 @@ func foldIdentifierlessMessages(messages []*message.Message) []*message.Message 
 			continue
 		}
 
-		merged := next.Clone()
-		merged.AuthorName = cmp.Or(next.AuthorName, current.AuthorName)
-		merged.AdditionalProperties = mergeProperties(current.AdditionalProperties, merged.AdditionalProperties)
-		if merged.CreatedAt.IsZero() {
-			merged.CreatedAt = current.CreatedAt
-		}
-		merged.Contents = append(slices.Clone(current.Contents), next.Contents...)
-		if merged.Source == (message.Source{}) {
-			merged.Source = current.Source
-		}
-		messages[i] = merged
+		messages[i] = mergeIdentifierlessMessageIntoNext(current, next)
 		messages = append(messages[:i-1], messages[i:]...)
 	}
 	return messages
+}
+
+func mergeIdentifierlessMessageIntoNext(current, next *message.Message) *message.Message {
+	merged := next.Clone()
+	merged.AuthorName = cmp.Or(next.AuthorName, current.AuthorName)
+	merged.AdditionalProperties = mergeProperties(current.AdditionalProperties, merged.AdditionalProperties)
+	if merged.CreatedAt.IsZero() {
+		merged.CreatedAt = current.CreatedAt
+	}
+	merged.Contents = append(slices.Clone(current.Contents), next.Contents...)
+	if merged.Source == (message.Source{}) {
+		merged.Source = current.Source
+	}
+	return merged
 }
 
 func isIdentifierlessAssistantReasoningMessage(msg *message.Message) bool {


### PR DESCRIPTION
## Summary

Extracted the private identifierless-message fold assembly into a focused helper in `workflow/agentworkflow/message_merger.go`. This keeps the flattened-message merge path structurally closer to the .NET `MessageMerger` implementation while preserving the existing Go merge conditions and field precedence.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/MessageMerger.cs` - flattened-message folding after response buckets are merged.
- `dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MessageMergerTests.cs` - preservation tests for message ordering and identifierless reasoning merges.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w workflow/agentworkflow/message_merger.go`
- `go test ./workflow/agentworkflow`

## Notes

Rejected candidates from the random .NET sample:

- `dotnet/src/Microsoft.Agents.AI.Workflows/Futures.cs` - .NET-only opt-in surface with no safe Go cleanup target.
- `dotnet/src/Microsoft.Agents.AI.Workflows/OutputTagJsonConverter.cs` - matching .NET null/empty handling would change current Go JSON behavior.
- `dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs` - no narrow internal Go cleanup was identified before choosing the more direct workflow candidate.

Open `[dotnet-code]` PR searches for the selected `MessageMerger` area did not find an overlap.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29963621322) · 246.3 AIC · ⌖ 28.1 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29963621322, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29963621322 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #591