### PR TITLE
[dotnet-code] Consolidate compaction provider message reduction

### DIFF
--- a/agent/compaction/provider.go
+++ b/agent/compaction/provider.go
@@ -78,11 +78,11 @@ func (p *contextProvider) Invoking(ctx context.Context, invoking agent.InvokingC
 	}
 	inputMessages := append([]*message.Message(nil), messages...)
 	if session == nil {
-		index := CreateMessageIndex(messages, p.tokenCounter)
-		if _, err := p.strategy.Compact(ctx, index); err != nil {
+		compactedMessages, err := Compact(ctx, p.strategy, messages, p.tokenCounter)
+		if err != nil {
 			return nil, nil, err
 		}
-		return p.markGeneratedMessages(index.IncludedMessages(), inputMessages), options, nil
+		return p.markGeneratedMessages(compactedMessages, inputMessages), options, nil
 	}
 	if session.ServiceID() != "" {
 		if p.logger != nil {


### PR DESCRIPTION
## Summary

Reused the existing `Compact` helper in the stateless compaction provider path instead of duplicating the message-index creation, strategy application, and included-message projection inline. This keeps the Go compaction provider closer to the .NET reducer adapter flow, where messages are wrapped into an index, compacted, and projected back through one shared path.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Compaction/ChatStrategyExtensions.cs` - adapts a compaction strategy by creating a message index, applying compaction, and returning included messages.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w agent/compaction/provider.go`
- `go test ./agent/compaction`

## Notes

Rejected candidates:

- `dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalState.cs` - rejected because open PR https://github.com/microsoft/agent-framework-go/pull/580 already covers adjacent tool approval state/response collection internals.
- `dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryState.cs` - rejected because open PR https://github.com/microsoft/agent-framework-go/pull/578 already covers nearby file skill/file-oriented internals and the sampled state shape did not present a safer tiny Go cleanup.
- `dotnet/src/Microsoft.Agents.AI.Workflows/ExecutorInstanceBinding.cs` - rejected because open PR https://github.com/microsoft/agent-framework-go/pull/579 already covers adjacent workflow binding setup internals.
- `dotnet/src/Microsoft.Agents.AI.Abstractions/AgentRunOptions.cs` - rejected because the corresponding Go option surface is public API-oriented and changing its structure would be higher risk for a portability cleanup.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29874430602) · 317.5 AIC · ⌖ 67.4 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 29874430602, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29874430602 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #584