### PR TITLE
[dotnet-port-fixes] Fix approval request checkpoint resume

### DIFF
--- a/workflow/agentworkflow/workflow.go
+++ b/workflow/agentworkflow/workflow.go
@@ -451,11 +451,15 @@ func requestDataContent(req *workflow.ExternalRequest) (message.Content, bool) {
 	if req == nil {
 		return nil, false
 	}
-	if data, ok := req.Data.As(reflect.TypeFor[*message.FunctionCallContent]()); ok {
-		return data.(*message.FunctionCallContent), true
+	if req.Data.TypeID.Match(reflect.TypeFor[*message.ToolApprovalRequestContent]()) {
+		if data, ok := req.Data.As(reflect.TypeFor[*message.ToolApprovalRequestContent]()); ok {
+			return data.(*message.ToolApprovalRequestContent), true
+		}
 	}
-	if data, ok := req.Data.As(reflect.TypeFor[*message.ToolApprovalRequestContent]()); ok {
-		return data.(*message.ToolApprovalRequestContent), true
+	if req.Data.TypeID.Match(reflect.TypeFor[*message.FunctionCallContent]()) {
+		if data, ok := req.Data.As(reflect.TypeFor[*message.FunctionCallContent]()); ok {
+			return data.(*message.FunctionCallContent), true
+		}
 	}
 	content, ok := req.Data.Any().(message.Content)
 	return content, ok

--- a/workflow/agentworkflow/workflow_test.go
+++ b/workflow/agentworkflow/workflow_test.go
@@ -250,6 +250,87 @@ func TestNew_SerializedSessionResumesFromCheckpoint(t *testing.T) {
 	}
 }
 
+func TestNew_SerializedSessionResumesApprovalRequestFromCheckpoint(t *testing.T) {
+	binding1 := approvalRequestExecutorBinding(t, "approval-persisted")
+	wf1, err := workflow.NewBuilder(binding1).WithOutputFrom(binding1).Build()
+	if err != nil {
+		t.Fatalf("Build first workflow: %v", err)
+	}
+	ag1, err := agentworkflow.NewAgent(wf1, agentworkflow.AgentConfig{
+		IncludeOutputsInResponse: true,
+	})
+	if err != nil {
+		t.Fatalf("New first agent: %v", err)
+	}
+	session, err := ag1.CreateSession(t.Context())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	first, err := ag1.RunText(t.Context(), "hi", agent.WithSession(session)).Collect()
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	var request *message.ToolApprovalRequestContent
+	for _, m := range first.Messages {
+		for _, c := range m.Contents {
+			if approval, ok := c.(*message.ToolApprovalRequestContent); ok {
+				request = approval
+			}
+		}
+	}
+	if request == nil {
+		t.Fatalf("expected approval request in first run, got %+v", first)
+	}
+	if request.RequestID != "approval-persisted_UserInput:req-1" {
+		t.Fatalf("first run request ID = %q, want %q", request.RequestID, "approval-persisted_UserInput:req-1")
+	}
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("Marshal session: %v", err)
+	}
+	if !strings.Contains(string(data), "checkpointStore") || !strings.Contains(string(data), "lastCheckpoint") {
+		t.Fatalf("serialized session did not include workflow checkpoint state: %s", string(data))
+	}
+	if !strings.Contains(string(data), "\"pending\"") || !strings.Contains(string(data), "\"RequestID\"") || !strings.Contains(string(data), "workflowSessionID") {
+		t.Fatalf("serialized session missing pending ExternalRequest/workflowSessionID: %s", string(data))
+	}
+
+	var restored agent.Session
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("Unmarshal session: %v", err)
+	}
+	binding2 := approvalRequestExecutorBinding(t, "approval-persisted")
+	wf2, err := workflow.NewBuilder(binding2).WithOutputFrom(binding2).Build()
+	if err != nil {
+		t.Fatalf("Build restored workflow: %v", err)
+	}
+	ag2, err := agentworkflow.NewAgent(wf2, agentworkflow.AgentConfig{
+		IncludeOutputsInResponse: true,
+	})
+	if err != nil {
+		t.Fatalf("New restored agent: %v", err)
+	}
+	resumeMsg := []*message.Message{{
+		Role:     message.RoleUser,
+		Contents: []message.Content{request.CreateResponse(true, "")},
+	}}
+	second, err := ag2.Run(t.Context(), resumeMsg, agent.WithSession(&restored)).Collect()
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	var finalText string
+	for _, m := range second.Messages {
+		if t := m.Contents.Text(); t == "approved" || t == "denied" {
+			finalText = t
+		}
+	}
+	if finalText != "approved" {
+		t.Fatalf("final text = %q, want %q", finalText, "approved")
+	}
+}
+
 func TestNew_StreamsUpdatesForUnhandledWorkflowEvents(t *testing.T) {
 	binding := echoExecutorBinding("echo")
 	wf, err := workflow.NewBuilder(binding).Build()


### PR DESCRIPTION
## Summary

Fix `workflow/agentworkflow` so checkpointed pending approval requests keep their concrete request kind after a session JSON round-trip. The host now identifies request content from the persisted `PortableValue.TypeID` before decoding, which prevents checkpointed `ToolApprovalRequestContent` payloads from being misread as empty function calls and restores the original inner `RequestID` when the approval response is routed back into the workflow.

This was selected as a narrow parity port from the upstream workflow session fix because Go already covered the function-call resume path but was missing the corresponding approval-request restore behavior and regression coverage.

Upstream commit: [`737042fc9372d5b934157638bc9171fd6840b138`](https://github.com/microsoft/agent-framework/commit/737042fc9372d5b934157638bc9171fd6840b138)

## Ported .NET PRs

- microsoft/agent-framework#7032 - fix workflow session external-request restoration after checkpoint/session round-trip

## Breaking Changes

No.

## Tests and Examples

- `go test ./workflow/...`
- `go test ./...`
- Added `TestNew_SerializedSessionResumesApprovalRequestFromCheckpoint` in `workflow/agentworkflow/workflow_test.go`
- No examples changed

## Notes

The existing Go regression already covered serialized-session resume for function-call requests. This PR narrows the parity port to the approval-request path that still lost the original inner request ID after restore.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/29977186136) · 1.1K AIC · ⌖ 48.7 AIC · ⊞ 21.7K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.60, model: gpt-5.4, id: 29977186136, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/29977186136 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #599