### PR TITLE
Surface Anthropic text citation annotations on the streaming path

### DIFF
--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -150,12 +150,26 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 			case anthropic.ContentBlockDeltaEvent:
 				contents = a.buildDelta(event.Delta.AsAny(), contents)
 			case anthropic.ContentBlockStopEvent:
-				if block, ok := accumulated.Content[event.Index].AsAny().(anthropic.ToolUseBlock); ok {
+				switch block := accumulated.Content[event.Index].AsAny().(type) {
+				case anthropic.ToolUseBlock:
 					contents = append(contents, &message.FunctionCallContent{
 						CallID:    block.ID,
 						Name:      block.Name,
 						Arguments: string(block.Input),
 					})
+				case anthropic.TextBlock:
+					// The text itself is streamed incrementally via TextDelta, but
+					// citations are only available on the accumulated block. Emit an
+					// annotations-only TextContent (empty Text avoids duplicating the
+					// streamed text) so streamed responses carry the same citation
+					// annotations as the non-streaming path.
+					if annotations := citationAnnotations(block.Citations); annotations != nil {
+						contents = append(contents, &message.TextContent{
+							ContentHeader: message.ContentHeader{
+								Annotations: annotations,
+							},
+						})
+					}
 				}
 			}
 
@@ -216,20 +230,10 @@ func toUsageDetailsDelta(usage anthropic.MessageDeltaUsage) message.UsageDetails
 func (a *client) buildBlock(index int, v any, contents []message.Content, functions map[int]*message.FunctionCallContent) []message.Content {
 	switch v := v.(type) {
 	case anthropic.TextBlock:
-		var annotations []message.Annotation
-		for _, citation := range v.Citations {
-			annotations = append(annotations, &message.CitationAnnotation{
-				FileID:            citation.FileID,
-				Snippet:           citation.CitedText,
-				Title:             cmp.Or(citation.DocumentTitle, citation.Title),
-				URL:               citation.URL,
-				RawRepresentation: citation,
-			})
-		}
 		contents = append(contents, &message.TextContent{
 			Text: v.Text,
 			ContentHeader: message.ContentHeader{
-				Annotations:       annotations,
+				Annotations:       citationAnnotations(v.Citations),
 				RawRepresentation: v,
 			},
 		})
@@ -256,6 +260,23 @@ func (a *client) buildBlock(index int, v any, contents []message.Content, functi
 		}
 	}
 	return contents
+}
+
+// citationAnnotations converts Anthropic text-block citations into
+// [message.CitationAnnotation] values. It returns nil when there are no
+// citations so callers can leave the annotations slice unset.
+func citationAnnotations(citations []anthropic.TextCitationUnion) []message.Annotation {
+	var annotations []message.Annotation
+	for _, citation := range citations {
+		annotations = append(annotations, &message.CitationAnnotation{
+			FileID:            citation.FileID,
+			Snippet:           citation.CitedText,
+			Title:             cmp.Or(citation.DocumentTitle, citation.Title),
+			URL:               citation.URL,
+			RawRepresentation: citation,
+		})
+	}
+	return annotations
 }
 
 func (a *client) buildDelta(v any, contents []message.Content) []message.Content {

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -166,7 +166,8 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 					if annotations := citationAnnotations(block.Citations); annotations != nil {
 						contents = append(contents, &message.TextContent{
 							ContentHeader: message.ContentHeader{
-								Annotations: annotations,
+								Annotations:       annotations,
+								RawRepresentation: block,
 							},
 						})
 					}

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -285,6 +285,70 @@ func TestTextCitationsBecomeAnnotations(t *testing.T) {
 	}
 }
 
+// TestStreamingTextCitationsBecomeAnnotations mirrors
+// TestTextCitationsBecomeAnnotations for the streaming path: citations are only
+// present on the accumulated text block, so the content_block_stop handler must
+// surface them as annotations. The streamed text arrives via text_delta and the
+// citation via a citations_delta.
+func TestStreamingTextCitationsBecomeAnnotations(t *testing.T) {
+	stream := "" +
+		"event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_stream_cite","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The answer cites the docs."}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location","cited_text":"source excerpt","encrypted_index":"enc_123","title":"Example Source","url":"https://example.com/source"}}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, stream)
+	}))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "cite something", agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var citation *message.CitationAnnotation
+	var streamedText string
+	for content := range resp.Contents() {
+		tc, ok := content.(*message.TextContent)
+		if !ok {
+			continue
+		}
+		streamedText += tc.Text
+		for _, ann := range tc.Annotations {
+			if c, ok := ann.(*message.CitationAnnotation); ok {
+				citation = c
+			}
+		}
+	}
+	if streamedText != "The answer cites the docs." {
+		t.Errorf("streamed text = %q, want %q", streamedText, "The answer cites the docs.")
+	}
+	if citation == nil {
+		t.Fatal("expected a citation annotation on the streamed text")
+	}
+	if citation.URL != "https://example.com/source" {
+		t.Errorf("citation URL = %q, want %q", citation.URL, "https://example.com/source")
+	}
+	if citation.Title != "Example Source" {
+		t.Errorf("citation Title = %q, want %q", citation.Title, "Example Source")
+	}
+	if citation.Snippet != "source excerpt" {
+		t.Errorf("citation Snippet = %q, want %q", citation.Snippet, "source excerpt")
+	}
+}
+
 // TestStructuredOutput_NonStreaming verifies that passing agent.WithStructuredOutput
 // with a typed struct causes the provider to:
 //  1. Send output_config.format with type "json_schema" and a schema derived


### PR DESCRIPTION
## What

The Anthropic streaming path dropped all text citation annotations. In `provider/anthropicprovider/agent.go` the streaming loop's `content_block_stop` handler only converted `tool_use` blocks, and `buildDelta` has no `citations_delta` case, so streamed text arrived without the `message.CitationAnnotation` values that the non-streaming `buildBlock` produces from `TextBlock.Citations`.

This change surfaces those citations on the streaming path. Citations are only populated on the *accumulated* text block (the SDK appends each `citations_delta` to `cb.Citations`), so when a text block stops we inspect `accumulated.Content[index]`; if it is a `TextBlock` with citations we emit an annotations-only `TextContent`. The text itself was already streamed via `text_delta`, so `Text` is left empty to avoid duplicating it. The citation-to-`CitationAnnotation` mapping is extracted into a small `citationAnnotations` helper shared by both paths.

## Why

Streamed and non-streamed responses should carry identical citation metadata. This matches the non-streaming behavior already covered by `TestTextCitationsBecomeAnnotations`, and aligns with the .NET and Python Agent Framework SDKs, where citation annotations are attached to streamed content updates as well as final messages.

## Tests

Adds `TestStreamingTextCitationsBecomeAnnotations` in the canonical `agent_test.go`, using the existing httptest SSE harness: `message_start` -> text `content_block_start` -> `text_delta` -> `citations_delta` (a `web_search_result_location` with cited_text/title/url) -> `content_block_stop` -> `message_delta`/`message_stop`. Run with `Stream(true)`, it asserts the collected `TextContent` carries a `*message.CitationAnnotation` with the expected Snippet/Title/URL. The test fails before the fix (no annotation) and passes after. `go build ./...`, `go vet ./provider/anthropicprovider/...`, and `go test ./provider/anthropicprovider/...` all pass.