### PR TITLE
Add godoc to CodeInterpreterToolCallContent and CodeInterpreterToolResultContent

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -858,6 +858,7 @@ func (t AlwaysApproveToolApprovalResponseContent) kind() contentKind {
 	return "alwaysApproveToolApprovalResponse"
 }
 
+// CodeInterpreterToolCallContent represents a call to a hosted code-interpreter tool, correlated by CallID, whose Inputs hold the submitted code or content.
 type CodeInterpreterToolCallContent struct {
 	ContentHeader
 
@@ -879,6 +880,7 @@ func (t *CodeInterpreterToolCallContent) MarshalJSON() ([]byte, error) {
 
 func (t CodeInterpreterToolCallContent) kind() contentKind { return "codeInterpreterToolCall" }
 
+// CodeInterpreterToolResultContent represents the result of a hosted code-interpreter tool call, correlated by CallID, whose Outputs hold the produced content.
 type CodeInterpreterToolResultContent struct {
 	ContentHeader
 


### PR DESCRIPTION
## What

Adds a one-line doc comment to `CodeInterpreterToolCallContent` and `CodeInterpreterToolResultContent` in `message/content.go`.

## Why

These are the only two exported content types in `content.go` without a preceding doc comment. Every other exported content type in the file is documented (TextContent, DataContent, ErrorContent, MCPServerToolCallContent, FunctionCallContent, FunctionResultContent, HostedFileContent, etc.), so `go doc` renders no description for just these two. The new comments mirror the neighboring `FunctionCallContent`/`FunctionResultContent` style and each begins with the type name per Go doc conventions.

This also aligns the Go SDK with the .NET and Python SDKs, where the equivalent CodeInterpreterToolCall / CodeInterpreterToolResult content is documented.

## How tested

Docs-only change. Verified with:
- `go doc message.CodeInterpreterToolCallContent` and the Result type now print the description.
- `go build ./...`, `go vet ./message/...`, and `go test ./message/...` all pass.