### PR TITLE
Add godoc to the exported hostedtool.MCPServer type

### DIFF
--- a/tool/hostedtool/hostedtool.go
+++ b/tool/hostedtool/hostedtool.go
@@ -65,15 +65,23 @@ func (t *CodeInterpreter) Description() string {
 	return ""
 }
 
+// MCPServer represents a hosted tool that can be specified to an AI service
+// to enable it to invoke tools exposed by a remote MCP server.
 type MCPServer struct {
 	AdditionalProperties map[string]any
 
-	ServerName        string
+	// ServerName is the name used to identify the MCP server.
+	ServerName string
+	// ServerDescription is an optional human-readable description of the MCP server.
 	ServerDescription string
-	ServerAddress     string
-	Authorization     string
-	AllowedTools      []string
-	Headers           map[string]string
+	// ServerAddress is the URL of the remote MCP server.
+	ServerAddress string
+	// Authorization is an optional authorization token used when connecting to the MCP server.
+	Authorization string
+	// AllowedTools optionally restricts the set of tools that may be invoked on the MCP server.
+	AllowedTools []string
+	// Headers contains optional HTTP headers to send when connecting to the MCP server.
+	Headers map[string]string
 }
 
 func (t *MCPServer) Name() string {

--- a/tool/hostedtool/hostedtool.go
+++ b/tool/hostedtool/hostedtool.go
@@ -68,6 +68,8 @@ func (t *CodeInterpreter) Description() string {
 // MCPServer represents a hosted tool that can be specified to an AI service
 // to enable it to invoke tools exposed by a remote MCP server.
 type MCPServer struct {
+	// AdditionalProperties holds provider-specific properties that are not
+	// represented by the other fields.
 	AdditionalProperties map[string]any
 
 	// ServerName is the name used to identify the MCP server.


### PR DESCRIPTION
## What

Add a doc comment to the exported `hostedtool.MCPServer` type, plus short comments on each of its fields.

## Why

`MCPServer` is the only marker type in `tool/hostedtool` without a doc comment. Its three siblings — `WebSearch`, `FileSearch`, and `CodeInterpreter` — each carry a type comment, so `go doc tool/hostedtool MCPServer` previously rendered the type with no description. The new comment is written in the siblings' voice and mirrors how the .NET/Python SDKs describe the hosted MCP tool: a marker that lets an AI service invoke tools exposed by a remote MCP server. This restores consistent, complete godoc across the package.

## How tested

Docs-only change. Verified with:
- `go build ./...`
- `go vet ./tool/hostedtool/...`
- `go test ./tool/hostedtool/...`
- `go doc ./tool/hostedtool MCPServer` now shows the new description sentence and field comments.