### PR TITLE
Add a sub-workflow request-interception example where a parent answers a nested workflow request locally

### DIFF
--- a/cmd/verifyexamples/examples.go
+++ b/cmd/verifyexamples/examples.go
@@ -843,4 +843,14 @@ var workflowExamples = []ExampleDefinition{
 			"Order completed:",
 		},
 	},
+	{
+		Name:            "03_workflows_subworkflows_request_interception",
+		ProjectPath:     "examples/03-workflows/subworkflows/request_interception",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Sub-Workflow Request Interception",
+			"Path: AUTO-APPROVED",
+			"Path: ESCALATED",
+		},
+	},
 }

--- a/examples/03-workflows/subworkflows/request_interception/main.go
+++ b/examples/03-workflows/subworkflows/request_interception/main.go
@@ -155,7 +155,11 @@ func expenseSubmitter(id string, port workflow.RequestPort) workflow.ExecutorBin
 						return nil, ctx.PostRequest(req)
 					}).
 					AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-						approved, _ := workflow.PortableValueAs[bool](msg.(*workflow.ExternalResponse).Data)
+						data := msg.(*workflow.ExternalResponse).Data
+						approved, ok := workflow.PortableValueAs[bool](data)
+						if !ok {
+							return nil, fmt.Errorf("expenseSubmitter: expected bool approval response, got %v", data)
+						}
 						return nil, ctx.YieldOutput(approved)
 					})
 				return pb, nil

--- a/examples/03-workflows/subworkflows/request_interception/main.go
+++ b/examples/03-workflows/subworkflows/request_interception/main.go
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+var _ = demo.NewLogger(
+	"Sub-Workflow Request Interception",
+	"This sample lets a parent workflow answer a nested subworkflow's request locally, only escalating large amounts to the user.",
+)
+
+// autoApproveThreshold is the largest expense the parent will approve on its own
+// without surfacing a top-level request to the user.
+const autoApproveThreshold = 1000
+
+// ExpenseReport is the payload a nested approval subworkflow asks about.
+type ExpenseReport struct {
+	ID     string
+	Amount int
+}
+
+func main() {
+	// A small expense is answered by the parent's interceptor: the child's
+	// request never becomes a top-level RequestInfoEvent.
+	runScenario(ExpenseReport{ID: "EXP-1", Amount: 250})
+
+	// A large expense is forwarded to a qualified request port, surfacing as a
+	// top-level RequestInfoEvent that a human answers via SendResponse.
+	runScenario(ExpenseReport{ID: "EXP-2", Amount: 5000})
+}
+
+func runScenario(report ExpenseReport) {
+	wf := buildWorkflow()
+
+	ctx := context.Background()
+	demo.Assistantf("Submitting %s for $%d (parent auto-approves <= $%d)", report.ID, report.Amount, autoApproveThreshold)
+
+	run, err := inproc.Default.RunStreaming(ctx, wf, report)
+	if err != nil {
+		demo.Panic(err)
+	}
+	defer func() { _ = run.Close(ctx) }()
+
+	escalated := false
+	for evt, err := range run.WatchStream(ctx) {
+		if err != nil {
+			demo.Panic(err)
+		}
+		switch e := evt.(type) {
+		case workflow.RequestInfoEvent:
+			// Only large expenses reach the user; auto-approved ones are
+			// answered inside the parent before they ever get here.
+			escalated = true
+			demo.Assistantf("  [User] Approval requested on port %q; approving", e.Request.PortInfo.PortID)
+			response, err := e.Request.CreateResponse(true)
+			if err != nil {
+				demo.Panic(err)
+			}
+			if err := run.SendResponse(ctx, response); err != nil {
+				demo.Panic(err)
+			}
+		case workflow.OutputEvent:
+			demo.Assistantf("  Child decision for %s: approved=%v", report.ID, e.Output)
+		case workflow.ErrorEvent:
+			demo.Panic(e.Error)
+		case workflow.ExecutorFailedEvent:
+			demo.Panicf("executor %q failed: %v", e.ExecutorID, e.Error)
+		}
+	}
+
+	if escalated {
+		demo.Assistantf("Path: ESCALATED - %s produced a top-level request answered by the user\n", report.ID)
+	} else {
+		demo.Assistantf("Path: AUTO-APPROVED - %s answered locally by the parent, no top-level request\n", report.ID)
+	}
+}
+
+// buildWorkflow constructs a fresh parent workflow around a nested approval
+// subworkflow. Everything is rebuilt per run because binding a subworkflow takes
+// ownership of it, so the child cannot be shared across parent builds.
+func buildWorkflow() *workflow.Workflow {
+	approvePort := workflow.RequestPort{
+		ID:       "approve",
+		Request:  reflect.TypeFor[ExpenseReport](),
+		Response: reflect.TypeFor[bool](),
+	}
+	child := buildChild(approvePort)
+
+	const hostID = "ApprovalSubworkflow"
+	host := inproc.BindSubworkflowAsExecutor(child, hostID)
+
+	// A nested request port is surfaced to the parent under a qualified ID of the
+	// form "<subworkflowID>.<portID>", so the escalation port must match it.
+	escalationPort := workflow.RequestPort{
+		ID:       hostID + "." + approvePort.ID,
+		Request:  approvePort.Request,
+		Response: approvePort.Response,
+	}
+	escalation := escalationPort.Bind()
+	interceptor := approvalInterceptor("PolicyGate", hostID, escalationPort.ID)
+
+	// Wiring:
+	//   host -> interceptor        (child's requests reach the parent's policy gate)
+	//   interceptor -> host        (locally-created responses go straight back)
+	//   interceptor -> escalation  (large requests are forwarded to a top-level port)
+	//   escalation -> host         (the user's answer flows back to the child)
+	parent, err := workflow.NewBuilder(host).
+		AddDirectEdge(host, interceptor, false, externalRequestOnly).
+		AddDirectEdge(interceptor, host, false, externalResponseOnly).
+		AddDirectEdge(interceptor, escalation, false, externalRequestOnly).
+		AddDirectEdge(escalation, host, false, externalResponseOnly).
+		WithOutputFrom(host).
+		Build()
+	if err != nil {
+		demo.Panic(err)
+	}
+	return parent
+}
+
+func buildChild(port workflow.RequestPort) *workflow.Workflow {
+	submitter := expenseSubmitter("SubmitExpense", port)
+	child, err := workflow.NewBuilder(submitter).
+		WithOutputFrom(submitter).
+		Build()
+	if err != nil {
+		demo.Panic(err)
+	}
+	return child
+}
+
+// expenseSubmitter is the child's start executor. It raises an approval request
+// via ctx.PostRequest and yields the boolean decision once the response arrives.
+func expenseSubmitter(id string, port workflow.RequestPort) workflow.ExecutorBinding {
+	return workflow.BindNewExecutorFunc(id, func(_ string, executorID string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: executorID,
+			DisableAutoSendMessageHandlerResultObject: true,
+			DisableAutoYieldOutputHandlerResultObject: true,
+			ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				pb.YieldsOutputType(reflect.TypeFor[bool]())
+				pb.RouteBuilder.
+					AddHandlerRaw(reflect.TypeFor[ExpenseReport](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+						req, err := workflow.NewExternalRequest("", port, msg.(ExpenseReport))
+						if err != nil {
+							return nil, err
+						}
+						return nil, ctx.PostRequest(req)
+					}).
+					AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+						approved, _ := workflow.PortableValueAs[bool](msg.(*workflow.ExternalResponse).Data)
+						return nil, ctx.YieldOutput(approved)
+					})
+				return pb, nil
+			},
+		}, nil
+	})
+}
+
+// approvalInterceptor sits between the subworkflow host and the outside world.
+// Small expenses are answered in-process; large ones are forwarded to a
+// top-level request port so the user can decide.
+func approvalInterceptor(id, hostID, escalationPortID string) workflow.ExecutorBinding {
+	return workflow.BindNewExecutorFunc(id, func(_ string, executorID string) (*workflow.Executor, error) {
+		return &workflow.Executor{
+			ID: executorID,
+			DisableAutoSendMessageHandlerResultObject: true,
+			ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+				pb.SendsMessageType(
+					reflect.TypeFor[*workflow.ExternalResponse](),
+					reflect.TypeFor[*workflow.ExternalRequest](),
+				)
+				// A catch-all keeps this edge type-compatible with the host, which
+				// declares that it sends the child's output type. The
+				// externalRequestOnly edge condition guarantees only forwarded
+				// requests actually reach this handler at runtime.
+				pb.RouteBuilder.AddCatchAll(func(ctx *workflow.Context, msg workflow.PortableValue) (any, error) {
+					req, ok := workflow.PortableValueAs[*workflow.ExternalRequest](msg)
+					if !ok {
+						return nil, nil
+					}
+					report, ok := workflow.PortableValueAs[ExpenseReport](req.Data)
+					if !ok {
+						return nil, fmt.Errorf("interceptor: unexpected request payload %v", req.PortInfo.RequestType)
+					}
+					if report.Amount <= autoApproveThreshold {
+						demo.Assistantf("  [PolicyGate] $%d <= $%d: approving %s locally", report.Amount, autoApproveThreshold, report.ID)
+						response, err := req.CreateResponse(true)
+						if err != nil {
+							return nil, err
+						}
+						return nil, ctx.SendMessage(hostID, response)
+					}
+					demo.Assistantf("  [PolicyGate] $%d > $%d: escalating %s to the user", report.Amount, autoApproveThreshold, report.ID)
+					return nil, ctx.SendMessage(escalationPortID, req)
+				})
+				return pb, nil
+			},
+		}, nil
+	})
+}
+
+func externalRequestOnly(msg any) bool {
+	_, ok := msg.(*workflow.ExternalRequest)
+	return ok
+}
+
+func externalResponseOnly(msg any) bool {
+	_, ok := msg.(*workflow.ExternalResponse)
+	return ok
+}

--- a/workflow/inproc/subworkflow_test.go
+++ b/workflow/inproc/subworkflow_test.go
@@ -169,7 +169,11 @@ func TestSubworkflowBinding_ParentInterceptsChildRequestLocally(t *testing.T) {
 							return nil, ctx.PostRequest(req)
 						}).
 						AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-							approved, _ := workflow.PortableValueAs[bool](msg.(*workflow.ExternalResponse).Data)
+							data := msg.(*workflow.ExternalResponse).Data
+							approved, ok := workflow.PortableValueAs[bool](data)
+							if !ok {
+								return nil, fmt.Errorf("approve response: expected bool, got %v", data)
+							}
 							return nil, ctx.YieldOutput(approved)
 						})
 					return pb, nil
@@ -202,7 +206,10 @@ func TestSubworkflowBinding_ParentInterceptsChildRequestLocally(t *testing.T) {
 						if !ok {
 							return nil, nil
 						}
-						amount, _ := workflow.PortableValueAs[int](req.Data)
+						amount, ok := workflow.PortableValueAs[int](req.Data)
+						if !ok {
+							return nil, fmt.Errorf("gate request: expected int, got %v", req.Data)
+						}
 						if amount <= threshold {
 							response, err := req.CreateResponse(true)
 							if err != nil {

--- a/workflow/inproc/subworkflow_test.go
+++ b/workflow/inproc/subworkflow_test.go
@@ -140,6 +140,133 @@ func TestSubworkflowBinding_QualifiedRequestPortRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSubworkflowBinding_ParentInterceptsChildRequestLocally exercises a parent
+// executor answering a nested subworkflow's request in-process. Small requests
+// are answered locally and never surface as a top-level RequestInfoEvent, while
+// large ones are forwarded to a qualified request port and answered via Resume.
+func TestSubworkflowBinding_ParentInterceptsChildRequestLocally(t *testing.T) {
+	const threshold = 1000
+	buildInterceptionWorkflow := func(t *testing.T) *workflow.Workflow {
+		t.Helper()
+		approvePort := workflow.RequestPort{
+			ID:       "approve",
+			Request:  reflect.TypeFor[int](),
+			Response: reflect.TypeFor[bool](),
+		}
+		childStart := workflow.BindNewExecutorFunc("submit", func(_ string, executorID string) (*workflow.Executor, error) {
+			return &workflow.Executor{
+				ID: executorID,
+				DisableAutoSendMessageHandlerResultObject: true,
+				DisableAutoYieldOutputHandlerResultObject: true,
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					pb.YieldsOutputType(reflect.TypeFor[bool]())
+					pb.RouteBuilder.
+						AddHandlerRaw(reflect.TypeFor[int](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+							req, err := workflow.NewExternalRequest("", approvePort, msg.(int))
+							if err != nil {
+								return nil, err
+							}
+							return nil, ctx.PostRequest(req)
+						}).
+						AddHandlerRaw(reflect.TypeFor[*workflow.ExternalResponse](), nil, func(ctx *workflow.Context, msg any) (any, error) {
+							approved, _ := workflow.PortableValueAs[bool](msg.(*workflow.ExternalResponse).Data)
+							return nil, ctx.YieldOutput(approved)
+						})
+					return pb, nil
+				},
+			}, nil
+		})
+		child, err := workflow.NewBuilder(childStart).
+			WithOutputFrom(childStart).
+			Build()
+		if err != nil {
+			t.Fatalf("Build child: %v", err)
+		}
+
+		const hostID = "approver"
+		host := inproc.BindSubworkflowAsExecutor(child, hostID)
+		escalationPort := workflow.RequestPort{
+			ID:       hostID + "." + approvePort.ID,
+			Request:  approvePort.Request,
+			Response: approvePort.Response,
+		}
+		escalation := escalationPort.Bind()
+		interceptor := workflow.BindNewExecutorFunc("gate", func(_ string, executorID string) (*workflow.Executor, error) {
+			return &workflow.Executor{
+				ID: executorID,
+				DisableAutoSendMessageHandlerResultObject: true,
+				ConfigureProtocol: func(pb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+					pb.SendsMessageType(reflect.TypeFor[*workflow.ExternalResponse](), reflect.TypeFor[*workflow.ExternalRequest]())
+					pb.RouteBuilder.AddCatchAll(func(ctx *workflow.Context, msg workflow.PortableValue) (any, error) {
+						req, ok := workflow.PortableValueAs[*workflow.ExternalRequest](msg)
+						if !ok {
+							return nil, nil
+						}
+						amount, _ := workflow.PortableValueAs[int](req.Data)
+						if amount <= threshold {
+							response, err := req.CreateResponse(true)
+							if err != nil {
+								return nil, err
+							}
+							return nil, ctx.SendMessage(hostID, response)
+						}
+						return nil, ctx.SendMessage(escalationPort.ID, req)
+					})
+					return pb, nil
+				},
+			}, nil
+		})
+		parent, err := workflow.NewBuilder(host).
+			AddDirectEdge(host, interceptor, false, externalRequestOnly).
+			AddDirectEdge(interceptor, host, false, externalResponseOnly).
+			AddDirectEdge(interceptor, escalation, false, externalRequestOnly).
+			AddDirectEdge(escalation, host, false, externalResponseOnly).
+			WithOutputFrom(host).
+			Build()
+		if err != nil {
+			t.Fatalf("Build parent: %v", err)
+		}
+		return parent
+	}
+
+	t.Run("auto_approved_locally", func(t *testing.T) {
+		run, err := inproc.Lockstep.Run(t.Context(), buildInterceptionWorkflow(t), 250)
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		events := slicesCollect(run.OutgoingEvents())
+		if requests := requestsFromEvents(events); len(requests) != 0 {
+			t.Fatalf("top-level request count = %d, want 0 (parent should answer locally)", len(requests))
+		}
+		outputs := outputEvents(events)
+		if len(outputs) != 1 || outputs[0].Output != true {
+			t.Fatalf("outputs = %#v, want one true output", outputs)
+		}
+	})
+
+	t.Run("escalated_to_top_level", func(t *testing.T) {
+		run, err := inproc.Lockstep.Run(t.Context(), buildInterceptionWorkflow(t), 5000)
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		request := firstRequest(t, run.OutgoingEvents())
+		if request.PortInfo.PortID != "approver.approve" {
+			t.Fatalf("request port = %q, want approver.approve", request.PortInfo.PortID)
+		}
+		response, err := request.CreateResponse(true)
+		if err != nil {
+			t.Fatalf("CreateResponse: %v", err)
+		}
+		if _, err := run.Resume(t.Context(), response); err != nil {
+			t.Fatalf("Resume: %v", err)
+		}
+		outputs := outputEvents(slicesCollect(run.NewEvents()))
+		if len(outputs) != 1 || outputs[0].Output != true {
+			t.Fatalf("outputs = %#v, want one true output", outputs)
+		}
+	})
+}
+
 func TestCheckpoint_Resume_SubworkflowWithPendingRequests_RepublishesQualifiedRequestInfoEvents(t *testing.T) {
 	for _, env := range checkpointTestEnvironments() {
 		t.Run(env.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Adds `examples/03-workflows/subworkflows/request_interception/main.go`, a deterministic, offline example showing a **parent workflow intercepting and answering a nested subworkflow's request locally**.

A child workflow's start executor raises an approval request via `ctx.PostRequest(NewExternalRequest(...))` and yields the boolean decision once the `*ExternalResponse` arrives. The child is bound with `inproc.BindSubworkflowAsExecutor`. In the parent, the host's nested `RequestInfoEvent` is routed to a policy-gate executor over an `externalRequestOnly` direct edge:

- **Auto-approved path** — for small amounts the gate calls `req.CreateResponse(true)` and sends the response straight back to the host over an `externalResponseOnly` edge, so the request is answered in-process and never becomes a top-level `RequestInfoEvent`.
- **Escalated path** — for large amounts the gate forwards the request to a qualified `RequestPort` binding (`"<subworkflowID>.<portID>"`), surfacing it as a top-level `RequestInfoEvent` that a human answers via `SendResponse`.

The example prints both paths.

## Why

`workflow/inproc/subworkflow.go` already forwards a nested `RequestInfoEvent`'s `*ExternalRequest` into the parent graph and accepts an `*ExternalResponse` back, and `subworkflow_test.go` exercises the qualified request-port round-trip. However, nothing demonstrated a **parent executor answering the child's request locally** rather than always bubbling it to the top level — a first-class use of the interception primitives. This mirrors the .NET/Python `RequestInfoExecutor` interception samples, where a host can short-circuit a nested request without escalating, keeping cross-SDK parity for the subworkflow request-port feature.

## How it is tested

- New black-box test `TestSubworkflowBinding_ParentInterceptsChildRequestLocally` in the canonical `workflow/inproc/subworkflow_test.go`, mirroring the example wiring. It asserts the auto-approved amount produces **no** top-level `RequestInfoEvent` (output `true`), while the escalated amount produces exactly one, answered via `Resume`.
- Registered in `cmd/verifyexamples` with deterministic `MustContain` checks for both the auto-approved and escalated paths.
- `go build ./...`, `go vet`, and `go test ./workflow/inproc/ ./cmd/verifyexamples/` all pass; `go run` of the example prints both paths.