### PR TITLE
Add godoc to functool.New and functool.MustNew

### DIFF
--- a/tool/functool/func.go
+++ b/tool/functool/func.go
@@ -35,6 +35,9 @@ type Handler func(ctx context.Context, args string) (any, error)
 //     Invalid input is rejected before getting to the handler.
 type HandlerFor[In, Out any] func(context.Context, In) (Out, error)
 
+// MustNew is like [New] but panics if schema construction fails. It is intended
+// for package-level initialization where a construction failure is a programming
+// error that should surface immediately.
 func MustNew[In, Out any](cfg Config, h HandlerFor[In, Out]) tool.FuncTool {
 	t, err := New(cfg, h)
 	if err != nil {
@@ -43,6 +46,10 @@ func MustNew[In, Out any](cfg Config, h HandlerFor[In, Out]) tool.FuncTool {
 	return t
 }
 
+// New builds a [tool.FuncTool] from cfg and the typed handler h. It derives the
+// JSON input schema from In and the output schema from Out, wrapping non-struct
+// inputs and validating arguments before invoking h. It returns an error if
+// either schema cannot be constructed.
 func New[In, Out any](cfg Config, h HandlerFor[In, Out]) (tool.FuncTool, error) {
 	t := funcTool{
 		cfg: cfg,


### PR DESCRIPTION
## What

Add Go-convention doc comments to the two exported constructors in `tool/functool/func.go`: `New` and `MustNew`. Each comment begins with the symbol name per Go doc conventions.

- `New`: documents that it builds a `tool.FuncTool` from the config and typed handler, deriving the JSON input schema from `In` and the output schema from `Out`, wrapping non-struct inputs and validating arguments before invoking the handler, returning an error if either schema cannot be constructed.
- `MustNew`: documents that it is the panic-on-error wrapper around `New`, intended for package-level initialization.

## Why

These were the only undocumented exported symbols in the file — `Config`, `Handler`, and `HandlerFor` are all already documented. `New` is the primary entry point for constructing function tools and `MustNew` its convenience wrapper, so they are the most important symbols to document. Completing the godoc here brings the package's public surface in line with the documentation coverage the .NET/Python function-tool factories provide for their equivalent constructors, aiding cross-SDK discoverability.

## How tested

Docs-only change, no behavior modified. Verified with `go build ./...`, `go vet ./tool/functool/...`, and `go test ./tool/functool/...` — all green.