### PR TITLE
Add godoc for workflow.Builder WithName, WithDescription, and WithOutputFrom

### DIFF
--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -48,6 +48,8 @@ func NewBuilder(start ExecutorBinding) *Builder {
 	return bld
 }
 
+// WithName sets the workflow's human-readable name. It is a no-op if the
+// builder already holds an error.
 func (wb *Builder) WithName(name string) *Builder {
 	if wb.err != nil {
 		return wb
@@ -56,6 +58,8 @@ func (wb *Builder) WithName(name string) *Builder {
 	return wb
 }
 
+// WithDescription sets the workflow's human-readable description. It is a
+// no-op if the builder already holds an error.
 func (wb *Builder) WithDescription(description string) *Builder {
 	if wb.err != nil {
 		return wb
@@ -73,6 +77,9 @@ func (wb *Builder) WithTelemetry(tracer workflowobservability.Tracer, options Te
 	return wb
 }
 
+// WithOutputFrom registers the given bindings as terminal (untagged) workflow
+// output sources. It mirrors [Builder.WithIntermediateOutputFrom] but without
+// the [OutputTagIntermediate] tag.
 func (wb *Builder) WithOutputFrom(bindings ...ExecutorBinding) *Builder {
 	return wb.withOutputFrom(nil, bindings...)
 }


### PR DESCRIPTION
## What

Adds doc comments to three exported `workflow.Builder` methods that were missing them:

- `WithName` — sets the workflow's human-readable name (no-op if the builder already holds an error).
- `WithDescription` — sets the workflow's human-readable description (no-op if the builder already holds an error).
- `WithOutputFrom` — registers the given bindings as terminal (untagged) workflow output sources, mirroring `WithIntermediateOutputFrom` but without the `OutputTagIntermediate` tag.

## Why

Their immediate siblings `WithTelemetry` and `WithIntermediateOutputFrom` are already documented, and prior PR #661 documented `Builder`/`NewBuilder`/`Event`/`RequestHaltEvent` but left these three undocumented. Filling the gap gives the builder's fluent API complete, consistent godoc — matching the naming/description surface exposed by the corresponding `WorkflowBuilder` configuration in the .NET and Python SDKs, where name/description and terminal-vs-intermediate output are documented concepts. Each comment starts with the method name per Go doc convention.

## Testing

Docs-only change. `go build ./...`, `go vet ./workflow/...`, and `go test ./workflow/...` all pass, and `go doc ./workflow Builder` now lists all three methods.