### PR TITLE
Capture Gemini thought_signature carried on function-call response parts for multi-turn tool round-trips

### DIFF
--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -423,6 +423,20 @@ func buildResponsePart(part *genai.Part, contents []message.Content) ([]message.
 		if err != nil {
 			return nil, fmt.Errorf("geminiprovider: failed to marshal function call arguments: %w", err)
 		}
+		// Gemini 3 attaches the opaque thought_signature to the same part that
+		// carries the function call (Thought is false, Text is empty). Capture it
+		// as a preceding TextReasoningContent so buildRequestParts can replay it
+		// on the next turn, mirroring the Python reference which emits a
+		// text-reasoning content (protected_data=base64(thought_signature))
+		// immediately before the function call.
+		if len(part.ThoughtSignature) > 0 {
+			contents = append(contents, &message.TextReasoningContent{
+				ProtectedData: base64.StdEncoding.EncodeToString(part.ThoughtSignature),
+				ContentHeader: message.ContentHeader{
+					RawRepresentation: part,
+				},
+			})
+		}
 		contents = append(contents, &message.FunctionCallContent{
 			CallID:    part.FunctionCall.ID,
 			Name:      part.FunctionCall.Name,

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -874,6 +874,77 @@ func TestResponseWithThoughtSignature(t *testing.T) {
 	}
 }
 
+// TestResponseWithFunctionCallThoughtSignature verifies that a thought signature
+// carried on the same part as a function call (Gemini 3 behavior) is captured as
+// a TextReasoningContent emitted immediately before the FunctionCallContent, so
+// it can be replayed on the next turn.
+func TestResponseWithFunctionCallThoughtSignature(t *testing.T) {
+	const wantProtectedData = "dGhpbmtpbmcgc2lnbmF0dXJlIGRhdGE="
+	resp := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"role": "model",
+					"parts": []any{
+						map[string]any{
+							"thoughtSignature": wantProtectedData,
+							"functionCall": map[string]any{
+								"id":   "call-1",
+								"name": "get_weather",
+								"args": map[string]any{"city": "Paris"},
+							},
+						},
+					},
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     8,
+			"candidatesTokenCount": 15,
+			"totalTokenCount":      23,
+		},
+	}
+	respBody, _ := json.Marshal(resp)
+
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "application/json", string(respBody)))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+
+	result, err := a.RunText(t.Context(), "What's the weather in Paris?").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var contents []message.Content
+	for _, msg := range result.Messages {
+		contents = append(contents, msg.Contents...)
+	}
+
+	reasoningIdx, callIdx := -1, -1
+	for i, c := range contents {
+		switch cc := c.(type) {
+		case *message.TextReasoningContent:
+			reasoningIdx = i
+			if cc.ProtectedData != wantProtectedData {
+				t.Errorf("reasoning ProtectedData = %q, want %q", cc.ProtectedData, wantProtectedData)
+			}
+		case *message.FunctionCallContent:
+			callIdx = i
+		}
+	}
+	if reasoningIdx == -1 {
+		t.Fatal("expected TextReasoningContent capturing the function-call thought signature")
+	}
+	if callIdx == -1 {
+		t.Fatal("expected FunctionCallContent in response")
+	}
+	if reasoningIdx >= callIdx {
+		t.Errorf("TextReasoningContent (index %d) must precede FunctionCallContent (index %d)", reasoningIdx, callIdx)
+	}
+}
+
 // TestInvalidReasoningProtectedData verifies that invalid base64 in
 // TextReasoningContent.ProtectedData returns a clear error.
 func TestInvalidReasoningProtectedData(t *testing.T) {


### PR DESCRIPTION
## What

In `provider/geminiprovider/agent.go`, `buildResponsePart` only read `part.ThoughtSignature` inside the `if part.Thought` branch. Gemini 3 attaches the opaque `thought_signature` to the *same* part that carries the `function_call` (`Thought` is false, `Text` is empty, `ThoughtSignature` is set). For such a part the `Thought` branch is skipped, the `else if part.Text != ""` branch is skipped, and the `FunctionCall` branch fired without capturing the signature, so it was silently dropped. Because it was never parsed into `ProtectedData`, the replay path in `buildRequestParts` (which decodes `TextReasoningContent.ProtectedData` back into `part.ThoughtSignature`) could never send it back, breaking multi-turn tool round-trips.

The fix emits a `TextReasoningContent{ProtectedData: base64(part.ThoughtSignature)}` immediately before the `FunctionCallContent` whenever a function-call part carries a signature.

## Why (parity)

This mirrors the Python reference, which emits a text-reasoning content (`protected_data=base64(part.thought_signature)`) immediately preceding the function call. The existing replay path already decodes `ProtectedData` back into `part.ThoughtSignature`, so the round-trip closes with no other change.

## Testing

Added `TestResponseWithFunctionCallThoughtSignature` in the canonical `agent_test.go`: it feeds a response whose single part has `functionCall` set (no `thought`, no `text`) plus a `thoughtSignature`, and asserts the returned contents include a `*message.TextReasoningContent` whose `ProtectedData` equals the base64 signature, ordered before the `*message.FunctionCallContent`. The test fails before the fix and passes after. `go build ./...`, `go vet ./provider/geminiprovider/...`, and `go test ./provider/geminiprovider/...` all pass.