### PR TITLE
Add godoc to the exported workflow.ErrInvalidInputType sentinel error

### DIFF
--- a/workflow/errors.go
+++ b/workflow/errors.go
@@ -6,4 +6,7 @@ import (
 	"errors"
 )
 
+// ErrInvalidInputType is returned (wrapped) when a message enqueued as
+// workflow input has a type that the workflow's start executor does not
+// accept. Callers can test for it with errors.Is.
 var ErrInvalidInputType = errors.New("invalid workflow input type")


### PR DESCRIPTION
## What

Add a doc comment to `workflow.ErrInvalidInputType`, currently the only exported symbol in `workflow/errors.go` and the only one lacking godoc. The comment documents that the error is returned (wrapped with `%w`) when a message enqueued as workflow input has a type the workflow's start executor does not accept, and that callers can match it with `errors.Is`.

## Why

`ErrInvalidInputType` is a sentinel meant to be matched: it is wrapped in `workflow/inproc/runner.go` and `workflow/internal/execution/run.go`, and `errors.Is(err, workflow.ErrInvalidInputType)` is already exercised in `workflow/inproc/events_test.go`. Without godoc, callers get no signal that this is a matchable sentinel or when it fires. Documenting exported sentinel errors matches the conventions used across the .NET and Python SDKs (and idiomatic Go), where such sentinels carry an explicit contract for consumers.

## Testing

Docs-only change. `go build ./...`, `go vet ./workflow/...`, and `go test ./workflow/...` all pass; the existing `errors.Is` test is unchanged and still passes.