### PR TITLE
Use the short error.type name in workflow observability to match other spans and Python

### DIFF
--- a/workflow/internal/observability/observability.go
+++ b/workflow/internal/observability/observability.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
+	"github.com/microsoft/agent-framework-go/internal/otelx"
 	workflowobservability "github.com/microsoft/agent-framework-go/workflow/observability"
 )
 
@@ -153,7 +153,7 @@ func (s *Activity) CaptureError(err error) {
 	}
 	s.span.RecordError(err)
 	s.span.SetAttributes(
-		workflowobservability.StringAttribute(TagErrorType, reflect.TypeOf(err).String()),
+		workflowobservability.StringAttribute(TagErrorType, otelx.ErrorTypeName(err)),
 		workflowobservability.StringAttribute(TagErrorMessage, err.Error()),
 	)
 	s.span.SetError(err.Error())
@@ -285,7 +285,7 @@ func BuildErrorAttributes(err error) []workflowobservability.Attribute {
 	}
 	return []workflowobservability.Attribute{
 		workflowobservability.StringAttribute(TagBuildErrorMessage, err.Error()),
-		workflowobservability.StringAttribute(TagBuildErrorType, reflect.TypeOf(err).String()),
+		workflowobservability.StringAttribute(TagBuildErrorType, otelx.ErrorTypeName(err)),
 	}
 }
 
@@ -294,7 +294,7 @@ func ErrorAttributes(err error) []workflowobservability.Attribute {
 		return nil
 	}
 	return []workflowobservability.Attribute{
-		workflowobservability.StringAttribute(TagErrorType, reflect.TypeOf(err).String()),
+		workflowobservability.StringAttribute(TagErrorType, otelx.ErrorTypeName(err)),
 		workflowobservability.StringAttribute(TagErrorMessage, err.Error()),
 	}
 }

--- a/workflow/internal/observability/observability_test.go
+++ b/workflow/internal/observability/observability_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package observability_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	observability "github.com/microsoft/agent-framework-go/workflow/internal/observability"
+	workflowobservability "github.com/microsoft/agent-framework-go/workflow/observability"
+)
+
+func attributeValue(t *testing.T, attrs []workflowobservability.Attribute, key string) string {
+	t.Helper()
+	for _, attr := range attrs {
+		if attr.Key == key {
+			value, ok := attr.Value.(string)
+			if !ok {
+				t.Fatalf("attribute %q value is %T, want string", key, attr.Value)
+			}
+			return value
+		}
+	}
+	t.Fatalf("attribute %q not found", key)
+	return ""
+}
+
+func TestErrorAttributesShortTypeName(t *testing.T) {
+	attrs := observability.ErrorAttributes(errors.New("boom"))
+	if got := attributeValue(t, attrs, observability.TagErrorType); got != "errorString" {
+		t.Errorf("error.type = %q, want %q", got, "errorString")
+	}
+
+	wrapped := fmt.Errorf("ctx: %w", errors.New("boom"))
+	attrs = observability.ErrorAttributes(wrapped)
+	if got := attributeValue(t, attrs, observability.TagErrorType); got != "wrapError" {
+		t.Errorf("wrapped error.type = %q, want %q", got, "wrapError")
+	}
+}
+
+func TestBuildErrorAttributesShortTypeName(t *testing.T) {
+	attrs := observability.BuildErrorAttributes(errors.New("boom"))
+	if got := attributeValue(t, attrs, observability.TagBuildErrorType); got != "errorString" {
+		t.Errorf("build.error.type = %q, want %q", got, "errorString")
+	}
+
+	wrapped := fmt.Errorf("ctx: %w", errors.New("boom"))
+	attrs = observability.BuildErrorAttributes(wrapped)
+	if got := attributeValue(t, attrs, observability.TagBuildErrorType); got != "wrapError" {
+		t.Errorf("wrapped build.error.type = %q, want %q", got, "wrapError")
+	}
+}
+
+type fakeSpan struct {
+	attrs []workflowobservability.Attribute
+}
+
+func (s *fakeSpan) End()                                                {}
+func (s *fakeSpan) AddEvent(string, ...workflowobservability.Attribute) {}
+func (s *fakeSpan) SetAttributes(attrs ...workflowobservability.Attribute) {
+	s.attrs = append(s.attrs, attrs...)
+}
+func (s *fakeSpan) RecordError(error) {}
+func (s *fakeSpan) SetError(string)   {}
+
+type fakeTracer struct {
+	span *fakeSpan
+}
+
+func (tr *fakeTracer) Start(ctx context.Context, _ string, _ workflowobservability.SpanOptions) (context.Context, workflowobservability.Span) {
+	return ctx, tr.span
+}
+func (tr *fakeTracer) ExtractTraceContext(context.Context) map[string]string { return nil }
+
+func TestCaptureErrorShortTypeName(t *testing.T) {
+	span := &fakeSpan{}
+	telemetry := observability.New(observability.Options{Tracer: &fakeTracer{span: span}})
+
+	_, activity := telemetry.StartWorkflowRun(context.Background(), observability.WorkflowMetadata{ID: "wf"})
+	activity.CaptureError(errors.New("boom"))
+
+	if got := attributeValue(t, span.attrs, observability.TagErrorType); got != "errorString" {
+		t.Errorf("captured error.type = %q, want %q", got, "errorString")
+	}
+}

--- a/workflow/internal/observability/observability_test.go
+++ b/workflow/internal/observability/observability_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	observability "github.com/microsoft/agent-framework-go/workflow/internal/observability"
@@ -35,8 +36,10 @@ func TestErrorAttributesShortTypeName(t *testing.T) {
 
 	wrapped := fmt.Errorf("ctx: %w", errors.New("boom"))
 	attrs = observability.ErrorAttributes(wrapped)
-	if got := attributeValue(t, attrs, observability.TagErrorType); got != "wrapError" {
-		t.Errorf("wrapped error.type = %q, want %q", got, "wrapError")
+	// Assert the observable requirement (unqualified/short type name) rather than a
+	// specific stdlib-internal type name, which is not a public API and may change.
+	if got := attributeValue(t, attrs, observability.TagErrorType); got == "" || strings.ContainsAny(got, ".*") {
+		t.Errorf("wrapped error.type = %q, want unqualified short type name", got)
 	}
 }
 
@@ -48,8 +51,10 @@ func TestBuildErrorAttributesShortTypeName(t *testing.T) {
 
 	wrapped := fmt.Errorf("ctx: %w", errors.New("boom"))
 	attrs = observability.BuildErrorAttributes(wrapped)
-	if got := attributeValue(t, attrs, observability.TagBuildErrorType); got != "wrapError" {
-		t.Errorf("wrapped build.error.type = %q, want %q", got, "wrapError")
+	// Assert the observable requirement (unqualified/short type name) rather than a
+	// specific stdlib-internal type name, which is not a public API and may change.
+	if got := attributeValue(t, attrs, observability.TagBuildErrorType); got == "" || strings.ContainsAny(got, ".*") {
+		t.Errorf("wrapped build.error.type = %q, want unqualified short type name", got)
 	}
 }
 
@@ -78,7 +83,7 @@ func TestCaptureErrorShortTypeName(t *testing.T) {
 	span := &fakeSpan{}
 	telemetry := observability.New(observability.Options{Tracer: &fakeTracer{span: span}})
 
-	_, activity := telemetry.StartWorkflowRun(context.Background(), observability.WorkflowMetadata{ID: "wf"})
+	_, activity := telemetry.StartWorkflowRun(t.Context(), observability.WorkflowMetadata{ID: "wf"})
 	activity.CaptureError(errors.New("boom"))
 
 	if got := attributeValue(t, span.attrs, observability.TagErrorType); got != "errorString" {


### PR DESCRIPTION
## What

Workflow observability spans set the `error.type` and `build.error.type` attributes using `reflect.TypeOf(err).String()` at three sites in `workflow/internal/observability/observability.go` (`CaptureError`, `BuildErrorAttributes`, `ErrorAttributes`). For `errors.New` that yields `*errors.errorString` and for `fmt.Errorf(...: %w)` it yields `*fmt.wrapError`.

This replaces those calls with `otelx.ErrorTypeName(err)` (the `reflect` import is dropped and `internal/otelx` added). The `err == nil` guards are unchanged.

## Why

Every other `error.type` site in the repo already uses `otelx.ErrorTypeName` — see `provider/otelprovider/otel.go` and `agent/harness/toolautocall/autocall.go`. `ErrorTypeName` formats `%T` and strips through the last dot, producing the short unqualified name (`errorString`, `wrapError`), and is documented to match Python's `type(exception).__name__`.

Before this change the same `error.type` attribute carried `errorString` on provider/tool spans but `*errors.errorString` on workflow spans — an intra-repo inconsistency and a cross-SDK parity break with the Python SDK. This aligns the workflow path with the provider/tool paths and with Python.

## Tests

Added `workflow/internal/observability/observability_test.go`:
- `ErrorAttributes(errors.New("boom"))` and `BuildErrorAttributes(...)` assert the type value equals `errorString`, not `*errors.errorString`.
- A wrapped `fmt.Errorf("ctx: %w", ...)` asserts `wrapError`, not `*fmt.wrapError`.
- `CaptureError` is driven through `StartWorkflowRun` with a fake tracer/span and asserts the captured `error.type` equals `errorString`.

`go build ./...`, `go vet ./workflow/internal/observability/...`, and `go test ./workflow/internal/observability/...` all pass; the new tests fail before the fix and pass after.