### PR TITLE
Set FunctionResultContent.Error on failed Copilot tool executions

### DIFF
--- a/provider/copilotprovider/copilot.go
+++ b/provider/copilotprovider/copilot.go
@@ -554,6 +554,7 @@ func (p *provider) toolExecutionCompleteUpdate(event copilot.SessionEvent, data 
 		ContentHeader: message.ContentHeader{RawRepresentation: event},
 		CallID:        data.ToolCallID,
 		Result:        toolExecutionResult(data),
+		Error:         toolExecutionError(data),
 	}
 	return &agent.ResponseUpdate{
 		RawRepresentation: event,
@@ -577,6 +578,25 @@ func toolExecutionResult(data *copilot.ToolExecutionCompleteData) any {
 		return data.Error.Message
 	}
 	return "Tool execution failed"
+}
+
+// toolExecutionError maps a failed tool execution to the FunctionResultContent
+// failure channel, mirroring how the framework surfaces tool errors (frc.Error)
+// across providers. It returns nil for successful executions.
+func toolExecutionError(data *copilot.ToolExecutionCompleteData) error {
+	if data == nil {
+		return errors.New("tool execution failed")
+	}
+	if data.Success {
+		return nil
+	}
+	if data.Error != nil && data.Error.Message != "" {
+		if data.Error.Code != nil {
+			return fmt.Errorf("%s (%s)", data.Error.Message, *data.Error.Code)
+		}
+		return errors.New(data.Error.Message)
+	}
+	return errors.New("tool execution failed")
 }
 
 func (p *provider) assistantUsageUpdate(event copilot.SessionEvent, data *copilot.AssistantUsageData) *agent.ResponseUpdate {

--- a/provider/copilotprovider/copilot.go
+++ b/provider/copilotprovider/copilot.go
@@ -590,11 +590,20 @@ func toolExecutionError(data *copilot.ToolExecutionCompleteData) error {
 	if data.Success {
 		return nil
 	}
-	if data.Error != nil && data.Error.Message != "" {
+	if data.Error != nil {
+		msg := data.Error.Message
+		code := ""
 		if data.Error.Code != nil {
-			return fmt.Errorf("%s (%s)", data.Error.Message, *data.Error.Code)
+			code = *data.Error.Code
 		}
-		return errors.New(data.Error.Message)
+		switch {
+		case msg != "" && code != "":
+			return fmt.Errorf("%s (%s)", msg, code)
+		case msg != "":
+			return errors.New(msg)
+		case code != "":
+			return fmt.Errorf("tool execution failed (%s)", code)
+		}
 	}
 	return errors.New("tool execution failed")
 }

--- a/provider/copilotprovider/copilot_test.go
+++ b/provider/copilotprovider/copilot_test.go
@@ -440,6 +440,12 @@ func TestConvertToAgentResponseUpdate_ToolExecutionCompleteEvent_WithFailureNoEr
 	if result.CallID != "call-000" || result.Result != "Tool execution failed" {
 		t.Fatalf("result = (%q, %#v), want default failure", result.CallID, result.Result)
 	}
+	if result.Error == nil {
+		t.Fatalf("Error = nil, want non-nil failure error")
+	}
+	if msg := result.Error.Error(); !strings.Contains(msg, "tool execution failed") {
+		t.Fatalf("Error = %q, want default failure message", msg)
+	}
 }
 
 func TestConvertToAgentResponseUpdate_ToolExecutionCompleteEvent_WithNullData_ProducesEmptyResult(t *testing.T) {

--- a/provider/copilotprovider/copilot_test.go
+++ b/provider/copilotprovider/copilot_test.go
@@ -397,6 +397,9 @@ func TestConvertToAgentResponseUpdate_ToolExecutionCompleteEvent_WithSuccess_Pro
 	if result.CallID != "call-123" || result.Result != resultJSON {
 		t.Fatalf("result = (%q, %#v), want (call-123, %q)", result.CallID, result.Result, resultJSON)
 	}
+	if result.Error != nil {
+		t.Fatalf("Error = %v, want nil on success", result.Error)
+	}
 }
 
 func TestConvertToAgentResponseUpdate_ToolExecutionCompleteEvent_WithError_ProducesErrorResult(t *testing.T) {
@@ -413,6 +416,12 @@ func TestConvertToAgentResponseUpdate_ToolExecutionCompleteEvent_WithError_Produ
 	result := firstContent[*message.FunctionResultContent](t, response)
 	if result.CallID != "call-789" || result.Result != "Access denied to resource" {
 		t.Fatalf("result = (%q, %#v), want access denied", result.CallID, result.Result)
+	}
+	if result.Error == nil {
+		t.Fatalf("Error = nil, want non-nil failure error")
+	}
+	if msg := result.Error.Error(); !strings.Contains(msg, "Access denied to resource") || !strings.Contains(msg, "PERMISSION_DENIED") {
+		t.Fatalf("Error = %q, want message and code", msg)
 	}
 }
 


### PR DESCRIPTION
## What

When the Copilot provider converts a `tool.execution_complete` event with `success == false`, `toolExecutionCompleteUpdate` now sets `FunctionResultContent.Error` in addition to `Result`. The error is built from the SDK `ToolExecutionCompleteError`: the human-readable `Message`, combined with the machine-readable `Code` when present (`"<message> (<code>)"`), falling back to a default when the SDK omits error details. `Result` is still populated for display continuity.

## Why

The framework treats `FunctionResultContent.Error` as the canonical failure channel: autocall collects tool errors via `frc.Error != nil`, and the mcptool tests set `Error` on failure. Previously the Copilot provider only ever set `Result` and left `Error` nil, so a failed Copilot tool call looked identical to a successful one to any consumer that inspects `Error`. This matches the .NET/Python semantics where a failed function result carries its exception/error rather than folding it into the result payload, keeping cross-SDK behavior aligned.

## How tested

Extended the existing tests in `copilot_test.go`:
- The failure test now asserts `Error != nil` and that its message includes both the SDK `Message` and `Code`.
- The success test now asserts `Error == nil`.

`go build ./...`, `go vet ./provider/copilotprovider/...`, and `go test ./provider/copilotprovider/...` all pass.