### PR TITLE
Add godoc to the exported Annotations and AnnotatedRegions slice types

### DIFF
--- a/message/annotation.go
+++ b/message/annotation.go
@@ -34,6 +34,9 @@ func init() {
 // It is unexported to prevent external implementations of Annotation.
 type annotationKind string
 
+// Annotations is a slice of [Annotation] values; its UnmarshalJSON decodes each
+// element as a discriminated union based on its type discriminator (currently
+// [CitationAnnotation]).
 type Annotations []Annotation
 
 func (as *Annotations) UnmarshalJSON(data []byte) error {
@@ -77,6 +80,9 @@ func (t *CitationAnnotation) kind() annotationKind { return "citation" }
 
 type annotatedRegionKind string
 
+// AnnotatedRegions is a slice of [AnnotatedRegion] values; its UnmarshalJSON
+// decodes each element as a discriminated union based on its type discriminator
+// (currently [TextSpanAnnotatedRegion]).
 type AnnotatedRegions []AnnotatedRegion
 
 func (as *AnnotatedRegions) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
## What

Adds one-line doc comments to the exported `Annotations` and `AnnotatedRegions` slice types in `message/annotation.go`. Both begin with the type name, per Go doc convention.

## Why

The interface element types (`Annotation`, `AnnotatedRegion`) and the concrete implementations (`CitationAnnotation`, `TextSpanAnnotatedRegion`) already carry doc comments, but their exported slice wrappers were bare. `AnnotatedRegions` is the declared type of the exported `CitationAnnotation.AnnotatedRegions` field, so it appears directly in the public API surface and shows up undocumented in godoc.

Both slice types define a custom discriminated-union `UnmarshalJSON` whose behavior was previously undocumented; the comments now describe how each element is decoded based on its type discriminator. This mirrors the discriminated-union content shapes in the .NET and Python SDKs, where the polymorphic annotation collections are documented as part of the public contract.

## How tested

Docs-only change. Verified with:
- `go doc ./message Annotations` and `go doc ./message AnnotatedRegions` show the new comments
- `go build ./...`, `go vet ./message/...`, and `go test ./message/...` all pass