### PR TITLE
Surface web-search url_citation annotations on the OpenAI Chat Completions path like the Responses provider

### DIFF
--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -133,7 +133,9 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 				})
 			}
 			if choice.Message.Content != "" {
-				contents = append(contents, &message.TextContent{Text: choice.Message.Content})
+				textContent := &message.TextContent{Text: choice.Message.Content}
+				populateChatAnnotations(choice.Message.Annotations, textContent)
+				contents = append(contents, textContent)
 			}
 			if choice.Message.Refusal != "" {
 				contents = append(contents, &message.ErrorContent{Message: choice.Message.Refusal})
@@ -502,6 +504,19 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 
 	default:
 		panic("unknown message role: " + string(msg.Role))
+	}
+}
+
+// populateChatAnnotations maps Chat Completions message annotations (e.g. the
+// url_citation entries produced by the web-search tool) onto the text content's
+// annotations, mirroring populateAnnotations on the Responses path.
+func populateChatAnnotations(anns []openai.ChatCompletionMessageAnnotation, content *message.TextContent) {
+	for _, ann := range anns {
+		content.Annotations = append(content.Annotations, &message.CitationAnnotation{
+			URL:               ann.URLCitation.URL,
+			Title:             ann.URLCitation.Title,
+			RawRepresentation: ann,
+		})
 	}
 }
 

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -512,6 +512,11 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 // annotations, mirroring populateAnnotations on the Responses path.
 func populateChatAnnotations(anns []openai.ChatCompletionMessageAnnotation, content *message.TextContent) {
 	for _, ann := range anns {
+		// Only url_citation annotations carry a populated URLCitation payload;
+		// skip other variants (and empty URLs) to avoid emitting bogus citations.
+		if ann.Type != "url_citation" || ann.URLCitation.URL == "" {
+			continue
+		}
 		content.Annotations = append(content.Annotations, &message.CitationAnnotation{
 			URL:               ann.URLCitation.URL,
 			Title:             ann.URLCitation.Title,

--- a/provider/openaiprovider/chat_test.go
+++ b/provider/openaiprovider/chat_test.go
@@ -232,6 +232,80 @@ func TestChatBasicRequestResponse_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestChatURLCitationAnnotations_NonStreaming(t *testing.T) {
+	const input = `
+            {
+                "messages":[{"role":"user","content":"hello"}],
+                "model":"gpt-4o-mini"
+            }
+            `
+	const output = `
+            {
+              "id": "chatcmpl-URLCIT",
+              "object": "chat.completion",
+              "created": 1727888631,
+              "model": "gpt-4o-mini-2024-07-18",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "See Example.",
+                    "annotations": [
+                      {
+                        "type": "url_citation",
+                        "url_citation": {
+                          "url": "https://example.com",
+                          "title": "Example",
+                          "start_index": 4,
+                          "end_index": 11
+                        }
+                      }
+                    ]
+                  },
+                  "logprobs": null,
+                  "finish_reason": "stop"
+                }
+              ]
+            }
+            `
+
+	server := newTestServer(t, input, output)
+	defer server.Close()
+
+	a := newTestClient(server)
+
+	resp, err := a.RunText(t.Context(), "hello").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	var text *message.TextContent
+	for _, msg := range resp.Messages {
+		for _, c := range msg.Contents {
+			if tc, ok := c.(*message.TextContent); ok {
+				text = tc
+			}
+		}
+	}
+	if text == nil {
+		t.Fatalf("no TextContent in response")
+	}
+	if len(text.Annotations) != 1 {
+		t.Fatalf("expected 1 annotation, got %d", len(text.Annotations))
+	}
+	citation, ok := text.Annotations[0].(*message.CitationAnnotation)
+	if !ok {
+		t.Fatalf("expected *message.CitationAnnotation, got %T", text.Annotations[0])
+	}
+	if citation.URL != "https://example.com" {
+		t.Errorf("expected URL https://example.com, got %q", citation.URL)
+	}
+	if citation.Title != "Example" {
+		t.Errorf("expected Title Example, got %q", citation.Title)
+	}
+}
+
 func newTestServerStreaming(t *testing.T, input string, output string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider/openaiprovider/chat_test.go
+++ b/provider/openaiprovider/chat_test.go
@@ -306,6 +306,72 @@ func TestChatURLCitationAnnotations_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestChatURLCitationAnnotations_SkipsEmptyURL(t *testing.T) {
+	const input = `
+            {
+                "messages":[{"role":"user","content":"hello"}],
+                "model":"gpt-4o-mini"
+            }
+            `
+	// An annotation whose url_citation payload has an empty URL must not
+	// produce a bogus CitationAnnotation.
+	const output = `
+            {
+              "id": "chatcmpl-URLCIT-EMPTY",
+              "object": "chat.completion",
+              "created": 1727888631,
+              "model": "gpt-4o-mini-2024-07-18",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "No citation.",
+                    "annotations": [
+                      {
+                        "type": "url_citation",
+                        "url_citation": {
+                          "url": "",
+                          "title": "",
+                          "start_index": 0,
+                          "end_index": 0
+                        }
+                      }
+                    ]
+                  },
+                  "logprobs": null,
+                  "finish_reason": "stop"
+                }
+              ]
+            }
+            `
+
+	server := newTestServer(t, input, output)
+	defer server.Close()
+
+	a := newTestClient(server)
+
+	resp, err := a.RunText(t.Context(), "hello").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	var text *message.TextContent
+	for _, msg := range resp.Messages {
+		for _, c := range msg.Contents {
+			if tc, ok := c.(*message.TextContent); ok {
+				text = tc
+			}
+		}
+	}
+	if text == nil {
+		t.Fatalf("no TextContent in response")
+	}
+	if len(text.Annotations) != 0 {
+		t.Fatalf("expected 0 annotations, got %d", len(text.Annotations))
+	}
+}
+
 func newTestServerStreaming(t *testing.T, input string, output string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

The OpenAI Chat Completions non-streaming conversion built `TextContent` only from `choice.Message.Content` and never read `choice.Message.Annotations`. As a result, the `url_citation` annotations that the web-search tool emits (the SDK's `ChatCompletionMessageAnnotation` with `URLCitation{URL, Title, StartIndex, EndIndex}`) were silently dropped, even though `buildCompletionParams` enables the web-search tool for `*hostedtool.WebSearch`.

This adds a small `populateChatAnnotations` helper that maps each `url_citation` onto the `TextContent`'s `Annotations` as a `*message.CitationAnnotation{URL, Title, RawRepresentation}`, mirroring `populateAnnotations` on the Responses path.

## Why

The Responses provider already surfaces web-search citations via `populateAnnotations` (`ResponseOutputTextAnnotationURLCitation` -> `*message.CitationAnnotation`) on both its streaming and non-streaming paths. The Chat Completions path was the only surface that discarded them, an inconsistency across the two OpenAI surfaces. The .NET and Python SDKs expose web-search citations on both the Chat Completions and Responses surfaces, so this restores cross-SDK and cross-surface parity.

## Scope

Scoped to `provider/openaiprovider/chat.go` and its canonical test file. `responses.go` is intentionally untouched.

## Testing

Added `TestChatURLCitationAnnotations_NonStreaming` in `chat_test.go`, a black-box test that drives a Chat Completion whose message carries a `url_citation` annotation through the existing httptest harness and asserts the emitted `TextContent.Annotations` contains a `*message.CitationAnnotation` with `URL == https://example.com` and `Title == Example`. The test fails before the change and passes after. `go build ./...`, `go vet ./provider/openaiprovider/...`, and `go test ./provider/openaiprovider/...` are green.