### PR TITLE
Route bare MCP connector IDs to connector_id instead of an invalid server_url in the Responses provider

### DIFF
--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -413,7 +413,14 @@ func responsesBuildCompletionParams(config AgentConfig, messages []*message.Mess
 		case *hostedtool.MCPServer:
 			var variant responses.ToolMcpParam
 			variant.ServerLabel = tl.ServerName
-			if _, err := url.Parse(tl.ServerAddress); err == nil {
+			// The Responses API accepts either a server_url (a full HTTP(S)
+			// endpoint) or a connector_id (a bare service-connector identifier
+			// such as "connector_googledrive"); the two are mutually exclusive.
+			// url.Parse only errors on control-char/malformed input, so it
+			// cannot distinguish the two. Discriminate on an actual URL scheme
+			// instead, routing scheme-bearing addresses to server_url and bare
+			// connector IDs to connector_id.
+			if u, err := url.Parse(tl.ServerAddress); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
 				variant.ServerURL = openai.String(tl.ServerAddress)
 			} else {
 				variant.ConnectorID = tl.ServerAddress

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -2288,6 +2288,75 @@ data: {"type":"response.completed","response":{"id":"resp_001","object":"respons
 	}
 }
 
+func TestResponsesMCPServerToolAddressRouting(t *testing.T) {
+	const output = `
+            {
+                "id": "resp_test",
+                "object": "response",
+                "created_at": 1741891428,
+                "status": "completed",
+                "error": null,
+                "incomplete_details": null,
+                "model": "gpt-4o-mini",
+                "output": [{
+                    "type": "message",
+                    "id": "msg_test",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Hello", "annotations": []}]
+                }]
+            }
+            `
+
+	tests := []struct {
+		name          string
+		serverAddress string
+		wantTool      string
+	}{
+		{
+			name:          "bare connector id routes to connector_id",
+			serverAddress: "connector_googledrive",
+			wantTool:      `{"type":"mcp","server_label":"drive","connector_id":"connector_googledrive"}`,
+		},
+		{
+			name:          "https url routes to server_url",
+			serverAddress: "https://example.com/mcp",
+			wantTool:      `{"type":"mcp","server_label":"drive","server_url":"https://example.com/mcp"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := `
+                {
+                    "model":"gpt-4o-mini",
+                    "input":[{
+                        "type":"message",
+                        "role":"user",
+                        "content":[{"type":"input_text","text":"hello"}]
+                    }],
+                    "tools":[` + tt.wantTool + `]
+                }
+                `
+
+			server := newTestResponsesServer(t, input, output)
+			defer server.Close()
+
+			a := newTestResponsesClient(server, "gpt-4o-mini")
+
+			_, err := a.RunText(t.Context(), "hello",
+				agent.WithTool(&hostedtool.MCPServer{
+					ServerName:    "drive",
+					ServerAddress: tt.serverAddress,
+				}),
+			).Collect()
+			if err != nil {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
 func TestResponsesCodeInterpreterTool_NonStreaming(t *testing.T) {
 	const input = `
             {


### PR DESCRIPTION
## What

The Responses provider decides whether a hosted `MCPServer`'s `ServerAddress` is a full server URL or a service-connector ID by inspecting `url.Parse`'s error:

```go
if _, err := url.Parse(tl.ServerAddress); err == nil {
    variant.ServerURL = openai.String(tl.ServerAddress)
} else {
    variant.ConnectorID = tl.ServerAddress
}
```

`url.Parse` only returns an error for control-character/malformed input, so a bare connector identifier like `connector_googledrive` parses successfully (empty scheme, no error). Every realistic connector ID therefore fell into the `server_url` branch. Because `server_url` is `format:uri` and mutually exclusive with `connector_id`, the Responses API rejects the request, and service-connector support was effectively unreachable.

This change discriminates on an actual URL scheme instead:

```go
if u, err := url.Parse(tl.ServerAddress); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
    variant.ServerURL = openai.String(tl.ServerAddress)
} else {
    variant.ConnectorID = tl.ServerAddress
}
```

Scheme-bearing addresses go to `server_url`; bare connector IDs go to `connector_id`.

## Why

The Responses API requires exactly one of `server_url`, `connector_id`, or `tunnel_id`. This aligns Go with the .NET/Python SDKs, which route a bare service-connector identifier to `connector_id` rather than treating it as a URL.

## Testing

Added `TestResponsesMCPServerToolAddressRouting` in `responses_test.go`, a table test driven through the existing black-box request-capture harness (`newTestResponsesServer`). It asserts the outgoing tool params:
- `ServerAddress: "connector_googledrive"` -> `connector_id` set, `server_url` unset.
- `ServerAddress: "https://example.com/mcp"` -> `server_url` set, `connector_id` unset.

The test fails before the fix (the connector ID is emitted as `server_url`) and passes after. `go build ./...`, `go vet ./provider/openaiprovider/...`, and `go test ./provider/openaiprovider/...` all pass.