### PR TITLE
Add a concurrent agent-workflow example demonstrating a custom fan-in aggregator

### DIFF
--- a/cmd/verifyexamples/examples.go
+++ b/cmd/verifyexamples/examples.go
@@ -785,6 +785,17 @@ var workflowExamples = []ExampleDefinition{
 		},
 	},
 	{
+		Name:                         "03_workflows_concurrent_concurrent_custom_aggregator",
+		ProjectPath:                  "examples/03-workflows/concurrent/concurrent_custom_aggregator",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		MustContain:                  []string{"Combined expert summary:"},
+		ExpectedOutputDescription: []string{
+			"The output should show several domain experts' answers folded into a single combined summary message.",
+			"The output should not contain error messages or stack traces.",
+		},
+	},
+	{
 		Name:            "03_workflows_conditional_edges_01_edge_condition",
 		ProjectPath:     "examples/03-workflows/conditional-edges/01_edge_condition",
 		IsDeterministic: true,

--- a/examples/03-workflows/concurrent/concurrent_custom_aggregator/main.go
+++ b/examples/03-workflows/concurrent/concurrent_custom_aggregator/main.go
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/provider/foundryprovider"
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/agentworkflow"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+var logger = demo.NewLogger(
+	"Concurrent Workflow With Custom Aggregator",
+	"This sample fans a prompt out to several domain experts and folds their answers into a single summary message using a custom fan-in aggregator.",
+	"Model", demo.FoundryModel,
+)
+
+func main() {
+	agents := []*agent.Agent{
+		newExpertAgent("Physicist", "physics"),
+		newExpertAgent("Chemist", "chemistry"),
+		newExpertAgent("Biologist", "biology"),
+	}
+
+	// WithAggregator replaces the default aggregator (which keeps each agent's
+	// last message unchanged) with a fan-in function that consolidates every
+	// agent's final response into one summary message.
+	wf, err := agentworkflow.NewConcurrentWorkflowBuilder(agents...).
+		WithName("Domain Experts With Custom Aggregator").
+		WithAggregator(summarize).
+		Build()
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	results, err := runWorkflow(context.Background(), wf, []*message.Message{
+		message.NewText("Why is the sky blue?"),
+	})
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	demo.Assistantf("Aggregated %d message(s):", len(results))
+	for _, msg := range results {
+		demo.Assistantf("%s", msg.String())
+	}
+}
+
+// summarize is the custom [agentworkflow.MessageAggregator]. It receives one
+// message batch per agent (each batch holding that agent's turn output) and
+// folds the last message of every batch into a single assistant summary.
+func summarize(_ context.Context, batches [][]*message.Message) []*message.Message {
+	var b strings.Builder
+	b.WriteString("Combined expert summary:")
+	for _, batch := range batches {
+		if len(batch) == 0 {
+			continue
+		}
+		last := batch[len(batch)-1]
+		fmt.Fprintf(&b, "\n- %s", last.String())
+	}
+	return []*message.Message{message.NewText(b.String())}
+}
+
+func runWorkflow(ctx context.Context, wf *workflow.Workflow, messages []*message.Message) ([]*message.Message, error) {
+	run, err := inproc.Default.RunStreaming(ctx, wf, messages)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = run.Close(ctx) }()
+
+	emitEvents := true
+	if err := run.SendMessage(ctx, workflow.TurnToken{EmitEvents: &emitEvents}); err != nil {
+		return nil, err
+	}
+
+	for evt, err := range run.WatchStream(ctx) {
+		if err != nil {
+			return nil, err
+		}
+		switch e := evt.(type) {
+		case workflow.OutputEvent:
+			if outputMessages, ok := e.Output.([]*message.Message); ok {
+				return outputMessages, nil
+			}
+		case workflow.ErrorEvent:
+			return nil, e.Error
+		case workflow.ExecutorFailedEvent:
+			return nil, fmt.Errorf("executor %q failed: %v", e.ExecutorID, e.Error)
+		}
+	}
+	return nil, nil
+}
+
+func newExpertAgent(name, domain string) *agent.Agent {
+	return foundryprovider.NewAgent(
+		demo.FoundryProjectEndpoint,
+		demo.FoundryTokenCredential(),
+		foundryprovider.ModelDeployment(demo.FoundryModel),
+		foundryprovider.AgentConfig{
+			Instructions: fmt.Sprintf("You are a %s expert. Answer the question from a %s point of view in a single concise sentence.", domain, domain),
+			Config: agent.Config{
+				Name:        name,
+				Middlewares: []agent.Middleware{logger},
+			},
+		},
+	)
+}

--- a/examples/03-workflows/concurrent/concurrent_custom_aggregator/main.go
+++ b/examples/03-workflows/concurrent/concurrent_custom_aggregator/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow/inproc"
 )
 
-var logger = demo.NewLogger(
+var _ = demo.NewLogger(
 	"Concurrent Workflow With Custom Aggregator",
 	"This sample fans a prompt out to several domain experts and folds their answers into a single summary message using a custom fan-in aggregator.",
 	"Model", demo.FoundryModel,
@@ -66,7 +66,9 @@ func summarize(_ context.Context, batches [][]*message.Message) []*message.Messa
 		last := batch[len(batch)-1]
 		fmt.Fprintf(&b, "\n- %s", last.String())
 	}
-	return []*message.Message{message.NewText(b.String())}
+	summary := message.NewText(b.String())
+	summary.Role = message.RoleAssistant
+	return []*message.Message{summary}
 }
 
 func runWorkflow(ctx context.Context, wf *workflow.Workflow, messages []*message.Message) ([]*message.Message, error) {
@@ -96,7 +98,7 @@ func runWorkflow(ctx context.Context, wf *workflow.Workflow, messages []*message
 			return nil, fmt.Errorf("executor %q failed: %v", e.ExecutorID, e.Error)
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("workflow stream ended without producing an output event")
 }
 
 func newExpertAgent(name, domain string) *agent.Agent {
@@ -107,8 +109,7 @@ func newExpertAgent(name, domain string) *agent.Agent {
 		foundryprovider.AgentConfig{
 			Instructions: fmt.Sprintf("You are a %s expert. Answer the question from a %s point of view in a single concise sentence.", domain, domain),
 			Config: agent.Config{
-				Name:        name,
-				Middlewares: []agent.Middleware{logger},
+				Name: name,
 			},
 		},
 	)


### PR DESCRIPTION
## What

Adds `examples/03-workflows/concurrent/concurrent_custom_aggregator`, a runnable sample that fans a prompt out to several domain-expert agents (physicist, chemist, biologist) via `agentworkflow.NewConcurrentWorkflowBuilder(...).WithAggregator(fn).Build()` and folds every agent's final response into a single summary message with a custom fan-in aggregator. The workflow is run through the in-process runner and the yielded `[]*message.Message` is printed.

The sample is registered in `cmd/verifyexamples/examples.go` next to the existing concurrent entry.

## Why

`ConcurrentWorkflowBuilder.WithAggregator` / the `MessageAggregator` type are public API, but nothing under `examples/` exercised them: the one agentworkflow concurrent example relies on the default aggregator (which just keeps each agent's last message), and the raw concurrent example hand-builds non-agent executors and never touches the agentworkflow builder. This mirrors the .NET/Python `ConcurrentBuilder` aggregator samples, where consolidating fan-out results into a single summarized output is a first-class documented pattern, so a Go example keeps the SDKs aligned.

## Testing

- `go build ./...`
- `go vet ./cmd/verifyexamples/... ./examples/03-workflows/concurrent/concurrent_custom_aggregator/... ./workflow/agentworkflow/...`
- `go test ./workflow/agentworkflow/...`

The custom-aggregator behavior itself is already covered by `TestConcurrentWorkflowBuilder_UsesCustomAggregator` in `workflow/agentworkflow/concurrent_test.go`; this change is example-only.