### PR TITLE
Add godoc to the exported message.NewURIContent constructor

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -533,6 +533,9 @@ type URIContent struct {
 	URI       string
 }
 
+// NewURIContent creates a [URIContent] for the given URI. When mediaType is
+// empty it is inferred from the URI; a non-empty mediaType is validated. It
+// returns an error if the URI is invalid or the media type is malformed.
 func NewURIContent(uri string, mediaType string) (*URIContent, error) {
 	if err := validateURIContentURI(uri); err != nil {
 		return nil, err


### PR DESCRIPTION
## What

Adds a doc comment to the exported `NewURIContent` constructor in `message/content.go`.

## Why

The `URIContent` type is documented, but its constructor had no doc comment, making it an undocumented exported outlier. The constructor's behavior is non-obvious: it validates the URI, infers the media type from the URI when `mediaType` is empty, otherwise validates the provided media type, and returns an error on invalid input. Callers need this documented.

This mirrors the documentation conventions of the .NET and Python SDKs, where content constructors document their inference and validation semantics; adding it keeps the Go port aligned.

## Testing

Pure docs change. `go build ./...`, `go vet ./message/...`, and `go test ./message/...` all pass. `go doc ./message NewURIContent` prints the new doc sentence.