### PR TITLE
Deduplicate repeated target indices within a SwitchBuilder case to avoid duplicate delivery

### DIFF
--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -607,6 +607,7 @@ func (s *SwitchBuilder) WithDefault(targets ...ExecutorBinding) *SwitchBuilder {
 
 func (s *SwitchBuilder) collectTargets(targets []ExecutorBinding) []int {
 	out := make([]int, 0, len(targets))
+	seen := make(map[int]struct{}, len(targets))
 	for _, t := range targets {
 		idx, ok := s.targetIndexByID[t.ID]
 		if !ok {
@@ -614,6 +615,13 @@ func (s *SwitchBuilder) collectTargets(targets []ExecutorBinding) []int {
 			s.targets = append(s.targets, t)
 			s.targetIndexByID[t.ID] = idx
 		}
+		if _, dup := seen[idx]; dup {
+			// Skip repeated targets within a single case/default so a message
+			// is delivered at most once per target, matching .NET's
+			// HashSet<int> semantics.
+			continue
+		}
+		seen[idx] = struct{}{}
 		out = append(out, idx)
 	}
 	return out

--- a/workflow/builder_test.go
+++ b/workflow/builder_test.go
@@ -447,6 +447,68 @@ func TestAddSwitch_FallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestAddSwitch_DeduplicatesRepeatedTargetsWithinCase(t *testing.T) {
+	var trace []string
+	src := recordingBinding("src", &trace)
+	target := recordingBinding("target", &trace)
+
+	bld := workflow.NewBuilder(src)
+	// The same binding is listed twice within a single case. It must still
+	// receive the matched message exactly once, mirroring .NET's HashSet<int>
+	// target semantics.
+	bld.AddSwitch(src).
+		AddCase(func(msg any) bool { return msg == "hit" }, target, target).
+		AddToBuilder(bld)
+	wf, err := bld.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if _, err := inproc.Default.Run(context.Background(), wf, "hit"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var deliveries int
+	for _, ent := range trace {
+		if ent == "target:hit" {
+			deliveries++
+		}
+	}
+	if deliveries != 1 {
+		t.Errorf("expected duplicated target to be delivered exactly once, got %d; trace=%v", deliveries, trace)
+	}
+}
+
+func TestAddSwitch_DeduplicatesRepeatedDefaultTargets(t *testing.T) {
+	var trace []string
+	src := recordingBinding("src", &trace)
+	def := recordingBinding("def", &trace)
+
+	bld := workflow.NewBuilder(src)
+	bld.AddSwitch(src).
+		AddCase(func(msg any) bool { return msg == "match" }, recordingBinding("branch", &trace)).
+		WithDefault(def, def).
+		AddToBuilder(bld)
+	wf, err := bld.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if _, err := inproc.Default.Run(context.Background(), wf, "no-match"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var deliveries int
+	for _, ent := range trace {
+		if ent == "def:no-match" {
+			deliveries++
+		}
+	}
+	if deliveries != 1 {
+		t.Errorf("expected duplicated default target to be delivered exactly once, got %d; trace=%v", deliveries, trace)
+	}
+}
+
 func TestBuilder_Validation_FailsWhenOutputExecutorNotInGraph(t *testing.T) {
 	start := newNoOpExecutor("start")
 


### PR DESCRIPTION
## What

`SwitchBuilder.collectTargets` deduplicates the aggregated fan-out `targets` slice via `targetIndexByID`, but the per-call `out` slice appended an index for every binding passed with no membership check. Listing the same target twice within a single case or default — `AddCase(pred, t1, t1)` or `WithDefault(t1, t1)` — therefore produced indices `[0, 0]`.

Nothing downstream deduplicates either: the assigner yields index 0 twice, `selectedTargetIDs` appends the same sink ID twice, `resolveTargets` returns the same executor twice, the type filter keeps both, and `MapInto` enqueues the envelope once per entry — so the matched message is delivered to that executor twice.

This change tracks a per-call `seen` set in `collectTargets` and emits each index at most once. It applies identically to `AddCase` and `WithDefault` since both route through `collectTargets`.

## Why

Mirrors the .NET implementation, where a switch case's targets are backed by `HashSet<int>` so a repeated target collapses to a single delivery. This restores cross-SDK parity: a message routed through a switch should reach each distinct target exactly once regardless of how many times it was listed.

## Testing

Added two black-box behavioral tests in `workflow/builder_test.go` using the existing `recordingBinding` harness:
- `TestAddSwitch_DeduplicatesRepeatedTargetsWithinCase` — `AddCase(pred, target, target)`, asserts the target's handler fires exactly once.
- `TestAddSwitch_DeduplicatesRepeatedDefaultTargets` — `WithDefault(def, def)`, asserts the default target fires exactly once.

Both fail before the fix (delivered twice) and pass after. `go build ./...`, `go vet ./workflow/...`, and `go test ./workflow/...` are green.