### PR TITLE
Realign todo and agentmode harness default prompt strings with current .NET

### DIFF
--- a/agent/harness/agentmode/agentmode.go
+++ b/agent/harness/agentmode/agentmode.go
@@ -86,9 +86,12 @@ Process to follow when in plan mode:
 	},
 	{
 		Name: "execute",
-		Description: `Use this mode when carrying out approved plans. Work autonomously using your best judgment — do not ask the user questions or wait for feedback.
+		Description: `Determine the type of ask:
+1. Simple question that doesn't require any further work to answer.
+2. Any other work, including complex user request that requires a multi-step process to satisfy.
 
-Process to follow when in execute mode:
+If 1. just answer the question directly.
+If 2. Work autonomously using your best judgment — do not ask the user questions or wait for feedback and follow the following process:
 1. If you don't have a plan or tasks yet, analyze the user request and create tasks and a plan. (**Skip this step if you came from plan mode**)
 2. Work autonomously — use your best judgment to make decisions and keep progressing without asking the user questions. The goal is to have a complete, useful result ready when the user returns.
 3. If you encounter ambiguity or an unexpected situation during execution, choose the most reasonable option, note your choice, and keep going.

--- a/agent/harness/agentmode/agentmode_test.go
+++ b/agent/harness/agentmode/agentmode_test.go
@@ -621,3 +621,24 @@ func TestDefaultInstructions_ModesSectionHeaderFormat(t *testing.T) {
 		t.Error("expected '#### execute' section header in instructions")
 	}
 }
+
+// Verify the execute-mode description matches the current .NET AgentModeProvider
+// text: it opens with the simple-vs-complex "Determine the type of ask" decision
+// and no longer uses the old "carrying out approved plans" phrasing.
+func TestDefaultInstructions_ExecuteModeDescription(t *testing.T) {
+	p := agentmode.New(agentmode.Config{})
+	opts := sessionOpts()
+
+	_, outOpts, err := invokeProvider(p, context.Background(), newMessages("hi"), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instructions := collectInstructions(outOpts)
+	if !strings.Contains(instructions, "Determine the type of ask:") {
+		t.Error("expected execute-mode instructions to contain 'Determine the type of ask:'")
+	}
+	if strings.Contains(instructions, "carrying out approved plans") {
+		t.Error("expected execute-mode instructions to no longer contain 'carrying out approved plans'")
+	}
+}

--- a/agent/harness/todo/todo.go
+++ b/agent/harness/todo/todo.go
@@ -29,11 +29,16 @@ const stateKey = "todoProviderState"
 const defaultInstructions = `## Todo Items
 
 You have access to a todo list for tracking work items.
-While planning, make sure that you break down complex tasks into manageable todo items and add them to the list.
+When a user asks you to perform a task, follow these steps to manage your work:
+1. Determine whether the ask requires multiple steps to complete (complex) or can be completed using a single step (simple).
+2. If complex, turn the task into manageable todo items and add them to the list.
+3. If simple, don't add a todo item, but rather just complete the task directly.
+
+### General TODO Guidelines
 Ask questions from the user where clarification is needed to create effective todos.
-If the user provides feedback on your plan, adjust your todos accordingly by adding new items or removing irrelevant ones.
+If the user provides feedback on your plan, adjust your todos accordingly by adding new items or removing irrelevant/old ones.
 During execution, use the todo list to keep track of what needs to be done, mark items as complete when finished, and remove any items that are no longer needed.
-When a user changes the topic or changes their mind, ensure that you update the todo list accordingly by removing irrelevant items or adding new ones as needed.
+When a user changes the topic, changes their mind or switches to a new request, ensure that you update the todo list accordingly by removing irrelevant/old items, clearing the list, or adding new ones as needed.
 
 Use these tools to manage your tasks:
 - Use todos_add to break down complex work into trackable items (supports adding one or many at once).

--- a/agent/harness/todo/todo_test.go
+++ b/agent/harness/todo/todo_test.go
@@ -102,6 +102,16 @@ func TestProvide_ReturnsToolsAndInstructions(t *testing.T) {
 	if instructions == "" {
 		t.Fatal("expected non-empty instructions")
 	}
+	// Default instructions mirror the current .NET TodoProvider text: a
+	// numbered simple-vs-complex decision and a General TODO Guidelines heading.
+	for _, want := range []string{
+		"### General TODO Guidelines",
+		"just complete the task directly",
+	} {
+		if !strings.Contains(instructions, want) {
+			t.Errorf("expected default instructions to contain %q", want)
+		}
+	}
 }
 
 // 2. AddTodos_CreatesSingleItem


### PR DESCRIPTION
## What

Realign two harness context-provider default prompt strings with the current .NET implementation. Both ship as the runtime system prompt via `WithInstructions`, so drift here changes agent behavior relative to the .NET SDK.

- **`agent/harness/todo/todo.go`** — `defaultInstructions` was the old flat text. The current .NET `TodoProvider.DefaultInstructions` was reworked into a numbered simple-vs-complex decision (1-3) plus a `### General TODO Guidelines` heading. Copied verbatim. The `todos_*` tool bullets already matched and are unchanged.
- **`agent/harness/agentmode/agentmode.go`** — the execute-mode `Description` began with `Use this mode when carrying out approved plans...`. The current .NET `AgentModeProvider` execute description now begins with `Determine the type of ask:` (1. simple question → answer directly; 2. other work → autonomous), preceding the same numbered 1-5 process. Copied verbatim. Plan-mode description and the `mode_*` tool descriptions already matched and are untouched.

## Why

Cross-SDK parity. The .NET strings are the source of truth for the Go port's harness prompts; the previous strings predate the .NET rework. Same class of fix as the accepted #621, which realigned the top-level agentmode default instructions. Strings were fetched from `raw.githubusercontent.com/microsoft/agent-framework/main` and copied verbatim:
- `dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProvider.cs`
- `dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeProvider.cs`

## Tests

Extended the existing black-box table assertions in the canonical test files:
- `todo_test.go`: default instructions contain `### General TODO Guidelines` and `just complete the task directly`.
- `agentmode_test.go`: default execute-mode instructions contain `Determine the type of ask:` and no longer contain `carrying out approved plans`.

`go build ./...`, `go vet`, and `go test ./agent/harness/todo/... ./agent/harness/agentmode/...` all pass.
