### PR TITLE
Add a sequential agent-workflow example demonstrating WithChainOnlyAgentResponses

### DIFF
--- a/cmd/verifyexamples/examples.go
+++ b/cmd/verifyexamples/examples.go
@@ -702,6 +702,17 @@ var workflowExamples = []ExampleDefinition{
 		},
 	},
 	{
+		Name:            "03_workflows_01_start_here_08_sequential_chain_only_responses",
+		ProjectPath:     "examples/03-workflows/01-start-here/08_sequential_chain_only_responses",
+		IsDeterministic: true,
+		MustContain: []string{
+			"Seed prompt: Write a one-line greeting.",
+			"Translator received 1 message(s):",
+			"Translator responds: Bonjour, le monde!",
+			"Approved: Bonjour, le monde!",
+		},
+	},
+	{
 		Name:                         "03_workflows_agents_custom_agent_executors",
 		ProjectPath:                  "examples/03-workflows/agents/custom_agent_executors",
 		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},

--- a/examples/03-workflows/01-start-here/08_sequential_chain_only_responses/main.go
+++ b/examples/03-workflows/01-start-here/08_sequential_chain_only_responses/main.go
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"iter"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/message"
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/agentworkflow"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+var _ = demo.NewLogger(
+	"Sequential Chain-Only Responses",
+	"This sample chains three agents and forwards only each agent's own response to the next.",
+)
+
+// The seed prompt is sent to the first agent only. With
+// WithChainOnlyAgentResponses(true) every agent forwards just its own response
+// to the next stage, so the translator and reviewer never see the seed prompt
+// or the full accumulated conversation.
+const seedPrompt = "Write a one-line greeting."
+
+func main() {
+	writer := newStageAgent("writer", "Writer", func(string) string {
+		return "Hello, world!"
+	})
+	translator := newStageAgent("translator", "Translator", func(string) string {
+		return "Bonjour, le monde!"
+	})
+	reviewer := newStageAgent("reviewer", "Reviewer", func(input string) string {
+		return "Approved: " + input
+	})
+
+	wf, err := agentworkflow.NewSequentialWorkflowBuilder(writer, translator, reviewer).
+		WithName("chain-only-sequential").
+		WithChainOnlyAgentResponses(true).
+		Build()
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	ctx := context.Background()
+	demo.Assistantf("Seed prompt: %s", seedPrompt)
+
+	run, err := inproc.Default.RunStreaming(ctx, wf, []*message.Message{message.NewText(seedPrompt)})
+	if err != nil {
+		demo.Panic(err)
+	}
+	defer func() { _ = run.Close(ctx) }()
+
+	emitEvents := true
+	if err := run.SendMessage(ctx, workflow.TurnToken{EmitEvents: &emitEvents}); err != nil {
+		demo.Panic(err)
+	}
+
+	for evt, err := range run.WatchStream(ctx) {
+		if err != nil {
+			demo.Panic(err)
+		}
+		switch e := evt.(type) {
+		case workflow.OutputEvent:
+			if outputMessages, ok := e.Output.([]*message.Message); ok {
+				demo.Assistant("=== Final workflow output ===")
+				for _, msg := range outputMessages {
+					demo.Assistantf("  [%s] %s", msg.Role, messageText(msg))
+				}
+			}
+		case workflow.ErrorEvent:
+			demo.Panic(e.Error)
+		case workflow.ExecutorFailedEvent:
+			demo.Panicf("executor %q failed: %v", e.ExecutorID, e.Error)
+		}
+	}
+}
+
+// newStageAgent returns a deterministic agent that prints the messages it
+// received before replying with respond(input). Printing the received messages
+// makes the chain-only behavior visible: the translator and reviewer only ever
+// receive the single message produced by the previous agent.
+func newStageAgent(id, name string, respond func(input string) string) *agent.Agent {
+	run := func(_ context.Context, messages []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			demo.Assistantf("=== %s ===", name)
+			demo.Assistantf("%s received %d message(s):", name, len(messages))
+			for _, msg := range messages {
+				demo.Assistantf("  [%s] %s", msg.Role, messageText(msg))
+			}
+			reply := respond(messageText(messages...))
+			demo.Assistantf("%s responds: %s", name, reply)
+			yield(&agent.ResponseUpdate{
+				Role:       message.RoleAssistant,
+				AgentID:    id,
+				AuthorName: name,
+				Contents:   []message.Content{&message.TextContent{Text: reply}},
+			}, nil)
+		}
+	}
+	return agent.New(
+		agent.ProviderConfig{ProviderName: "demo-stage", Run: run},
+		agent.Config{ID: id, Name: name, DisableFuncAutoCall: true},
+	)
+}
+
+// messageText concatenates the text content of the given messages.
+func messageText(messages ...*message.Message) string {
+	var builder strings.Builder
+	for _, msg := range messages {
+		for _, content := range msg.Contents {
+			if textContent, ok := content.(*message.TextContent); ok {
+				builder.WriteString(textContent.Text)
+			}
+		}
+	}
+	return builder.String()
+}


### PR DESCRIPTION
## What

Adds `examples/03-workflows/01-start-here/08_sequential_chain_only_responses`, a runnable example that demonstrates `SequentialWorkflowBuilder.WithChainOnlyAgentResponses(true)`.

The example chains three deterministic agents (writer -> translator -> reviewer) via `agentworkflow.NewSequentialWorkflowBuilder(...).WithChainOnlyAgentResponses(true).Build()`. Each stage prints the messages it received before replying, so the reader can see that the translator and reviewer only ever receive the single message produced by the previous agent — not the seed prompt or the full accumulated conversation.

Sample output:

```
Seed prompt: Write a one-line greeting.
=== Writer ===
Writer received 1 message(s):
  [user] Write a one-line greeting.
Writer responds: Hello, world!
=== Translator ===
Translator received 1 message(s):
  [user] Hello, world!
Translator responds: Bonjour, le monde!
=== Reviewer ===
Reviewer received 1 message(s):
  [user] Bonjour, le monde!
Reviewer responds: Approved: Bonjour, le monde!
=== Final workflow output ===
  [assistant] Approved: Bonjour, le monde!
```

The example is registered as a deterministic entry in `cmd/verifyexamples/examples.go`, mirroring the existing `07_writer_critic_workflow` block.

## Why

`WithChainOnlyAgentResponses` had no example coverage — the only usage outside tests was none, and both existing sequential examples rely on the default (`false`). The flag controls whether each agent forwards only its own response or the accumulated conversation, which is a meaningful behavioral distinction worth showing. This mirrors the .NET/Python `SequentialBuilder` chain-only option, and giving it a first-class example keeps the Go samples aligned with the other SDKs where the sequential-orchestration samples make the message-forwarding semantics explicit.

## How it is tested

- Deterministic agents (no external provider/credentials), so the example runs offline. `go run ./examples/03-workflows/01-start-here/08_sequential_chain_only_responses/` produces the fixed output above.
- Registered as an `IsDeterministic` entry with `MustContain` assertions (including `Translator received 1 message(s):`), which is the distinguishing signal — with the default the translator would receive the accumulated conversation instead.
- The underlying behavior is already covered by `TestSequentialWorkflowBuilder_ChainOnlyAgentResponses` in `workflow/agentworkflow/sequential_test.go`.
- `go build ./...`, `go vet`, and `go test ./cmd/verifyexamples/ ./workflow/agentworkflow/` all pass.