### PR TITLE
Add godoc to the exported workflow.PortableValue.As accessor

### DIFF
--- a/workflow/portable.go
+++ b/workflow/portable.go
@@ -164,9 +164,11 @@ func (v *PortableValue) Is(typ reflect.Type) bool {
 	return true
 }
 
-// As returns the contained value coerced to typ and true when the value is
-// (or can be delayed-deserialized to) typ; otherwise it returns nil and false.
-// It is the comma-ok extraction counterpart to [PortableValue.Is].
+// As returns the contained value and true when it is assignable to typ (or can
+// be delayed-deserialized to a value assignable to typ); otherwise it returns
+// nil and false. No conversion is performed: when typ is an interface, the
+// returned value is the concrete value assignable to that interface. It is the
+// comma-ok extraction counterpart to [PortableValue.Is].
 func (v *PortableValue) As(typ reflect.Type) (any, bool) {
 	if v.Is(typ) {
 		return v.Any(), true

--- a/workflow/portable.go
+++ b/workflow/portable.go
@@ -164,6 +164,9 @@ func (v *PortableValue) Is(typ reflect.Type) bool {
 	return true
 }
 
+// As returns the contained value coerced to typ and true when the value is
+// (or can be delayed-deserialized to) typ; otherwise it returns nil and false.
+// It is the comma-ok extraction counterpart to [PortableValue.Is].
 func (v *PortableValue) As(typ reflect.Type) (any, bool) {
 	if v.Is(typ) {
 		return v.Any(), true


### PR DESCRIPTION
## What

Add a doc comment to the exported `(*PortableValue).As` accessor in `workflow/portable.go`.

## Why

`As` was the only undocumented method in its immediate neighborhood: its siblings `Is` and `Delayed` both carry godoc, and the generic free function `PortableValueAs` is documented too. `As` is a public accessor callers use to pull a typed payload out of a `PortableValue`, so it warrants the same coverage. Documenting it keeps the exported surface consistent and mirrors the extraction/type-test pairing found in the .NET and Python SDKs, where the value container exposes a documented comma-ok style extraction next to its type test.

## What changed

Added a doc comment describing that `As` returns the contained value coerced to `typ` and `true` when the value is (or can be delayed-deserialized to) `typ`, otherwise `nil` and `false`, and noting it is the comma-ok extraction counterpart to `Is`. No code change.

## Testing

Pure doc change, so no test added.

- `gofmt -l workflow/portable.go` clean
- `go build ./...` passes
- `go vet ./workflow/...` passes
- `go test ./workflow/...` passes
- `go doc ./workflow PortableValue.As` renders the new comment