### PR TITLE
Add godoc to workflow.Builder edge-construction and finalize methods

### DIFF
--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -106,6 +106,8 @@ func (wb *Builder) withOutputFrom(tags []OutputTag, bindings ...ExecutorBinding)
 	return wb
 }
 
+// BindExecutor registers an executor binding without adding any edge. It
+// records an error if binding is a placeholder registration.
 func (wb *Builder) BindExecutor(binding ExecutorBinding) *Builder {
 	if wb.err != nil {
 		return wb
@@ -118,10 +120,18 @@ func (wb *Builder) BindExecutor(binding ExecutorBinding) *Builder {
 	return wb
 }
 
+// AddEdge adds a single unconditional edge from source to target. It is a
+// convenience wrapper over [Builder.AddDirectEdge] with idempotent=false and a
+// nil condition.
 func (wb *Builder) AddEdge(source ExecutorBinding, target ExecutorBinding, opts ...EdgeOption) *Builder {
 	return wb.AddDirectEdge(source, target, false, nil, opts...)
 }
 
+// AddDirectEdge adds an edge from source to target. A non-nil condition makes
+// the edge fire only when condition returns true; a nil condition makes it
+// unconditional. When a matching conditionless edge already exists, idempotent=true
+// silently skips the duplicate while idempotent=false records an error. Only
+// conditionless edges participate in the duplicate-edge check.
 func (wb *Builder) AddDirectEdge(source ExecutorBinding, target ExecutorBinding, idempotent bool, condition func(any) bool, opts ...EdgeOption) *Builder {
 	if wb.err != nil {
 		return wb
@@ -219,6 +229,9 @@ func (wb *Builder) AddFanInBarrierEdge(sources []ExecutorBinding, target Executo
 	return wb
 }
 
+// Build validates the assembled graph, including orphan-executor checks, and
+// returns the immutable *Workflow. It returns the first accumulated error if
+// any builder step failed or validation did not pass.
 func (wb *Builder) Build() (*Workflow, error) {
 	return wb.build(true)
 }


### PR DESCRIPTION
## What

Adds doc comments to four previously-undocumented `workflow.Builder` methods:

- `BindExecutor` — registers an executor binding without adding any edge; records an error on a placeholder registration.
- `AddEdge` — adds a single unconditional edge; a convenience wrapper over `AddDirectEdge` with idempotent=false and a nil condition.
- `AddDirectEdge` — documents the non-obvious idempotent/condition semantics: a non-nil condition gates the edge, a nil condition is unconditional, and when a matching conditionless edge already exists idempotent=true silently skips while idempotent=false records an error (only conditionless edges participate in the dedup check).
- `Build` — validates the assembled graph (including orphan-executor checks) and returns the immutable `*Workflow` or the first accumulated error.

## Why

These methods are core surface of the workflow builder, yet their documented siblings (`WithTelemetry`, `WithIntermediateOutputFrom`, `AddFanOutEdge`, `AddFanInBarrierEdge`) already carry doc comments, leaving an inconsistent gap. Matching the .NET/Python `WorkflowBuilder` API surface, where the equivalent `AddEdge`/`Build` members are documented, keeps the Go port's godoc aligned across SDKs. `AddDirectEdge`'s idempotent-vs-error and conditionless-only-dedup behavior is subtle enough that callers benefit from it being spelled out rather than inferred from the source.

## Testing

Docs-only change. Verified with `go build ./...`, `go vet ./workflow/...`, `gofmt -l workflow/builder.go` (clean), `go test ./workflow/...` (all pass), and `go doc ./workflow Builder.AddDirectEdge`.