### PR TITLE
Set SendMessageRequest.Config.ReturnImmediately from AllowBackgroundResponses on the A2A client

### DIFF
--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -102,9 +102,12 @@ func (a *a2aProvider) run(ctx context.Context, messages []*message.Message, opti
 				seq = a.client.SendStreamingMessage(ctx, params)
 			} else {
 				// Mirror .NET A2AAgent.RunCoreAsync, which sets the send
-				// configuration only on the non-streaming send.
-				allowBackground, _ := agent.GetOption(options, agent.AllowBackgroundResponses)
-				params.Config = &a2a.SendMessageConfig{ReturnImmediately: allowBackground}
+				// configuration only on the non-streaming send. Only set Config
+				// when background responses are explicitly enabled so the wire
+				// request stays unchanged (Config nil) in the default case.
+				if allowBackground, _ := agent.GetOption(options, agent.AllowBackgroundResponses); allowBackground {
+					params.Config = &a2a.SendMessageConfig{ReturnImmediately: true}
+				}
 				resp, err := a.client.SendMessage(ctx, params)
 				seq = func(yield func(a2a.Event, error) bool) {
 					yield(resp, err)

--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -101,6 +101,10 @@ func (a *a2aProvider) run(ctx context.Context, messages []*message.Message, opti
 			if stream {
 				seq = a.client.SendStreamingMessage(ctx, params)
 			} else {
+				// Mirror .NET A2AAgent.RunCoreAsync, which sets the send
+				// configuration only on the non-streaming send.
+				allowBackground, _ := agent.GetOption(options, agent.AllowBackgroundResponses)
+				params.Config = &a2a.SendMessageConfig{ReturnImmediately: allowBackground}
 				resp, err := a.client.SendMessage(ctx, params)
 				seq = func(yield func(a2a.Event, error) bool) {
 					yield(resp, err)

--- a/provider/a2aprovider/a2a_test.go
+++ b/provider/a2aprovider/a2a_test.go
@@ -413,8 +413,8 @@ func TestRunAllowBackgroundResponsesSetsReturnImmediately(t *testing.T) {
 		if transport.capturedMessageSendParams == nil {
 			t.Fatal("capturedMessageSendParams is nil")
 		}
-		if cfg := transport.capturedMessageSendParams.Config; cfg != nil && cfg.ReturnImmediately {
-			t.Error("Config.ReturnImmediately = true, want false")
+		if cfg := transport.capturedMessageSendParams.Config; cfg != nil {
+			t.Errorf("Config = %+v, want nil to preserve the default wire request", cfg)
 		}
 	})
 }

--- a/provider/a2aprovider/a2a_test.go
+++ b/provider/a2aprovider/a2a_test.go
@@ -365,6 +365,60 @@ func TestRunWithExistingSession(t *testing.T) {
 	}
 }
 
+// TestRunAllowBackgroundResponsesSetsReturnImmediately verifies that the
+// AllowBackgroundResponses option propagates to the non-streaming send config's
+// ReturnImmediately field, mirroring .NET A2AAgent.RunCoreAsync.
+func TestRunAllowBackgroundResponsesSetsReturnImmediately(t *testing.T) {
+	newSession := func(a *agent.Agent) *agent.Session {
+		t.Helper()
+		session, err := a.CreateSession(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return session
+	}
+
+	t.Run("enabled", func(t *testing.T) {
+		transport := &mockA2ATransport{}
+		a := newTestAgent(transport, agent.Config{})
+
+		_, err := a.RunText(t.Context(), "Test message",
+			agent.WithSession(newSession(a)),
+			agent.AllowBackgroundResponses(true),
+		).Collect()
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if transport.capturedMessageSendParams == nil {
+			t.Fatal("capturedMessageSendParams is nil")
+		}
+		if transport.capturedMessageSendParams.Config == nil {
+			t.Fatal("capturedMessageSendParams.Config is nil, want non-nil")
+		}
+		if !transport.capturedMessageSendParams.Config.ReturnImmediately {
+			t.Error("Config.ReturnImmediately = false, want true")
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		transport := &mockA2ATransport{}
+		a := newTestAgent(transport, agent.Config{})
+
+		_, err := a.RunText(t.Context(), "Test message",
+			agent.WithSession(newSession(a)),
+		).Collect()
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if transport.capturedMessageSendParams == nil {
+			t.Fatal("capturedMessageSendParams is nil")
+		}
+		if cfg := transport.capturedMessageSendParams.Config; cfg != nil && cfg.ReturnImmediately {
+			t.Error("Config.ReturnImmediately = true, want false")
+		}
+	})
+}
+
 // TestRunWithSessionHavingDifferentContextID tests error when context ID mismatch
 func TestRunWithSessionHavingDifferentContextID(t *testing.T) {
 	transport := &mockA2ATransport{


### PR DESCRIPTION
## What

The A2A client provider (`provider/a2aprovider/a2a.go`) built the `a2a.SendMessageRequest` with no `Config`, so `run()` never read the `AllowBackgroundResponses` option. This change reads the option and sets `SendMessageConfig.ReturnImmediately` on the non-streaming send.

## Why

`AllowBackgroundResponses` is a real client option that is validated generically in `agent.go` (it requires a session). A caller passing `agent.AllowBackgroundResponses(true)` therefore passed validation, but the A2A provider silently ignored it, so the request never asked the remote agent to return immediately after creating the task. `openaiprovider/responses.go` already reads the same option correctly.

This mirrors .NET `A2AAgent.RunCoreAsync`, which sets the send `Configuration` only on the non-streaming send; the streaming `SendStreamingMessage` path is left unchanged.

## Tests

Added `TestRunAllowBackgroundResponsesSetsReturnImmediately` to `a2a_test.go`, reusing the existing `mockA2ATransport` that captures `capturedMessageSendParams`:
- with `AllowBackgroundResponses(true)` + a session, asserts `Config.ReturnImmediately == true`;
- without the option, asserts `Config` is nil or `ReturnImmediately == false`.

The test fails before the fix and passes after. `go build ./...`, `go vet ./provider/a2aprovider/...`, and `go test ./provider/a2aprovider/...` all pass.