### PR TITLE
Surface AG-UI TEXT_MESSAGE_CHUNK events as assistant text on the client

### DIFF
--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -373,6 +373,10 @@ type pendingToolCall struct {
 
 type toolCallAccumulator struct {
 	pending map[string]*pendingToolCall
+	// lastChunkMessageID is the MessageID of the most recent
+	// TextMessageChunkEvent that carried one. Chunks that omit MessageID
+	// continue that message.
+	lastChunkMessageID string
 }
 
 func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUpdate, error) {
@@ -420,9 +424,16 @@ func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUp
 		if delta == "" {
 			return nil, nil
 		}
+		// A chunk may omit MessageID to continue the current text message.
+		// Reuse the last seen chunk MessageID so the collector groups the
+		// delta with its message instead of merging it into an unrelated
+		// last message (see agent.Response.targetMessage).
+		if id := deref(e.MessageID); id != "" {
+			a.lastChunkMessageID = id
+		}
 		return []*agent.ResponseUpdate{{
 			Role:      message.RoleAssistant,
-			MessageID: deref(e.MessageID),
+			MessageID: a.lastChunkMessageID,
 			CreatedAt: eventTime(evt),
 			Contents:  message.Contents{&message.TextContent{Text: delta}},
 		}}, nil

--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -415,6 +415,17 @@ func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUp
 			CreatedAt: eventTime(evt),
 			Contents:  message.Contents{&message.TextContent{Text: e.Delta}},
 		}}, nil
+	case *aguiEvents.TextMessageChunkEvent:
+		delta := deref(e.Delta)
+		if delta == "" {
+			return nil, nil
+		}
+		return []*agent.ResponseUpdate{{
+			Role:      message.RoleAssistant,
+			MessageID: deref(e.MessageID),
+			CreatedAt: eventTime(evt),
+			Contents:  message.Contents{&message.TextContent{Text: delta}},
+		}}, nil
 	case *aguiEvents.ReasoningMessageContentEvent:
 		return []*agent.ResponseUpdate{{
 			Role:      message.RoleAssistant,

--- a/provider/aguiprovider/agui_test.go
+++ b/provider/aguiprovider/agui_test.go
@@ -87,6 +87,42 @@ func TestAGUIAgentRun_SkipsEmptyTextMessageChunkEvents(t *testing.T) {
 	}
 }
 
+func TestAGUIAgentRun_ChunkWithoutMessageIDContinuesItsOwnMessage(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent("thread-1", "run-1"))
+		// A text chunk establishes message "msg-1".
+		writeSSE(t, w, aguiEvents.NewTextMessageChunkEvent(strPtr("msg-1"), strPtr("assistant"), strPtr("Hello")))
+		// A different message (reasoning) becomes the last collected message.
+		writeSSE(t, w, aguiEvents.NewReasoningMessageContentEvent("msg-r", "thinking"))
+		// A chunk omitting MessageID must continue "msg-1", not merge into "msg-r".
+		writeSSE(t, w, aguiEvents.NewTextMessageChunkEvent(nil, nil, strPtr(" World")))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent("thread-1", "run-1"))
+	}))
+	defer server.Close()
+
+	a := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := a.RunText(context.Background(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	for _, msg := range resp.Messages {
+		if msg.ID != "msg-r" {
+			continue
+		}
+		for _, c := range msg.Contents {
+			if tc, ok := c.(*message.TextContent); ok && strings.Contains(tc.Text, "World") {
+				t.Fatalf("chunk without MessageID was mis-grouped into reasoning message %q", msg.ID)
+			}
+		}
+	}
+	if got := resp.String(); !strings.Contains(got, "Hello") || !strings.Contains(got, "World") {
+		t.Fatalf("response text = %q, want it to contain both chunk deltas", got)
+	}
+}
+
 func TestAGUIAgentRun_ConfigInstructionsBecomeSystemMessage(t *testing.T) {
 	var captured aguiTypes.RunAgentInput
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider/aguiprovider/agui_test.go
+++ b/provider/aguiprovider/agui_test.go
@@ -43,6 +43,50 @@ func TestAGUIAgentRun_AggregatesStreamingText(t *testing.T) {
 	}
 }
 
+func TestAGUIAgentRun_SurfacesTextMessageChunkEvents(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent("thread-1", "run-1"))
+		writeSSE(t, w, aguiEvents.NewTextMessageChunkEvent(strPtr("msg-1"), strPtr("assistant"), strPtr("Hello")))
+		writeSSE(t, w, aguiEvents.NewTextMessageChunkEvent(strPtr("msg-1"), strPtr("assistant"), strPtr(" World")))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent("thread-1", "run-1"))
+	}))
+	defer server.Close()
+
+	a := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := a.RunText(context.Background(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if got := resp.String(); got != "Hello World" {
+		t.Fatalf("response text = %q, want %q", got, "Hello World")
+	}
+}
+
+func TestAGUIAgentRun_SkipsEmptyTextMessageChunkEvents(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent("thread-1", "run-1"))
+		writeSSE(t, w, aguiEvents.NewTextMessageChunkEvent(strPtr("msg-1"), strPtr("assistant"), nil))
+		writeSSE(t, w, aguiEvents.NewTextMessageChunkEvent(strPtr("msg-1"), strPtr("assistant"), strPtr("")))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent("thread-1", "run-1"))
+	}))
+	defer server.Close()
+
+	a := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := a.RunText(context.Background(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	for content := range resp.Contents() {
+		if _, ok := content.(*message.TextContent); ok {
+			t.Fatalf("expected no text content for empty chunk deltas, got %#v", content)
+		}
+	}
+}
+
 func TestAGUIAgentRun_ConfigInstructionsBecomeSystemMessage(t *testing.T) {
 	var captured aguiTypes.RunAgentInput
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What changed

The AG-UI provider's `onEvent` switch (`provider/aguiprovider/agui.go`) had cases for `TextMessageContentEvent`, the tool-call events, reasoning, and state events, but **no case for `TextMessageChunkEvent`**. The imported AG-UI Go SDK decodes `EventTypeTextMessageChunk` straight into `TextMessageChunkEvent{MessageID, Role, Delta *string}` without expanding it into START/CONTENT/END. As a result, any server that streams assistant text via `TEXT_MESSAGE_CHUNK` had every chunk fall through to `default: return nil, nil` and be silently discarded — all response content lost.

This adds a case for `*aguiEvents.TextMessageChunkEvent` that mirrors the `TextMessageContentEvent` handling, dereferencing the event's pointer fields via the existing `deref` helper and skipping updates when the delta is nil/empty.

## Why

`TEXT_MESSAGE_CHUNK` is a first-class emission mode in the AG-UI protocol — chunk-style streaming is a legitimate alternative to the START/CONTENT/END sequence, and a multi-vendor protocol client must accept both. The chunk event carries the same assistant-text semantics as `TEXT_MESSAGE_CONTENT`, so it maps to the same `TextContent` update keyed by message ID, consistent with how the .NET and Python AG-UI clients treat chunk events as equivalent assistant text. Scope is intentionally limited to `TEXT_MESSAGE_CHUNK`; `TOOL_CALL_CHUNK` is left for a follow-up.

## How it is tested

Two black-box table-style tests added to the canonical `agui_test.go`, driven through the existing SSE `httptest` harness and `RunText().Collect()`:

- `TestAGUIAgentRun_SurfacesTextMessageChunkEvents` streams two `TextMessageChunkEvent`s and asserts the collected response is `"Hello World"`. This test fails before the change (response text is empty) and passes after.
- `TestAGUIAgentRun_SkipsEmptyTextMessageChunkEvents` streams chunks with nil and empty deltas and asserts no `TextContent` is emitted.

`go build ./...`, `go vet ./provider/aguiprovider/...`, and `go test ./provider/aguiprovider/...` all pass.