### PR TITLE
Add godoc to the TopLevelMediaType methods on DataContent, HostedFileContent, and URIContent

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -235,6 +235,7 @@ func (t *DataContent) Bytes() ([]byte, error) {
 	return base64.StdEncoding.DecodeString(t.Data)
 }
 
+// TopLevelMediaType returns the top-level part of the content's MediaType - the portion before the / (for example image for image/png), or an empty string if MediaType is unset.
 func (t *DataContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }
@@ -425,6 +426,7 @@ type HostedFileContent struct {
 	MediaType string `json:",omitempty"`
 }
 
+// TopLevelMediaType returns the top-level part of the content's MediaType - the portion before the / (for example image for image/png), or an empty string if MediaType is unset.
 func (t *HostedFileContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }
@@ -545,6 +547,7 @@ func NewURIContent(uri string, mediaType string) (*URIContent, error) {
 	return &URIContent{URI: uri, MediaType: mediaType}, nil
 }
 
+// TopLevelMediaType returns the top-level part of the content's MediaType - the portion before the / (for example image for image/png), or an empty string if MediaType is unset.
 func (t *URIContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }

--- a/message/content.go
+++ b/message/content.go
@@ -235,7 +235,7 @@ func (t *DataContent) Bytes() ([]byte, error) {
 	return base64.StdEncoding.DecodeString(t.Data)
 }
 
-// TopLevelMediaType returns the top-level part of the content's MediaType - the portion before the / (for example image for image/png), or an empty string if MediaType is unset.
+// TopLevelMediaType returns the normalized (lowercased, whitespace-trimmed) top-level part of the content's MediaType - the portion before the / (for example image for image/png). If MediaType contains no /, the whole normalized value is returned; if MediaType is unset, it returns an empty string.
 func (t *DataContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }
@@ -426,7 +426,7 @@ type HostedFileContent struct {
 	MediaType string `json:",omitempty"`
 }
 
-// TopLevelMediaType returns the top-level part of the content's MediaType - the portion before the / (for example image for image/png), or an empty string if MediaType is unset.
+// TopLevelMediaType returns the normalized (lowercased, whitespace-trimmed) top-level part of the content's MediaType - the portion before the / (for example image for image/png). If MediaType contains no /, the whole normalized value is returned; if MediaType is unset, it returns an empty string.
 func (t *HostedFileContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }
@@ -547,7 +547,7 @@ func NewURIContent(uri string, mediaType string) (*URIContent, error) {
 	return &URIContent{URI: uri, MediaType: mediaType}, nil
 }
 
-// TopLevelMediaType returns the top-level part of the content's MediaType - the portion before the / (for example image for image/png), or an empty string if MediaType is unset.
+// TopLevelMediaType returns the normalized (lowercased, whitespace-trimmed) top-level part of the content's MediaType - the portion before the / (for example image for image/png). If MediaType contains no /, the whole normalized value is returned; if MediaType is unset, it returns an empty string.
 func (t *URIContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }


### PR DESCRIPTION
## What

Adds a one-line doc comment to the three exported `TopLevelMediaType` methods on `DataContent`, `HostedFileContent`, and `URIContent` in `message/content.go`. The wording is identical across all three so the trio reads uniformly.

## Why

These exported methods previously had no doc comment, even though their immediately-preceding sibling accessor (e.g. `DataContent.Bytes`) is documented, and the returned value is used behaviorally (`a.TopLevelMediaType() == "text"`). Documenting them keeps godoc coverage consistent with the rest of the content API and mirrors the intent-revealing naming used for the equivalent media-type helpers in the .NET/Python SDKs, where the top-level media type is a first-class, documented concept.

## Testing

Docs-only change. Verified with:
- `go build ./...`
- `go vet ./message/...`
- `go test ./message/...`
- `go doc ./message DataContent.TopLevelMediaType` (and the HostedFileContent/URIContent variants) shows the new comment.

All clean.