### PR TITLE
Handle message.Contents named type in agentResultToMCPCallToolResult

### DIFF
--- a/tool/mcptool/mcp.go
+++ b/tool/mcptool/mcp.go
@@ -272,6 +272,8 @@ func agentResultToMCPCallToolResult(result any) *mcp.CallToolResult {
 		}
 		callResult.Content = []mcp.Content{agentContentToMCPContent(resultValue)}
 		return callResult
+	case message.Contents:
+		return agentResultToMCPCallToolResult([]message.Content(resultValue))
 	case []message.Content:
 		callResult := &mcp.CallToolResult{Content: make([]mcp.Content, 0, len(resultValue))}
 		for _, contentValue := range resultValue {

--- a/tool/mcptool/mcp_test.go
+++ b/tool/mcptool/mcp_test.go
@@ -706,6 +706,53 @@ func TestAddToolReturnsDataAndMultipleContentResults(t *testing.T) {
 	})
 }
 
+// message.Contents is the named slice type (type Contents []Content) that
+// Message.Contents is declared as. A Go type switch matches on dynamic type
+// identity, so a message.Contents value must be handled explicitly; otherwise
+// it misses the []message.Content branch, falls through to the JSON fallback,
+// and collapses every block into a single TextContent (losing image/audio
+// blocks and never setting IsError). This mirrors the .NET/Python behavior of
+// iterating each content block individually.
+func TestAddToolReturnsNamedContentsSlice(t *testing.T) {
+	result := callAddedTool(t, stubFuncTool{
+		name:         "named-contents-result",
+		description:  "returns a message.Contents named slice",
+		schema:       map[string]any{"type": "object"},
+		returnSchema: map[string]any{"type": "object"},
+		call: func(context.Context, string) (any, error) {
+			return message.Contents{
+				&message.TextContent{Text: "hi"},
+				&message.DataContent{Data: "iVBORw0KGgo=", MediaType: "image/png"},
+				&message.ErrorContent{Message: "boom"},
+			}, nil
+		},
+	})
+
+	if len(result.Content) != 3 {
+		t.Fatalf("expected three content items, got %d", len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content is %T, want *mcp.TextContent", result.Content[0])
+	}
+	if text.Text != "hi" {
+		t.Fatalf("first text = %q, want hi", text.Text)
+	}
+	image, ok := result.Content[1].(*mcp.ImageContent)
+	if !ok {
+		t.Fatalf("second content is %T, want *mcp.ImageContent", result.Content[1])
+	}
+	if image.MIMEType != "image/png" {
+		t.Fatalf("image MIMEType = %q, want image/png", image.MIMEType)
+	}
+	if _, ok := result.Content[2].(*mcp.TextContent); !ok {
+		t.Fatalf("third content is %T, want *mcp.TextContent", result.Content[2])
+	}
+	if !result.IsError {
+		t.Fatal("IsError = false, want true (error content block present)")
+	}
+}
+
 // A text-typed DataContent whose bytes are not valid UTF-8 must fall back to a
 // binary Blob resource; putting invalid UTF-8 in Text corrupts it on transport.
 func TestAddToolReturnsInvalidUTF8TextAsBlob(t *testing.T) {


### PR DESCRIPTION
## What

`agentResultToMCPCallToolResult` in `tool/mcptool/mcp.go` type-switched on `case message.Content:` and `case []message.Content:` but had no case for `message.Contents` — the named slice type (`type Contents []Content`) that `Message.Contents` is actually declared as.

A Go type switch matches on dynamic type identity, so a `message.Contents` value does **not** match `case []message.Content:`, nor does it satisfy the `Content` interface. It fell through to `default -> structuredResultToMCPCallToolResult`, which `json.Marshal`ed the whole slice into a single `TextContent`. That:

- collapsed multiple content blocks into one,
- encoded image/audio `DataContent` as base64 JSON strings instead of `mcp.ImageContent`/`mcp.AudioContent`, and
- never set `IsError` for `*message.ErrorContent` blocks.

The same defect affected the `FunctionResultContent.Result` path via `functionResultToMCPCallToolResult`.

## Fix

Add `case message.Contents:` that converts to `[]message.Content` and delegates to the existing correct branch. That branch already iterates each block, calls `agentContentToMCPContent` per item (mapping image/audio/resource types), and sets `IsError` for error content. Minimal and surgical.

## Parity

This restores the .NET/Python semantics of surfacing each content block individually to MCP (distinct image/audio/text blocks and an error flag), rather than one opaque JSON text block.

## Testing

Added `TestAddToolReturnsNamedContentsSlice` in `tool/mcptool/mcp_test.go`: a stub tool returns `message.Contents{TextContent, image DataContent, ErrorContent}` and the test asserts the resulting `mcp.CallToolResult` has three blocks — distinct `*mcp.TextContent` and `*mcp.ImageContent` (not one JSON text) — with `IsError == true`. The test fails before the fix (one collapsed block) and passes after. `go build ./...`, `go vet ./tool/mcptool/...`, and `go test ./tool/mcptool/...` are green.