### PR TITLE
Surface AG-UI MESSAGES_SNAPSHOT events as metadata instead of dropping them

### DIFF
--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -479,6 +479,14 @@ func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUp
 			CreatedAt: eventTime(evt),
 			Contents:  message.Contents{newJSONDataContent(e.Delta, "application/json-patch+json")},
 		}}, nil
+	case *aguiEvents.MessagesSnapshotEvent:
+		return []*agent.ResponseUpdate{{
+			Role:      message.RoleAssistant,
+			CreatedAt: eventTime(evt),
+			AdditionalProperties: map[string]any{
+				"agui_messages_snapshot": e.Messages,
+			},
+		}}, nil
 	default:
 		return nil, nil
 	}

--- a/provider/aguiprovider/agui_test.go
+++ b/provider/aguiprovider/agui_test.go
@@ -488,6 +488,47 @@ func TestAGUIAgentRun_ConvertsStateSnapshotEventToDataContent(t *testing.T) {
 	}
 }
 
+func TestAGUIAgentRun_SurfacesMessagesSnapshotEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent("thread-1", "run-1"))
+		writeSSE(t, w, aguiEvents.NewMessagesSnapshotEvent([]aguiTypes.Message{{
+			ID:      "msg-1",
+			Role:    aguiTypes.RoleAssistant,
+			Content: "restored history",
+		}}))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent("thread-1", "run-1"))
+	}))
+	defer server.Close()
+
+	a := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := a.RunText(context.Background(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	var snapshot any
+	for _, msg := range resp.Messages {
+		if v, ok := msg.AdditionalProperties["agui_messages_snapshot"]; ok {
+			snapshot = v
+			break
+		}
+	}
+	if snapshot == nil {
+		t.Fatal("expected agui_messages_snapshot in message metadata")
+	}
+	messages, ok := snapshot.([]aguiTypes.Message)
+	if !ok {
+		t.Fatalf("agui_messages_snapshot type = %T, want []aguiTypes.Message", snapshot)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("snapshot length = %d, want 1", len(messages))
+	}
+	if messages[0].ID != "msg-1" || messages[0].Content != "restored history" {
+		t.Fatalf("snapshot message = %#v, want id msg-1 content 'restored history'", messages[0])
+	}
+}
+
 func TestAGUIAgentRun_WithUnknownEventType_ReturnsError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
## What

`onEvent` in `provider/aguiprovider/agui.go` switched over `StateSnapshotEvent` and `StateDeltaEvent` and then hit `default: return nil, nil`. There was no `case *aguiEvents.MessagesSnapshotEvent`. The vendored AG-UI SDK decodes `MESSAGES_SNAPSHOT` into a distinct typed `*MessagesSnapshotEvent{ *BaseEvent; Messages []Message }` and feeds it to `onEvent`, so every MESSAGES_SNAPSHOT frame reached the default branch and was silently discarded.

This adds a `case *aguiEvents.MessagesSnapshotEvent` that emits a single assistant `*agent.ResponseUpdate` with `CreatedAt: eventTime(evt)` and the snapshot exposed under `AdditionalProperties["agui_messages_snapshot"]`.

## Why

MESSAGES_SNAPSHOT is a first-class AG-UI event that lets a server re-sync the full conversation history to the client. Dropping it means consumers lose that history-continuity signal entirely. The metadata-surfacing form is the lowest-risk mapping and matches how RunStarted metadata and the state snapshot/delta events are already surfaced instead of dropped, keeping consistent behavior across the provider's event handling. Surfacing the snapshot as provider-specific metadata (rather than fabricating message content) aligns with the .NET/Python AG-UI clients, which expose the snapshot to callers rather than discarding it.

## Testing

Added `TestAGUIAgentRun_SurfacesMessagesSnapshotEvent` to `agui_test.go` (parallel to the existing state-snapshot test): it streams a `NewMessagesSnapshotEvent` with one message during a run and asserts a collected message carries `AdditionalProperties["agui_messages_snapshot"]` holding that message list. The test fails before the change (the frame yields no such update) and passes after. `go build ./...`, `go vet ./provider/aguiprovider/...`, and `go test ./provider/aguiprovider/...` all pass.