### PR TITLE
Add a stdio (subprocess) MCP-client example using mcp.CommandTransport

### DIFF
--- a/cmd/verifyexamples/examples.go
+++ b/cmd/verifyexamples/examples.go
@@ -583,6 +583,13 @@ var agentsExamples = []ExampleDefinition{
 		SkipReason:                   "Starts an MCP server that does not exit.",
 	},
 	{
+		Name:                         "02_agents_mcp_local_stdio_mcp",
+		ProjectPath:                  "examples/02-agents/mcp/local_stdio_mcp",
+		RequiredEnvironmentVariables: []string{"FOUNDRY_PROJECT_ENDPOINT"},
+		OptionalEnvironmentVariables: []string{"FOUNDRY_MODEL"},
+		SkipReason:                   "Spawns a local stdio MCP server subprocess (go run) that requires live Foundry credentials.",
+	},
+	{
 		Name:        "02_agents_providers_github_copilot",
 		ProjectPath: "examples/02-agents/providers/github-copilot",
 		Inputs:      inputLines("Y", "Y", "Y"),

--- a/examples/02-agents/mcp/local_stdio_mcp/main.go
+++ b/examples/02-agents/mcp/local_stdio_mcp/main.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to connect an agent to a local MCP server that runs as
+// a subprocess, communicating over stdin/stdout via mcp.CommandTransport.
+//
+// It spawns the sibling "step10_as_mcp_tool" example (an agent exposed as an
+// MCP tool over a stdio transport) as a child process, lists the tools it
+// exposes, and attaches them to a Foundry agent. This mirrors the Python and
+// .NET "stdio MCP client" samples, where a local command-based MCP server is
+// launched and consumed by an agent.
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/examples/internal/demo"
+	"github.com/microsoft/agent-framework-go/provider/foundryprovider"
+	"github.com/microsoft/agent-framework-go/tool/mcptool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// stdioServerDir resolves the sibling stdio MCP server example relative to this
+// source file so the sample works regardless of the current working directory.
+func stdioServerDir() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "agents", "step10_as_mcp_tool")
+}
+
+func main() {
+	logger := demo.NewLogger(
+		"Local stdio MCP Client",
+		"Demonstrates connecting an agent to a local MCP server launched as a subprocess over stdio.",
+		"Model", demo.FoundryModel,
+	)
+
+	ctx := context.Background()
+	token := demo.FoundryTokenCredential()
+
+	// Launch the sibling stdio MCP server ("go run .") as a child process and
+	// connect to it over stdin/stdout. Closing the session terminates the child.
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = stdioServerDir()
+	cmd.Stderr = os.Stderr
+
+	session, err := mcptool.Connect(ctx, &mcp.CommandTransport{Command: cmd})
+	if err != nil {
+		demo.Panic(err)
+	}
+	defer func() { _ = session.Close() }()
+
+	// Retrieve the list of tools exposed by the local MCP server.
+	tools, err := mcptool.ListTools(ctx, session)
+	if err != nil {
+		demo.Panic(err)
+	}
+
+	// Create the agent with the tools discovered from the local MCP server.
+	a := foundryprovider.NewAgent(
+		demo.FoundryProjectEndpoint,
+		token,
+		foundryprovider.ModelDeployment(demo.FoundryModel),
+		foundryprovider.AgentConfig{
+			Instructions: "You are a helpful assistant. Use the available tools to answer the user's request.",
+			Config: agent.Config{
+				Name:        "LocalMCPAgent",
+				Middlewares: []agent.Middleware{logger}, // for logging agent interactions
+				Tools:       tools,
+			},
+		},
+	)
+
+	// Invoke the agent and output the text result.
+	resp, err := a.RunText(ctx, "Tell me a joke about a pirate.").Collect()
+	demo.Response(resp, err)
+}

--- a/examples/02-agents/mcp/local_stdio_mcp/main_test.go
+++ b/examples/02-agents/mcp/local_stdio_mcp/main_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/tool/mcptool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestMain lets this test binary double as a trivial stdio MCP server when the
+// AF_STDIO_MCP_HELPER environment variable is set. This lets the client-side
+// test spawn a real subprocess and talk to it over stdin/stdout via
+// mcp.CommandTransport with no network access.
+func TestMain(m *testing.M) {
+	if os.Getenv("AF_STDIO_MCP_HELPER") == "1" {
+		runStubMCPServer()
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func runStubMCPServer() {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "stub-stdio-server", Version: "1.0.0"}, nil)
+	srv.AddTool(&mcp.Tool{
+		Name:        "echo",
+		Description: "Echoes a canned message.",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "pong"}}}, nil
+	})
+	_ = srv.Run(context.Background(), &mcp.StdioTransport{})
+}
+
+// TestLocalStdioMCPClient exercises the transport wiring used by this sample:
+// mcp.CommandTransport -> mcptool.Connect -> mcptool.ListTools, and verifies
+// that closing the session terminates the spawned child process.
+func TestLocalStdioMCPClient(t *testing.T) {
+	ctx := context.Background()
+
+	// Re-invoke this test binary as the stdio MCP server (see TestMain).
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(), "AF_STDIO_MCP_HELPER=1")
+
+	session, err := mcptool.Connect(ctx, &mcp.CommandTransport{Command: cmd})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	tools, err := mcptool.ListTools(ctx, session)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("ListTools() returned %d tools, want 1", len(tools))
+	}
+	if got := tools[0].Name(); got != "echo" {
+		t.Fatalf("tool name = %q, want %q", got, "echo")
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+		t.Fatalf("child process did not terminate after Close(); ProcessState = %v", cmd.ProcessState)
+	}
+}

--- a/examples/02-agents/mcp/local_stdio_mcp/main_test.go
+++ b/examples/02-agents/mcp/local_stdio_mcp/main_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -33,7 +34,10 @@ func runStubMCPServer() {
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "pong"}}}, nil
 	})
-	_ = srv.Run(context.Background(), &mcp.StdioTransport{})
+	if err := srv.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+		fmt.Fprintf(os.Stderr, "stub stdio MCP server failed: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 // TestLocalStdioMCPClient exercises the transport wiring used by this sample:
@@ -50,6 +54,14 @@ func TestLocalStdioMCPClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Connect() error = %v", err)
 	}
+	// Ensure the spawned helper process is torn down even if a later assertion
+	// fails before the explicit Close() below runs.
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = session.Close()
+		}
+	})
 
 	tools, err := mcptool.ListTools(ctx, session)
 	if err != nil {
@@ -65,6 +77,7 @@ func TestLocalStdioMCPClient(t *testing.T) {
 	if err := session.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
 	}
+	closed = true
 	if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
 		t.Fatalf("child process did not terminate after Close(); ProcessState = %v", cmd.ProcessState)
 	}


### PR DESCRIPTION
## What

Adds `examples/02-agents/mcp/local_stdio_mcp` — a stdio (subprocess) MCP **client** example.

The sample launches the sibling `agents/step10_as_mcp_tool` stdio MCP server as a child process via `mcp.CommandTransport{Command: exec.Command("go", "run", ".")}`, connects to it with `mcptool.Connect`, discovers its tools with `mcptool.ListTools`, attaches them to a Foundry agent through `agent.Config.Tools`, and runs a prompt. The session's `defer Close()` terminates the child.

It also registers the example in `cmd/verifyexamples/examples.go` and adds an offline test.

## Why

`mcp.CommandTransport` (subprocess over stdin/stdout) already exists in the pinned go-sdk, but no example used it: every client call site used `&mcp.StreamableClientTransport{}` (remote HTTP), and `step10_as_mcp_tool` is only the **server** side over `StdioTransport`. The client side of a locally-spawned stdio MCP server was missing.

This closes a cross-SDK parity gap: the Python and .NET agent-framework SDKs both ship a first-class "stdio / command-based MCP client" sample where a local MCP server process is launched and consumed by an agent. This Go sample gives that same story using the existing `mcptool` API unchanged.

## How it is tested

`main_test.go` runs the full transport flow offline with no network:
- `TestMain` lets the test binary double as a trivial stdio MCP server (guarded by an env var) exposing a single `echo` tool.
- `TestLocalStdioMCPClient` re-invokes that binary through `mcp.CommandTransport`, asserts `mcptool.Connect` + `ListTools` return the expected tool, and verifies `session.Close()` terminates the child process (`cmd.ProcessState.Exited()`).

`go build ./...`, `go vet ./examples/02-agents/mcp/local_stdio_mcp/...` and `go test ./examples/02-agents/mcp/local_stdio_mcp/... ./cmd/verifyexamples/...` all pass.
