### PR TITLE
Add godoc to the MiddlewareFunc.Run adapter method

### DIFF
--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -27,6 +27,7 @@ type Middleware interface {
 // MiddlewareFunc adapts a function to the [Middleware] interface.
 type MiddlewareFunc func(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error]
 
+// Run calls the underlying function, letting a plain func be used wherever a [Middleware] is required.
 func (mf MiddlewareFunc) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
 	return mf(next, ctx, messages, options...)
 }

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -27,7 +27,8 @@ type Middleware interface {
 // MiddlewareFunc adapts a function to the [Middleware] interface.
 type MiddlewareFunc func(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error]
 
-// Run calls the underlying function, letting a plain func be used wherever a [Middleware] is required.
+// Run calls the underlying function, letting a plain func be used wherever a
+// [Middleware] is required.
 func (mf MiddlewareFunc) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
 	return mf(next, ctx, messages, options...)
 }


### PR DESCRIPTION
## What

Add a doc comment to `MiddlewareFunc.Run` in `agent/middleware.go`. This adapter method was the only exported member of the middleware surface without a doc comment: the `Middleware` interface, its `Run` contract, and the `MiddlewareFunc` type are all already documented in the same file.

## Why

Keeps the middleware surface consistently documented. The method that actually satisfies the `Middleware` interface for func-based middleware should describe its role, mirroring the documented `Middleware.Run` contract. This also aligns with the .NET/Python SDKs, where the delegate-to-middleware adapter surface is documented so users writing inline middleware get IDE/godoc hints.

## Testing

Docs-only change.
- `go build ./...`, `go vet ./agent/...`, `go test ./agent/...` all pass.
- `gofmt -l agent/middleware.go` is clean.
- `go doc ./agent MiddlewareFunc.Run` now renders the new comment.