### PR TITLE
Document message.Contents.Usage and message.UsageDetails.Add accessors

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -101,6 +101,7 @@ func (cs Contents) Text() string {
 	return sb.String()
 }
 
+// Usage sums the UsageDetails of every UsageContent in the slice, returning the aggregate token usage (a zero UsageDetails if none is present).
 func (cs Contents) Usage() UsageDetails {
 	var usage UsageDetails
 	for _, c := range cs {
@@ -573,6 +574,7 @@ type UsageDetails struct {
 	ReasoningTokenCount   int64
 }
 
+// Add accumulates other into u, summing each token count field and merging AdditionalCounts (allocating the map on first use).
 func (u *UsageDetails) Add(other UsageDetails) {
 	u.InputTokenCount += other.InputTokenCount
 	u.OutputTokenCount += other.OutputTokenCount


### PR DESCRIPTION
## What

Add doc comments to two exported accessors in `message/content.go` that were missing them:

- `Contents.Usage()` — sums the `UsageDetails` of every `UsageContent` in the slice, returning the aggregate token usage.
- `UsageDetails.Add(other)` — accumulates `other` into the receiver, summing each token count field and merging `AdditionalCounts`.

## Why

Both are non-boilerplate exported accessors, yet their documented sibling `Contents.Text` already carries a doc comment while these two did not. Documenting them keeps the public API surface consistently discoverable via `go doc` and godoc. These accessors are the Go equivalents of the .NET/Python usage aggregation helpers (UsageDetails.Add / usage summing over content), so documenting their aggregation-and-merge semantics aligns the Go port's public docs with the cross-SDK behavior contract.

## Testing

Docs-only change; no behavioral change. Verified with:

- `go build ./...`, `go vet ./message/...`, `go test ./message/...` all pass.
- `gofmt -l message/content.go` reports clean.
- `go doc ./message Contents.Usage` and `go doc ./message UsageDetails.Add` render the new comments.