### PR TITLE
Map Gemini hosted tools (Google Search, code execution, file search) to genai.Tool

### DIFF
--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent/harness/toolautocall"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
+	"github.com/microsoft/agent-framework-go/tool/hostedtool"
 	"google.golang.org/genai"
 )
 
@@ -195,19 +196,40 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 		appendSystemInstruction(cfg, strings.Join(instructions, "\n"))
 	}
 
-	// Collect tools from options.
+	// Collect tools from options. Function tools are aggregated into a single
+	// genai.Tool holding all FunctionDeclarations, while each hosted tool maps
+	// onto its own genai.Tool entry (Gemini does not allow combining native
+	// tools with function declarations in a single Tool). This mirrors the
+	// hosted-tool mapping already performed by the openaiprovider.
 	var funcDecls []*genai.FunctionDeclaration
 	for tl := range agent.AllOptions(opts, agent.WithTool) {
-		if ft, ok := tl.(tool.FuncTool); ok {
-			decl := &genai.FunctionDeclaration{
-				Name:        ft.Name(),
-				Description: ft.Description(),
+		switch tl := tl.(type) {
+		case *hostedtool.WebSearch:
+			cfg.Tools = append(cfg.Tools, &genai.Tool{GoogleSearch: &genai.GoogleSearch{}})
+		case *hostedtool.CodeInterpreter:
+			cfg.Tools = append(cfg.Tools, &genai.Tool{CodeExecution: &genai.ToolCodeExecution{}})
+		case *hostedtool.FileSearch:
+			fs := &genai.FileSearch{}
+			for _, input := range tl.Inputs {
+				if hosted, ok := input.(*message.HostedVectorStoreContent); ok {
+					fs.FileSearchStoreNames = append(fs.FileSearchStoreNames, hosted.VectorStoreID)
+				}
 			}
-			if schema := ft.Schema(); schema != nil {
+			if tl.MaximumResultCount != 0 {
+				topK := int32(tl.MaximumResultCount)
+				fs.TopK = &topK
+			}
+			cfg.Tools = append(cfg.Tools, &genai.Tool{FileSearch: fs})
+		case tool.FuncTool:
+			decl := &genai.FunctionDeclaration{
+				Name:        tl.Name(),
+				Description: tl.Description(),
+			}
+			if schema := tl.Schema(); schema != nil {
 				// Use ParametersJsonSchema to pass through the JSON schema directly.
 				decl.ParametersJsonSchema = schema
 			}
-			if schema := ft.ReturnSchema(); schema != nil {
+			if schema := tl.ReturnSchema(); schema != nil {
 				decl.ResponseJsonSchema = schema
 			}
 			funcDecls = append(funcDecls, decl)

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"math"
 	"reflect"
 	"slices"
 	"strings"
@@ -215,7 +216,10 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 					fs.FileSearchStoreNames = append(fs.FileSearchStoreNames, hosted.VectorStoreID)
 				}
 			}
-			if tl.MaximumResultCount != 0 {
+			// Guard against negative or out-of-range values before the
+			// int32 conversion: negatives would produce an invalid TopK and
+			// large values would overflow on 64-bit platforms.
+			if tl.MaximumResultCount > 0 && tl.MaximumResultCount <= math.MaxInt32 {
 				topK := int32(tl.MaximumResultCount)
 				fs.TopK = &topK
 			}

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -1722,3 +1722,92 @@ func TestHostedTools_MappedToGenaiTools(t *testing.T) {
 		})
 	}
 }
+
+// TestHostedTools_FileSearchMapping verifies that a FileSearch hosted tool is
+// mapped onto a native genai fileSearch tool with its vector store names and
+// (range-checked) TopK serialized. A missing case here previously allowed
+// FileSearch to be silently omitted or mis-serialized.
+func TestHostedTools_FileSearchMapping(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	server := httptest.NewServer(captureAndRespond(t, bodyCh, "application/json", minimalTextResponse("ok")))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+
+	fileSearch := &hostedtool.FileSearch{
+		Inputs: []message.Content{
+			&message.HostedVectorStoreContent{VectorStoreID: "store-a"},
+			&message.HostedVectorStoreContent{VectorStoreID: "store-b"},
+		},
+		MaximumResultCount: 7,
+	}
+	if _, err := a.RunText(t.Context(), "hi", agent.WithTool(fileSearch)).Collect(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(<-bodyCh, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	toolsAny, ok := req["tools"].([]any)
+	if !ok || len(toolsAny) == 0 {
+		t.Fatalf("request missing tools or tools is not an array: %v", req["tools"])
+	}
+	var fileSearchMap map[string]any
+	for _, tAny := range toolsAny {
+		tMap, ok := tAny.(map[string]any)
+		if !ok {
+			continue
+		}
+		if fsAny, ok := tMap["fileSearch"].(map[string]any); ok {
+			fileSearchMap = fsAny
+			break
+		}
+	}
+	if fileSearchMap == nil {
+		t.Fatalf("request tools missing fileSearch entry: %v", toolsAny)
+	}
+
+	names, _ := fileSearchMap["fileSearchStoreNames"].([]any)
+	if len(names) != 2 || names[0] != "store-a" || names[1] != "store-b" {
+		t.Errorf("fileSearchStoreNames = %v, want [store-a store-b]", fileSearchMap["fileSearchStoreNames"])
+	}
+	if topK, _ := fileSearchMap["topK"].(float64); topK != 7 {
+		t.Errorf("topK = %v, want 7", fileSearchMap["topK"])
+	}
+}
+
+// TestHostedTools_FileSearchInvalidTopK verifies that a negative
+// MaximumResultCount is not serialized as an invalid TopK.
+func TestHostedTools_FileSearchInvalidTopK(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	server := httptest.NewServer(captureAndRespond(t, bodyCh, "application/json", minimalTextResponse("ok")))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+
+	fileSearch := &hostedtool.FileSearch{
+		Inputs:             []message.Content{&message.HostedVectorStoreContent{VectorStoreID: "store-a"}},
+		MaximumResultCount: -1,
+	}
+	if _, err := a.RunText(t.Context(), "hi", agent.WithTool(fileSearch)).Collect(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(<-bodyCh, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	toolsAny, _ := req["tools"].([]any)
+	for _, tAny := range toolsAny {
+		tMap, ok := tAny.(map[string]any)
+		if !ok {
+			continue
+		}
+		if fsAny, ok := tMap["fileSearch"].(map[string]any); ok {
+			if _, present := fsAny["topK"]; present {
+				t.Errorf("negative MaximumResultCount should not serialize topK, got %v", fsAny["topK"])
+			}
+		}
+	}
+}

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/provider/geminiprovider"
+	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
+	"github.com/microsoft/agent-framework-go/tool/hostedtool"
 	"google.golang.org/genai"
 )
 
@@ -1667,5 +1669,56 @@ func TestUsageContent_Streaming_CumulativeUsageNotSummed(t *testing.T) {
 	}
 	if usage.OutputTokenCount != 5 {
 		t.Errorf("OutputTokenCount = %d, want 5", usage.OutputTokenCount)
+	}
+}
+
+// TestHostedTools_MappedToGenaiTools verifies that hosted tools attached via
+// agent.WithTool are mapped onto their native genai.Tool entries in the outgoing
+// request. Before this mapping, non-FuncTool options were silently dropped and
+// the request carried no tools at all.
+func TestHostedTools_MappedToGenaiTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		tool    tool.Tool
+		toolKey string
+	}{
+		{"web_search", &hostedtool.WebSearch{}, "googleSearch"},
+		{"code_interpreter", &hostedtool.CodeInterpreter{}, "codeExecution"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyCh := make(chan []byte, 1)
+			server := httptest.NewServer(captureAndRespond(t, bodyCh, "application/json", minimalTextResponse("ok")))
+			defer server.Close()
+
+			a := newTestClient(t, server)
+
+			if _, err := a.RunText(t.Context(), "hi", agent.WithTool(tc.tool)).Collect(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var req map[string]any
+			if err := json.Unmarshal(<-bodyCh, &req); err != nil {
+				t.Fatalf("unmarshal request body: %v", err)
+			}
+			toolsAny, ok := req["tools"].([]any)
+			if !ok || len(toolsAny) == 0 {
+				t.Fatalf("request missing tools or tools is not an array: %v", req["tools"])
+			}
+			found := false
+			for _, tAny := range toolsAny {
+				tMap, ok := tAny.(map[string]any)
+				if !ok {
+					continue
+				}
+				if _, ok := tMap[tc.toolKey]; ok {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("request tools missing %q entry: %v", tc.toolKey, toolsAny)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Extends the tool loop in `buildParams` (`provider/geminiprovider/agent.go`) so that hosted tools attached via `agent.WithTool` are mapped onto their native `genai.Tool` fields instead of being silently dropped:

- `*hostedtool.WebSearch` -> `&genai.Tool{GoogleSearch: &genai.GoogleSearch{}}`
- `*hostedtool.CodeInterpreter` -> `&genai.Tool{CodeExecution: &genai.ToolCodeExecution{}}`
- `*hostedtool.FileSearch` -> `&genai.Tool{FileSearch: ...}` (store names from `HostedVectorStoreContent` inputs, `MaximumResultCount` -> `TopK`)

Function tools still aggregate into a single `genai.Tool{FunctionDeclarations: ...}`. Each hosted tool is appended as its own `genai.Tool` entry because Gemini does not allow combining native tools with function declarations in one `Tool`.

## Why

Previously the loop only handled `tool.FuncTool`; any non-FuncTool option fell through with no error. The hosted-tool marker types are not FuncTools, so attaching e.g. `&hostedtool.WebSearch{}` to a Gemini agent was a silent no-op even though `genai.Tool` natively exposes `GoogleSearch`, `CodeExecution`, and `FileSearch`. Notably the response parser already decodes `ExecutableCode`/`CodeExecutionResult` into `CodeInterpreterToolCall`/`Result` content, so the provider consumed code-execution output but had no request-side path to enable it.

This aligns Gemini with the cross-SDK parity already established by `openaiprovider`, which performs the same hosted-tool mapping (and mirrors the .NET/Python behavior of forwarding hosted tools to the provider's native tool types).

## How it is tested

Adds `TestHostedTools_MappedToGenaiTools` in the canonical `agent_test.go` (black-box, using the existing `captureAndRespond` request-capture harness). It attaches `&hostedtool.WebSearch{}` and `&hostedtool.CodeInterpreter{}` and asserts the outgoing request's `tools` array contains a `googleSearch` (resp. `codeExecution`) entry. Before the change the request carried no tools and the test fails.

`go build ./...`, `go vet ./provider/geminiprovider/...`, and `go test ./provider/geminiprovider/...` all pass.