### PR TITLE
Add godoc to ToolApprovalRequestContent.CreateResponse

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -663,6 +663,10 @@ func (t *ToolApprovalRequestContent) UnmarshalJSON(data []byte) error {
 
 func (t ToolApprovalRequestContent) kind() contentKind { return "toolApprovalRequest" }
 
+// CreateResponse builds a [ToolApprovalResponseContent] that approves or rejects this
+// request. It carries over the RequestID, records the decision and reason, and clones the
+// pending tool call along with the AdditionalProperties and Annotations of the content
+// header. Note that RawRepresentation is copied by reference.
 func (t *ToolApprovalRequestContent) CreateResponse(approved bool, reason string) *ToolApprovalResponseContent {
 	return &ToolApprovalResponseContent{
 		RequestID: t.RequestID,


### PR DESCRIPTION
## What

Adds a doc comment to the exported `ToolApprovalRequestContent.CreateResponse` method in `message/content.go`, which previously had none.

The comment documents that the method builds a `ToolApprovalResponseContent` approving or rejecting the request, carries over the `RequestID`, records the decision and reason, and clones the pending tool call along with the `AdditionalProperties` and `Annotations` of the content header. It also notes that `RawRepresentation` is copied by reference, so the response is not a fully deep copy.

## Why

`CreateResponse` is a meaningful factory used in the tool-approval flow (called in two places within the package). Documenting it improves godoc coverage and matches the .NET/Python approval-content APIs, where the equivalent response-creation helper is documented. This aligns the Go port's public surface with the other SDKs.

## Testing

Docs-only change.
- `go build ./...` passes
- `go vet ./message/...` passes
- `go test ./message/...` passes
- `go doc` confirms the comment renders on the method