### PR TITLE
Add godoc to the shelltool.Local tool.Tool interface methods

### DIFF
--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -145,12 +145,15 @@ type Local struct {
 	exec *localShellExecutor
 }
 
+// Name returns the tool identifier (run_shell).
 func (t *Local) Name() string { return "run_shell" }
 
+// Description returns the model-facing description of the shell tool.
 func (t *Local) Description() string {
 	return t.exec.opts.defaultDescription()
 }
 
+// Schema returns the JSON schema for the tool's command argument.
 func (t *Local) Schema() any {
 	return map[string]any{
 		"type": "object",
@@ -164,8 +167,10 @@ func (t *Local) Schema() any {
 	}
 }
 
+// ReturnSchema returns nil because the tool yields free-form model-formatted output.
 func (t *Local) ReturnSchema() any { return nil }
 
+// Call unmarshals the command argument, executes it via Run, and returns model-formatted output.
 func (t *Local) Call(ctx context.Context, args string) (any, error) {
 	var in shellInput
 	if err := json.Unmarshal([]byte(args), &in); err != nil {


### PR DESCRIPTION
## What

Adds one-line doc comments to the five exported methods on `shelltool.Local` that make it usable as an agent tool: `Name`, `Description`, `Schema`, `ReturnSchema`, and `Call`.

## Why

Every other exported symbol on the `Local` type is already documented (`Local`, `NewLocal`, `Run`, `Initialize`, `Close`, `ApprovalRequired`) — the core `tool.Tool` interface method set was the only remaining documentation gap on this public type. Documenting the full exported surface keeps the Go SDK consistent with the .NET/Python shell-tool ports, where the equivalent tool metadata members (name, description, input/return schema, invoke) are documented, and satisfies Go's convention that all exported identifiers carry doc comments.

## How tested

Docs-only change, so no behavior test:
- `gofmt -l tool/shelltool/localshell.go` prints nothing
- `go build ./...` passes
- `go vet ./tool/shelltool/...` passes
- `go test ./tool/shelltool/...` passes
- `go doc ./tool/shelltool Local` and the per-method `go doc` output confirm the comments render