### PR TITLE
Clone AdditionalProperties in AlwaysApprove tool-approval responses

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -715,7 +715,7 @@ func (t *ToolApprovalRequestContent) AlwaysApproveToolResponse() *AlwaysApproveT
 	return &AlwaysApproveToolApprovalResponseContent{
 		InnerResponse:     t.CreateResponse(true, ""),
 		AlwaysApproveTool: true,
-		ContentHeader:     ContentHeader{AdditionalProperties: t.AdditionalProperties},
+		ContentHeader:     ContentHeader{AdditionalProperties: maps.Clone(t.AdditionalProperties)},
 	}
 }
 
@@ -726,7 +726,7 @@ func (t *ToolApprovalRequestContent) AlwaysApproveToolWithArgumentsResponse() *A
 	return &AlwaysApproveToolApprovalResponseContent{
 		InnerResponse:                  t.CreateResponse(true, ""),
 		AlwaysApproveToolWithArguments: true,
-		ContentHeader:                  ContentHeader{AdditionalProperties: t.AdditionalProperties},
+		ContentHeader:                  ContentHeader{AdditionalProperties: maps.Clone(t.AdditionalProperties)},
 	}
 }
 

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -354,6 +354,39 @@ func TestToolApprovalRequestContent_CreateResponseSnapshotsFunctionCall(t *testi
 	}
 }
 
+func TestToolApprovalRequestContent_AlwaysApproveSnapshotsAdditionalProperties(t *testing.T) {
+	newRequest := func() *message.ToolApprovalRequestContent {
+		return &message.ToolApprovalRequestContent{
+			ContentHeader: message.ContentHeader{
+				AdditionalProperties: map[string]any{"request": "value"},
+			},
+			RequestID: "approval-1",
+			ToolCall: &message.FunctionCallContent{
+				CallID: "call-1",
+				Name:   "deploy",
+			},
+		}
+	}
+
+	t.Run("AlwaysApproveToolResponse", func(t *testing.T) {
+		request := newRequest()
+		response := request.AlwaysApproveToolResponse()
+		request.AdditionalProperties["request"] = "changed"
+		if response.AdditionalProperties["request"] != "value" {
+			t.Fatalf("expected response additional properties to be snapshotted, got %v", response.AdditionalProperties["request"])
+		}
+	})
+
+	t.Run("AlwaysApproveToolWithArgumentsResponse", func(t *testing.T) {
+		request := newRequest()
+		response := request.AlwaysApproveToolWithArgumentsResponse()
+		request.AdditionalProperties["request"] = "changed"
+		if response.AdditionalProperties["request"] != "value" {
+			t.Fatalf("expected response additional properties to be snapshotted, got %v", response.AdditionalProperties["request"])
+		}
+	})
+}
+
 func TestToolApprovalRequestContent_CreateResponseSnapshotsMCPServerToolCall(t *testing.T) {
 	toolCall := &message.MCPServerToolCallContent{
 		ContentHeader: message.ContentHeader{


### PR DESCRIPTION
## What

`ToolApprovalRequestContent.AlwaysApproveToolResponse` and `AlwaysApproveToolWithArgumentsResponse` set `ContentHeader{AdditionalProperties: t.AdditionalProperties}`, copying the request's map by reference. The request and the emitted response therefore share one map instance, so mutating the request's `AdditionalProperties` after creating the response silently leaks into the response.

This changes both helpers to `maps.Clone(t.AdditionalProperties)` so the response carries an independent snapshot. `maps.Clone(nil)` returns `nil`, so no nil guard is needed; `maps` is already imported.

## Why

`CreateResponse` already clones with `maps.Clone`, and `TestToolApprovalRequestContent_CreateResponseSnapshotsFunctionCall` asserts that a post-response mutation of the request must not affect the response. The AlwaysApprove helpers violated that same contract. This aligns them with the response-is-a-snapshot semantics used across the .NET and Python SDKs, where approval responses capture request metadata by value rather than aliasing the live request.

## How tested

Added `TestToolApprovalRequestContent_AlwaysApproveSnapshotsAdditionalProperties`, which builds a request with `AdditionalProperties`, calls each AlwaysApprove helper, mutates the request's map afterward, and asserts the response value is unchanged. It fails before the fix (both subtests) and passes after. `go build ./...`, `go vet ./message/...`, and `go test ./message/...` are green.