### PR TITLE
Surface a Gemini prompt-block (PromptFeedback.BlockReason) as ErrorContent instead of an empty success

### DIFF
--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -111,6 +111,9 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				}
 			}
 		}
+		if blocked := promptBlockedContent(resp); blocked != nil {
+			responseContents = append(responseContents, blocked)
+		}
 		if resp.UsageMetadata != nil {
 			responseContents = append(responseContents, &message.UsageContent{
 				Details: toUsageDetails(resp.UsageMetadata),
@@ -147,6 +150,9 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 					}
 				}
 			}
+			if blocked := promptBlockedContent(resp); blocked != nil {
+				streamContents = append(streamContents, blocked)
+			}
 			// Gemini reports usageMetadata cumulatively across chunks, with the
 			// final chunk authoritative. Emitting a UsageContent per chunk would
 			// make the downstream Usage() aggregation sum the running totals, so
@@ -172,6 +178,27 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				RawRepresentation: latestUsageResp,
 			}, nil)
 		}
+	}
+}
+
+// promptBlockedContent returns an ErrorContent when Gemini blocked the prompt
+// for a content or safety policy violation. A blocked prompt yields zero
+// candidates and populates resp.PromptFeedback.BlockReason, so without this the
+// caller could not distinguish a policy block from a legitimately empty
+// completion. Mirrors the .NET/Python providers, which surface PromptFeedback
+// as an error rather than an empty success.
+func promptBlockedContent(resp *genai.GenerateContentResponse) *message.ErrorContent {
+	if resp == nil || resp.PromptFeedback == nil || resp.PromptFeedback.BlockReason == "" {
+		return nil
+	}
+	msg := resp.PromptFeedback.BlockReasonMessage
+	if msg == "" {
+		msg = "prompt blocked by Gemini content filter"
+	}
+	return &message.ErrorContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: resp},
+		ErrorCode:     string(resp.PromptFeedback.BlockReason),
+		Message:       msg,
 	}
 }
 

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -1628,6 +1628,87 @@ func TestGenerateContentConfigOption(t *testing.T) {
 	}
 }
 
+// findErrorContent returns the first *message.ErrorContent across all messages
+// of a response, or nil if none is present.
+func findErrorContent(resp *agent.Response) *message.ErrorContent {
+	for _, msg := range resp.Messages {
+		for _, c := range msg.Contents {
+			if ec, ok := c.(*message.ErrorContent); ok {
+				return ec
+			}
+		}
+	}
+	return nil
+}
+
+// TestPromptBlocked_NonStreaming verifies that a prompt blocked by Gemini's
+// content filter (zero candidates + promptFeedback.blockReason) surfaces as an
+// ErrorContent rather than an empty successful response.
+func TestPromptBlocked_NonStreaming(t *testing.T) {
+	resp := map[string]any{
+		"promptFeedback": map[string]any{
+			"blockReason":        "SAFETY",
+			"blockReasonMessage": "blocked",
+		},
+	}
+	respBody, _ := json.Marshal(resp)
+
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "application/json", string(respBody)))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+
+	result, err := a.RunText(t.Context(), "something disallowed").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ec := findErrorContent(result)
+	if ec == nil {
+		t.Fatal("expected ErrorContent for blocked prompt, got none")
+	}
+	if ec.ErrorCode != "SAFETY" {
+		t.Errorf("ErrorContent.ErrorCode = %q, want %q", ec.ErrorCode, "SAFETY")
+	}
+	if ec.Message != "blocked" {
+		t.Errorf("ErrorContent.Message = %q, want %q", ec.Message, "blocked")
+	}
+}
+
+// TestPromptBlocked_Streaming verifies that a streamed chunk carrying only
+// promptFeedback.blockReason (no candidates) surfaces an ErrorContent.
+func TestPromptBlocked_Streaming(t *testing.T) {
+	resp := map[string]any{
+		"promptFeedback": map[string]any{
+			"blockReason":        "SAFETY",
+			"blockReasonMessage": "blocked",
+		},
+	}
+	respBody, _ := json.Marshal(resp)
+	streamResp := "data:" + string(respBody) + "\n\n"
+
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "text/event-stream", streamResp))
+	defer server.Close()
+
+	a := newTestClient(t, server)
+
+	result, err := a.RunText(t.Context(), "something disallowed", agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ec := findErrorContent(result)
+	if ec == nil {
+		t.Fatal("expected ErrorContent for blocked prompt, got none")
+	}
+	if ec.ErrorCode != "SAFETY" {
+		t.Errorf("ErrorContent.ErrorCode = %q, want %q", ec.ErrorCode, "SAFETY")
+	}
+	if ec.Message != "blocked" {
+		t.Errorf("ErrorContent.Message = %q, want %q", ec.Message, "blocked")
+	}
+}
+
 // Gemini streams usageMetadata cumulatively across chunks, with the final
 // chunk's totals authoritative. The provider must report that final total once,
 // not sum the running totals from every chunk.


### PR DESCRIPTION
## What

When the Gemini API blocks a *prompt* for a content/safety policy violation, the response contains **zero candidates** and instead populates `resp.PromptFeedback.BlockReason` (with an optional `BlockReasonMessage`). The provider gated all content extraction behind `if len(resp.Candidates) > 0` in both the non-streaming and streaming paths and never inspected `PromptFeedback`, so a blocked prompt produced a **successful, empty `ResponseUpdate`**. Callers had no way to distinguish a policy-blocked prompt from a legitimately empty completion.

This adds a small `promptBlockedContent` helper that, when `PromptFeedback.BlockReason` is set, appends a `message.ErrorContent` with:
- `ErrorCode` = the block reason (e.g. `SAFETY`)
- `Message` = `BlockReasonMessage`, or `"prompt blocked by Gemini content filter"` when the API omits one

It is invoked right after the candidate-extraction block in both paths; in the streaming loop the content is appended before the chunk is yielded so the block surfaces on the emitting update.

## Why

This mirrors the existing `ErrorContent` precedent already used in this provider for non-OK code-execution outcomes, and aligns with the .NET/Python Gemini providers, which surface `PromptFeedback` as an error signal rather than silently returning an empty success. It is distinct from the candidate `FinishReason` path (different field, different failure mode).

## Tests

`TestPromptBlocked_NonStreaming` and `TestPromptBlocked_Streaming` (in the canonical `agent_test.go`, reusing the existing `httptest` harness) marshal a response with empty candidates and `PromptFeedback{BlockReason: SAFETY, BlockReasonMessage: blocked}` and assert the collected response contains an `*message.ErrorContent` whose `ErrorCode == "SAFETY"` instead of an empty successful update.

`go build ./...`, `go vet ./provider/geminiprovider/...`, and `go test ./provider/geminiprovider/...` all pass.