### PR TITLE
Fix stale message.New godoc: it takes no role and always sets RoleUser

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -48,8 +48,8 @@ type Message struct {
 	RawRepresentation    any       `json:"-"`
 }
 
-// New creates a new user-role [Message] with the given contents.
-// To use a different role, set the Role field on the returned Message.
+// New creates a new [Message] with the given contents and [RoleUser].
+// To use a different role, set [Message.Role] on the returned Message.
 func New(contents ...Content) *Message {
 	return &Message{
 		Role:     RoleUser,

--- a/message/message.go
+++ b/message/message.go
@@ -48,7 +48,8 @@ type Message struct {
 	RawRepresentation    any       `json:"-"`
 }
 
-// New creates a new [Message] with the given role and contents.
+// New creates a new user-role [Message] with the given contents.
+// To use a different role, set the Role field on the returned Message.
 func New(contents ...Content) *Message {
 	return &Message{
 		Role:     RoleUser,


### PR DESCRIPTION
## What

The doc comment on `message.New` claimed it creates a message "with the given role and contents", but the signature is `func New(contents ...Content) *Message` — it takes no role argument and unconditionally hardcodes `Role: RoleUser`. The "given role" phrasing is misleading: callers cannot influence the role through this constructor.

Reworded the comment to describe the actual behavior and point callers at the `Role` field when they need a different role.

## Why

This mirrors the .NET/Python message factories, where the user-role constructor is the default entry point and other roles are set explicitly on the message rather than passed to the constructor. The godoc should match the real API shape so cross-SDK users are not misled.

## Testing

Docs-only change. Verified with:
- `go build ./...`
- `go vet ./message/...`
- `go test ./message/...`
- `go doc ./message New` confirms the godoc no longer mentions a role parameter.