### PR TITLE
Add godoc to workflow.EdgeConnection.Equal

### DIFF
--- a/workflow/edge.go
+++ b/workflow/edge.go
@@ -79,6 +79,7 @@ type EdgeConnection struct {
 	SinkIDs   []string
 }
 
+// Equal reports whether c and other connect the same ordered SourceIDs and SinkIDs.
 func (c EdgeConnection) Equal(other EdgeConnection) bool {
 	return slices.Equal(c.SourceIDs, other.SourceIDs) && slices.Equal(c.SinkIDs, other.SinkIDs)
 }


### PR DESCRIPTION
## What

Adds a godoc comment to the exported `EdgeConnection.Equal` method in `workflow/edge.go`.

## Why

`EdgeConnection.Equal` was the only undocumented member of the workflow edge equality API: the sibling `Edge.Equal` already carries a godoc comment, and the `EdgeConnection` type itself is documented. Documenting all exported members keeps the API surface consistent and matches the .NET/Python graph model, where the edge-connection equality semantics (equality over the ordered source and sink collections) are explicit. The comment states exactly what the implementation does — `slices.Equal` on both the ordered `SourceIDs` and `SinkIDs`.

## Testing

Docs-only change. Verified with:
- `go build ./...`
- `go vet ./workflow/...`
- `go test ./workflow/...`
- `go doc ./workflow EdgeConnection.Equal` renders the new comment.