### PR TITLE
Document the exported agent.Response.String/Usage/Update and ResponseUpdate.Usage accessors

### DIFF
--- a/agent/response.go
+++ b/agent/response.go
@@ -63,6 +63,7 @@ type Response struct {
 	Messages []*message.Message
 }
 
+// String returns the concatenated text of all TextContent items across the response messages.
 func (resp *Response) String() string {
 	if resp == nil {
 		return ""
@@ -95,6 +96,7 @@ func (resp *Response) Contents() iter.Seq[message.Content] {
 	}
 }
 
+// Usage returns the token usage aggregated (summed) across all of the response's messages.
 func (resp *Response) Usage() message.UsageDetails {
 	var usage message.UsageDetails
 	if resp == nil {
@@ -174,6 +176,7 @@ func isZeroUsage(usage message.UsageDetails) bool {
 		len(usage.AdditionalCounts) == 0
 }
 
+// Update folds a streaming [ResponseUpdate] into resp, appending its contents to the matching message and updating response-level fields from later updates.
 func (resp *Response) Update(update *ResponseUpdate) {
 	if update == nil {
 		return
@@ -316,6 +319,7 @@ func (r *ResponseUpdate) String() string {
 	return sb.String()
 }
 
+// Usage returns the token usage carried by this update's UsageContent items.
 func (m *ResponseUpdate) Usage() message.UsageDetails {
 	if m == nil || m.Contents == nil {
 		return message.UsageDetails{}


### PR DESCRIPTION
## What

Adds one-line godoc comments to four exported accessors in `agent/response.go` that were missing them:

- `Response.String()` — concatenated text of all TextContent items across the response messages.
- `Response.Usage()` — token usage aggregated (summed) across all of the response's messages.
- `Response.Update()` — folds a streaming `ResponseUpdate` into the response.
- `ResponseUpdate.Usage()` — token usage carried by this update's UsageContent items.

## Why

These accessors sit next to documented neighbors — `Response.Contents` and `ResponseUpdate.String` both carry godoc — so the missing comments read as an inconsistency and leave gaps in `go doc ./agent`. Documenting the full public surface of `Response`/`ResponseUpdate` keeps the Go API discoverable and aligned with the well-documented equivalents in the .NET and Python SDKs, where the corresponding response/update text and usage members are described. This is a pure documentation change: the comments are factual restatements of existing behavior, no code changes.

## Testing

Docs-only. Verified with `go build ./...`, `go vet ./agent/...`, `go test ./agent/...` (all pass), and confirmed the comments render via `go doc ./agent Response` and `go doc ./agent ResponseUpdate`.