### PR TITLE
Add godoc to Foundry MemoryProvider.Invoking and Invoked

### DIFF
--- a/provider/foundryprovider/memory.go
+++ b/provider/foundryprovider/memory.go
@@ -116,10 +116,14 @@ func newMemoryProvider(client *azaiprojects.MemoryStoresClient, memoryStoreName 
 	return p
 }
 
+// Invoking is called before an agent run. It searches the Foundry memory store for memories
+// relevant to the incoming messages and returns them as additional context to inject into the run.
 func (p *MemoryProvider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 	return p.provider.Invoking(ctx, invoking)
 }
 
+// Invoked is called after an agent run to persist the request and response messages as memory
+// updates in the Foundry memory store.
 func (p *MemoryProvider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
 }


### PR DESCRIPTION
## What

Adds godoc comments to the two exported `MemoryProvider` methods in `provider/foundryprovider/memory.go`:

- `Invoking` — called before an agent run; searches the Foundry memory store for memories relevant to the incoming messages and returns them as additional context to inject into the run.
- `Invoked` — called after an agent run to persist the request and response messages as memory updates in the Foundry memory store.

## Why

Every other exported symbol in the file (`MemoryProviderConfig` and its fields, `MemoryProvider`, `NewMemoryProvider`) is already documented. These two methods are the runtime entry points that satisfy the `agent.ContextProvider` interface, so their behavior should be discoverable via `go doc`. Documenting the interface entry points also keeps the Go provider aligned with the .NET/Python context-provider surfaces, whose equivalent invoking/invoked hooks carry XML/docstring documentation.

## How tested

Documentation-only change (no code change). Verified with:

- `go build ./...`
- `go vet ./provider/foundryprovider/...`
- `go test ./provider/foundryprovider/...` (pass)
- `go doc ./provider/foundryprovider MemoryProvider.Invoking` and `.Invoked` now render the new text.