### PR TITLE
Add godoc to the Invoking/Invoked ContextProvider methods on harness todo/agentmode providers and shelltool.EnvironmentProvider

### DIFF
--- a/agent/harness/agentmode/agentmode.go
+++ b/agent/harness/agentmode/agentmode.go
@@ -202,10 +202,12 @@ func (p *Provider) getSessionLock(opts []agent.Option) *sync.Mutex {
 	return actual.(*sync.Mutex)
 }
 
+// Invoking implements agent.ContextProvider by delegating to the wrapped provider, applying this provider's context/instructions to the invocation.
 func (p *Provider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 	return p.provider.Invoking(ctx, invoking)
 }
 
+// Invoked implements agent.ContextProvider by delegating to the wrapped provider, persisting post-invocation state.
 func (p *Provider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
 }

--- a/agent/harness/agentmode/agentmode.go
+++ b/agent/harness/agentmode/agentmode.go
@@ -207,7 +207,8 @@ func (p *Provider) Invoking(ctx context.Context, invoking agent.InvokingContext)
 	return p.provider.Invoking(ctx, invoking)
 }
 
-// Invoked implements agent.ContextProvider by delegating to the wrapped provider, persisting post-invocation state.
+// Invoked implements agent.ContextProvider by delegating to the wrapped provider.
+// The wrapped provider is configured without a Store, so this is a no-op on success.
 func (p *Provider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
 }

--- a/agent/harness/todo/todo.go
+++ b/agent/harness/todo/todo.go
@@ -114,10 +114,12 @@ func New(opts *Options) *Provider {
 	return p
 }
 
+// Invoking implements agent.ContextProvider by delegating to the wrapped provider, applying this provider's context/instructions to the invocation.
 func (p *Provider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 	return p.provider.Invoking(ctx, invoking)
 }
 
+// Invoked implements agent.ContextProvider by delegating to the wrapped provider, persisting post-invocation state.
 func (p *Provider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
 }

--- a/agent/harness/todo/todo.go
+++ b/agent/harness/todo/todo.go
@@ -119,7 +119,8 @@ func (p *Provider) Invoking(ctx context.Context, invoking agent.InvokingContext)
 	return p.provider.Invoking(ctx, invoking)
 }
 
-// Invoked implements agent.ContextProvider by delegating to the wrapped provider, persisting post-invocation state.
+// Invoked implements agent.ContextProvider by delegating to the wrapped provider.
+// The wrapped provider is configured without a Store, so this is a no-op on success.
 func (p *Provider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
 }

--- a/tool/shelltool/environment.go
+++ b/tool/shelltool/environment.go
@@ -131,10 +131,12 @@ func NewEnvironmentProvider(executor Executor, config EnvironmentProviderConfig)
 	return p
 }
 
+// Invoking implements agent.ContextProvider by delegating to the wrapped provider, applying this provider's context/instructions to the invocation.
 func (p *EnvironmentProvider) Invoking(ctx context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 	return p.provider.Invoking(ctx, invoking)
 }
 
+// Invoked implements agent.ContextProvider by delegating to the wrapped provider, persisting post-invocation state.
 func (p *EnvironmentProvider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
 }

--- a/tool/shelltool/environment.go
+++ b/tool/shelltool/environment.go
@@ -136,7 +136,8 @@ func (p *EnvironmentProvider) Invoking(ctx context.Context, invoking agent.Invok
 	return p.provider.Invoking(ctx, invoking)
 }
 
-// Invoked implements agent.ContextProvider by delegating to the wrapped provider, persisting post-invocation state.
+// Invoked implements agent.ContextProvider by delegating to the wrapped provider.
+// The wrapped provider is configured without a Store, so this is a no-op on success.
 func (p *EnvironmentProvider) Invoked(ctx context.Context, invoked agent.InvokedContext) error {
 	return p.provider.Invoked(ctx, invoked)
 }


### PR DESCRIPTION
## What

Add one-line doc comments to the `Invoking` and `Invoked` methods on `todo.Provider`, `agentmode.Provider`, and `shelltool.EnvironmentProvider`. These six methods are undocumented pass-throughs that delegate to the wrapped context provider.

## Why

Each of these three types satisfies `agent.ContextProvider` (defined in `agent/context.go` as `interface { Invoking; Invoked }`, whose interface methods are both documented). The `Invoking`/`Invoked` methods are exactly the interface-satisfying surface, yet they carried no godoc while their neighboring exported methods did — `GetAllItems` on `todo.Provider`, and `CurrentSnapshot`/`Refresh` on `shelltool.EnvironmentProvider`. This closes that documentation gap so the full exported surface of each provider is documented. Parity note: the .NET/Python AIContextProvider surface documents its Invoking/Invoked equivalents, so documenting the Go port's interface methods keeps cross-SDK alignment.

## Tested

- `go build ./...`, `go vet`, and `go test` pass for the three changed packages.
- `go doc ./agent/harness/todo Provider.Invoking` (and the agentmode/shelltool equivalents) confirm the comments render.

Docs-only; no behavior change.