### PR TITLE
fix(openaiprovider): correct reasoning item replay for Responses API

### DIFF
--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -562,14 +562,21 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 				})
 			case *message.TextReasoningContent:
 				flushOutputContents()
-				// Reasoning content is added as a separate input item
-				var reasoning responses.ResponseReasoningItemParam
-				if c.ProtectedData != "" {
-					reasoning.EncryptedContent = openai.String(c.ProtectedData)
+				// Only replay reasoning when we hold its encrypted content (store=false).
+				// With store=true the server retains the reasoning item by id, so
+				// re-sending it would duplicate a server-side item.
+				if c.ProtectedData == "" {
+					continue
 				}
-				reasoning.Content = append(reasoning.Content, responses.ResponseReasoningItemContentParam{
-					Text: c.Text,
-				})
+				var reasoning responses.ResponseReasoningItemParam
+				// summary is required by the Responses API; send an empty array when absent.
+				reasoning.Summary = []responses.ResponseReasoningItemSummaryParam{}
+				// id is required and must match the original reasoning item; recover it.
+				if item, ok := c.RawRepresentation.(responses.ResponseReasoningItem); ok {
+					reasoning.ID = item.ID
+				}
+				// content must stay empty on input; reasoning is replayed via encrypted_content.
+				reasoning.EncryptedContent = openai.String(c.ProtectedData)
 				resp = append(resp, responses.ResponseInputItemUnionParam{
 					OfReasoning: &reasoning,
 				})

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -1432,6 +1432,48 @@ data: {"type":"response.completed","sequence_number":10,"response":{"id":"resp_e
 	if !strings.Contains(capturedBody, `"encrypted_content":"`+encrypted+`"`) {
 		t.Fatalf("expected replay request to carry encrypted_content %q, body = %s", encrypted, capturedBody)
 	}
+	// summary is required by the Responses API even when empty.
+	if !strings.Contains(capturedBody, `"summary":[]`) {
+		t.Fatalf("expected replay request to include an (empty) reasoning summary, body = %s", capturedBody)
+	}
+	// Plaintext reasoning content must not be replayed on input.
+	if strings.Contains(capturedBody, `"reasoning_text"`) {
+		t.Fatalf("expected replay request to omit plaintext reasoning content, body = %s", capturedBody)
+	}
+}
+
+// TestResponsesReasoningReplay_StoreTrue_SkipsReasoningItem verifies that when a
+// reasoning item has no encrypted content (store=true), it is not replayed in the
+// request. Under store=true the server retains the reasoning item by id, so
+// re-sending it would fail with a duplicate-item error.
+func TestResponsesReasoningReplay_StoreTrue_SkipsReasoningItem(t *testing.T) {
+	var capturedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed reading request body: %v", err)
+		}
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_store1","object":"response","created_at":1756752901,"status":"completed","model":"o4-mini-2025-04-16","output":[{"type":"message","id":"msg_store1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"ok","annotations":[]}]}]}`)
+	}))
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "o4-mini")
+	messages := []*message.Message{
+		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Solve this problem step by step."}}},
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			// No ProtectedData: reasoning was stored server-side (store=true).
+			&message.TextReasoningContent{Text: "Analyzing."},
+			&message.TextContent{Text: "The solution is 42."},
+		}},
+	}
+	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatalf("replay error = %v", err)
+	}
+	if strings.Contains(capturedBody, `"type":"reasoning"`) {
+		t.Fatalf("expected reasoning item to be skipped under store=true, body = %s", capturedBody)
+	}
 }
 
 func TestResponsesChatOptions_Model_OverridesClientModel_Streaming(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the reasoning-item replay in the OpenAI **Responses** provider (`responsesBuildMessageParam`). On a multi-turn tool-calling conversation, replaying a `*message.TextReasoningContent` back to the API produced a chain of `400 Bad Request` errors.

Fixes #783.

## Problem

When the assistant history contained a reasoning item, the next request serialized it into an invalid `responses.ResponseReasoningItemParam`. Fixing each error surfaced the next:

1. `Missing required parameter: 'input[N].summary'` — `Summary` (`json:"summary,omitzero" api:"required"`) was never set, so the nil slice was dropped.
2. `Invalid 'input[N].id': ''` — `ID` (`json:"id"`, required, non-empty) was never echoed back from the original item.
3. `Invalid 'input[N].content': array too long. Expected an array with maximum length 0` — plaintext reasoning text was always sent, but input reasoning items must not carry plaintext `content`.
4. `Duplicate item found with id rs_...` — under `store=true` (default), the server already retains the reasoning item by id, so replaying it duplicates a server-side item.

## Fix

Only replay a reasoning item when we hold its encrypted content (`store=false`):

- set `Summary` to a non-nil empty slice (required, may be empty),
- recover the original `id` from `RawRepresentation` (a `responses.ResponseReasoningItem`),
- send `encrypted_content`, and
- omit plaintext `content`.

Skip the item entirely when there is no encrypted content (`store=true`), since the server retains it by id.

## Tests

- Extended `TestResponsesReasoningEncryptedContent_Streaming` to assert the replayed request includes an empty `summary` and omits plaintext reasoning content.
- Added `TestResponsesReasoningReplay_StoreTrue_SkipsReasoningItem` verifying the reasoning item is not replayed when it has no encrypted content.

`go test ./provider/openaiprovider/` and `go vet` pass.

## Note / follow-up

The `id` is recovered from `ContentHeader.RawRepresentation`, which is `json:"-"` and therefore lost if the conversation is serialized and reloaded. A durable follow-up would add a dedicated id field to `message.TextReasoningContent` that survives (de)serialization.
