### PR TITLE
[dotnet-code] Consolidate compaction included group helpers

### DIFF
--- a/agent/compaction/index.go
+++ b/agent/compaction/index.go
@@ -291,11 +291,25 @@ func (index *MessageIndex) IncludedTurnCount() int {
 func (index *MessageIndex) IncludedNonSystemGroupCount() int {
 	var total int
 	for _, group := range index.Groups {
-		if !group.IsExcluded && group.Kind != GroupKindSystem {
+		if isIncludedNonSystemGroup(group) {
 			total++
 		}
 	}
 	return total
+}
+
+func (index *MessageIndex) includedNonSystemGroupIndices() []int {
+	var indices []int
+	for i, group := range index.Groups {
+		if isIncludedNonSystemGroup(group) {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
+func isIncludedNonSystemGroup(group *MessageGroup) bool {
+	return !group.IsExcluded && group.Kind != GroupKindSystem
 }
 
 // RawMessageCount returns the number of original messages represented by the index.

--- a/agent/compaction/summarization.go
+++ b/agent/compaction/summarization.go
@@ -79,12 +79,7 @@ func (strategy *SummarizationStrategy) Compact(ctx context.Context, index *Messa
 	summarizationPrompt := cmp.Or(strategy.SummarizationPrompt, defaultSummarizationPrompt)
 	summaryUnavailableMessage := cmp.Or(strategy.SummaryUnavailableMessage, "[Summary unavailable]")
 
-	nonSystemIncludedCount := 0
-	for _, group := range index.Groups {
-		if !group.IsExcluded && group.Kind != GroupKindSystem {
-			nonSystemIncludedCount++
-		}
-	}
+	nonSystemIncludedCount := index.IncludedNonSystemGroupCount()
 	protectedFromEnd := min(minimumPreservedGroups, nonSystemIncludedCount)
 	maxSummarizable := nonSystemIncludedCount - protectedFromEnd
 	if maxSummarizable <= 0 {

--- a/agent/compaction/toolresult.go
+++ b/agent/compaction/toolresult.go
@@ -45,12 +45,7 @@ func (strategy *ToolResultStrategy) Compact(_ context.Context, index *MessageInd
 	}
 
 	minimumPreservedGroups := cmp.Or(max(strategy.MinimumPreservedGroups, 0), defaultMinimumPreservedToolResultGroups)
-	var nonSystemIncludedIndices []int
-	for i, group := range index.Groups {
-		if !group.IsExcluded && group.Kind != GroupKindSystem {
-			nonSystemIncludedIndices = append(nonSystemIncludedIndices, i)
-		}
-	}
+	nonSystemIncludedIndices := index.includedNonSystemGroupIndices()
 	protectedStart := len(nonSystemIncludedIndices) - minimumPreservedGroups
 	if protectedStart < 0 {
 		protectedStart = 0


### PR DESCRIPTION
## Summary

Consolidates the compaction internals that identify included, non-system groups behind unexported helpers on `MessageIndex`. This keeps `SummarizationStrategy` and `ToolResultStrategy` aligned around the same protected-group calculation shape, making future .NET-to-Go compaction ports easier to compare without changing exported Go APIs.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Compaction/CompactionMessageIndex.cs` - central message-index structure and included/excluded group semantics.
- `dotnet/src/Microsoft.Agents.AI/Compaction/SummarizationCompactionStrategy.cs` - counts included non-system groups before protecting recent groups.
- `dotnet/src/Microsoft.Agents.AI/Compaction/ToolResultCompactionStrategy.cs` - builds included non-system group indices before selecting protected groups.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/compaction`

## Notes

Rejected sampled candidates:

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/CallResult.cs` - no comparable small Go workflow result helper was found for a safe internal-only cleanup.
- `dotnet/src/Microsoft.Agents.AI.Workflows/ExecutorEvent.cs` - event formatting did not reveal a low-risk portability cleanup.
- `dotnet/src/Microsoft.Agents.AI/Compaction/ChatReducerCompactionStrategy.cs` - useful compaction context, but Go has no matching reducer strategy to port without adding behavior.

Open `[dotnet-code]` PR details were filtered by the read tool, so this PR intentionally stays narrow in compaction included-group helper wiring.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31053652293) · gpt55 · 85.3 AIC · ⌖ 15.5 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 31053652293, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31053652293 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #789