### PR TITLE
[dotnet-code] Clarify message workflow route handlers

### DIFF
--- a/message/messageworkflow/messageworkflow.go
+++ b/message/messageworkflow/messageworkflow.go
@@ -90,50 +90,65 @@ func Configure(executor *workflow.Executor, options *Options) {
 				rb.SendsMessageType(reflect.TypeFor[workflow.TurnToken]())
 			}
 			if options.StringMessageRole != "" {
-				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
-						return append(messages, &message.Message{
-							Role:     message.Role(options.StringMessageRole),
-							Contents: []message.Content{&message.TextContent{Text: msg.(string)}},
-						}), nil
-					})
-				})
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, accumulateStringMessage(state, message.Role(options.StringMessageRole)))
 			}
 			rb.RouteBuilder.
-				AddHandlerRaw(reflect.TypeFor[*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
-						return append(messages, msg.(*message.Message)), nil
-					})
-				}).
-				AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(ctx *workflow.Context, msgs any) (any, error) {
-					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
-						return append(messages, msgs.([]*message.Message)...), nil
-					})
-				}).
-				AddHandlerRaw(reflect.TypeFor[iter.Seq[*message.Message]](), nil, func(ctx *workflow.Context, msgs any) (any, error) {
-					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
-						for msg := range msgs.(iter.Seq[*message.Message]) {
-							messages = append(messages, msg)
-						}
-						return messages, nil
-					})
-				}).
-				AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-					return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
-						token := msg.(workflow.TurnToken)
-						if err := options.TakeTurnHandler(ctx, token, messages); err != nil {
-							return nil, err
-						}
-						if !options.DisableAutoSendTurnToken {
-							if err := ctx.SendMessage("", token); err != nil {
-								return nil, err
-							}
-						}
-						return nil, nil
-					})
-				})
+				AddHandlerRaw(reflect.TypeFor[*message.Message](), nil, accumulateMessage(state)).
+				AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, accumulateMessages(state)).
+				AddHandlerRaw(reflect.TypeFor[iter.Seq[*message.Message]](), nil, accumulateMessageSeq(state)).
+				AddHandlerRaw(reflect.TypeFor[workflow.TurnToken](), nil, takeAccumulatedTurn(state, options))
 			return rb, nil
 		},
 	}
 	executor.Extend(&messageExecutor)
+}
+
+func accumulateStringMessage(state *MessageState, role message.Role) func(*workflow.Context, any) (any, error) {
+	return func(ctx *workflow.Context, msg any) (any, error) {
+		return appendTurnMessages(ctx, state, &message.Message{
+			Role:     role,
+			Contents: []message.Content{&message.TextContent{Text: msg.(string)}},
+		})
+	}
+}
+
+func accumulateMessage(state *MessageState) func(*workflow.Context, any) (any, error) {
+	return func(ctx *workflow.Context, msg any) (any, error) {
+		return appendTurnMessages(ctx, state, msg.(*message.Message))
+	}
+}
+
+func accumulateMessages(state *MessageState) func(*workflow.Context, any) (any, error) {
+	return func(ctx *workflow.Context, msg any) (any, error) {
+		return appendTurnMessages(ctx, state, msg.([]*message.Message)...)
+	}
+}
+
+func accumulateMessageSeq(state *MessageState) func(*workflow.Context, any) (any, error) {
+	return func(ctx *workflow.Context, msg any) (any, error) {
+		return appendTurnMessages(ctx, state, messageSeqToSlice(msg.(iter.Seq[*message.Message]))...)
+	}
+}
+
+func appendTurnMessages(ctx *workflow.Context, state *MessageState, incoming ...*message.Message) (any, error) {
+	return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
+		return append(messages, incoming...), nil
+	})
+}
+
+func takeAccumulatedTurn(state *MessageState, options *Options) func(*workflow.Context, any) (any, error) {
+	return func(ctx *workflow.Context, msg any) (any, error) {
+		return struct{}{}, state.ProcessTurnMessages(ctx, func(ctx *workflow.Context, messages []*message.Message) ([]*message.Message, error) {
+			token := msg.(workflow.TurnToken)
+			if err := options.TakeTurnHandler(ctx, token, messages); err != nil {
+				return nil, err
+			}
+			if !options.DisableAutoSendTurnToken {
+				if err := ctx.SendMessage("", token); err != nil {
+					return nil, err
+				}
+			}
+			return nil, nil
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Refactored the message workflow `Configure` route registration so each incoming route delegates to a small unexported helper for accumulating messages or taking a turn. This keeps the registration shape closer to the .NET workflow router separation while preserving the existing accepted message types and turn-token behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/IMessageRouter.cs` - internal workflow router interface separates route capability from message dispatch.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./message/messageworkflow`

## Notes

Rejected candidates from the random sample:

- `dotnet/src/Microsoft.Agents.AI/Harness/FileStore/FileLineEdit.cs` - no close Go file-store editing counterpart in the current sampled Go areas, so a portability cleanup would have been speculative.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/IdGenerator.cs` - no corresponding Go ID generator was found in the sampled repository paths.
- `dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryProvider.cs` - the nearby Go Foundry memory provider is a different provider surface; changing it based on the file-memory reference risked unrelated behavior churn.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30670671754) · gpt55 · 140.7 AIC · ⌖ 17.9 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 30670671754, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30670671754 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #773