### PR TITLE
[dotnet-code] Extract content external request ID helper

### DIFF
--- a/internal/contentexthandler/contentexthandler.go
+++ b/internal/contentexthandler/contentexthandler.go
@@ -109,15 +109,15 @@ func (h *Handler[TRequest, TResponse]) DispatchRequest(ctx *workflow.Context, re
 		return ctx.SendMessage("", request)
 	}
 	id := h.requestID(request)
-	req, err := workflow.NewExternalRequest(h.createExternalRequestID(id), h.port, request)
+	req, err := workflow.NewExternalRequest(createExternalRequestID(h.port.ID, id), h.port, request)
 	if err != nil {
 		return err
 	}
 	return ctx.PostRequest(req)
 }
 
-func (h *Handler[TRequest, TResponse]) createExternalRequestID(requestID string) string {
-	return fmt.Sprintf("%d:%s:%s", len(h.port.ID), h.port.ID, requestID)
+func createExternalRequestID(portID, requestID string) string {
+	return fmt.Sprintf("%d:%s:%s", len(portID), portID, requestID)
 }
 
 func (h *Handler[TRequest, TResponse]) Reset() error {

--- a/internal/contentexthandler/contentexthandler_test.go
+++ b/internal/contentexthandler/contentexthandler_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package contentexthandler
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+)
+
+func TestMakePendingRequestsStateKey(t *testing.T) {
+	got := makePendingRequestsStateKey("toolCalls")
+	const want = "toolCalls_PendingRequests"
+	if got != want {
+		t.Fatalf("makePendingRequestsStateKey() = %q, want %q", got, want)
+	}
+}
+
+func TestCreateExternalRequestID(t *testing.T) {
+	got := createExternalRequestID("approval-port", "request-1")
+	const want = "13:approval-port:request-1"
+	if got != want {
+		t.Fatalf("createExternalRequestID() = %q, want %q", got, want)
+	}
+}
+
+func TestHandlerDispatchRequestUsesExternalRequestID(t *testing.T) {
+	port := workflow.RequestPort{
+		ID:       "call-port",
+		Request:  reflect.TypeFor[string](),
+		Response: reflect.TypeFor[string](),
+	}
+	handler := New(Options[string, string]{
+		Port:      port,
+		RequestID: func(request string) string { return request },
+	})
+
+	var posted *workflow.ExternalRequest
+	ctx := &workflow.Context{
+		PostRequest: func(request *workflow.ExternalRequest) error {
+			posted = request
+			return nil
+		},
+	}
+
+	if err := handler.DispatchRequest(ctx, "call-1"); err != nil {
+		t.Fatalf("DispatchRequest() error = %v", err)
+	}
+	if posted == nil {
+		t.Fatal("DispatchRequest() did not post a request")
+	}
+	const wantID = "9:call-port:call-1"
+	if posted.RequestID != wantID {
+		t.Fatalf("posted RequestID = %q, want %q", posted.RequestID, wantID)
+	}
+}


### PR DESCRIPTION
## Summary

Extracted the content external handler's external request ID formatting into a small unexported helper and added focused tests for the pending-request state key and request ID formats. This keeps the Go internals closer to the .NET handler shape, where request key and external ID construction are dedicated helper operations, without changing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/AIContentExternalHandler.cs` - uses dedicated helpers for pending-request state keys and external request ID formatting.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./internal/contentexthandler`
- `go test ./workflow/agentworkflow`
- Added preservation tests in `internal/contentexthandler/contentexthandler_test.go`.

## Notes

Rejected sampled candidates:

- `dotnet/src/Microsoft.Agents.AI.A2A/A2AJsonUtilities.cs` - Go's A2A provider shape centers on conversion helpers rather than equivalent serializer options, so no small safe cleanup was apparent.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Observability/Tags.cs` - the Go equivalent has similar constants, but key/name changes would be behavior-sensitive telemetry churn.
- `dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillResource.cs` - Go already reads file-backed resources through the skill filesystem with no useful narrow structural cleanup found.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30588064635) · gpt55 · 77.2 AIC · ⌖ 20.1 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 30588064635, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30588064635 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #771