### PR TITLE
[dotnet-code] Consolidate workflow edge connection construction

### DIFF
--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -143,10 +143,7 @@ func (wb *Builder) AddDirectEdge(source ExecutorBinding, target ExecutorBinding,
 	if wb.err != nil {
 		return wb
 	}
-	conn := EdgeConnection{
-		SourceIDs: []string{source.ID},
-		SinkIDs:   []string{target.ID},
-	}
+	conn := newDirectEdgeConnection(source.ID, target.ID)
 	if condition == nil && slices.ContainsFunc(wb.conditionlessConnections, func(c EdgeConnection) bool {
 		return conn.Equal(c)
 	}) {
@@ -193,10 +190,7 @@ func (wb *Builder) AddFanOutEdge(source ExecutorBinding, targets []ExecutorBindi
 		}
 		sinkIDs = append(sinkIDs, target.ID)
 	}
-	conn := EdgeConnection{
-		SourceIDs: []string{source.ID},
-		SinkIDs:   sinkIDs,
-	}
+	conn := newEdgeConnection([]string{source.ID}, sinkIDs)
 	edge := Edge{
 		Connection: conn,
 		Index:      wb.edgeIdx(),
@@ -223,11 +217,8 @@ func (wb *Builder) AddFanInBarrierEdge(sources []ExecutorBinding, target Executo
 		sourceIDs = append(sourceIDs, source.ID)
 	}
 	edge := Edge{
-		Connection: EdgeConnection{
-			SourceIDs: sourceIDs,
-			SinkIDs:   []string{target.ID},
-		},
-		Index: wb.edgeIdx(),
+		Connection: newEdgeConnection(sourceIDs, []string{target.ID}),
+		Index:      wb.edgeIdx(),
 	}
 	applyEdgeOptions(&edge, opts)
 	for _, id := range sourceIDs {

--- a/workflow/edge.go
+++ b/workflow/edge.go
@@ -79,6 +79,7 @@ type EdgeConnection struct {
 	SinkIDs   []string
 }
 
+// newEdgeConnection returns an EdgeConnection that aliases sourceIDs and sinkIDs.
 func newEdgeConnection(sourceIDs, sinkIDs []string) EdgeConnection {
 	return EdgeConnection{
 		SourceIDs: sourceIDs,

--- a/workflow/edge.go
+++ b/workflow/edge.go
@@ -79,6 +79,17 @@ type EdgeConnection struct {
 	SinkIDs   []string
 }
 
+func newEdgeConnection(sourceIDs, sinkIDs []string) EdgeConnection {
+	return EdgeConnection{
+		SourceIDs: sourceIDs,
+		SinkIDs:   sinkIDs,
+	}
+}
+
+func newDirectEdgeConnection(sourceID, sinkID string) EdgeConnection {
+	return newEdgeConnection([]string{sourceID}, []string{sinkID})
+}
+
 // Equal reports whether c and other connect the same ordered SourceIDs and SinkIDs.
 func (c EdgeConnection) Equal(other EdgeConnection) bool {
 	return slices.Equal(c.SourceIDs, other.SourceIDs) && slices.Equal(c.SinkIDs, other.SinkIDs)


### PR DESCRIPTION
## Summary

Centralized internal workflow edge-connection construction behind unexported helpers and routed the builder's direct, fan-out, and fan-in edge creation through them. This keeps Go's internal construction shape closer to the .NET `EdgeConnection` constructor pattern while preserving the existing exported struct and behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeConnection.cs` - defines `EdgeConnection` as an ordered source/sink connection object constructed from source and sink ID lists.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow`
- `go test ./workflow/...`

## Notes

Rejected sampled candidates:

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/MessageDelivery.cs` - the nearest Go delivery mapping structure is already internal but differs in runtime shape; changing it would risk churn beyond a tiny cleanup.
- `dotnet/src/Microsoft.Agents.AI.Workflows/SuperStepEvent.cs` - closer alignment would imply string/event surface changes, which could affect behavior or public API expectations.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/RunnerStateData.cs` - Go runner state includes additional request-owner maps, so structural alignment was not a safe tiny refactor.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30496859874) · gpt55 · 89.5 AIC · ⌖ 10.6 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 30496859874, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30496859874 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #768