### PR TITLE
[dotnet-code] Consolidate skill member lookup internals

### DIFF
--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -449,19 +449,9 @@ func (p *providerState) loadSkill(ctx context.Context, skills providedSkillSet, 
 }
 
 func (p *providerState) readSkillResource(ctx context.Context, skills providedSkillSet, skillName, resourceName string) any {
-	if lookupError := validateSkillName(skillName); lookupError != "" {
-		return lookupError
-	}
-	if strings.TrimSpace(resourceName) == "" {
-		return "Error: Resource name cannot be empty."
-	}
-	resolved, lookupError := skills.lookupSkill(skillName)
+	_, resource, lookupError := resolveSkillItem(skills, skillName, resourceName, "Resource", providedSkill.lookupResource)
 	if lookupError != "" {
 		return lookupError
-	}
-	resource, ok := resolved.lookupResource(resourceName)
-	if !ok {
-		return fmt.Sprintf("Error: Resource '%s' not found in skill '%s'.", resourceName, skillName)
 	}
 	if resource.Read == nil {
 		p.logger.Error("Failed to read resource from skill", "resourceName", resourceName, "skillName", skillName, "error", "resource reader is nil")
@@ -476,19 +466,9 @@ func (p *providerState) readSkillResource(ctx context.Context, skills providedSk
 }
 
 func (p *providerState) runSkillScript(ctx context.Context, skills providedSkillSet, skillName, scriptName string, arguments []string) (any, error) {
-	if lookupError := validateSkillName(skillName); lookupError != "" {
-		return lookupError, nil
-	}
-	if strings.TrimSpace(scriptName) == "" {
-		return "Error: Script name cannot be empty.", nil
-	}
-	resolved, lookupError := skills.lookupSkill(skillName)
+	resolved, script, lookupError := resolveSkillItem(skills, skillName, scriptName, "Script", providedSkill.lookupScript)
 	if lookupError != "" {
 		return lookupError, nil
-	}
-	script, ok := resolved.lookupScript(scriptName)
-	if !ok {
-		return fmt.Sprintf("Error: Script '%s' not found in skill '%s'.", scriptName, skillName), nil
 	}
 	if script.Run == nil {
 		err := errors.New("script runner is nil")
@@ -522,6 +502,29 @@ func (skills providedSkillSet) lookupSkill(skillName string) (providedSkill, str
 		return providedSkill{}, fmt.Sprintf("Error: Skill '%s' not found.", skillName)
 	}
 	return resolved, ""
+}
+
+func resolveSkillItem[T any](
+	skills providedSkillSet,
+	skillName, itemName, itemKind string,
+	lookup func(providedSkill, string) (T, bool),
+) (providedSkill, T, string) {
+	var zero T
+	if lookupError := validateSkillName(skillName); lookupError != "" {
+		return providedSkill{}, zero, lookupError
+	}
+	if strings.TrimSpace(itemName) == "" {
+		return providedSkill{}, zero, fmt.Sprintf("Error: %s name cannot be empty.", itemKind)
+	}
+	resolved, lookupError := skills.lookupSkill(skillName)
+	if lookupError != "" {
+		return providedSkill{}, zero, lookupError
+	}
+	item, ok := lookup(resolved, itemName)
+	if !ok {
+		return providedSkill{}, zero, fmt.Sprintf("Error: %s '%s' not found in skill '%s'.", itemKind, itemName, skillName)
+	}
+	return resolved, item, ""
 }
 
 func validateSkillName(skillName string) string {

--- a/agent/skills/provider_test.go
+++ b/agent/skills/provider_test.go
@@ -453,6 +453,65 @@ func TestProvider_RunSkillScript_RequiresExactName(t *testing.T) {
 	}
 }
 
+func TestProvider_SkillMemberLookupErrors(t *testing.T) {
+	skill := mustInlineSkill(
+		skills.Frontmatter{Name: "lookup-skill", Description: "Lookup skill"},
+		"Body.",
+		[]skills.Resource{{Name: "docs/readme.md", Read: func(context.Context) (any, error) {
+			return "docs", nil
+		}}},
+		[]skills.Script{{Name: "scripts/run", Run: func(context.Context, *skills.Skill, []string) (any, error) {
+			return "ok", nil
+		}}},
+	)
+	provider := skills.NewContextProvider(skills.ContextProviderOptions{Skills: []*skills.Skill{skill}})
+	_, tools := captureProviderContext(t, provider)
+
+	tests := []struct {
+		name    string
+		tool    string
+		payload string
+		want    string
+	}{
+		{
+			name:    "empty resource name",
+			tool:    "read_skill_resource",
+			payload: `{"skillName":"lookup-skill","resourceName":" "}`,
+			want:    "Error: Resource name cannot be empty.",
+		},
+		{
+			name:    "missing resource",
+			tool:    "read_skill_resource",
+			payload: `{"skillName":"lookup-skill","resourceName":"missing.md"}`,
+			want:    "Error: Resource 'missing.md' not found in skill 'lookup-skill'.",
+		},
+		{
+			name:    "empty script name",
+			tool:    "run_skill_script",
+			payload: `{"skillName":"lookup-skill","scriptName":" "}`,
+			want:    "Error: Script name cannot be empty.",
+		},
+		{
+			name:    "missing script",
+			tool:    "run_skill_script",
+			payload: `{"skillName":"lookup-skill","scriptName":"missing"}`,
+			want:    "Error: Script 'missing' not found in skill 'lookup-skill'.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := findTool(t, tools, tt.tool).Call(t.Context(), tt.payload)
+			if err != nil {
+				t.Fatalf("expected no tool error, got %v", err)
+			}
+			if result != tt.want {
+				t.Fatalf("expected %q, got %#v", tt.want, result)
+			}
+		})
+	}
+}
+
 func TestProvider_RunSkillScript_PropagatesErrorByDefault(t *testing.T) {
 	skill := mustInlineSkill(
 		skills.Frontmatter{Name: "script-skill", Description: "Script skill"},


### PR DESCRIPTION
## Summary

Consolidates the duplicated `read_skill_resource` and `run_skill_script` skill/member lookup flow behind an unexported helper. This keeps Go's skills provider internals easier to compare against the .NET provider's shared skill tool handling while preserving the existing tool response strings.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs` - skill provider tool registration plus load/resource/script lookup methods.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/skills`
- Added `TestProvider_SkillMemberLookupErrors` to preserve resource/script lookup error strings through the shared helper.

## Notes

Rejected sampled candidates:
- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/DirectEdgeRunner.cs` mapped to Go edge dispatch, but Go already centralizes direct/fan-out/fan-in routing in `workflow/internal/execution/edgerunner.go`, so a tiny alignment risked churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/OutputFilter.cs` mapped to `workflow/inproc/outputfilter.go`, which was already small and structurally close.
- `dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderBuilder.cs` has no matching public builder surface in Go, so adding one would violate the portability-only/no-public-API-change scope.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30405411549) · 703.1 AIC · ⌖ 43.9 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 30405411549, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30405411549 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #763