### PR TITLE
[dotnet-code] Add ScopeID equality preservation test

### DIFF
--- a/workflow/json_test.go
+++ b/workflow/json_test.go
@@ -272,6 +272,31 @@ func TestScopeID_JsonRoundtrip(t *testing.T) {
 	}
 }
 
+func TestScopeID_Equal(t *testing.T) {
+	privateScope1 := workflow.ScopeID{ExecutorID: "executor1"}
+	privateScope2 := workflow.ScopeID{ExecutorID: "executor2"}
+
+	if privateScope1.Equal(privateScope2) {
+		t.Fatal("private scopes from different executors should not be equal")
+	}
+	if !privateScope1.Equal(workflow.ScopeID{ExecutorID: "executor1"}) {
+		t.Fatal("private scopes from the same executor should be equal")
+	}
+
+	sharedScope1 := workflow.ScopeID{ExecutorID: "executor1", ScopeName: "sharedScope"}
+	sharedScope2 := workflow.ScopeID{ExecutorID: "executor2", ScopeName: "sharedScope"}
+
+	if !sharedScope1.Equal(sharedScope2) {
+		t.Fatal("shared scopes with the same scope name should be equal")
+	}
+	if sharedScope1.Equal(workflow.ScopeID{ExecutorID: "executor1", ScopeName: "differentScope"}) {
+		t.Fatal("shared scopes with different scope names should not be equal")
+	}
+	if sharedScope1.Equal(privateScope1) {
+		t.Fatal("shared and private scopes should not be equal")
+	}
+}
+
 func TestScopeKey_JsonRoundtrip(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Added a narrow preservation test for `workflow.ScopeID.Equal` so the Go workflow state-scope semantics are easier to compare with the .NET `ScopeId` behavior during future ports. The test locks the existing private-scope, shared-scope, and private-vs-shared equality rules without changing production code.

## .NET Reference

- `dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/StateKeyObjectTests.cs` - verifies `ScopeId` equality semantics for private executor scopes and shared named scopes.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- Added `TestScopeID_Equal` in `workflow/json_test.go`.
- Ran `gofmt -w workflow/json_test.go`.
- Ran `go test ./workflow`.

## Notes

Rejected candidates from the random .NET sample:

- `dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoItemInput.cs` - the Go todo harness already has the corresponding input shape and recent parity-aligned locking/internals, so no safer tiny improvement was identified.
- `dotnet/src/Microsoft.Agents.AI.Abstractions/ChatHistoryProvider.cs` - initially promising for naming default filter helpers, but an open `HistoryProvider` PR search returned a filtered result, so this candidate was rejected to avoid overlap.
- `dotnet/src/Microsoft.Agents.AI.Workflows/MagenticProgressLedger.cs` - no current Go magentic progress ledger counterpart was found, and adding one would be feature work.
- `dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/PolymorphicOutputTests.cs` - rejected because open PR searches returned filtered polymorphic-output results, so overlap could not be ruled out.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30311536940) · 527.8 AIC · ⌖ 41.6 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 30311536940, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30311536940 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #760