### PR TITLE
[dotnet-code] Extract Anthropic schema map helper

### DIFF
--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -310,22 +310,9 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 			var properties any
 			var required []string
 
-			// Extract schema details - first convert to map[string]any if needed
-			schema := ft.Schema()
-			var schemaMap map[string]any
-
-			switch s := schema.(type) {
-			case map[string]any:
-				schemaMap = s
-			default:
-				// For *jsonschema.Schema or other types, marshal to JSON then unmarshal to map
-				if schema != nil {
-					jsonBytes, err := json.Marshal(schema)
-					if err == nil {
-						_ = json.Unmarshal(jsonBytes, &schemaMap)
-					}
-				}
-			}
+			// Preserve existing lenient tool schema handling: unusable schemas
+			// simply leave properties and required empty.
+			schemaMap, _ := schemaMapFromAny(ft.Schema())
 
 			if schemaMap != nil {
 				if props, ok := schemaMap["properties"]; ok {
@@ -386,18 +373,9 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 	if frmt, ok := agent.GetOption(opts, agent.WithResponseFormat); ok {
 		if frmt.Kind == "json" {
 			if schema := frmt.Schema; schema != nil {
-				var schemaMap map[string]any
-				switch s := schema.(type) {
-				case map[string]any:
-					schemaMap = s
-				default:
-					jsonBytes, err := json.Marshal(s)
-					if err != nil {
-						return anthropic.MessageNewParams{}, fmt.Errorf("failed to marshal structured output schema: %w", err)
-					}
-					if err := json.Unmarshal(jsonBytes, &schemaMap); err != nil {
-						return anthropic.MessageNewParams{}, fmt.Errorf("failed to unmarshal structured output schema: %w", err)
-					}
+				schemaMap, err := schemaMapFromAny(schema)
+				if err != nil {
+					return anthropic.MessageNewParams{}, err
 				}
 				if schemaMap != nil {
 					params.OutputConfig.Format = anthropic.JSONOutputFormatParam{
@@ -438,6 +416,25 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 	}
 
 	return params, nil
+}
+
+func schemaMapFromAny(schema any) (map[string]any, error) {
+	switch s := schema.(type) {
+	case nil:
+		return nil, nil
+	case map[string]any:
+		return s, nil
+	default:
+		jsonBytes, err := json.Marshal(s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal structured output schema: %w", err)
+		}
+		var schemaMap map[string]any
+		if err := json.Unmarshal(jsonBytes, &schemaMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal structured output schema: %w", err)
+		}
+		return schemaMap, nil
+	}
 }
 
 func buildMessageParam(msg *message.Message) (anthropic.MessageParam, error) {


### PR DESCRIPTION
## Summary

Extracted the Anthropic provider's repeated JSON schema-to-map conversion into an unexported helper. This keeps tool schema setup and structured output schema setup routed through one internal conversion path, closer to the sampled .NET Anthropic JSON context pattern where supported JSON payload shapes are centralized.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Anthropic/AnthropicClientJsonContext.cs` - centralizes Anthropic JSON serializer support for JSON elements, strings, and dictionary payloads.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `gofmt -w provider/anthropicprovider/agent.go`
- `go test ./provider/anthropicprovider`

## Notes

Rejected candidates from the random .NET sample:

- `dotnet/src/Microsoft.Agents.AI.Abstractions/AdditionalPropertiesExtensions.cs` - rejected because the corresponding Go additional-properties maps are public struct fields, and adding typed helpers would change the public API surface.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/InputMessageContent.cs` - rejected because Go relies on the OpenAI SDK response input union types, and reshaping that path would be broader than a tiny internal portability cleanup.
- `dotnet/src/Microsoft.Agents.AI/Harness/FileStore/FileSearchResult.cs` - rejected because no direct Go file-store/file-search result counterpart was identified for a safe structural cleanup.

Open `[dotnet-code]` PR search found existing PRs in superstep tracing, compaction provider reduction, and message merger folding, but no open Anthropic-specific overlap.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30131627156) · 278.9 AIC · ⌖ 18 AIC · ⊞ 20.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.60, model: gpt-5.5, id: 30131627156, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30131627156 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #758