### PR TITLE
[dotnet-port-fixes] Surface response.failed error content

### DIFF
--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -947,12 +947,8 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 	if usage := responsesUsageToContent(resp.Usage); usage != nil {
 		currentUpdate.Contents = append(currentUpdate.Contents, usage)
 	}
-	// If there's an error in the response, add an ErrorContent
-	if resp.Error.Message != "" {
-		currentUpdate.Contents = append(currentUpdate.Contents, &message.ErrorContent{
-			Message:   resp.Error.Message,
-			ErrorCode: string(resp.Error.Code),
-		})
+	if failure := responsesFailureContent(resp); failure != nil {
+		currentUpdate.Contents = append(currentUpdate.Contents, failure)
 	}
 	yield(currentUpdate, nil)
 }
@@ -998,6 +994,35 @@ func responsesUsageToContent(usage responses.ResponseUsage) *message.UsageConten
 			CachedInputTokenCount: usage.InputTokensDetails.CachedTokens,
 			ReasoningTokenCount:   usage.OutputTokensDetails.ReasoningTokens,
 		},
+	}
+}
+
+const (
+	responsesDefaultFailureMessage = "The agent run failed."
+	responsesDefaultFailureCode    = "failed"
+)
+
+func responsesFailureContent(resp *responses.Response) *message.ErrorContent {
+	if resp == nil {
+		return nil
+	}
+	if resp.Status != responses.ResponseStatusFailed && resp.Error.Message == "" && resp.Error.Code == "" {
+		return nil
+	}
+	return responsesErrorContent(resp.Error.Message, string(resp.Error.Code), "")
+}
+
+func responsesErrorContent(msg string, code string, details string) *message.ErrorContent {
+	if strings.TrimSpace(msg) == "" {
+		msg = responsesDefaultFailureMessage
+	}
+	if code == "" {
+		code = responsesDefaultFailureCode
+	}
+	return &message.ErrorContent{
+		Message:   msg,
+		Details:   details,
+		ErrorCode: code,
 	}
 }
 
@@ -1062,6 +1087,15 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 		u.AdditionalProperties = responsesPopulateAdditionalProperties(&event.Response)
 		if contToken := createContinuationToken(event.Response.ID, event.SequenceNumber, event.Response.Status, isBackground); contToken != "" {
 			u.ContinuationToken = contToken
+		}
+
+	case responses.ResponseFailedEvent:
+		u = createUpdate(message.RoleAssistant, nil)
+		u.CreatedAt = time.Unix(int64(event.Response.CreatedAt), 0)
+		u.ResponseID = event.Response.ID
+		u.AdditionalProperties = responsesPopulateAdditionalProperties(&event.Response)
+		if failure := responsesFailureContent(&event.Response); failure != nil {
+			u.Contents = []message.Content{failure}
 		}
 
 	case responses.ResponseTextDeltaEvent:
@@ -1201,11 +1235,7 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 		}
 	case responses.ResponseErrorEvent:
 		u = createUpdate(message.RoleAssistant, []message.Content{
-			&message.ErrorContent{
-				Message:   event.Message,
-				ErrorCode: event.Code,
-				Details:   event.Param,
-			},
+			responsesErrorContent(event.Message, event.Code, event.Param),
 		})
 		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusFailed, isBackground); contToken != "" {
 			u.ContinuationToken = contToken

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -2678,6 +2678,28 @@ data: {"type":"response.failed","response":{"id":"resp_001","object":"response",
 		t.Errorf("expected at least 2 updates, got %d", len(updates))
 	}
 
+	var errorContent *message.ErrorContent
+	for _, update := range updates {
+		for _, content := range update.Contents {
+			if ec, ok := content.(*message.ErrorContent); ok {
+				errorContent = ec
+				break
+			}
+		}
+		if errorContent != nil {
+			break
+		}
+	}
+	if errorContent == nil {
+		t.Fatal("expected response.failed update to surface ErrorContent")
+	}
+	if errorContent.Message != "Internal error" {
+		t.Errorf("expected error message %q, got %q", "Internal error", errorContent.Message)
+	}
+	if errorContent.ErrorCode != "internal_error" {
+		t.Errorf("expected error code %q, got %q", "internal_error", errorContent.ErrorCode)
+	}
+
 	// Verify all updates have the same response ID
 	for i, update := range updates {
 		if update.ResponseID != "resp_001" {
@@ -3910,6 +3932,57 @@ func TestResponsesResponseWithError_IncludesInAdditionalPropertiesAndMessage(t *
 	}
 }
 
+func TestResponsesResponseWithFailedStatusWithoutErrorDetails_UsesDefaultErrorContent(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}]
+            }
+            `
+
+	const output = `
+            {
+              "id":"resp_004",
+              "object":"response",
+              "created_at":1741892091,
+              "status":"failed",
+              "model":"gpt-4o-mini",
+              "output":[]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+
+	resp, err := a.RunText(t.Context(), "test").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(resp.Messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+
+	lastMessage := resp.Messages[len(resp.Messages)-1]
+	var errorContent *message.ErrorContent
+	for _, content := range lastMessage.Contents {
+		if ec, ok := content.(*message.ErrorContent); ok {
+			errorContent = ec
+			break
+		}
+	}
+	if errorContent == nil {
+		t.Fatal("expected ErrorContent in last message")
+	}
+	if errorContent.Message != "The agent run failed." {
+		t.Errorf("expected default error message, got %q", errorContent.Message)
+	}
+	if errorContent.ErrorCode != "failed" {
+		t.Errorf("expected default error code, got %q", errorContent.ErrorCode)
+	}
+}
+
 func TestResponsesStreamingErrorUpdate_ActualErroneousFormat_ParsesCorrectly(t *testing.T) {
 	const input = `
             {
@@ -3995,11 +4068,11 @@ data: {"type":"response.failed","sequence_number":2,"response":{"id":"resp_003",
 		updates = append(updates, update)
 	}
 
-	// Find error update with empty error information
+	// Find synthesized failure content from the response.failed event.
 	var errorUpdate *agent.ResponseUpdate
 	for _, update := range updates {
 		for _, content := range update.Contents {
-			if _, ok := content.(*message.ErrorContent); ok {
+			if ec, ok := content.(*message.ErrorContent); ok && ec.Message == "The agent run failed." {
 				errorUpdate = update
 				break
 			}
@@ -4013,7 +4086,6 @@ data: {"type":"response.failed","sequence_number":2,"response":{"id":"resp_003",
 		t.Fatal("expected to find an update with ErrorContent")
 	}
 
-	// Verify error content has empty fields
 	var errorContent *message.ErrorContent
 	for _, content := range errorUpdate.Contents {
 		if ec, ok := content.(*message.ErrorContent); ok {
@@ -4025,13 +4097,11 @@ data: {"type":"response.failed","sequence_number":2,"response":{"id":"resp_003",
 	if errorContent == nil {
 		t.Fatal("expected ErrorContent in error update")
 	}
-
-	// Verify all fields are empty (like C#)
-	if errorContent.Message != "" {
-		t.Errorf("expected empty Message, got %q", errorContent.Message)
+	if errorContent.Message != "The agent run failed." {
+		t.Errorf("expected default Message, got %q", errorContent.Message)
 	}
-	if errorContent.ErrorCode != "" {
-		t.Errorf("expected empty ErrorCode, got %q", errorContent.ErrorCode)
+	if errorContent.ErrorCode != "failed" {
+		t.Errorf("expected default ErrorCode, got %q", errorContent.ErrorCode)
 	}
 	if errorContent.Details != "" {
 		t.Errorf("expected empty Details, got %q", errorContent.Details)


### PR DESCRIPTION
## Summary

Port the .NET failure-handling fix from microsoft/agent-framework#7497 into the shared Go Responses provider path so `response.failed` events surface structured `ErrorContent` instead of empty updates. The Go change also applies the same fallback to failed non-streaming responses when the provider omits explicit error details, using a default message/code rather than silently dropping the failure.

## Ported .NET PRs

- microsoft/agent-framework#7497 - fail declarative workflows when an agent returns an error

Upstream commit referenced: `d56e81357e5179b6f916b180c0cb34ea2e73c80b`.

## Breaking Changes

No. This keeps the public Go API unchanged and only corrects how existing failed Responses API events are surfaced to callers.

## Tests and Examples

- `go test ./provider/openaiprovider`
- `go test ./provider/foundryprovider`
- Added coverage for streaming `response.failed` events and failed responses without explicit provider error details

## Notes

- Duplicate check: no recent `[dotnet-port-fixes]` or `[dotnet-port-api]` issue/PR title in `microsoft/agent-framework-go` matched this failure-handling area.
- The fix is intentionally scoped to the shared OpenAI Responses translation path used by Foundry, so no exported API or docs/example updates were needed.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30972303862) · gpt54 · 282.5 AIC · ⌖ 13.4 AIC · ⊞ 24.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 30972303862, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30972303862 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #787