### PR TITLE
[dotnet-port-fixes] Suppress duplicate hosted workflow responses

### DIFF
--- a/workflow/agentworkflow/hosting.go
+++ b/workflow/agentworkflow/hosting.go
@@ -167,6 +167,12 @@ type hostExecutor struct {
 	turnEmitEvents  *bool
 }
 
+type generatedHostedMessageState struct {
+	messageID  string
+	responseID string
+	role       message.Role
+}
+
 func newHostExecutor(a *agent.Agent, cfg Config) *hostExecutor {
 	id := descriptiveID(a)
 	ports := hostPorts(id)
@@ -406,10 +412,12 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context, messages []*m
 	}
 
 	var resp agent.Response
+	var generatedMessageState generatedHostedMessageState
 	for update, err := range h.agent.Run(wctx, agentInput, runOpts...) {
 		if err != nil {
 			return err
 		}
+		update = stampHostedUpdateMessageID(update, &generatedMessageState)
 		if emitUpdates {
 			if err := wctx.YieldOutput(update); err != nil {
 				return err
@@ -452,6 +460,48 @@ func (h *hostExecutor) runAgentAndDispatch(wctx *workflow.Context, messages []*m
 		return err
 	}
 	return nil
+}
+
+func stampHostedUpdateMessageID(update *agent.ResponseUpdate, state *generatedHostedMessageState) *agent.ResponseUpdate {
+	if update == nil {
+		return nil
+	}
+	if update.MessageID != "" {
+		if state != nil {
+			*state = generatedHostedMessageState{}
+		}
+		return update
+	}
+	if !responseUpdateHasContent(update) || state == nil {
+		return update
+	}
+	if state.messageID == "" ||
+		(state.responseID != "" && update.ResponseID != "" && state.responseID != update.ResponseID) ||
+		(state.role != "" && update.Role != "" && state.role != update.Role) {
+		state.messageID = newMessageID()
+	}
+	if update.ResponseID != "" {
+		state.responseID = update.ResponseID
+	}
+	if update.Role != "" {
+		state.role = update.Role
+	}
+	clone := *update
+	clone.MessageID = state.messageID
+	return &clone
+}
+
+func responseUpdateHasContent(update *agent.ResponseUpdate) bool {
+	if update == nil {
+		return false
+	}
+	for _, content := range update.Contents {
+		if text, ok := content.(*message.TextContent); ok && text.Text == "" {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // releasePendingTurnIfReady propagates the held TurnToken downstream once all

--- a/workflow/agentworkflow/workflow.go
+++ b/workflow/agentworkflow/workflow.go
@@ -23,6 +23,7 @@ import (
 	"iter"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -55,6 +56,21 @@ type AgentConfig struct {
 	// [workflow.ErrorEvent]s in the agent response stream. When false, a
 	// generic message is emitted instead.
 	IncludeErrorDetails bool
+}
+
+func recordStreamedMessageID(streamed map[streamedMessageKey]struct{}, executorID string, messageID string) {
+	if strings.TrimSpace(messageID) == "" {
+		return
+	}
+	streamed[streamedMessageKey{executorID: executorID, messageID: messageID}] = struct{}{}
+}
+
+func messageWasStreamed(streamed map[streamedMessageKey]struct{}, executorID string, messageID string) bool {
+	if strings.TrimSpace(messageID) == "" {
+		return false
+	}
+	_, ok := streamed[streamedMessageKey{executorID: executorID, messageID: messageID}]
+	return ok
 }
 
 // NewAgent wraps a [*workflow.Workflow] as an [*agent.Agent].
@@ -117,6 +133,7 @@ func NewAgent(wf *workflow.Workflow, cfg AgentConfig) (*agent.Agent, error) {
 			responseID := uuid.NewString()
 			stream, _ := agent.GetOption(options, agent.Stream)
 			mergeState := newCollectedResponseMergeState()
+			streamedMessageIDs := make(map[streamedMessageKey]struct{})
 			emitUpdate := func(update *agent.ResponseUpdate, terminalWorkflowOutput bool) bool {
 				if update == nil {
 					return true
@@ -197,7 +214,9 @@ func NewAgent(wf *workflow.Workflow, cfg AgentConfig) (*agent.Agent, error) {
 				case workflow.OutputEvent:
 					switch out := e.Output.(type) {
 					case *agent.ResponseUpdate:
-						if !emitUpdate(stampUpdate(out, responseID, e), false) {
+						stamped := stampUpdate(out, responseID, e)
+						recordStreamedMessageID(streamedMessageIDs, e.ExecutorID, stamped.MessageID)
+						if !emitUpdate(stamped, false) {
 							return
 						}
 					case *agent.Response:
@@ -207,8 +226,20 @@ func NewAgent(wf *workflow.Workflow, cfg AgentConfig) (*agent.Agent, error) {
 						if out == nil {
 							continue
 						}
+						emittedMessage := false
+						suppressedStreamedMessage := false
 						for _, msg := range out.Messages {
+							if msg != nil && messageWasStreamed(streamedMessageIDs, e.ExecutorID, msg.ID) {
+								suppressedStreamedMessage = true
+								continue
+							}
+							emittedMessage = true
 							if !emitUpdate(messageToUpdate(msg, responseID, e), false) {
+								return
+							}
+						}
+						if !emittedMessage && suppressedStreamedMessage {
+							if !emitUpdate(newUpdate(responseID, e), false) {
 								return
 							}
 						}
@@ -296,6 +327,11 @@ func createSession(_ context.Context, sess *agent.Session, _ ...agent.Option) er
 type matchedExternalResponse struct {
 	contentID string
 	response  *workflow.ExternalResponse
+}
+
+type streamedMessageKey struct {
+	executorID string
+	messageID  string
 }
 
 // splitResponses scans messages for response content matching pending

--- a/workflow/agentworkflow/workflow_test.go
+++ b/workflow/agentworkflow/workflow_test.go
@@ -105,6 +105,26 @@ func fixedTextAgent(id, name, text string) *agent.Agent {
 	)
 }
 
+func fixedUpdatesAgent(id, name string, updates ...*agent.ResponseUpdate) *agent.Agent {
+	run := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			for _, update := range updates {
+				if !yield(update, nil) {
+					return
+				}
+			}
+		}
+	}
+	return agent.New(
+		agent.ProviderConfig{ProviderName: "fixed-updates", Run: run},
+		agent.Config{
+			ID:                  id,
+			Name:                name,
+			DisableFuncAutoCall: true,
+		},
+	)
+}
+
 func uppercaseLatestTextBinding(id string) workflow.ExecutorBinding {
 	binding := workflow.ExecutorBinding{
 		ID:               id,
@@ -445,7 +465,7 @@ func TestNew_GatesHostedAgentResponseOutputsByDefault(t *testing.T) {
 		t.Fatalf("New included: %v", err)
 	}
 	var sawResponseOutput bool
-	for update, err := range included.RunText(t.Context(), "ping") {
+	for update, err := range included.RunText(t.Context(), "ping", agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("RunText included: %v", err)
 		}
@@ -457,6 +477,87 @@ func TestNew_GatesHostedAgentResponseOutputsByDefault(t *testing.T) {
 	}
 	if !sawResponseOutput {
 		t.Fatalf("aggregated hosted agent response output was not forwarded when included")
+	}
+}
+
+func TestNew_SuppressesDuplicateHostedAgentResponseMessages(t *testing.T) {
+	host := agentworkflow.New(
+		fixedUpdatesAgent("hosted-id", "hosted-name", &agent.ResponseUpdate{
+			Role:      message.RoleAssistant,
+			MessageID: "streamed-message",
+			Contents: message.Contents{
+				&message.TextContent{Text: "hosted-response"},
+			},
+		}),
+		agentworkflow.Config{
+			EmitUpdateEvents:   true,
+			EmitResponseEvents: true,
+		},
+	)
+	wf, err := workflow.NewBuilder(host).
+		WithOutputFrom(host).
+		Build()
+	if err != nil {
+		t.Fatalf("build workflow: %v", err)
+	}
+	ag, err := agentworkflow.NewAgent(wf, agentworkflow.AgentConfig{IncludeOutputsInResponse: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var textUpdates int
+	var sawCompletionOutput bool
+	for update, err := range ag.RunText(t.Context(), "ping", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("RunText: %v", err)
+		}
+		if update.Contents.Text() == "hosted-response" {
+			textUpdates++
+		}
+		if raw, ok := update.RawRepresentation.(workflow.OutputEvent); ok && len(update.Contents) == 0 {
+			if _, isResponse := raw.Output.(*agent.Response); isResponse {
+				sawCompletionOutput = true
+			}
+		}
+	}
+	if textUpdates != 1 {
+		t.Fatalf("hosted response text updates = %d, want 1", textUpdates)
+	}
+	if !sawCompletionOutput {
+		t.Fatalf("expected raw-only completion update for suppressed hosted response output")
+	}
+}
+
+func TestNew_SuppressesDuplicateHostedAgentResponseMessagesWithoutProviderMessageIDs(t *testing.T) {
+	host := agentworkflow.New(
+		fixedUpdatesAgent("hosted-id", "hosted-name", &agent.ResponseUpdate{
+			Role: message.RoleAssistant,
+			Contents: message.Contents{
+				&message.TextContent{Text: "hosted-response"},
+			},
+		}),
+		agentworkflow.Config{
+			EmitUpdateEvents:   true,
+			EmitResponseEvents: true,
+		},
+	)
+	wf, err := workflow.NewBuilder(host).
+		WithOutputFrom(host).
+		Build()
+	if err != nil {
+		t.Fatalf("build workflow: %v", err)
+	}
+	ag, err := agentworkflow.NewAgent(wf, agentworkflow.AgentConfig{IncludeOutputsInResponse: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := ag.RunText(t.Context(), "ping").Collect()
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if got, want := responseTexts(resp), []string{"hosted-response"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("response texts = %v, want %v; response = %+v", got, want, resp)
 	}
 }
 


### PR DESCRIPTION
## Summary

Align `workflow/agentworkflow` with the .NET hosted-workflow fix from microsoft/agent-framework#7217 (upstream commit `bfc73a5b14b40d40a90bf949d601324894d1bc34`).

This change:
- synthesizes stable message IDs for contentful hosted-agent streaming updates when the provider does not supply one
- suppresses completed `*agent.Response` messages that were already surfaced as streamed updates when `IncludeOutputsInResponse` is enabled
- preserves the hosted response completion event as a raw-only observability update in streaming mode
- adds end-to-end tests covering duplicate suppression with and without provider-supplied message IDs

## Ported .NET PRs

- microsoft/agent-framework#7217 - Fix declarative autosend output

## Breaking Changes

No.

## Tests and Examples

- Added workflow tests for hosted-agent duplicate suppression and completion-event observability
- `go test ./workflow/agentworkflow`
- `go test ./...`
- No examples changed

## Notes

- Upstream evidence: `dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs`, `dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/AIAgentHostExecutor.cs`
- The duplicate suppression is intentionally scoped to completed hosted-agent `*agent.Response` outputs; existing `IncludeOutputsInResponse` behavior for non-hosted generic workflow message outputs is unchanged
- Commit ported from upstream head `e90b6de5a72d922ea3b803cf4f194e2f1bae354b` inspected during selection


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/30064412170) · 1.1K AIC · ⌖ 18.6 AIC · ⊞ 21.7K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.60, model: gpt-5.4, id: 30064412170, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/30064412170 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #735