### PR TITLE
[dotnet-code] Split workflow output filter internals

### DIFF
--- a/workflow/inproc/context.go
+++ b/workflow/inproc/context.go
@@ -616,10 +616,10 @@ func (proc *runnerContext) yieldOutput(ctx context.Context, executorID string, o
 		return fmt.Errorf("executor %q cannot output object of type %s; expected one of %v", executorID, reflect.TypeOf(output), expectedTypes)
 	}
 
-	tags, ok := proc.outputFilter.tryGetTags(executorID)
-	if !ok {
+	if !proc.outputFilter.canOutput(executorID, output) {
 		return nil
 	}
+	tags, _ := proc.outputFilter.tryGetTags(executorID)
 	return proc.addEvent(ctx, workflow.OutputEvent{
 		ExecutorID: executorID,
 		Output:     output,

--- a/workflow/inproc/outputfilter.go
+++ b/workflow/inproc/outputfilter.go
@@ -19,6 +19,14 @@ func newOutputFilter(wf *workflow.Workflow) *outputFilter {
 	return &outputFilter{tagsByExecutor: wf.OutputExecutors()}
 }
 
+func (f *outputFilter) canOutput(executorID string, _ any) bool {
+	if f == nil {
+		return false
+	}
+	_, ok := f.tagsByExecutor[executorID]
+	return ok
+}
+
 func (f *outputFilter) tryGetTags(executorID string) ([]workflow.OutputTag, bool) {
 	if f == nil {
 		return nil, false


### PR DESCRIPTION
## Summary

Split the in-process workflow output filter so output eligibility is checked separately from tag lookup. This keeps the Go runner behavior unchanged while making the internal shape closer to the .NET `OutputFilter`, where `CanOutput` and `TryGetTags` are distinct operations.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/OutputFilter.cs` - separates output eligibility (`CanOutput`) from output tag retrieval (`TryGetTags`).

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow/inproc`

## Notes

Random sample candidates inspected included workflow output filtering, loop context, MCP skill resources, and tool approval rules. Rejected `LoopContext.cs` because the comparable Go loop context is public API shape rather than a safe internal cleanup. Rejected `AgentMcpSkillResource.cs` because the current Go MCP tool integration does not have a directly comparable skill-resource abstraction to refactor without adding features. Rejected `ToolApprovalRule.cs` because Go already preserves the .NET null-vs-empty argument rule distinction with existing tests, so further edits would add churn.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31542873955) · gpt55 · 69.5 AIC · ⌖ 11.9 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 31542873955, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31542873955 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #825