### PR TITLE
[dotnet-code] Clarify completion marker feedback internals

### DIFF
--- a/agent/harness/loop/evaluators.go
+++ b/agent/harness/loop/evaluators.go
@@ -38,10 +38,9 @@ func NewCompletionMarkerEvaluator(config CompletionMarkerConfig) *CompletionMark
 	if config.FeedbackMessageTemplate != "" {
 		template = config.FeedbackMessageTemplate
 	}
-	template = strings.ReplaceAll(template, completionMarkerPlaceholder, marker)
 	return &CompletionMarkerEvaluator{
 		completionMarker:        marker,
-		feedbackMessageTemplate: template,
+		feedbackMessageTemplate: prepareCompletionMarkerFeedbackTemplate(template, marker),
 	}
 }
 
@@ -57,6 +56,13 @@ func (e *CompletionMarkerEvaluator) Evaluate(_ context.Context, loop *Context) (
 	if strings.Contains(responseText, e.completionMarker) {
 		return Stop(), nil
 	}
-	feedback := strings.ReplaceAll(e.feedbackMessageTemplate, lastResponsePlaceholder, responseText)
-	return Continue(feedback), nil
+	return Continue(formatCompletionMarkerFeedback(e.feedbackMessageTemplate, responseText)), nil
+}
+
+func prepareCompletionMarkerFeedbackTemplate(template, marker string) string {
+	return strings.ReplaceAll(template, completionMarkerPlaceholder, marker)
+}
+
+func formatCompletionMarkerFeedback(template, responseText string) string {
+	return strings.ReplaceAll(template, lastResponsePlaceholder, responseText)
 }


### PR DESCRIPTION
## Summary

Extracted unexported helpers for preparing completion-marker feedback templates and formatting per-response feedback. This keeps the Go evaluator structure closer to the .NET constructor/evaluation split, where the completion marker is substituted once and the latest response placeholder is substituted during evaluation.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Harness/Loop/CompletionMarkerLoopEvaluator.cs` - separates fixed completion marker template preparation from per-evaluation last response substitution.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/harness/loop`

## Notes

Rejected candidates from the random sample:
- `dotnet/src/Microsoft.Agents.AI.Workflows/InProcessExecution.cs` / Go `workflow/inproc` execution entry points: Go is already structurally different due to package-level environment types and changing it would risk public API churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Observability/Tags.cs` / Go workflow observability constants: tags are already centralized in Go and no safe cleanup was apparent.
- `dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsSource.cs` / Go `agent/skills` sources: the .NET disposable base-class shape does not translate cleanly to Go without changing source semantics or public API.

An open `[dotnet-code]` PR exists but its details were filtered in this environment, so this PR intentionally stays limited to loop completion-marker internals.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31224119508) · gpt55 · 62.4 AIC · ⌖ 10.5 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 31224119508, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31224119508 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #815