### PR TITLE
[dotnet-code] Consolidate agent host request dispatch internals

### DIFF
--- a/workflow/agentworkflow/hosting.go
+++ b/workflow/agentworkflow/hosting.go
@@ -581,44 +581,36 @@ func (h *hostExecutor) dispatchRequests(wctx *workflow.Context, msgs []*message.
 		}
 	}
 
-	var approvalDispatches []*message.ToolApprovalRequestContent
-	var callDispatches []*message.FunctionCallContent
-	for _, id := range approvalOrder {
-		approval, ok := approvalRequests[id]
-		if !ok {
-			continue
-		}
-		delete(approvalRequests, id)
-		added, err := h.approvalHandler.TrackRequest(wctx, approval)
-		if err != nil {
-			return err
-		}
-		if added {
-			approvalDispatches = append(approvalDispatches, approval)
-		}
+	if err := dispatchTrackedRequests(wctx, approvalOrder, approvalRequests, h.approvalHandler); err != nil {
+		return err
 	}
-	for _, id := range callOrder {
-		call, ok := functionCalls[id]
+	return dispatchTrackedRequests(wctx, callOrder, functionCalls, h.callHandler)
+}
+
+type requestDispatcher[T any] interface {
+	TrackRequest(*workflow.Context, T) (bool, error)
+	DispatchRequest(*workflow.Context, T) error
+}
+
+func dispatchTrackedRequests[T any](wctx *workflow.Context, order []string, requests map[string]T, dispatcher requestDispatcher[T]) error {
+	dispatches := make([]T, 0, len(order))
+	for _, id := range order {
+		request, ok := requests[id]
 		if !ok {
 			continue
 		}
-		delete(functionCalls, id)
-		added, err := h.callHandler.TrackRequest(wctx, call)
+		delete(requests, id)
+		added, err := dispatcher.TrackRequest(wctx, request)
 		if err != nil {
 			return err
 		}
 		if added {
-			callDispatches = append(callDispatches, call)
+			dispatches = append(dispatches, request)
 		}
 	}
 
-	for _, approval := range approvalDispatches {
-		if err := h.approvalHandler.DispatchRequest(wctx, approval); err != nil {
-			return err
-		}
-	}
-	for _, call := range callDispatches {
-		if err := h.callHandler.DispatchRequest(wctx, call); err != nil {
+	for _, request := range dispatches {
+		if err := dispatcher.DispatchRequest(wctx, request); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Consolidates the duplicated hosted-agent request tracking and dispatch loops used for tool approval requests and unterminated function calls into one unexported helper. This keeps the Go hosting internals structurally closer to the .NET host option model where request interception is handled through common host behavior, while preserving the existing public Go config shape and dispatch semantics.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/AIAgentHostOptions.cs` - host options describing intercepted user-input requests, intercepted unterminated function calls, forwarded messages, and agent response/update emission.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow/agentworkflow`

## Notes

Rejected sampled candidates:
- `dotnet/src/Microsoft.Agents.AI.Workflows/SwitchBuilder.cs` / Go workflow edge dispatch: already covered by open PR https://github.com/microsoft/agent-framework-go/pull/799.
- `dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FilteringAgentSkillsSourceTests.cs` / Go skills lookup: already covered by open PR https://github.com/microsoft/agent-framework-go/pull/800.
- `dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/ChatReducerCompactionStrategyTests.cs` / Go compaction internals: overlapped active compaction cleanup PRs https://github.com/microsoft/agent-framework-go/pull/794, https://github.com/microsoft/agent-framework-go/pull/795, and https://github.com/microsoft/agent-framework-go/pull/796.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/CheckpointManagerImpl.cs` / Go checkpoint manager: inspected, but no smaller safe structural improvement was preferable to the hosting cleanup.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31134250362) · gpt55 · 112.1 AIC · ⌖ 32.4 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 31134250362, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31134250362 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #811