### PR TITLE
[dotnet-port-fixes] Skip symlinked file-skill assets

### DIFF
--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -547,14 +547,7 @@ func hasNonSymlinkSkillFile(entries []fs.DirEntry) bool {
 }
 
 func isSymlinkEntry(entry fs.DirEntry) bool {
-	if entry.Type()&fs.ModeSymlink != 0 {
-		return true
-	}
-	info, err := entry.Info()
-	if err != nil {
-		return false
-	}
-	return info.Mode()&fs.ModeSymlink != 0
+	return entry.Type()&fs.ModeSymlink != 0
 }
 
 func buildExtensionSet(extensions []string, defaults []string) map[string]bool {

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -204,8 +204,11 @@ func discoverSkillDirectories(filesystems []fs.FS) []discoveredSkillDir {
 // script discovery within an already-discovered skill directory. This matches
 // the .NET SDK, which bounds the two concerns separately.
 func searchForSkills(filesystem fs.FS, dir string, results *[]discoveredSkillDir, currentDepth int) {
-	skillPath := path.Join(dir, skillFileName)
-	if _, err := fs.Stat(filesystem, skillPath); err == nil {
+	entries, err := fs.ReadDir(filesystem, dir)
+	if err != nil {
+		return
+	}
+	if hasNonSymlinkSkillFile(entries) {
 		sub := filesystem
 		var subErr error
 		if dir != "." {
@@ -217,10 +220,6 @@ func searchForSkills(filesystem fs.FS, dir string, results *[]discoveredSkillDir
 		}
 	}
 	if currentDepth >= defaultSearchDepth {
-		return
-	}
-	entries, err := fs.ReadDir(filesystem, dir)
-	if err != nil {
 		return
 	}
 	for _, entry := range entries {
@@ -501,6 +500,10 @@ func (s *Source) scanForFiles(
 	}
 
 	for _, entry := range entries {
+		if isSymlinkEntry(entry) {
+			continue
+		}
+
 		entryPath := path.Join(dir, entry.Name())
 		if entry.IsDir() {
 			if currentDepth < s.searchDepth {
@@ -532,6 +535,26 @@ func (s *Source) scanForFiles(
 
 		collect(relativePath)
 	}
+}
+
+func hasNonSymlinkSkillFile(entries []fs.DirEntry) bool {
+	for _, entry := range entries {
+		if entry.Name() == skillFileName && !isSymlinkEntry(entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSymlinkEntry(entry fs.DirEntry) bool {
+	if entry.Type()&fs.ModeSymlink != 0 {
+		return true
+	}
+	info, err := entry.Info()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&fs.ModeSymlink != 0
 }
 
 func buildExtensionSet(extensions []string, defaults []string) map[string]bool {

--- a/agent/skills/fsskills/source_script_test.go
+++ b/agent/skills/fsskills/source_script_test.go
@@ -342,6 +342,30 @@ func TestFileSource_ScriptFilter_IncludesOnlyMatchingScripts(t *testing.T) {
 	}
 }
 
+func TestFileSource_SymlinkedScript_IsNotDiscovered(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	createSkillDir(t, root, "symlink-script-skill", "Symlink script test", "Body.")
+	outsideScript := filepath.Join(outside, "run.py")
+	if err := os.WriteFile(outsideScript, []byte("print('secret')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustCreateSymlink(t, outsideScript, filepath.Join(root, "symlink-script-skill", "scripts", "run.py"))
+
+	source := fsskills.NewSourceOptions(fsskills.SourceOptions{
+		ScriptRunner: func(context.Context, *skills.Skill, *skills.Script, []string) (any, error) {
+			return nil, nil
+		},
+	}, os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded[0].Scripts) != 0 {
+		t.Fatalf("expected symlinked script to be ignored, got %d scripts", len(loaded[0].Scripts))
+	}
+}
+
 func TestFileScript_RunWithNonFileSkill_ReturnsError(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "script-owner", "Script owner", "Body.")

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -36,6 +36,29 @@ func TestFileSource_NonExistentPath_ReturnsEmptyList(t *testing.T) {
 	}
 }
 
+func TestFileSource_SymlinkedSkillFile_IsNotDiscovered(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	linkedSkillDir := filepath.Join(root, "linked-skill")
+	if err := os.MkdirAll(linkedSkillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outsideSkillFile := filepath.Join(outside, "SKILL.md")
+	if err := os.WriteFile(outsideSkillFile, []byte("---\nname: linked-skill\ndescription: Linked\n---\nBody."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustCreateSymlink(t, outsideSkillFile, filepath.Join(linkedSkillDir, "SKILL.md"))
+
+	source := fsskills.NewSource(os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("expected symlinked SKILL.md to be ignored, got %d skills", len(loaded))
+	}
+}
+
 func TestFileSource_NoResourceFiles_ReturnsEmptyResources(t *testing.T) {
 	root := t.TempDir()
 	createSkillDir(t, root, "no-resources", "A skill", "No resources here.")
@@ -548,6 +571,26 @@ func TestFileSource_NoDuplicateResourcesFromSamePath(t *testing.T) {
 	}
 }
 
+func TestFileSource_SymlinkedResource_IsNotDiscovered(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	createSkillDir(t, root, "symlink-resource-skill", "Symlink resource test", "Body.")
+	outsideResource := filepath.Join(outside, "secret.md")
+	if err := os.WriteFile(outsideResource, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustCreateSymlink(t, outsideResource, filepath.Join(root, "symlink-resource-skill", "references", "secret.md"))
+
+	source := fsskills.NewSource(os.DirFS(root))
+	loaded, err := source.Skills(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded[0].Resources) != 0 {
+		t.Fatalf("expected symlinked resource to be ignored, got %d resources", len(loaded[0].Resources))
+	}
+}
+
 func createSkillDir(t *testing.T, root, name, description, body string) {
 	t.Helper()
 	skillDir := filepath.Join(root, name)
@@ -592,5 +635,15 @@ func createRelativeFile(t *testing.T, root, relativePath, content string) {
 	}
 	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func mustCreateSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Aligned `agent/skills/fsskills` with the upstream .NET hardening in microsoft/agent-framework#7540 by skipping symlinked `SKILL.md` files during skill discovery and skipping symlinked resource/script files during asset discovery. This keeps file-backed skills from following linked content outside the intended skill tree without changing the Go public API.

## Ported .NET PRs

- microsoft/agent-framework#7540 - Harden file skill discovery
- Upstream commit: `94bbfb2ac8382450219afd978bbe17b7eb44efbf`

## Breaking Changes

No. Existing exported Go symbols and signatures are unchanged; the change only excludes symlinked file-skill assets from discovery.

## Tests and Examples

- `go test ./agent/skills/fsskills`
- Added parity coverage for symlinked `SKILL.md`, resource, and script files

## Notes

This PR intentionally ports the narrow symlink-screening behavior that maps cleanly to the current Go `io/fs` implementation. It does not introduce API changes or broader file-system inspection behavior beyond the discovered file entries themselves.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31351525315) · gpt54 · 176.2 AIC · ⌖ 11.6 AIC · ⊞ 24.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 31351525315, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31351525315 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #817