### PR TITLE
Fix PR classifier label permissions

### DIFF
--- a/.github/workflows/classify-pull-request.yml
+++ b/.github/workflows/classify-pull-request.yml
@@ -16,7 +16,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: classify-pull-request-${{ github.event.pull_request.number || inputs.pr-number || 'all' }}
@@ -24,11 +24,11 @@ concurrency:
 
 jobs:
   classify-size-area:
-    uses: microsoft/go-infra/.github/workflows/classify-pull-request.yml@33bdb51f63044f5caa3df215d983d226ebdfef6c
+    uses: microsoft/go-infra/.github/workflows/classify-pull-request.yml@35d34d21089773bebd2dd5efc6197a38f16490bf
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     with:
       pr-number: ${{ github.event.pull_request.number || inputs.pr-number || 0 }}
       area-prefixes: |
@@ -55,7 +55,7 @@ jobs:
   classify-kind:
     if: github.event_name != 'workflow_dispatch' || inputs.pr-number != 0
     needs: classify-size-area
-    uses: microsoft/go-infra/.github/workflows/classify-pull-request-kind.lock.yml@33bdb51f63044f5caa3df215d983d226ebdfef6c
+    uses: microsoft/go-infra/.github/workflows/classify-pull-request-kind.lock.yml@35d34d21089773bebd2dd5efc6197a38f16490bf
     secrets: inherit
     permissions:
       actions: read

--- a/.github/workflows/classify-pull-request.yml
+++ b/.github/workflows/classify-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
       issues: write
       pull-requests: write
     with:
-      pr-number: ${{ github.event.pull_request.number || inputs.pr-number || 0 }}
+      pr-number: ${{ github.event.pull_request.number || fromJSON(github.event.inputs.pr-number || '0') }}
       area-prefixes: |
         {
           "area:agent": ["agent/"],
@@ -53,7 +53,7 @@ jobs:
         }
 
   classify-kind:
-    if: github.event_name != 'workflow_dispatch' || inputs.pr-number != 0
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.pr-number != '0'
     needs: classify-size-area
     uses: microsoft/go-infra/.github/workflows/classify-pull-request-kind.lock.yml@35d34d21089773bebd2dd5efc6197a38f16490bf
     secrets: inherit
@@ -64,4 +64,4 @@ jobs:
       pull-requests: write
       copilot-requests: write
     with:
-      pr_number: ${{ github.event.pull_request.number || inputs.pr-number }}
+      pr_number: ${{ github.event.pull_request.number || fromJSON(github.event.inputs.pr-number || '0') }}


### PR DESCRIPTION
## Summary

- grant the classifier caller and deterministic job `pull-requests: write`
- pin both reusable classifier jobs to the corresponding go-infra fix commit
- convert manual-dispatch PR numbers to the numeric reusable-workflow input type

GitHub authorizes adding a label to a pull request through the `pull-requests` permission, even though the REST route is `/issues/{number}/labels`. Production run https://github.com/microsoft/agent-framework-go/actions/runs/31719034436 had `Issues: write` but only `PullRequests: read`, so every label POST returned `403 Resource not accessible by integration`.

The first validation dispatch also exposed that the caller's logical-OR expression converted the numeric dispatch input into an invalid reusable-workflow value. `fromJSON(github.event.inputs.pr-number)` preserves the required number type.

Depends on https://github.com/microsoft/go-infra/pull/545.

## Validation

- actionlint passes for `.github/workflows/classify-pull-request.yml`
- workflow-dispatch run https://github.com/microsoft/agent-framework-go/actions/runs/31733681923 passed deterministic classification, activation, agent execution, threat detection, safe outputs, and conclusion
- the deterministic job received `PullRequests: write` and applied `size:medium` plus `area:agent` to PR #835
- the semantic stage added `kind:code` and `kind:tests`

## Bootstrap check

The automatic classifier check on this PR is expected to reproduce the existing `403` until this caller fix reaches `main`: `pull_request_target` always loads the workflow definition from the default branch rather than from the pull request. The branch-based `workflow_dispatch` validation above exercised this exact diff and passed end to end.
