### PR TITLE
[dotnet-code] Consolidate route handler option normalization

### DIFF
--- a/workflow/route.go
+++ b/workflow/route.go
@@ -36,6 +36,16 @@ type addHandlerOptions struct {
 	overwrite bool
 }
 
+func normalizeAddHandlerOptions(options []AddHandlerOption) addHandlerOptions {
+	addHandlerOptions := addHandlerOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&addHandlerOptions)
+		}
+	}
+	return addHandlerOptions
+}
+
 // WithHandlerOverwrite controls whether handler registration replaces an
 // existing handler.
 //
@@ -82,12 +92,7 @@ func (rb *RouteBuilder) AddHandlerRaw(messageType reflect.Type, outputType refle
 	if handler == nil {
 		panic("handler cannot be nil")
 	}
-	addHandlerOptions := addHandlerOptions{}
-	for _, option := range options {
-		if option != nil {
-			option(&addHandlerOptions)
-		}
-	}
+	addHandlerOptions := normalizeAddHandlerOptions(options)
 	if rb.err != nil {
 		return rb
 	}
@@ -133,12 +138,7 @@ func (rb *RouteBuilder) AddCatchAll(handler func(*Context, PortableValue) (any, 
 	if handler == nil {
 		panic("handler cannot be nil")
 	}
-	addHandlerOptions := addHandlerOptions{}
-	for _, option := range options {
-		if option != nil {
-			option(&addHandlerOptions)
-		}
-	}
+	addHandlerOptions := normalizeAddHandlerOptions(options)
 	if rb.err != nil {
 		return rb
 	}


### PR DESCRIPTION
## Summary

Extracts shared RouteBuilder handler option normalization into an unexported helper used by both typed handler and catch-all registration. This keeps the Go route-building internals closer to the .NET RouteBuilder shape, where common handler registration setup is centralized, without changing registration behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/RouteBuilder.cs` - centralizes route handler registration setup around shared internal route-builder paths.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow`

## Notes

Rejected candidates:
- `dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellResult.cs` / `tool/shelltool`: Go already closely mirrors the .NET model-formatting flow and has focused coverage, so changes there would be churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/CheckpointManagerImpl.cs` / `workflow/checkpoint`: Go has additional validation and storage mechanics around the same manager operations; refactoring that path looked riskier than this small cleanup.
- `dotnet/src/Microsoft.Agents.AI.Workflows/HandoffWorkflowBuilder.cs`: sampled and inspected, but the matching Go orchestration surface was less direct, making a behavior-preserving tiny cleanup less suitable for this PR.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32076262770) · gpt55 · 76.8 AIC · ⌖ 17.7 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 32076262770, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32076262770 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #852