### PR TITLE
[dotnet-code] Extract skills cached context helper

### DIFF
--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -221,8 +221,7 @@ func (p *providerState) provide(ctx context.Context, invoking agent.InvokingCont
 	}
 
 	p.mu.Lock()
-	if p.cached != nil {
-		cached := *p.cached
+	if cached, ok := p.cachedContextLocked(); ok {
 		p.mu.Unlock()
 		outMessages, outOptions = providedContext(cached)
 		return outMessages, outOptions, nil
@@ -234,16 +233,14 @@ func (p *providerState) provide(ctx context.Context, invoking agent.InvokingCont
 
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		if p.cached == nil {
-			result, err := p.buildContext(ctx)
+		result, ok := p.cachedContextLocked()
+		if !ok {
+			result, err = p.buildContext(ctx)
 			if err != nil {
 				return nil, nil, err
 			}
-			outMessages, outOptions = providedContext(result)
-			return outMessages, outOptions, nil
 		}
-		cached := *p.cached
-		outMessages, outOptions = providedContext(cached)
+		outMessages, outOptions = providedContext(result)
 		return outMessages, outOptions, nil
 	}
 	p.loading = make(chan struct{})
@@ -272,6 +269,13 @@ func (p *providerState) provide(ctx context.Context, invoking agent.InvokingCont
 	}
 	outMessages, outOptions = providedContext(result)
 	return outMessages, outOptions, nil
+}
+
+func (p *providerState) cachedContextLocked() (providerContext, bool) {
+	if p.cached == nil {
+		return providerContext{}, false
+	}
+	return *p.cached, true
 }
 
 func providedContext(result providerContext) ([]*message.Message, []agent.Option) {


### PR DESCRIPTION
## Summary

Extracts the skills provider's cached context lookup into a small unexported helper. This keeps the Go cache retrieval path closer to the .NET caching source's dedicated fresh-result helper shape, making future .NET-to-Go cache-related ports easier to compare without changing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Skills/Decorators/CachingAgentSkillsSource.cs` - uses a dedicated cache-result helper before and after waiting on the per-key fetch gate.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/skills/...`

## Notes

Rejected candidates:
- `dotnet/src/Microsoft.Agents.AI.Workflows/Futures.cs` - workflow output filtering/tagging overlaps existing open `[dotnet-code]` PR #828.
- `dotnet/src/Microsoft.Agents.AI.Workflows/SuperStepEvent.cs` - adding Go stringer/API surface would risk changing public API, so it was not used.
- `dotnet/tests/Microsoft.Agents.AI.UnitTests/Shared/UsageAggregationExtensionsTests.cs` - Go usage aggregation already has focused tests and no small production-code portability cleanup was evident from this sample.
- `dotnet/src/Microsoft.Agents.AI/FunctionInvocationDelegatingAgent.cs` - Go middleware internals use a different public middleware model, making a tiny structural alignment riskier than the skills cache helper.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31846865995) · gpt55 · 76.8 AIC · ⌖ 13.7 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 31846865995, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31846865995 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #844