### PR TITLE
[dotnet-code] Extract portable builtin decode helper

### DIFF
--- a/workflow/portable.go
+++ b/workflow/portable.go
@@ -74,37 +74,8 @@ func (v *PortableValue) Any() any {
 }
 
 func decodeKnownPortableType(typeID TypeID, raw json.RawMessage) (any, bool) {
-	if typeID.PackageName == "" {
-		switch typeID.TypeName {
-		case "string":
-			return decodePortableJSON[string](raw)
-		case "bool":
-			return decodePortableJSON[bool](raw)
-		case "int":
-			return decodePortableJSON[int](raw)
-		case "int8":
-			return decodePortableJSON[int8](raw)
-		case "int16":
-			return decodePortableJSON[int16](raw)
-		case "int32":
-			return decodePortableJSON[int32](raw)
-		case "int64":
-			return decodePortableJSON[int64](raw)
-		case "uint":
-			return decodePortableJSON[uint](raw)
-		case "uint8":
-			return decodePortableJSON[uint8](raw)
-		case "uint16":
-			return decodePortableJSON[uint16](raw)
-		case "uint32":
-			return decodePortableJSON[uint32](raw)
-		case "uint64":
-			return decodePortableJSON[uint64](raw)
-		case "float32":
-			return decodePortableJSON[float32](raw)
-		case "float64":
-			return decodePortableJSON[float64](raw)
-		}
+	if decoded, ok := decodeBuiltinPortableType(typeID, raw); ok {
+		return decoded, true
 	}
 	if typ, ok := runtimeTypeForTypeID(typeID); ok {
 		if decoded, ok := decodePortableJSONType(typ, raw); ok {
@@ -112,6 +83,44 @@ func decodeKnownPortableType(typeID TypeID, raw json.RawMessage) (any, bool) {
 		}
 	}
 	return nil, false
+}
+
+func decodeBuiltinPortableType(typeID TypeID, raw json.RawMessage) (any, bool) {
+	if typeID.PackageName != "" {
+		return nil, false
+	}
+	switch typeID.TypeName {
+	case "string":
+		return decodePortableJSON[string](raw)
+	case "bool":
+		return decodePortableJSON[bool](raw)
+	case "int":
+		return decodePortableJSON[int](raw)
+	case "int8":
+		return decodePortableJSON[int8](raw)
+	case "int16":
+		return decodePortableJSON[int16](raw)
+	case "int32":
+		return decodePortableJSON[int32](raw)
+	case "int64":
+		return decodePortableJSON[int64](raw)
+	case "uint":
+		return decodePortableJSON[uint](raw)
+	case "uint8":
+		return decodePortableJSON[uint8](raw)
+	case "uint16":
+		return decodePortableJSON[uint16](raw)
+	case "uint32":
+		return decodePortableJSON[uint32](raw)
+	case "uint64":
+		return decodePortableJSON[uint64](raw)
+	case "float32":
+		return decodePortableJSON[float32](raw)
+	case "float64":
+		return decodePortableJSON[float64](raw)
+	default:
+		return nil, false
+	}
 }
 
 func decodePortableJSONType(typ reflect.Type, raw json.RawMessage) (any, bool) {


### PR DESCRIPTION
## Summary

Extracted delayed portable-value builtin decoding into a small unexported helper. This keeps builtin/system type normalization separate from runtime type lookup, matching the structure of the .NET portable value normalization path and making future .NET-to-Go ports easier to compare without changing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Kit/PortableValueExtensions.cs` - separates portable value normalization for system primitives from other value shapes before evaluation.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow`

## Notes

Rejected candidates:
- `dotnet/src/Microsoft.Agents.AI.Hosting/NoopAgentSessionStore.cs` - no small corresponding Go session-store cleanup was available without introducing new API or behavior.
- `dotnet/src/Microsoft.Agents.AI.Abstractions/AIAgentMetadata.cs` - Go already exposes provider naming through existing agent internals; adding metadata would affect public API shape.
- `dotnet/src/Microsoft.Agents.AI.Declarative/Extensions/McpServerToolExtensions.cs` - the Go hosted MCP mapping was already localized in provider conversion code, and further changes risked provider behavior churn.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31647363973) · gpt55 · 92 AIC · ⌖ 16.2 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 31647363973, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31647363973 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #839