### PR TITLE
[dotnet-port-fixes] Aggregate loop usage across iterations

### DIFF
--- a/agent/harness/loop/loop.go
+++ b/agent/harness/loop/loop.go
@@ -176,6 +176,7 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 		returnLastResponseOnly := cfg.NonStreamingReturnsLastResponseOnly && !stream
 		initialSession, hasSession := agent.GetOption(opts, agent.WithSession)
 		var initialSessionSnapshot []byte
+		var aggregatedUsage message.UsageDetails
 		loopCtx := &Context{
 			InitialMessages:      initialMessages,
 			Options:              slices.Clone(opts),
@@ -197,6 +198,7 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 				if update != nil {
 					resp.Update(update)
 					if returnLastResponseOnly {
+						aggregatedUsage.Add(update.Usage())
 						iterationUpdates = append(iterationUpdates, cloneResponseUpdate(update))
 					}
 				}
@@ -217,7 +219,7 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 
 			if hasPendingApprovalRequests(&resp) || loopCtx.Iteration >= maxIterations {
 				if returnLastResponseOnly {
-					if !yieldResponseUpdates(yield, iterationUpdates) {
+					if !yieldResponseUpdates(yield, responseUpdatesWithAggregatedUsage(iterationUpdates, aggregatedUsage)) {
 						return
 					}
 				}
@@ -231,7 +233,7 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 			}
 			if !ok {
 				if returnLastResponseOnly {
-					if !yieldResponseUpdates(yield, iterationUpdates) {
+					if !yieldResponseUpdates(yield, responseUpdatesWithAggregatedUsage(iterationUpdates, aggregatedUsage)) {
 						return
 					}
 				}
@@ -351,6 +353,76 @@ func yieldResponseUpdates(yield func(*agent.ResponseUpdate, error) bool, updates
 		}
 	}
 	return true
+}
+
+func responseUpdatesWithAggregatedUsage(updates []*agent.ResponseUpdate, usage message.UsageDetails) []*agent.ResponseUpdate {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	out := make([]*agent.ResponseUpdate, 0, len(updates))
+	for _, update := range updates {
+		if stripped := stripUsageFromResponseUpdate(update); stripped != nil {
+			out = append(out, stripped)
+		}
+	}
+	if isZeroUsageDetails(usage) {
+		return out
+	}
+
+	for i := len(out) - 1; i >= 0; i-- {
+		if len(out[i].Contents) == 0 {
+			continue
+		}
+		out[i].Contents = append(out[i].Contents, &message.UsageContent{Details: usage})
+		return out
+	}
+
+	return append(out, &agent.ResponseUpdate{
+		Contents: message.Contents{&message.UsageContent{Details: usage}},
+	})
+}
+
+func stripUsageFromResponseUpdate(update *agent.ResponseUpdate) *agent.ResponseUpdate {
+	if update == nil {
+		return nil
+	}
+
+	out := cloneResponseUpdate(update)
+	contents := out.Contents[:0]
+	for _, content := range out.Contents {
+		if _, ok := content.(*message.UsageContent); ok {
+			continue
+		}
+		contents = append(contents, content)
+	}
+	out.Contents = contents
+	if len(out.Contents) == 0 && !hasResponseUpdateMetadata(out) {
+		return nil
+	}
+	return out
+}
+
+func hasResponseUpdateMetadata(update *agent.ResponseUpdate) bool {
+	return update.RawRepresentation != nil ||
+		update.AdditionalProperties != nil ||
+		update.AgentID != "" ||
+		update.MessageID != "" ||
+		update.ResponseID != "" ||
+		update.FinishReason != "" ||
+		update.AuthorName != "" ||
+		update.Role != "" ||
+		update.ContinuationToken != "" ||
+		!update.CreatedAt.IsZero()
+}
+
+func isZeroUsageDetails(usage message.UsageDetails) bool {
+	return usage.InputTokenCount == 0 &&
+		usage.OutputTokenCount == 0 &&
+		usage.TotalTokenCount == 0 &&
+		usage.CachedInputTokenCount == 0 &&
+		usage.ReasoningTokenCount == 0 &&
+		len(usage.AdditionalCounts) == 0
 }
 
 func snapshotSession(session *agent.Session) ([]byte, error) {

--- a/agent/harness/loop/loop_test.go
+++ b/agent/harness/loop/loop_test.go
@@ -359,6 +359,46 @@ func TestLoop_NonStreamingReturnsLastResponseOnly(t *testing.T) {
 	}
 }
 
+func TestLoop_NonStreamingReturnsLastResponseOnly_AggregatesUsage(t *testing.T) {
+	capture := newCaptureAgent(func(call int, _ []*message.Message) []*agent.ResponseUpdate {
+		return textAndUsageUpdates("iteration "+strconv.Itoa(call), message.UsageDetails{
+			InputTokenCount:  int64(call),
+			OutputTokenCount: int64(call * 2),
+			TotalTokenCount:  int64(call * 3),
+			AdditionalCounts: map[string]int64{"cache_read": int64(call)},
+		})
+	})
+	a := agent.New(capture.provider(), agent.Config{
+		Middlewares: []agent.Middleware{loop.New(loop.Config{
+			NonStreamingReturnsLastResponseOnly: true,
+			Evaluators: []loop.Evaluator{loop.EvaluatorFunc(func(_ context.Context, ctx *loop.Context) (loop.Evaluation, error) {
+				if ctx.LastResponse.String() == "iteration 3" {
+					return loop.Stop(), nil
+				}
+				return loop.Continue("follow-up"), nil
+			})},
+		})},
+	})
+
+	resp, err := a.RunText(context.Background(), "go").Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage := resp.Usage()
+	if usage.InputTokenCount != 6 {
+		t.Fatalf("input tokens = %d, want 6", usage.InputTokenCount)
+	}
+	if usage.OutputTokenCount != 12 {
+		t.Fatalf("output tokens = %d, want 12", usage.OutputTokenCount)
+	}
+	if usage.TotalTokenCount != 18 {
+		t.Fatalf("total tokens = %d, want 18", usage.TotalTokenCount)
+	}
+	if usage.AdditionalCounts["cache_read"] != 6 {
+		t.Fatalf("cache_read = %d, want 6", usage.AdditionalCounts["cache_read"])
+	}
+}
+
 func TestLoop_NonStreamingReturnsLastResponseOnly_IgnoredForStreaming(t *testing.T) {
 	capture := newCaptureAgent(func(call int, _ []*message.Message) []*agent.ResponseUpdate {
 		return textUpdates("iteration " + strconv.Itoa(call))
@@ -505,6 +545,18 @@ func textUpdates(text string) []*agent.ResponseUpdate {
 		Role:     message.RoleAssistant,
 		Contents: []message.Content{&message.TextContent{Text: text}},
 	}}
+}
+
+func textAndUsageUpdates(text string, usage message.UsageDetails) []*agent.ResponseUpdate {
+	return []*agent.ResponseUpdate{
+		{
+			Role:     message.RoleAssistant,
+			Contents: []message.Content{&message.TextContent{Text: text}},
+		},
+		{
+			Contents: []message.Content{&message.UsageContent{Details: usage}},
+		},
+	}
 }
 
 func messageTexts(messages []*message.Message) []string {


### PR DESCRIPTION
## Summary

Align the Go loop harness with the LoopAgent portion of microsoft/agent-framework#7539 so `NonStreamingReturnsLastResponseOnly` still reports usage from every loop iteration. The loop middleware now accumulates usage across all iterations, removes per-iteration usage from the buffered final response, and reattaches the aggregated usage to the surfaced last response. I also added a regression test that exercises summed token counts and merged `AdditionalCounts`.

## Ported .NET PRs

- microsoft/agent-framework#7539 - aggregate usage across looping agents and chat clients

Upstream commit referenced: `ec32e86646469585bf6d7be83b343c88bf606950` from microsoft/agent-framework. This PR ports only the LoopAgent behavior that maps to `agent/harness/loop`.

## Breaking Changes

No. This corrects internal usage accounting for existing loop runs without changing exported Go API.

## Tests and Examples

- Ran `go test ./agent/harness/loop`
- Added regression coverage in `agent/harness/loop/loop_test.go` for aggregated usage in last-response-only non-streaming runs
- No example changes were needed for this internal behavior fix

## Notes

This intentionally scopes the upstream port to the Go loop harness slice of microsoft/agent-framework#7539. The broader .NET PR also updated other looping components that do not map to this narrow Go change set.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/31988928128) · gpt54 · 250.2 AIC · ⌖ 14.4 AIC · ⊞ 24.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 31988928128, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/31988928128 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #847