### PR TITLE
Return content headers by pointer

### DIFF
--- a/message/content.go
+++ b/message/content.go
@@ -55,7 +55,7 @@ type ContentHeader struct {
 	RawRepresentation    any            `json:"-"`
 }
 
-func (ch ContentHeader) Header() ContentHeader {
+func (ch *ContentHeader) Header() *ContentHeader {
 	return ch
 }
 
@@ -63,7 +63,7 @@ func (ch ContentHeader) Header() ContentHeader {
 type Content interface {
 	json.Marshaler
 	kind() contentKind
-	Header() ContentHeader
+	Header() *ContentHeader
 }
 
 // ToolCallContent represents content that requests a tool call.


### PR DESCRIPTION
## Summary
- return `*ContentHeader` from `Content.Header`
- expose the embedded header for direct mutation without copying

## Testing
- `go test ./message ./internal/messagetest ./provider/a2aprovider ./tool/mcptool ./examples/02-agents/providers/foundry/step21_web_search`
