### PR TITLE
Rename Option.Value to MAFValue

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -537,7 +537,7 @@ type agentKey struct{}
 
 type noSessionOpt bool
 
-func (o noSessionOpt) Value() any { return bool(o) }
+func (o noSessionOpt) MAFValue() any { return bool(o) }
 
 func noSessionProvided(v bool) Option {
 	return noSessionOpt(v)

--- a/agent/harness/agentmode/agentmode_test.go
+++ b/agent/harness/agentmode/agentmode_test.go
@@ -31,7 +31,7 @@ func invokeProvider(provider *agentmode.Provider, ctx context.Context, messages 
 func collectTools(opts []agent.Option) []tool.Tool {
 	var tools []tool.Tool
 	for _, opt := range opts {
-		if tt, ok := opt.Value().(tool.Tool); ok {
+		if tt, ok := opt.MAFValue().(tool.Tool); ok {
 			tools = append(tools, tt)
 		}
 	}

--- a/agent/harness/todo/todo_test.go
+++ b/agent/harness/todo/todo_test.go
@@ -32,7 +32,7 @@ func invokeProvider(provider *todo.Provider, ctx context.Context, messages []*me
 func collectTools(opts []agent.Option) []tool.Tool {
 	var tools []tool.Tool
 	for _, opt := range opts {
-		if tt, ok := opt.Value().(tool.Tool); ok {
+		if tt, ok := opt.MAFValue().(tool.Tool); ok {
 			tools = append(tools, tt)
 		}
 	}
@@ -62,7 +62,7 @@ func callTool(t *testing.T, opts []agent.Option, name string, argsJSON string) s
 	t.Helper()
 	var tools []tool.Tool
 	for _, opt := range opts {
-		if tt, ok := opt.Value().(tool.Tool); ok {
+		if tt, ok := opt.MAFValue().(tool.Tool); ok {
 			tools = append(tools, tt)
 		}
 	}

--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -480,7 +480,7 @@ func prepareOptionsForLastIteration(opts []agent.Option) []agent.Option {
 
 	updated := make([]agent.Option, 0, len(opts)+len(nonSchemaTools)+1)
 	for _, opt := range opts {
-		if _, ok := opt.Value().(tool.Tool); ok {
+		if _, ok := opt.MAFValue().(tool.Tool); ok {
 			continue
 		}
 		updated = append(updated, opt)

--- a/agent/options.go
+++ b/agent/options.go
@@ -17,7 +17,7 @@ import (
 // [GetOption] and [AllOptions] use the option's type
 // to uniquely identify each option.
 type Option interface {
-	Value() any
+	MAFValue() any
 }
 
 type (
@@ -35,19 +35,19 @@ type (
 	structuredOutputOpt struct{ any }
 )
 
-func (o responseFormatOpt) Value() any           { return o.ResponseFormat }
-func (o streamOpt) Value() any                   { return bool(o) }
-func (o continuationTokenOpt) Value() any        { return string(o) }
-func (o instructionsOpt) Value() any             { return string(o) }
-func (o allowBackgroundResponsesOpt) Value() any { return bool(o) }
-func (o toolModeOpt) Value() any                 { return tool.ToolMode(o) }
-func (o toolOpt) Value() any                     { return o.Tool }
-func (o structuredOutputOpt) Value() any         { return o.any }
-func (o serviceIDOpt) Value() any                { return string(o) }
+func (o responseFormatOpt) MAFValue() any           { return o.ResponseFormat }
+func (o streamOpt) MAFValue() any                   { return bool(o) }
+func (o continuationTokenOpt) MAFValue() any        { return string(o) }
+func (o instructionsOpt) MAFValue() any             { return string(o) }
+func (o allowBackgroundResponsesOpt) MAFValue() any { return bool(o) }
+func (o toolModeOpt) MAFValue() any                 { return tool.ToolMode(o) }
+func (o toolOpt) MAFValue() any                     { return o.Tool }
+func (o structuredOutputOpt) MAFValue() any         { return o.any }
+func (o serviceIDOpt) MAFValue() any                { return string(o) }
 
 type sessionOpt struct{ *Session }
 
-func (o sessionOpt) Value() any { return o.Session }
+func (o sessionOpt) MAFValue() any { return o.Session }
 
 // GetOption returns the value stored in opts with the provided setter,
 // reporting whether the value is present.
@@ -60,7 +60,7 @@ func GetOption[T any](opts []Option, setter func(T) Option) (T, bool) {
 	setterType := reflect.TypeOf(setter(zero))
 	for _, opt := range slices.Backward(opts) {
 		if reflect.TypeOf(opt) == setterType {
-			v, ok := opt.Value().(T)
+			v, ok := opt.MAFValue().(T)
 			return v, ok
 		}
 	}
@@ -80,10 +80,10 @@ func AllOptions[T any](opts []Option, setter func(T) Option) iter.Seq[T] {
 		setterType := reflect.TypeOf(setter(zero))
 		for _, opt := range opts {
 			if reflect.TypeOf(opt) == setterType {
-				v, ok := opt.Value().(T)
+				v, ok := opt.MAFValue().(T)
 				if !ok {
 					// Skip an option whose value is absent for T (e.g. a
-					// WithTool(nil) whose Value() is a nil tool.Tool), mirroring
+					// WithTool(nil) whose MAFValue() is a nil tool.Tool), mirroring
 					// GetOption's graceful (zero, false) handling rather than
 					// panicking and aborting the entire collection.
 					continue

--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -27,7 +27,7 @@ type AgentConfig struct {
 
 type taskIDOpt struct{ string }
 
-func (o taskIDOpt) Value() any { return o.string }
+func (o taskIDOpt) MAFValue() any { return o.string }
 
 // TaskID returns an [agent.Option] that associates the run with an existing A2A
 // task, so the request continues that task rather than starting a new one.

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -24,7 +24,7 @@ import (
 
 type messageNewParamsOpt anthropic.MessageNewParams
 
-func (o messageNewParamsOpt) Value() any { return anthropic.MessageNewParams(o) }
+func (o messageNewParamsOpt) MAFValue() any { return anthropic.MessageNewParams(o) }
 
 // MessageNewParams allows passing custom parameters to the underlying anthropic API calls.
 func MessageNewParams(params anthropic.MessageNewParams) agent.Option {

--- a/provider/foundryprovider/clientheaders.go
+++ b/provider/foundryprovider/clientheaders.go
@@ -21,7 +21,7 @@ type clientHeadersContextKey struct{}
 
 type clientHeadersOpt map[string]string
 
-func (o clientHeadersOpt) Value() any { return map[string]string(o) }
+func (o clientHeadersOpt) MAFValue() any { return map[string]string(o) }
 
 // WithClientHeader adds a single x-client-* header to a Foundry agent run.
 func WithClientHeader(name string, value string) agent.Option {

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -25,7 +25,7 @@ import (
 
 type generateContentConfigOpt genai.GenerateContentConfig
 
-func (o generateContentConfigOpt) Value() any { return genai.GenerateContentConfig(o) }
+func (o generateContentConfigOpt) MAFValue() any { return genai.GenerateContentConfig(o) }
 
 // GenerateContentConfig allows passing custom parameters to the underlying genai API calls.
 func GenerateContentConfig(config genai.GenerateContentConfig) agent.Option {

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -38,7 +38,7 @@ type chatClient struct {
 
 type chatCompletionNewParamsOpt openai.ChatCompletionNewParams
 
-func (o chatCompletionNewParamsOpt) Value() any {
+func (o chatCompletionNewParamsOpt) MAFValue() any {
 	return openai.ChatCompletionNewParams(o)
 }
 

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -69,7 +69,7 @@ type responsesClient struct {
 
 type responsesNewParamsOpt responses.ResponseNewParams
 
-func (o responsesNewParamsOpt) Value() any {
+func (o responsesNewParamsOpt) MAFValue() any {
 	return responses.ResponseNewParams(o)
 }
 


### PR DESCRIPTION
## Summary
- rename agent.Option accessor from Value to MAFValue
- update all built-in option implementations and call sites

## Rationale
Namespacing the accessor prevents method collisions with non-MAF option types that define their own Value method and could otherwise unintentionally satisfy agent.Option.

## Testing
- go test ./agent/... ./provider/...