### PR TITLE
Use slices and maps helpers for collection operations

### DIFF
--- a/agent/compaction/provider.go
+++ b/agent/compaction/provider.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"context"
 	"log/slog"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/message"
@@ -76,7 +77,7 @@ func (p *contextProvider) Invoking(ctx context.Context, invoking agent.InvokingC
 		}
 		return messages, options, nil
 	}
-	inputMessages := append([]*message.Message(nil), messages...)
+	inputMessages := slices.Clone(messages)
 	if session == nil {
 		compactedMessages, err := Compact(ctx, p.strategy, messages, p.tokenCounter)
 		if err != nil {

--- a/agent/harness/todo/todo.go
+++ b/agent/harness/todo/todo.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"weak"
@@ -136,9 +137,7 @@ func (p *Provider) GetAllItems(opts ...agent.Option) []Item {
 	mu.Lock()
 	defer mu.Unlock()
 	st := p.loadState(opts)
-	result := make([]Item, len(st.Items))
-	copy(result, st.Items)
-	return result
+	return slices.Clone(st.Items)
 }
 
 // GetRemainingItems returns only the incomplete todo items from the session state.

--- a/agent/harness/toolapproval/toolapproval.go
+++ b/agent/harness/toolapproval/toolapproval.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"maps"
 	"slices"
 	"strings"
 
@@ -356,8 +357,8 @@ func matchesRule(rules []Rule, req *message.ToolApprovalRequestContent) bool {
 	if err != nil {
 		return false
 	}
-	for _, r := range rules {
-		if r.matches(fc.Name, args) {
+	for _, rule := range rules {
+		if rule.matches(fc.Name, args) {
 			return true
 		}
 	}
@@ -447,15 +448,7 @@ func argumentMapsEqual(a, b map[string]string) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}
-	if len(a) != len(b) {
-		return false
-	}
-	for k, av := range a {
-		if bv, ok := b[k]; !ok || av != bv {
-			return false
-		}
-	}
-	return true
+	return maps.Equal(a, b)
 }
 
 func addRuleIfNotExists(st *state, rule Rule) {

--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -998,10 +999,7 @@ func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.
 	if len(approvalRequestCallIDs) > 0 {
 		// Validation: If we got an approval for each request, we should have no call ids left.
 		// Collect call IDs for error message
-		callIDs := make([]string, 0, len(approvalRequestCallIDs))
-		for callID := range approvalRequestCallIDs {
-			callIDs = append(callIDs, callID)
-		}
+		callIDs := slices.Collect(maps.Keys(approvalRequestCallIDs))
 		slices.Sort(callIDs) // Sort for consistent error messages
 		return nil, nil, nil, fmt.Errorf("ToolApprovalRequestContent found with ToolCall.CallID(s) '%s' that have no matching ToolApprovalResponseContent", strings.Join(callIDs, "', '"))
 	}

--- a/agent/skills/frontmatter_source_test.go
+++ b/agent/skills/frontmatter_source_test.go
@@ -4,6 +4,7 @@ package skills_test
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -19,8 +20,8 @@ func mustInlineSkill(frontmatter skills.Frontmatter, content string, resources [
 		GetContent: func(context.Context) (string, error) {
 			return content, nil
 		},
-		Resources: append([]skills.Resource(nil), resources...),
-		Scripts:   append([]skills.Script(nil), scripts...),
+		Resources: slices.Clone(resources),
+		Scripts:   slices.Clone(scripts),
 	}
 }
 

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"path"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -157,7 +158,7 @@ func NewSourceOptions(opts SourceOptions, filesystems ...fs.FS) *Source {
 		searchDepth = defaultSearchDepth
 	}
 	return &Source{
-		filesystems:               append([]fs.FS(nil), filesystems...),
+		filesystems:               slices.Clone(filesystems),
 		logger:                    logger,
 		searchDepth:               searchDepth,
 		resourceFilter:            opts.ResourceFilter,

--- a/agent/skills/fsskills/source_script_test.go
+++ b/agent/skills/fsskills/source_script_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -54,7 +54,7 @@ func TestFileSource_WithMultipleScriptExtensions_DiscoversAll(t *testing.T) {
 	for _, script := range loaded[0].Scripts {
 		scriptNames = append(scriptNames, script.Name)
 	}
-	sort.Strings(scriptNames)
+	slices.Sort(scriptNames)
 	if len(scriptNames) != 6 {
 		t.Fatalf("expected 6 scripts, got %d", len(scriptNames))
 	}

--- a/agent/skills/provider.go
+++ b/agent/skills/provider.go
@@ -194,7 +194,7 @@ type skillSliceSource struct {
 }
 
 func newSkillSliceSource(skills ...*Skill) *skillSliceSource {
-	cloned := append([]*Skill(nil), skills...)
+	cloned := slices.Clone(skills)
 	for i, skill := range cloned {
 		if skill == nil {
 			panic(fmt.Sprintf("skill %d is nil", i))
@@ -546,7 +546,7 @@ func buildProviderSkillsInstructionPrompt(template string, skills []*Skill) stri
 		template = defaultSkillsInstructionPrompt
 	}
 
-	sortedSkills := append([]*Skill(nil), skills...)
+	sortedSkills := slices.Clone(skills)
 	slices.SortFunc(sortedSkills, func(left, right *Skill) int {
 		return strings.Compare(left.Frontmatter.Name, right.Frontmatter.Name)
 	})

--- a/agent/value.go
+++ b/agent/value.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 )
 
 // stateValue wraps a session state value in either serialized or deserialized form,
@@ -61,13 +62,13 @@ func (v *stateValue) MarshalJSON() ([]byte, error) {
 		return json.Marshal(v.cached)
 	}
 	if v.raw != nil {
-		return append([]byte(nil), v.raw...), nil
+		return slices.Clone(v.raw), nil
 	}
 	return []byte("null"), nil
 }
 
 func (v *stateValue) UnmarshalJSON(data []byte) error {
-	v.raw = append(json.RawMessage(nil), data...)
+	v.raw = slices.Clone(json.RawMessage(data))
 	v.cached = nil
 	v.cachedTyp = nil
 	v.hasCached = false

--- a/cmd/prfromissue/gh.go
+++ b/cmd/prfromissue/gh.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 )
 
@@ -33,7 +34,7 @@ func execGH(ctx context.Context, args ...string) (string, error) {
 }
 
 func redactGHArgs(args []string) []string {
-	redacted := append([]string(nil), args...)
+	redacted := slices.Clone(args)
 	for i, arg := range redacted {
 		switch {
 		case arg == "--body" && i+1 < len(redacted):

--- a/cmd/prfromissue/main.go
+++ b/cmd/prfromissue/main.go
@@ -81,8 +81,8 @@ func matchesAnyPrefix(title string, prefixes []string) bool {
 	if len(prefixes) == 0 {
 		return true
 	}
-	for _, p := range prefixes {
-		if strings.HasPrefix(title, p) {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(title, prefix) {
 			return true
 		}
 	}

--- a/cmd/verifyexamples/example_sets.go
+++ b/cmd/verifyexamples/example_sets.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"maps"
 	"slices"
 	"strings"
 )
@@ -25,10 +26,7 @@ func lookupExampleSet(category string) ([]ExampleDefinition, bool) {
 }
 
 func availableCategories() []string {
-	categories := make([]string, 0, len(exampleSets))
-	for category := range exampleSets {
-		categories = append(categories, category)
-	}
+	categories := slices.Collect(maps.Keys(exampleSets))
 	slices.Sort(categories)
 	return categories
 }

--- a/cmd/verifyexamples/options.go
+++ b/cmd/verifyexamples/options.go
@@ -106,11 +106,11 @@ func extractArg(args *[]string, flag string, stderr io.Writer) (string, bool) {
 		}
 		if i+1 >= len(*args) {
 			_, _ = fmt.Fprintf(stderr, "Missing value for %s.\n", flag)
-			*args = append((*args)[:i], (*args)[i+1:]...)
+			*args = slices.Delete(*args, i, i+1)
 			return "", false
 		}
 		value := (*args)[i+1]
-		*args = append((*args)[:i], (*args)[i+2:]...)
+		*args = slices.Delete(*args, i, i+2)
 		return value, true
 	}
 	return "", true
@@ -119,7 +119,7 @@ func extractArg(args *[]string, flag string, stderr io.Writer) (string, bool) {
 func extractFlag(args *[]string, flag string) bool {
 	for i, arg := range *args {
 		if arg == flag {
-			*args = append((*args)[:i], (*args)[i+1:]...)
+			*args = slices.Delete(*args, i, i+1)
 			return true
 		}
 	}

--- a/examples/02-agents/agents/step17_additional_ai_context/main.go
+++ b/examples/02-agents/agents/step17_additional_ai_context/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/microsoft/agent-framework-go/agent"
@@ -192,7 +193,7 @@ func provideTodoListContext(_ context.Context, invoking agent.InvokingContext) (
 			return "", fmt.Errorf("todo item index %d is out of range", args.Index)
 		}
 		removed := state.Items[args.Index]
-		state.Items = append(state.Items[:args.Index], state.Items[args.Index+1:]...)
+		state.Items = slices.Delete(state.Items, args.Index, args.Index+1)
 		setTodoListState(session, state)
 		return fmt.Sprintf("Removed todo item: %s", removed), nil
 	})

--- a/examples/03-workflows/checkpoint/filesystem_checkpoint/main.go
+++ b/examples/03-workflows/checkpoint/filesystem_checkpoint/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/examples/internal/demo"
 	"github.com/microsoft/agent-framework-go/workflow"
@@ -169,7 +169,7 @@ func listCheckpointFiles(dir string) {
 	for _, entry := range entries {
 		names = append(names, entry.Name())
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	demo.Assistantf("Files written under %s:", dir)
 	for _, name := range names {
 		demo.Assistantf("  - %s", filepath.Join(dir, name))

--- a/examples/03-workflows/concurrent/map_reduce/main.go
+++ b/examples/03-workflows/concurrent/map_reduce/main.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -272,7 +273,7 @@ func newCompletion(id string, expected int) workflow.ExecutorBinding {
 			if len(paths) < expected {
 				return nil
 			}
-			out := append([]string(nil), paths...)
+			out := slices.Clone(paths)
 			paths = nil
 			return ctx.YieldOutput(out)
 		}).Extend(&workflow.Executor{
@@ -307,11 +308,8 @@ type wordGroup struct {
 }
 
 func partitionGroups(groups map[string][]int, count int) [][]wordGroup {
-	keys := make([]string, 0, len(groups))
-	for key := range groups {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Collect(maps.Keys(groups))
+	slices.Sort(keys)
 
 	partitions := make([][]wordGroup, count)
 	if count == 0 {

--- a/internal/concurrent/queue.go
+++ b/internal/concurrent/queue.go
@@ -4,6 +4,7 @@ package concurrent
 
 import (
 	"iter"
+	"slices"
 	"sync"
 )
 
@@ -57,8 +58,7 @@ func (q *Queue[T]) Len() int {
 func (q *Queue[T]) All() iter.Seq[T] {
 	return func(yield func(T) bool) {
 		q.mu.RLock()
-		items := make([]T, len(q.items))
-		copy(items, q.items)
+		items := slices.Clone(q.items)
 		q.mu.RUnlock()
 
 		for _, item := range items {

--- a/internal/jsonx/jsonx_test.go
+++ b/internal/jsonx/jsonx_test.go
@@ -5,6 +5,7 @@ package jsonx
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -39,7 +40,7 @@ func TestUnmarshalDiscriminatedUnionSliceWithFallback_UsesFallbackForMissingAndU
 		"known": reflect.TypeOf(knownUnion{}),
 	}
 	fallback := func(raw json.RawMessage) (testUnion, error) {
-		return &rawUnion{Raw: append(json.RawMessage(nil), raw...)}, nil
+		return &rawUnion{Raw: slices.Clone(json.RawMessage(raw))}, nil
 	}
 
 	values, err := UnmarshalDiscriminatedUnionSliceWithFallback(data, types, fallback)

--- a/internal/jsonx/jsonx_test.go
+++ b/internal/jsonx/jsonx_test.go
@@ -40,7 +40,7 @@ func TestUnmarshalDiscriminatedUnionSliceWithFallback_UsesFallbackForMissingAndU
 		"known": reflect.TypeOf(knownUnion{}),
 	}
 	fallback := func(raw json.RawMessage) (testUnion, error) {
-		return &rawUnion{Raw: slices.Clone(json.RawMessage(raw))}, nil
+		return &rawUnion{Raw: slices.Clone(raw)}, nil
 	}
 
 	values, err := UnmarshalDiscriminatedUnionSliceWithFallback(data, types, fallback)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -3,6 +3,7 @@
 package telemetry
 
 import (
+	"maps"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -83,10 +84,7 @@ func PrependAgentFrameworkToHTTPHeader(headers http.Header) http.Header {
 }
 
 func userAgentPrefixList() []string {
-	prefixes := make([]string, 0, len(userAgentPrefixes))
-	for prefix := range userAgentPrefixes {
-		prefixes = append(prefixes, prefix)
-	}
+	prefixes := slices.Collect(maps.Keys(userAgentPrefixes))
 	slices.Sort(prefixes)
 	return prefixes
 }

--- a/message/annotation.go
+++ b/message/annotation.go
@@ -50,7 +50,7 @@ func (as *Annotations) UnmarshalJSON(data []byte) error {
 }
 
 func unmarshalRawAnnotation(data json.RawMessage) (Annotation, error) {
-	return &RawAnnotation{RawRepresentation: slices.Clone(json.RawMessage(data))}, nil
+	return &RawAnnotation{RawRepresentation: slices.Clone(data)}, nil
 }
 
 // Annotation represents an annotation on content.
@@ -120,7 +120,7 @@ func (as *AnnotatedRegions) UnmarshalJSON(data []byte) error {
 }
 
 func unmarshalRawAnnotatedRegion(data json.RawMessage) (AnnotatedRegion, error) {
-	return &RawAnnotatedRegion{RawRepresentation: slices.Clone(json.RawMessage(data))}, nil
+	return &RawAnnotatedRegion{RawRepresentation: slices.Clone(data)}, nil
 }
 
 // AnnotatedRegion describes the portion of an associated [Content]

--- a/message/annotation.go
+++ b/message/annotation.go
@@ -5,6 +5,7 @@ package message
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/internal/jsonx"
 )
@@ -49,7 +50,7 @@ func (as *Annotations) UnmarshalJSON(data []byte) error {
 }
 
 func unmarshalRawAnnotation(data json.RawMessage) (Annotation, error) {
-	return &RawAnnotation{RawRepresentation: append(json.RawMessage(nil), data...)}, nil
+	return &RawAnnotation{RawRepresentation: slices.Clone(json.RawMessage(data))}, nil
 }
 
 // Annotation represents an annotation on content.
@@ -119,7 +120,7 @@ func (as *AnnotatedRegions) UnmarshalJSON(data []byte) error {
 }
 
 func unmarshalRawAnnotatedRegion(data json.RawMessage) (AnnotatedRegion, error) {
-	return &RawAnnotatedRegion{RawRepresentation: append(json.RawMessage(nil), data...)}, nil
+	return &RawAnnotatedRegion{RawRepresentation: slices.Clone(json.RawMessage(data))}, nil
 }
 
 // AnnotatedRegion describes the portion of an associated [Content]

--- a/message/content.go
+++ b/message/content.go
@@ -526,7 +526,7 @@ func (t *RawContent) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &header); err == nil {
 		t.ContentHeader = header
 	}
-	t.RawRepresentation = append(json.RawMessage(nil), data...)
+	t.RawRepresentation = slices.Clone(json.RawMessage(data))
 	return nil
 }
 

--- a/message/messagefilter/filter_test.go
+++ b/message/messagefilter/filter_test.go
@@ -5,6 +5,7 @@ package messagefilter
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/message"
@@ -133,7 +134,7 @@ func TestBuiltInFilters_DoNotAddMessages(t *testing.T) {
 	}
 
 	for _, filter := range filters {
-		out, err := filter(t.Context(), append([]*message.Message(nil), messages...))
+		out, err := filter(t.Context(), slices.Clone(messages))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/provider/copilotprovider/copilot.go
+++ b/provider/copilotprovider/copilot.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -411,10 +412,7 @@ func logApprovalGatingSkipped(names map[string]struct{}) {
 	if len(names) == 0 {
 		return
 	}
-	toolNames := make([]string, 0, len(names))
-	for name := range names {
-		toolNames = append(toolNames, name)
-	}
+	toolNames := slices.Collect(maps.Keys(names))
 	slices.Sort(toolNames)
 	slog.Warn(
 		"A custom OnPreToolUse hook is configured, so approval-required tools will not be automatically gated.",

--- a/provider/copilotprovider/copilot_test.go
+++ b/provider/copilotprovider/copilot_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1131,7 +1132,7 @@ func (r *fakeRuntime) handle(conn net.Conn, req jsonRPCRequest) {
 		r.mu.Lock()
 		r.sessionID = sessionID
 		r.resumeRequests = append(r.resumeRequests, params)
-		resumeEvents := append([]map[string]any(nil), r.resumeEvents...)
+		resumeEvents := slices.Clone(r.resumeEvents)
 		r.mu.Unlock()
 		// Emit any lifecycle events the CLI produces during session.resume
 		// before the RPC response, so they land in the window before a
@@ -1145,7 +1146,7 @@ func (r *fakeRuntime) handle(conn net.Conn, req jsonRPCRequest) {
 		r.mu.Lock()
 		r.sendRequests = append(r.sendRequests, params)
 		sessionID := r.sessionID
-		events := append([]map[string]any(nil), r.events...)
+		events := slices.Clone(r.events)
 		r.mu.Unlock()
 		writeResponse(r.t, conn, req.ID, map[string]any{"messageId": "sent-message"})
 		for _, event := range events {

--- a/provider/foundryprovider/helpers_test.go
+++ b/provider/foundryprovider/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -115,7 +116,7 @@ func (transport *recordingTransport) Do(req *http.Request) (*http.Response, erro
 func (transport *recordingTransport) Requests() []recordedRequest {
 	transport.mu.Lock()
 	defer transport.mu.Unlock()
-	return append([]recordedRequest(nil), transport.requests...)
+	return slices.Clone(transport.requests)
 }
 
 func jsonResponse(req *http.Request, status int, body string) *http.Response {

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -218,10 +218,10 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 		// Clone mutable slice fields so that appending to cfg.Tools or
 		// cfg.SystemInstruction.Parts below never aliases the caller's
 		// backing arrays (the option stores a shallow copy of the struct).
-		cfg.Tools = append([]*genai.Tool(nil), cfg.Tools...)
+		cfg.Tools = slices.Clone(cfg.Tools)
 		if cfg.SystemInstruction != nil {
 			si := *cfg.SystemInstruction
-			si.Parts = append([]*genai.Part(nil), si.Parts...)
+			si.Parts = slices.Clone(si.Parts)
 			cfg.SystemInstruction = &si
 		}
 	}

--- a/tool/shelltool/environment.go
+++ b/tool/shelltool/environment.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -423,11 +422,8 @@ func DefaultShellEnvironmentInstructions(snapshot ShellEnvironmentSnapshot) stri
 }
 
 func formatToolVersions(versions map[string]ToolVersion) (installed, missing []string) {
-	keys := make([]string, 0, len(versions))
-	for name := range versions {
-		keys = append(keys, name)
-	}
-	sort.Strings(keys)
+	keys := slices.Collect(maps.Keys(versions))
+	slices.Sort(keys)
 	for _, name := range keys {
 		version := versions[name]
 		if version.Found {

--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -7,11 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -528,7 +528,7 @@ func (o LocalConfig) resolvedShell() (resolvedShell, error) {
 		return resolvedShell{
 			binary:    o.ShellArgv[0],
 			kind:      classifyShellKind(o.ShellArgv[0]),
-			extraArgv: append([]string(nil), o.ShellArgv[1:]...),
+			extraArgv: slices.Clone(o.ShellArgv[1:]),
 		}, nil
 	}
 	binary := resolveShell(o.Shell)
@@ -686,11 +686,8 @@ func commandEnvironment(clean bool, overrides map[string]string, removals []stri
 		setEnvironmentValue(env, name, value)
 	}
 
-	keys := make([]string, 0, len(env))
-	for name := range env {
-		keys = append(keys, name)
-	}
-	sort.Strings(keys)
+	keys := slices.Collect(maps.Keys(env))
+	slices.Sort(keys)
 	result := make([]string, 0, len(keys))
 	for _, name := range keys {
 		result = append(result, name+"="+env[name])

--- a/workflow/agentworkflow/message_merger.go
+++ b/workflow/agentworkflow/message_merger.go
@@ -236,7 +236,7 @@ func foldIdentifierlessMessages(messages []*message.Message) []*message.Message 
 		}
 
 		messages[i] = mergeIdentifierlessMessageIntoNext(current, next)
-		messages = append(messages[:i-1], messages[i:]...)
+		messages = slices.Delete(messages, i-1, i)
 	}
 	return messages
 }

--- a/workflow/agentworkflow/session.go
+++ b/workflow/agentworkflow/session.go
@@ -56,7 +56,7 @@ func (s *sessionCheckpointStore) CreateCheckpoint(_ context.Context, sessionID s
 	}
 	s.Entries = append(s.Entries, sessionCheckpointEntry{
 		CheckpointInfo: info,
-		Data:           slices.Clone(json.RawMessage(data)),
+		Data:           slices.Clone(data),
 		Parent:         parentCopy,
 	})
 	return info, nil
@@ -68,7 +68,7 @@ func (s *sessionCheckpointStore) RetrieveCheckpoint(_ context.Context, sessionID
 	}
 	for _, entry := range s.Entries {
 		if entry.CheckpointInfo == info {
-			return slices.Clone(json.RawMessage(entry.Data)), nil
+			return slices.Clone(entry.Data), nil
 		}
 	}
 	return nil, fmt.Errorf("agentworkflow: checkpoint %s not found for session %s", info.CheckpointID, sessionID)

--- a/workflow/agentworkflow/session.go
+++ b/workflow/agentworkflow/session.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework-go/agent"
@@ -55,7 +56,7 @@ func (s *sessionCheckpointStore) CreateCheckpoint(_ context.Context, sessionID s
 	}
 	s.Entries = append(s.Entries, sessionCheckpointEntry{
 		CheckpointInfo: info,
-		Data:           append(json.RawMessage(nil), data...),
+		Data:           slices.Clone(json.RawMessage(data)),
 		Parent:         parentCopy,
 	})
 	return info, nil
@@ -67,7 +68,7 @@ func (s *sessionCheckpointStore) RetrieveCheckpoint(_ context.Context, sessionID
 	}
 	for _, entry := range s.Entries {
 		if entry.CheckpointInfo == info {
-			return append(json.RawMessage(nil), entry.Data...), nil
+			return slices.Clone(json.RawMessage(entry.Data)), nil
 		}
 	}
 	return nil, fmt.Errorf("agentworkflow: checkpoint %s not found for session %s", info.CheckpointID, sessionID)

--- a/workflow/executor_test.go
+++ b/workflow/executor_test.go
@@ -631,12 +631,7 @@ func executorWithSendTypes(sendTypes ...reflect.Type) *workflow.Executor {
 }
 
 func hasReflectType(types []reflect.Type, typ reflect.Type) bool {
-	for _, candidate := range types {
-		if candidate == typ {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(types, typ)
 }
 
 func TestBindExecutor_RecordsImplementationID(t *testing.T) {

--- a/workflow/info_test.go
+++ b/workflow/info_test.go
@@ -5,6 +5,7 @@ package workflow_test
 import (
 	"iter"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/workflow"
@@ -244,12 +245,7 @@ type (
 )
 
 func hasType(types []reflect.Type, typ reflect.Type) bool {
-	for _, candidate := range types {
-		if candidate == typ {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(types, typ)
 }
 
 func TestWorkflowDescribeProtocol_NilWorkflowReturnsError(t *testing.T) {

--- a/workflow/inproc/binding_test.go
+++ b/workflow/inproc/binding_test.go
@@ -859,12 +859,7 @@ func TestNewExecutor_DescribesProtocol(t *testing.T) {
 }
 
 func containsType(types []reflect.Type, want reflect.Type) bool {
-	for _, typ := range types {
-		if typ == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(types, want)
 }
 
 func TestFunctionExecutor_ReturnValueAutoSendAndYieldOptions(t *testing.T) {

--- a/workflow/internal/execution/execution.go
+++ b/workflow/internal/execution/execution.go
@@ -5,6 +5,7 @@ package execution
 import (
 	"context"
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/microsoft/agent-framework-go/workflow"
@@ -47,7 +48,7 @@ func (s *ConcurrentEventSink) RemoveHandler(handler func(context.Context, any, w
 	defer s.mu.Unlock()
 	for i, current := range s.EventRaised {
 		if reflect.ValueOf(current).Pointer() == target {
-			s.EventRaised = append(s.EventRaised[:i], s.EventRaised[i+1:]...)
+			s.EventRaised = slices.Delete(s.EventRaised, i, i+1)
 			return
 		}
 	}
@@ -61,7 +62,7 @@ func (s *ConcurrentEventSink) HandlerCount() int {
 
 func (s *ConcurrentEventSink) Enqueue(ctx context.Context, evt workflow.Event) error {
 	s.mu.RLock()
-	handlers := append([]func(context.Context, any, workflow.Event) error(nil), s.EventRaised...)
+	handlers := slices.Clone(s.EventRaised)
 	s.mu.RUnlock()
 
 	for _, handler := range handlers {

--- a/workflow/internal/execution/protocol_test.go
+++ b/workflow/internal/execution/protocol_test.go
@@ -4,6 +4,7 @@ package execution
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/workflow"
@@ -207,10 +208,5 @@ func executorWithYieldTypes(yieldTypes ...reflect.Type) *workflow.Executor {
 }
 
 func slicesContains(types []reflect.Type, typ reflect.Type) bool {
-	for _, candidate := range types {
-		if candidate == typ {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(types, typ)
 }

--- a/workflow/internal/workflowtest/recording_tracer.go
+++ b/workflow/internal/workflowtest/recording_tracer.go
@@ -4,6 +4,7 @@ package workflowtest
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -48,7 +49,7 @@ func (*RecordingTracer) ExtractTraceContext(ctx context.Context) map[string]stri
 func (tracer *RecordingTracer) Spans() []*RecordingSpan {
 	tracer.mu.Lock()
 	defer tracer.mu.Unlock()
-	return append([]*RecordingSpan(nil), tracer.spans...)
+	return slices.Clone(tracer.spans)
 }
 
 // LastSpan returns the most recently started span.
@@ -120,7 +121,7 @@ func (span *RecordingSpan) End() {
 func (span *RecordingSpan) AddEvent(name string, attrs ...observability.Attribute) {
 	span.mu.Lock()
 	defer span.mu.Unlock()
-	span.events = append(span.events, RecordingEvent{Name: name, Attributes: append([]observability.Attribute(nil), attrs...)})
+	span.events = append(span.events, RecordingEvent{Name: name, Attributes: slices.Clone(attrs)})
 }
 
 func (span *RecordingSpan) SetAttributes(attrs ...observability.Attribute) {
@@ -162,7 +163,7 @@ func (span *RecordingSpan) Attribute(key string) (any, bool) {
 func (span *RecordingSpan) Events() []RecordingEvent {
 	span.mu.Lock()
 	defer span.mu.Unlock()
-	return append([]RecordingEvent(nil), span.events...)
+	return slices.Clone(span.events)
 }
 
 // Ended reports whether End was called.

--- a/workflow/observability/opentelemetry/otel.go
+++ b/workflow/observability/opentelemetry/otel.go
@@ -6,6 +6,8 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/microsoft/agent-framework-go/workflow/observability"
@@ -123,9 +125,5 @@ type mapCarrier map[string]string
 func (c mapCarrier) Get(key string) string { return c[key] }
 func (c mapCarrier) Set(key, value string) { c[key] = value }
 func (c mapCarrier) Keys() []string {
-	keys := make([]string, 0, len(c))
-	for k := range c {
-		keys = append(keys, k)
-	}
-	return keys
+	return slices.Collect(maps.Keys(c))
 }

--- a/workflow/protocol_test.go
+++ b/workflow/protocol_test.go
@@ -5,6 +5,7 @@ package workflow
 import (
 	"errors"
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -98,10 +99,5 @@ func newProtocolBuilderWithHandler(inputType, outputType reflect.Type) *Protocol
 }
 
 func containsReflectType(types []reflect.Type, want reflect.Type) bool {
-	for _, typ := range types {
-		if typ == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(types, want)
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -337,8 +337,8 @@ func (w *Workflow) describeOutputYields() ([]reflect.Type, error) {
 // HasResettableExecutors reports whether any executor binding can reset shared
 // resources between workflow runs.
 func (w *Workflow) HasResettableExecutors() bool {
-	for _, er := range w.executorBindings {
-		if er.ResetFunc != nil {
+	for _, binding := range w.executorBindings {
+		if binding.ResetFunc != nil {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- replace manual slice cloning, deletion, sorting, and membership operations with standard slices helpers
- replace manual map key collection and equality operations with standard maps helpers
- preserve straightforward predicate loops where ContainsFunc would be more verbose

## Testing
- go test ./...