### PR TITLE
Preserve per-message usage in response updates

### DIFF
--- a/agent/response.go
+++ b/agent/response.go
@@ -127,15 +127,13 @@ func (resp *Response) Coalesce() {
 // ToUpdates converts this response into response updates suitable for streaming
 // scenarios.
 //
-// Each message in the response becomes a separate update. Response-level usage,
-// additional properties, and a non-empty continuation token are included as an
-// additional metadata-only update when present.
+// Each message in the response becomes a separate update. Response-level
+// additional properties and a non-empty continuation token are included as
+// an additional metadata-only update when present.
 func (resp *Response) ToUpdates() []*ResponseUpdate {
 	if resp == nil {
 		return nil
 	}
-	usage := resp.Usage()
-	hasUsage := !isZeroUsage(usage)
 	hasAdditionalProperties := resp.AdditionalProperties != nil
 
 	updates := make([]*ResponseUpdate, 0, len(resp.Messages)+1)
@@ -154,11 +152,11 @@ func (resp *Response) ToUpdates() []*ResponseUpdate {
 			AuthorName:           msg.AuthorName,
 			Role:                 msg.Role,
 			CreatedAt:            createdAt,
-			Contents:             contentsWithoutUsage(msg.Contents),
+			Contents:             msg.Contents,
 		})
 	}
 
-	if hasUsage || hasAdditionalProperties || resp.ContinuationToken != "" {
+	if hasAdditionalProperties || resp.ContinuationToken != "" {
 		extra := &ResponseUpdate{
 			AdditionalProperties: resp.AdditionalProperties,
 			AgentID:              resp.AgentID,
@@ -166,49 +164,10 @@ func (resp *Response) ToUpdates() []*ResponseUpdate {
 			ContinuationToken:    resp.ContinuationToken,
 			CreatedAt:            resp.CreatedAt,
 		}
-		if hasUsage {
-			extra.Contents = message.Contents{&message.UsageContent{Details: usage}}
-		}
 		updates = append(updates, extra)
 	}
 
 	return updates
-}
-
-// contentsWithoutUsage returns contents with any *message.UsageContent removed.
-// Per-message usage is re-emitted once as a trailing aggregate update in
-// ToUpdates, so retaining it here would cause Collect to double-count usage.
-// When no *message.UsageContent is present the input slice is returned as-is;
-// otherwise a filtered copy is returned. The input slice is never mutated, as
-// the owning Response is caller-owned.
-func contentsWithoutUsage(contents message.Contents) message.Contents {
-	hasUsage := false
-	for _, c := range contents {
-		if _, ok := c.(*message.UsageContent); ok {
-			hasUsage = true
-			break
-		}
-	}
-	if !hasUsage {
-		return contents
-	}
-	filtered := make(message.Contents, 0, len(contents))
-	for _, c := range contents {
-		if _, ok := c.(*message.UsageContent); ok {
-			continue
-		}
-		filtered = append(filtered, c)
-	}
-	return filtered
-}
-
-func isZeroUsage(usage message.UsageDetails) bool {
-	return usage.InputTokenCount == 0 &&
-		usage.OutputTokenCount == 0 &&
-		usage.TotalTokenCount == 0 &&
-		usage.CachedInputTokenCount == 0 &&
-		usage.ReasoningTokenCount == 0 &&
-		len(usage.AdditionalCounts) == 0
 }
 
 // Update folds a streaming [ResponseUpdate] into resp, appending its contents to the matching message and updating response-level fields from later updates.

--- a/agent/response_test.go
+++ b/agent/response_test.go
@@ -779,6 +779,9 @@ func TestResponse_ToUpdates_ProducesUpdates(t *testing.T) {
 	if update0.String() != "Text" {
 		t.Errorf("expected Text, got %q", update0.String())
 	}
+	if got := update0.Usage().TotalTokenCount; got != 100 {
+		t.Errorf("expected message update usage 100, got %d", got)
+	}
 
 	update1 := updates[1]
 	if update1.AdditionalProperties["key1"] != "value1" {
@@ -790,26 +793,28 @@ func TestResponse_ToUpdates_ProducesUpdates(t *testing.T) {
 	if update1.AdditionalProperties["key2"] != 42 {
 		t.Errorf("expected key2 42, got %v", update1.AdditionalProperties["key2"])
 	}
-	if len(update1.Contents) != 1 {
-		t.Fatalf("expected 1 extra content, got %d", len(update1.Contents))
-	}
-	usageContent, ok := update1.Contents[0].(*message.UsageContent)
-	if !ok {
-		t.Fatalf("expected UsageContent, got %T", update1.Contents[0])
-	}
-	if usageContent.Details.TotalTokenCount != 100 {
-		t.Errorf("expected total token count 100, got %d", usageContent.Details.TotalTokenCount)
+	if len(update1.Contents) != 0 {
+		t.Fatalf("expected metadata-only update, got %d contents", len(update1.Contents))
 	}
 }
 
-func TestResponse_ToUpdates_RoundTripDoesNotDoubleCountUsage(t *testing.T) {
+func TestResponse_ToUpdates_PreservesPerMessageUsage(t *testing.T) {
 	resp := &agent.Response{
 		Messages: []*message.Message{
 			{
+				ID:   "message-1",
 				Role: message.RoleAssistant,
 				Contents: message.Contents{
-					&message.TextContent{Text: "Text"},
+					&message.TextContent{Text: "First"},
 					&message.UsageContent{Details: message.UsageDetails{TotalTokenCount: 100}},
+				},
+			},
+			{
+				ID:   "message-2",
+				Role: message.RoleAssistant,
+				Contents: message.Contents{
+					&message.TextContent{Text: "Second"},
+					&message.UsageContent{Details: message.UsageDetails{TotalTokenCount: 200}},
 				},
 			},
 		},
@@ -819,17 +824,11 @@ func TestResponse_ToUpdates_RoundTripDoesNotDoubleCountUsage(t *testing.T) {
 	if len(updates) != 2 {
 		t.Fatalf("expected 2 updates, got %d", len(updates))
 	}
-
-	// The per-message update must not carry the UsageContent; otherwise the
-	// trailing aggregate update would cause Collect to double-count usage.
-	for _, c := range updates[0].Contents {
-		if _, ok := c.(*message.UsageContent); ok {
-			t.Errorf("expected per-message update to omit UsageContent, but found one")
-		}
+	if got := updates[0].Usage().TotalTokenCount; got != 100 {
+		t.Errorf("expected first update usage 100, got %d", got)
 	}
-	// The trailing update carries the aggregate usage exactly once.
-	if got := updates[1].Usage().TotalTokenCount; got != 100 {
-		t.Errorf("expected trailing update usage 100, got %d", got)
+	if got := updates[1].Usage().TotalTokenCount; got != 200 {
+		t.Errorf("expected second update usage 200, got %d", got)
 	}
 
 	collected, err := agent.ResponseStream(func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -842,8 +841,8 @@ func TestResponse_ToUpdates_RoundTripDoesNotDoubleCountUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error collecting updates: %v", err)
 	}
-	if got := collected.Usage().TotalTokenCount; got != 100 {
-		t.Errorf("expected collected usage 100, got %d", got)
+	if got := collected.Usage().TotalTokenCount; got != 300 {
+		t.Errorf("expected collected usage 300, got %d", got)
 	}
 }
 
@@ -880,12 +879,12 @@ func TestResponse_ToUpdates_WithUsageOnlyProducesSingleUpdate(t *testing.T) {
 
 	updates := resp.ToUpdates()
 
-	if len(updates) != 2 {
-		t.Fatalf("expected message update and usage update, got %d", len(updates))
+	if len(updates) != 1 {
+		t.Fatalf("expected one message update, got %d", len(updates))
 	}
-	usageContent, ok := updates[1].Contents[0].(*message.UsageContent)
+	usageContent, ok := updates[0].Contents[0].(*message.UsageContent)
 	if !ok {
-		t.Fatalf("expected UsageContent, got %T", updates[1].Contents[0])
+		t.Fatalf("expected UsageContent, got %T", updates[0].Contents[0])
 	}
 	if usageContent.Details.TotalTokenCount != 100 {
 		t.Errorf("expected total token count 100, got %d", usageContent.Details.TotalTokenCount)


### PR DESCRIPTION
## Summary
- preserve each message's usage content when converting a response to updates
- reserve trailing updates for response-level additional properties and continuation tokens
- cover multi-message usage preservation and round trips

## Testing
- go test ./agent