### PR TITLE
Reduce Agent.Run allocations

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -113,13 +113,13 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 			cfg.RunOptions = append(cfg.RunOptions, WithTool(tool))
 		}
 	}
-	cfg.Middlewares = slices.Clone(cfg.Middlewares)
+	agentMiddlewares := slices.Clone(cfg.Middlewares)
 	if cfg.Logger != nil && !cfg.DisableRunLogs {
-		cfg.Middlewares = append([]Middleware{newRunLoggerMiddleware(cfg.Logger, cfg.LogSensitiveData)}, cfg.Middlewares...)
+		agentMiddlewares = append([]Middleware{newRunLoggerMiddleware(cfg.Logger, cfg.LogSensitiveData)}, agentMiddlewares...)
 	}
-	prov.Middlewares = slices.Clone(prov.Middlewares)
+	providerMiddlewares := slices.Clone(prov.Middlewares)
 	if prov.Format != nil || prov.Unmarshal != nil {
-		prov.Middlewares = append(prov.Middlewares, &structuredOutputMiddleware{
+		providerMiddlewares = append(providerMiddlewares, &structuredOutputMiddleware{
 			format:    prov.Format,
 			unmarshal: prov.Unmarshal,
 		})
@@ -136,14 +136,12 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 		historyProvider = NewInMemoryHistoryProvider(InMemoryHistoryProviderConfig{})
 		hasDefaultHistoryProvider = true
 	}
-	prov.Middlewares = append(prov.Middlewares, authorMiddleware(cfg.ID, cfg.Name))
-	return &Agent{
+	a := &Agent{
 		id:                           cfg.ID,
 		name:                         cfg.Name,
 		description:                  cfg.Description,
 		provider:                     prov,
 		runOptions:                   cfg.RunOptions,
-		middlewares:                  cfg.Middlewares,
 		logger:                       cfg.Logger,
 		historyProvider:              historyProvider,
 		hasConfiguredHistory:         cfg.HistoryProvider != nil,
@@ -154,18 +152,26 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 		providerDoesNotManageHistory: prov.ServiceDoesNotManageHistory,
 		contextProviders:             contextProviders,
 	}
+	if len(providerMiddlewares) == 0 {
+		a.providerPipeline = prov.Run
+	} else {
+		a.providerPipeline = compileRunChain(prov.Run, providerMiddlewares)
+	}
+	a.runPipeline = compileRunChain(a.invoke, agentMiddlewares)
+	return a
 }
 
 // Agent coordinates message preparation, middleware, sessions, and provider execution.
 type Agent struct {
-	id          string
-	name        string
-	description string
-	provider    ProviderConfig
+	id               string
+	name             string
+	description      string
+	provider         ProviderConfig
+	providerPipeline RunFunc
+	runPipeline      RunFunc
 
-	middlewares []Middleware
-	runOptions  []Option
-	logger      *slog.Logger
+	runOptions []Option
+	logger     *slog.Logger
 
 	historyProvider HistoryProvider
 	// historyCleared records that a run promoted its session to service-managed
@@ -249,11 +255,7 @@ func (a *Agent) Run(ctx context.Context, messages []*message.Message, options ..
 			yield(nil, err)
 		}
 	}
-	return ResponseStream(a.run(ctx, preparedMessages, options...))
-}
-
-func (a *Agent) run(ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
-	return runChain(ctx, a.invoke, a.middlewares, messages, options...)
+	return ResponseStream(a.runPipeline(ctx, preparedMessages, options...))
 }
 
 func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
@@ -271,7 +273,10 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 		}
 		noSession, _ := GetOption(options, noSessionProvided)
 		stream, _ := GetOption(options, Stream)
-		inputMessages := slices.Clone(messages)
+		var inputMessages []*message.Message
+		if stream {
+			inputMessages = slices.Clone(messages)
+		}
 		lifecycleOptions := withoutContinuationToken(options)
 
 		historyProvider := a.historyProviderForRun(session, continuationToken, noSession)
@@ -297,65 +302,87 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 			}
 		}
 
-		requestMessages := slices.Clone(messages)
-		var contextResponse Response
-		var historyResponse Response
-		continuationUpdates := cloneResponseUpdates(continuationState.ResponseUpdates)
-		var runErr error
-		var stopped bool
+		var requestMessages []*message.Message
+		if historyProvider != nil || runContextProviders {
+			requestMessages = slices.Clone(messages)
+		}
+		trackContinuationUpdates := stream || continuationToken != ""
 
-		for update, err := range runChain(ctx, a.provider.Run, a.provider.Middlewares, messages, options...) {
+		// invocationState groups values captured by the provider sequence's yield
+		// callback so range-over-function lowering heap-boxes one object instead of
+		// allocating each captured local separately.
+		var state struct {
+			contextResponse     *Response
+			historyResponse     *Response
+			continuationUpdates []*ResponseUpdate
+			runErr              error
+			stopped             bool
+		}
+		if historyProvider != nil {
+			state.historyResponse = new(Response)
+		}
+		if runContextProviders {
+			state.contextResponse = new(Response)
+		}
+		if trackContinuationUpdates {
+			state.continuationUpdates = cloneResponseUpdates(continuationState.ResponseUpdates)
+		}
+
+		for update, err := range a.providerPipeline(ctx, messages, options...) {
 			if update != nil {
-				continuationUpdates = append(continuationUpdates, cloneResponseUpdate(update))
-				historyResponse.Update(update)
+				a.setAuthor(update)
+				if trackContinuationUpdates {
+					state.continuationUpdates = append(state.continuationUpdates, cloneResponseUpdate(update))
+				}
+				if historyProvider != nil {
+					state.historyResponse.Update(update)
+				}
 				if runContextProviders {
-					contextResponse.Update(update)
+					state.contextResponse.Update(update)
 				}
 				if update.ContinuationToken != "" {
 					var tokenInputMessages []*message.Message
 					var tokenResponseUpdates []*ResponseUpdate
 					if stream {
 						tokenInputMessages = inputMessagesForContinuation(inputMessages, continuationState)
-						tokenResponseUpdates = continuationUpdates
+						tokenResponseUpdates = state.continuationUpdates
 					}
 					wrappedToken, err := wrapContinuationToken(update.ContinuationToken, tokenInputMessages, tokenResponseUpdates)
 					if err != nil {
-						if !stopped {
-							yield(nil, err)
-						}
+						yield(nil, err)
 						return
 					}
 					update.ContinuationToken = wrappedToken
 				}
 			}
 			if err != nil {
-				runErr = err
-				stopped = !yield(update, err)
-				break
+				state.runErr = err
 			}
-			if !yield(update, nil) {
-				stopped = true
+			state.stopped = !yield(update, err)
+			if state.stopped || err != nil {
 				break
 			}
 		}
 
 		historyStoreProvider := historyProvider
-		storeRequestMessages := requestMessages
-		storeResponseMessages := historyResponse.Messages
+		var storeResponseMessages []*message.Message
+		if state.historyResponse != nil {
+			storeResponseMessages = state.historyResponse.Messages
+		}
 		if continuationToken != "" {
 			historyStoreProvider = a.historyProviderForContinuationStore(session, noSession)
-			storeRequestMessages = inputMessagesForContinuation(nil, continuationState)
-			continuationResponse := responseFromUpdates(continuationUpdates)
+			requestMessages = inputMessagesForContinuation(nil, continuationState)
+			continuationResponse := responseFromUpdates(state.continuationUpdates)
 			storeResponseMessages = continuationResponse.Messages
 		}
 
 		if historyStoreProvider != nil {
 			storeHistory := a.shouldStoreHistoryProvider(historyStoreProvider, session)
-			if runErr == nil {
+			if state.runErr == nil {
 				var err error
 				storeHistory, err = a.handleHistoryProviderConflict(ctx, historyStoreProvider, session)
 				if err != nil {
-					if !stopped {
+					if !state.stopped {
 						yield(nil, err)
 					}
 					return
@@ -364,11 +391,11 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 			}
 			if storeHistory {
 				if continuationToken == "" {
-					historyResponse.Coalesce()
-					storeResponseMessages = historyResponse.Messages
+					state.historyResponse.Coalesce()
+					storeResponseMessages = state.historyResponse.Messages
 				}
-				if err := historyStoreProvider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(storeRequestMessages), ResponseMessages: slices.Clone(storeResponseMessages), Options: withoutContinuationToken(options), Err: runErr}); err != nil {
-					if !stopped {
+				if err := historyStoreProvider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(requestMessages), ResponseMessages: slices.Clone(storeResponseMessages), Options: withoutContinuationToken(options), Err: state.runErr}); err != nil {
+					if !state.stopped {
 						yield(nil, err)
 					}
 					return
@@ -379,21 +406,33 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 		if runContextProviders || continuationToken != "" && len(a.contextProviders) > 0 {
 			var contextStoreResponseMessages []*message.Message
 			if continuationToken != "" {
-				continuationResponse := responseFromUpdates(continuationUpdates)
+				continuationResponse := responseFromUpdates(state.continuationUpdates)
 				contextStoreResponseMessages = continuationResponse.Messages
 			} else {
-				contextResponse.Coalesce()
-				contextStoreResponseMessages = contextResponse.Messages
+				state.contextResponse.Coalesce()
+				contextStoreResponseMessages = state.contextResponse.Messages
 			}
 			for _, provider := range a.contextProviders {
-				if err := provider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(storeRequestMessages), ResponseMessages: slices.Clone(contextStoreResponseMessages), Options: withoutContinuationToken(options), Err: runErr}); err != nil {
-					if !stopped {
+				if err := provider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(requestMessages), ResponseMessages: slices.Clone(contextStoreResponseMessages), Options: withoutContinuationToken(options), Err: state.runErr}); err != nil {
+					if !state.stopped {
 						yield(nil, err)
 					}
 					return
 				}
 			}
 		}
+	}
+}
+
+func (a *Agent) setAuthor(update *ResponseUpdate) {
+	if update == nil {
+		return
+	}
+	if update.AgentID == "" {
+		update.AgentID = a.id
+	}
+	if update.AuthorName == "" {
+		update.AuthorName = a.name
 	}
 }
 
@@ -511,26 +550,6 @@ func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, opt
 	ctx = context.WithValue(ctx, agentKey{}, a)
 
 	return ctx, messages, options, nil
-}
-
-func authorMiddleware(id, name string) Middleware {
-	return MiddlewareFunc(func(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
-		return func(yield func(*ResponseUpdate, error) bool) {
-			for update, err := range next(ctx, messages, options...) {
-				if update != nil {
-					if update.AgentID == "" {
-						update.AgentID = id
-					}
-					if update.AuthorName == "" {
-						update.AuthorName = name
-					}
-				}
-				if !yield(update, err) {
-					return
-				}
-			}
-		}
-	})
 }
 
 type agentKey struct{}

--- a/agent/agent_benchmark_test.go
+++ b/agent/agent_benchmark_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package agent_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+func BenchmarkAgentRunNoUpdates(b *testing.B) {
+	benchmarkAgentRun(b, nil)
+}
+
+func BenchmarkAgentRunSingleTextUpdate(b *testing.B) {
+	benchmarkAgentRun(b, benchmarkTextUpdates(1))
+}
+
+func BenchmarkAgentRunTenTextUpdates(b *testing.B) {
+	benchmarkAgentRun(b, benchmarkTextUpdates(10))
+}
+
+func benchmarkAgentRun(b *testing.B, updates []*agent.ResponseUpdate) {
+	a := newBenchmarkAgent(updates)
+	session := &agent.Session{}
+	session.SetServiceID("benchmark-session")
+	options := []agent.Option{agent.WithSession(session)}
+	messages := []*message.Message{message.NewText("hello")}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		for _, err := range a.Run(b.Context(), messages, options...) {
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func newBenchmarkAgent(updates []*agent.ResponseUpdate) *agent.Agent {
+	run := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			for _, update := range updates {
+				if !yield(update, nil) {
+					return
+				}
+			}
+		}
+	}
+	return agent.New(agent.ProviderConfig{ProviderName: "fake", Run: run}, agent.Config{
+		ID:   "benchmark-agent",
+		Name: "Benchmark Agent",
+	})
+}
+
+func benchmarkTextUpdates(count int) []*agent.ResponseUpdate {
+	updates := make([]*agent.ResponseUpdate, count)
+	for i := range updates {
+		updates[i] = &agent.ResponseUpdate{
+			Role: message.RoleAssistant,
+			Contents: []message.Content{
+				&message.TextContent{Text: "chunk"},
+			},
+		}
+	}
+	return updates
+}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -170,6 +170,46 @@ func TestAgent_RunText(t *testing.T) {
 	}
 }
 
+func TestAgent_Run_AppliesAuthorAttributionAfterProviderMiddleware(t *testing.T) {
+	var observed bool
+	middleware := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			for update, err := range next(ctx, messages, options...) {
+				if update != nil {
+					observed = true
+					if update.AgentID != "" || update.AuthorName != "" {
+						t.Errorf("expected attribution after provider middleware, got agent ID %q and author name %q", update.AgentID, update.AuthorName)
+					}
+				}
+				if !yield(update, err) {
+					return
+				}
+			}
+		}
+	})
+	run := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: run, Middlewares: []agent.Middleware{middleware}}, agent.Config{
+		ID:   "test-agent",
+		Name: "Test Agent",
+	})
+
+	for update, err := range a.RunText(t.Context(), "hello") {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if update.AgentID != a.ID() || update.AuthorName != a.Name() {
+			t.Fatalf("expected agent attribution, got agent ID %q and author name %q", update.AgentID, update.AuthorName)
+		}
+	}
+	if !observed {
+		t.Fatal("expected provider middleware to observe a response update")
+	}
+}
+
 func TestAgent_RunMessage(t *testing.T) {
 	var capturedMessages []*message.Message
 	var capturedOptions []agent.Option

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -33,9 +33,8 @@ func (mf MiddlewareFunc) Run(next RunFunc, ctx context.Context, messages []*mess
 	return mf(next, ctx, messages, options...)
 }
 
-// runChain applies the given middlewares around the given RunFunc.
-func runChain(ctx context.Context, fn RunFunc, middlewares []Middleware, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
-	// Chain the middlewares together.
+// compileRunChain applies the given middlewares around fn.
+func compileRunChain(fn RunFunc, middlewares []Middleware) RunFunc {
 	for i := len(middlewares) - 1; i >= 0; i-- {
 		mw := middlewares[i]
 		fn = middlewareRunner{
@@ -43,7 +42,7 @@ func runChain(ctx context.Context, fn RunFunc, middlewares []Middleware, message
 			next:       fn,
 		}.Run
 	}
-	return fn(ctx, messages, options...)
+	return fn
 }
 
 type middlewareRunner struct {


### PR DESCRIPTION
## Summary

- compile agent and provider middleware chains once during agent construction
- avoid message cloning and response accumulation when lifecycle features do not need them
- consolidate iterator-captured invocation state and apply missing author attribution after provider middleware
- add raw `Agent.Run` allocation benchmarks for zero, one, and ten updates

## Benchmarks

Collected 10 samples per revision on Windows/ARM64, then compared with `benchstat before.txt after.txt`:

```text
go test ./agent -run '^$' -bench '^BenchmarkAgentRun(NoUpdates|SingleTextUpdate|TenTextUpdates)$' -benchmem -count=10
```

The benchmark file is new in this PR, so the before worktree used the parent production code with the identical benchmark file copied in.

### Time

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `AgentRunNoUpdates-12` | 797.6 ns/op +/- 6% | 306.2 ns/op +/- 6% | -61.62% |
| `AgentRunSingleTextUpdate-12` | 1,129.0 ns/op +/- 10% | 320.7 ns/op +/- 5% | -71.60% |
| `AgentRunTenTextUpdates-12` | 3,361.5 ns/op +/- 5% | 401.9 ns/op +/- 4% | -88.04% |
| geomean | 1.447 us/op | 340.4 ns/op | -76.47% |

### Bytes

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `AgentRunNoUpdates-12` | 1,040 B/op | 480 B/op | -53.85% |
| `AgentRunSingleTextUpdate-12` | 1,440 B/op | 480 B/op | -66.67% |
| `AgentRunTenTextUpdates-12` | 4,032 B/op | 480 B/op | -88.10% |
| geomean | 1.778 KiB/op | 480 B/op | -73.64% |

### Allocations

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `AgentRunNoUpdates-12` | 22 allocs/op | 10 allocs/op | -54.55% |
| `AgentRunSingleTextUpdate-12` | 28 allocs/op | 10 allocs/op | -64.29% |
| `AgentRunTenTextUpdates-12` | 54 allocs/op | 10 allocs/op | -81.48% |
| geomean | 32.16 allocs/op | 10 allocs/op | -68.91% |

All comparisons report `p=0.000, n=10`.

## Validation

- `go test ./...`
- `gofmt -d agent/agent.go agent/agent_benchmark_test.go agent/agent_test.go agent/middleware.go`
- `git diff HEAD^ --check`