### PR TITLE
Clarify agent input ownership

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,6 +16,8 @@ import (
 )
 
 // RunFunc is the provider function that executes an agent invocation.
+// Implementations must treat the message and option slices, and existing
+// messages, as read-only. Clone them before making changes.
 type RunFunc = func(ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error]
 
 // ProviderConfig configures the provider-specific implementation behind an Agent.
@@ -35,7 +37,8 @@ type ProviderConfig struct {
 	// Unmarshal decodes provider structured output into v using format.
 	Unmarshal func(format ResponseFormat, data []byte, v any) error
 
-	// CreateSession configures a provider-specific session.
+	// CreateSession configures a provider-specific session. Implementations must
+	// treat options as read-only and clone the slice before making changes.
 	CreateSession func(ctx context.Context, session *Session, options ...Option) error
 
 	// ServiceDoesNotManageHistory indicates that this provider never manages
@@ -113,13 +116,13 @@ func New(prov ProviderConfig, cfg Config) *Agent {
 			cfg.RunOptions = append(cfg.RunOptions, WithTool(tool))
 		}
 	}
-	agentMiddlewares := slices.Clone(cfg.Middlewares)
+	agentMiddlewares := cfg.Middlewares
 	if cfg.Logger != nil && !cfg.DisableRunLogs {
 		agentMiddlewares = append([]Middleware{newRunLoggerMiddleware(cfg.Logger, cfg.LogSensitiveData)}, agentMiddlewares...)
 	}
-	providerMiddlewares := slices.Clone(prov.Middlewares)
+	providerMiddlewares := prov.Middlewares
 	if prov.Format != nil || prov.Unmarshal != nil {
-		providerMiddlewares = append(providerMiddlewares, &structuredOutputMiddleware{
+		providerMiddlewares = append(slices.Clone(providerMiddlewares), &structuredOutputMiddleware{
 			format:    prov.Format,
 			unmarshal: prov.Unmarshal,
 		})
@@ -273,10 +276,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 		}
 		noSession, _ := GetOption(options, noSessionProvided)
 		stream, _ := GetOption(options, Stream)
-		var inputMessages []*message.Message
-		if stream {
-			inputMessages = slices.Clone(messages)
-		}
+		inputMessages := messages
 		lifecycleOptions := withoutContinuationToken(options)
 
 		historyProvider := a.historyProviderForRun(session, continuationToken, noSession)
@@ -291,7 +291,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 		}
 
 		if runContextProviders {
-			options = slices.Clone(lifecycleOptions)
+			options = lifecycleOptions
 			for _, provider := range a.contextProviders {
 				var err error
 				messages, options, err = provider.Invoking(ctx, InvokingContext{Messages: messages, Options: options})
@@ -304,7 +304,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 
 		var requestMessages []*message.Message
 		if historyProvider != nil || runContextProviders {
-			requestMessages = slices.Clone(messages)
+			requestMessages = messages
 		}
 		trackContinuationUpdates := stream || continuationToken != ""
 
@@ -394,7 +394,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 					state.historyResponse.Coalesce()
 					storeResponseMessages = state.historyResponse.Messages
 				}
-				if err := historyStoreProvider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(requestMessages), ResponseMessages: slices.Clone(storeResponseMessages), Options: withoutContinuationToken(options), Err: state.runErr}); err != nil {
+				if err := historyStoreProvider.Invoked(ctx, InvokedContext{RequestMessages: requestMessages, ResponseMessages: storeResponseMessages, Options: withoutContinuationToken(options), Err: state.runErr}); err != nil {
 					if !state.stopped {
 						yield(nil, err)
 					}
@@ -413,7 +413,7 @@ func (a *Agent) invoke(ctx context.Context, messages []*message.Message, options
 				contextStoreResponseMessages = state.contextResponse.Messages
 			}
 			for _, provider := range a.contextProviders {
-				if err := provider.Invoked(ctx, InvokedContext{RequestMessages: slices.Clone(requestMessages), ResponseMessages: slices.Clone(contextStoreResponseMessages), Options: withoutContinuationToken(options), Err: state.runErr}); err != nil {
+				if err := provider.Invoked(ctx, InvokedContext{RequestMessages: requestMessages, ResponseMessages: contextStoreResponseMessages, Options: withoutContinuationToken(options), Err: state.runErr}); err != nil {
 					if !state.stopped {
 						yield(nil, err)
 					}
@@ -519,8 +519,12 @@ func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider Hist
 
 func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, options []Option) (context.Context, []*message.Message, []Option, error) {
 	// Prepend options from agent configuration.
+	var optionsOwned bool
 	if len(a.runOptions) != 0 {
-		options = append(a.runOptions, options...)
+		combined := make([]Option, 0, len(a.runOptions)+len(options)+2)
+		combined = append(combined, a.runOptions...)
+		options = append(combined, options...)
+		optionsOwned = true
 	}
 
 	if _, ok := GetOption(options, WithSession); !ok {
@@ -533,6 +537,11 @@ func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, opt
 		session, err := a.CreateSession(ctx, options...)
 		if err != nil {
 			return nil, nil, nil, err
+		}
+		if !optionsOwned {
+			cloned := make([]Option, len(options), len(options)+2)
+			copy(cloned, options)
+			options = cloned
 		}
 		options = append(options, WithSession(session), noSessionProvided(true))
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -283,6 +283,24 @@ func TestAgent_Run(t *testing.T) {
 	}
 }
 
+func TestAgent_Run_DoesNotMutateInputOptionBackingArray(t *testing.T) {
+	a := agenttest.New(agenttest.NewResponseBuilder().AddText("response").Build())
+	options := make([]agent.Option, 1, 3)
+	options[0] = agent.Stream(false)
+	firstSentinel := agent.WithInstructions("first sentinel")
+	secondSentinel := agent.WithInstructions("second sentinel")
+	backing := options[:cap(options)]
+	backing[1] = firstSentinel
+	backing[2] = secondSentinel
+
+	if _, err := a.RunText(t.Context(), "input", options...).Collect(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backing[1] != firstSentinel || backing[2] != secondSentinel {
+		t.Fatal("expected Agent.Run not to modify the input option backing array")
+	}
+}
+
 func TestAgent_Run_RejectsMessagesWithContinuationToken(t *testing.T) {
 	runCalled := false
 	responseBuilder := agenttest.NewResponseBuilder(
@@ -607,8 +625,10 @@ func TestAgent_Run_InvokesSingleContextMiddleware(t *testing.T) {
 
 func TestAgent_Run_MarksMiddlewareAddedMessagesWithSource(t *testing.T) {
 	added := message.NewText("middleware")
+	var middlewareMessages []*message.Message
 	mw := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		messages = append(slices.Clone(messages), added)
+		middlewareMessages = messages
 		return next(ctx, messages, opts...)
 	})
 
@@ -634,6 +654,9 @@ func TestAgent_Run_MarksMiddlewareAddedMessagesWithSource(t *testing.T) {
 	}
 	if capturedMessages[1].Source != (message.Source{Type: agent.SourceTypeMiddleware}) {
 		t.Fatalf("middleware message source = %#v, want middleware source", capturedMessages[1].Source)
+	}
+	if middlewareMessages[1] != added || middlewareMessages[1].Source != (message.Source{}) {
+		t.Fatal("expected source stamping not to mutate messages passed by middleware")
 	}
 }
 
@@ -1156,7 +1179,6 @@ func TestAgent_Run_ContinuationToken_PersistsSavedInputMessages(t *testing.T) {
 func TestAgent_Run_UsesConfigContextProvider(t *testing.T) {
 	provideCalled := false
 	runCalled := false
-
 	contextProvider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx-provider",
 		Provide: func(_ context.Context, _ agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
@@ -1186,6 +1208,40 @@ func TestAgent_Run_UsesConfigContextProvider(t *testing.T) {
 	}
 	if !provideCalled {
 		t.Fatal("expected context provider to be used")
+	}
+}
+
+func TestAgent_Run_PassesReadOnlyContextSlicesWithoutCloning(t *testing.T) {
+	messages := []*message.Message{message.NewText("request")}
+	options := []agent.Option{agent.WithSession(agenttest.CreateSession())}
+	var invokingMessages []*message.Message
+	contextProvider := contextProviderFunc{
+		invoking: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			invokingMessages = invoking.Messages
+			if &invoking.Options[0] != &options[0] {
+				t.Error("expected InvokingContext to share the run option slice")
+			}
+			return invoking.Messages, invoking.Options, nil
+		},
+		invoked: func(_ context.Context, invoked agent.InvokedContext) error {
+			if &invoked.RequestMessages[0] != &invokingMessages[0] {
+				t.Error("expected InvokedContext to share the invocation message slice")
+			}
+			return nil
+		},
+	}
+	runFn := func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "ok"}}}, nil)
+		}
+	}
+	a := agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{
+		ID:               "test-agent",
+		ContextProviders: []agent.ContextProvider{contextProvider},
+	})
+
+	if _, err := a.Run(t.Context(), messages, options...).Collect(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -19,6 +19,12 @@ func invokeProvider(provider agent.ContextProvider, ctx context.Context, message
 	return provider.Invoking(ctx, agent.InvokingContext{Messages: messages, Options: options})
 }
 
+type strategyFunc func(context.Context, *compaction.MessageIndex) (bool, error)
+
+func (f strategyFunc) Compact(ctx context.Context, index *compaction.MessageIndex) (bool, error) {
+	return f(ctx, index)
+}
+
 func TestMessageIndex_GroupsToolCallsAtomically(t *testing.T) {
 	messages := []*message.Message{
 		textMessage(message.RoleSystem, "system"),
@@ -542,6 +548,32 @@ func TestNewProvider_SourceStampsGeneratedMessages(t *testing.T) {
 	}
 	if compactedMessages[1].Source != (message.Source{}) || compactedMessages[2].Source != (message.Source{}) {
 		t.Fatalf("expected preserved messages to keep original sources, got %#v and %#v", compactedMessages[1].Source, compactedMessages[2].Source)
+	}
+}
+
+func TestNewProvider_SourceStampingDoesNotMutateGeneratedMessage(t *testing.T) {
+	generated := textMessage(message.RoleAssistant, "generated")
+	provider := compaction.NewContextProvider(compaction.ContextProviderConfig{
+		Strategy: strategyFunc(func(_ context.Context, index *compaction.MessageIndex) (bool, error) {
+			index.AddGroup(compaction.GroupKindSummary, []*message.Message{generated}, nil)
+			return true, nil
+		}),
+		SourceID: "compaction-test",
+	})
+
+	input := textMessage(message.RoleUser, "input")
+	compactedMessages, _, err := invokeProvider(provider, t.Context(), []*message.Message{input})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(compactedMessages) != 2 || compactedMessages[0] != input {
+		t.Fatalf("unexpected compacted messages: %#v", compactedMessages)
+	}
+	if compactedMessages[1] == generated {
+		t.Fatal("expected generated message to be cloned before source attribution")
+	}
+	if generated.Source != (message.Source{}) {
+		t.Fatalf("expected generated message source to remain unchanged, got %#v", generated.Source)
 	}
 }
 

--- a/agent/compaction/provider.go
+++ b/agent/compaction/provider.go
@@ -6,7 +6,6 @@ import (
 	"cmp"
 	"context"
 	"log/slog"
-	"slices"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/message"
@@ -77,13 +76,12 @@ func (p *contextProvider) Invoking(ctx context.Context, invoking agent.InvokingC
 		}
 		return messages, options, nil
 	}
-	inputMessages := slices.Clone(messages)
 	if session == nil {
 		compactedMessages, err := Compact(ctx, p.strategy, messages, p.tokenCounter)
 		if err != nil {
 			return nil, nil, err
 		}
-		return p.markGeneratedMessages(compactedMessages, inputMessages), options, nil
+		return p.markGeneratedMessages(compactedMessages, messages), options, nil
 	}
 	if session.ServiceID() != "" {
 		if p.logger != nil {
@@ -119,7 +117,7 @@ func (p *contextProvider) Invoking(ctx context.Context, invoking agent.InvokingC
 
 	state.MessageGroups = index.Groups
 	session.Set(p.stateKey, state)
-	return p.markGeneratedMessages(index.IncludedMessages(), inputMessages), options, nil
+	return p.markGeneratedMessages(index.IncludedMessages(), messages), options, nil
 }
 
 func (p *contextProvider) Invoked(context.Context, agent.InvokedContext) error {

--- a/agent/context.go
+++ b/agent/context.go
@@ -46,6 +46,10 @@ type ContextProvider interface {
 
 // InvokingContext contains the agent invocation context available to a
 // [ContextProvider] before the provider run starts.
+//
+// Providers must treat the message and option slices, and existing messages,
+// as read-only. To modify the invocation, clone the slices and any message
+// being changed, then return the derived values from Invoking.
 type InvokingContext struct {
 	// Messages are the request messages currently being prepared for the invocation.
 	Messages []*message.Message
@@ -56,6 +60,9 @@ type InvokingContext struct {
 
 // InvokedContext contains the agent invocation context available to a
 // [ContextProvider] after a provider run completes.
+//
+// Providers must treat the message and option slices, and existing messages,
+// as read-only. Clone them before retaining modified copies.
 type InvokedContext struct {
 	// RequestMessages are the messages used for the invocation.
 	RequestMessages []*message.Message
@@ -133,21 +140,23 @@ func (p *defaultContextProvider) Invoking(ctx context.Context, invoking Invoking
 
 	outMessages := invoking.Messages
 	if len(providedMessages) > 0 {
+		outMessages = make([]*message.Message, len(invoking.Messages), len(invoking.Messages)+len(providedMessages))
+		copy(outMessages, invoking.Messages)
 		source := message.Source{Type: SourceTypeContextProvider, ID: p.config.SourceID}
-		for i, msg := range providedMessages {
+		for _, msg := range providedMessages {
 			if msg == nil || msg.Source == source {
+				outMessages = append(outMessages, msg)
 				continue
 			}
 			marked := msg.Clone()
 			marked.Source = source
-			providedMessages[i] = marked
+			outMessages = append(outMessages, marked)
 		}
-		outMessages = append(outMessages, providedMessages...)
 	}
 
 	outOptions := invoking.Options
 	if len(providedOptions) > 0 {
-		outOptions = append(outOptions, providedOptions...)
+		outOptions = append(slices.Clone(invoking.Options), providedOptions...)
 	}
 
 	return outMessages, outOptions, nil
@@ -168,17 +177,16 @@ func (p *defaultContextProvider) Invoked(ctx context.Context, invoked InvokedCon
 	if requestFilter == nil {
 		requestFilter = messagefilter.ExternalOnly
 	}
-	responseFilter := p.config.StoreInputResponseMessageFilter
-	if responseFilter == nil {
-		responseFilter = messagefilter.PassThrough
-	}
-	filteredReq, err := requestFilter(ctx, invoked.RequestMessages)
+	filteredReq, err := requestFilter(ctx, slices.Clone(invoked.RequestMessages))
 	if err != nil {
 		return err
 	}
-	filteredResp, err := responseFilter(ctx, invoked.ResponseMessages)
-	if err != nil {
-		return err
+	filteredResp := invoked.ResponseMessages
+	if responseFilter := p.config.StoreInputResponseMessageFilter; responseFilter != nil {
+		filteredResp, err = responseFilter(ctx, slices.Clone(invoked.ResponseMessages))
+		if err != nil {
+			return err
+		}
 	}
 	return p.config.Store(ctx, InvokedContext{RequestMessages: filteredReq, ResponseMessages: filteredResp, Options: invoked.Options, Err: invoked.Err})
 }
@@ -200,7 +208,6 @@ type contextProviderMiddleware struct {
 
 func (r *contextProviderMiddleware) Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error] {
 	return func(yield func(*ResponseUpdate, error) bool) {
-		options = slices.Clone(options)
 		var err error
 		messages, options, err = r.provider.Invoking(ctx, InvokingContext{Messages: messages, Options: options})
 		if err != nil {
@@ -208,7 +215,7 @@ func (r *contextProviderMiddleware) Run(next RunFunc, ctx context.Context, messa
 			return
 		}
 
-		requestMessages := slices.Clone(messages)
+		requestMessages := messages
 		var resp Response
 		var invokeErr error
 		var stopped bool

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -74,6 +74,42 @@ func TestContextProviderMiddleware_Run_ProviderOptionsEnrichTools(t *testing.T) 
 	}
 }
 
+func TestContextProviderMiddleware_Run_PassesReadOnlySlicesWithoutCloning(t *testing.T) {
+	messages := []*message.Message{message.NewText("request")}
+	options := []agent.Option{agent.WithSession(agenttest.CreateSession())}
+	provider := contextProviderFunc{
+		invoking: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			if &invoking.Messages[0] != &messages[0] {
+				t.Error("expected InvokingContext to share the input message slice")
+			}
+			if &invoking.Options[0] != &options[0] {
+				t.Error("expected InvokingContext to share the input option slice")
+			}
+			return invoking.Messages, invoking.Options, nil
+		},
+		invoked: func(_ context.Context, invoked agent.InvokedContext) error {
+			if &invoked.RequestMessages[0] != &messages[0] {
+				t.Error("expected InvokedContext to share the request message slice")
+			}
+			if &invoked.Options[0] != &options[0] {
+				t.Error("expected InvokedContext to share the input option slice")
+			}
+			return nil
+		},
+	}
+
+	if _, err := collectContextProviderMiddlewareResponse(agent.ContextProviderMiddleware(provider).Run(
+		func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return contextProviderMiddlewareSingleUpdate("ok")
+		},
+		context.Background(),
+		messages,
+		options...,
+	)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestContextProviderMiddleware_Run_SharedOptions_ProviderToolsDoNotAccumulateAcrossCalls(t *testing.T) {
 	toolCounts := make([]int, 0, 3)
 	provider := agent.NewContextProvider(agent.ContextProviderConfig{
@@ -351,6 +387,53 @@ func TestContextProvider_Invoking_SourceStampsProvidedMessages(t *testing.T) {
 	}
 }
 
+func TestContextProvider_Invoking_DoesNotMutateProvidedMessageSlice(t *testing.T) {
+	provided := message.NewText("provided")
+	providedMessages := []*message.Message{provided}
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
+		SourceID: "ctx",
+		Provide: func(context.Context, agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return providedMessages, nil, nil
+		},
+	})
+
+	if _, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{message.NewText("request")}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if providedMessages[0] != provided {
+		t.Fatal("expected context provider not to modify the provided message slice")
+	}
+}
+
+func TestContextProvider_Invoking_DoesNotMutateInputBackingArrays(t *testing.T) {
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
+		SourceID: "ctx",
+		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
+			return []*message.Message{message.NewText("provided")}, []agent.Option{agent.WithInstructions("provided")}, nil
+		},
+	})
+	messages := make([]*message.Message, 1, 2)
+	messages[0] = message.NewText("request")
+	messageSentinel := message.NewText("sentinel")
+	messageBacking := messages[:cap(messages)]
+	messageBacking[1] = messageSentinel
+	options := make([]agent.Option, 1, 2)
+	options[0] = agent.WithSession(agenttest.CreateSession())
+	optionSentinel := agent.WithInstructions("sentinel")
+	optionBacking := options[:cap(options)]
+	optionBacking[1] = optionSentinel
+
+	if _, _, err := invokeContextProvider(provider, t.Context(), messages, options...); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if messageBacking[1] != messageSentinel {
+		t.Fatal("expected context provider not to modify the input message backing array")
+	}
+	if optionBacking[1] != optionSentinel {
+		t.Fatal("expected context provider not to modify the input option backing array")
+	}
+}
+
 func TestContextProvider_Invoking_HonorsNilProvideOutputs(t *testing.T) {
 	provider := agent.NewContextProvider(agent.ContextProviderConfig{
 		SourceID: "ctx",
@@ -413,24 +496,32 @@ func TestContextProvider_Invoking_FiltersInputMessagesBeforeProvide(t *testing.T
 
 func TestContextProvider_Invoking_UsesCustomProvideInputMessageFilter(t *testing.T) {
 	request := message.NewText("request")
+	replacement := message.NewText("replacement")
 	ctxMessage := message.NewText("ctx")
 	ctxMessage.Source = message.Source{Type: agent.SourceTypeContextProvider, ID: "other"}
 	var providedInput []*message.Message
 	provider := agent.NewContextProvider(agent.ContextProviderConfig{
-		SourceID:                  "ctx",
-		ProvideInputMessageFilter: messagefilter.PassThrough,
+		SourceID: "ctx",
+		ProvideInputMessageFilter: func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
+			messages[0] = replacement
+			return messages, nil
+		},
 		Provide: func(_ context.Context, invoking agent.InvokingContext) ([]*message.Message, []agent.Option, error) {
 			providedInput = invoking.Messages
 			return nil, nil, nil
 		},
 	})
 
-	_, _, err := invokeContextProvider(provider, t.Context(), []*message.Message{request, ctxMessage}, agent.WithSession(agenttest.CreateSession()))
+	inputMessages := []*message.Message{request, ctxMessage}
+	_, _, err := invokeContextProvider(provider, t.Context(), inputMessages, agent.WithSession(agenttest.CreateSession()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := messageStrings(providedInput); !slices.Equal(got, []string{"request", "ctx"}) {
-		t.Fatalf("provided input messages = %v, want unfiltered input", got)
+	if got := messageStrings(providedInput); !slices.Equal(got, []string{"replacement", "ctx"}) {
+		t.Fatalf("provided input messages = %v, want custom-filtered input", got)
+	}
+	if inputMessages[0] != request {
+		t.Fatal("expected custom filter not to mutate the original input slice")
 	}
 }
 
@@ -557,6 +648,31 @@ func TestContextProvider_Invoked_CallsStoreAndIncludesExternalRequestMessagesByD
 	}
 	if len(storedResponse) != 1 || storedResponse[0] != resp {
 		t.Fatal("expected response messages to pass through unchanged")
+	}
+}
+
+func TestContextProvider_Invoked_FiltersDoNotMutateInputSlices(t *testing.T) {
+	contextMessage := message.NewText("context")
+	contextMessage.Source = message.Source{Type: agent.SourceTypeContextProvider, ID: "ctx"}
+	externalMessage := message.NewText("external")
+	requestMessages := []*message.Message{contextMessage, externalMessage}
+	responseMessages := []*message.Message{contextMessage, externalMessage}
+	provider := agent.NewContextProvider(agent.ContextProviderConfig{
+		SourceID:                        "ctx",
+		StoreInputResponseMessageFilter: messagefilter.ExternalOnly,
+		Store: func(context.Context, agent.InvokedContext) error {
+			return nil
+		},
+	})
+
+	if err := invokeContextProviderInvoked(provider, t.Context(), requestMessages, responseMessages); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requestMessages[0] != contextMessage || requestMessages[1] != externalMessage {
+		t.Fatal("expected request filtering not to mutate InvokedContext input")
+	}
+	if responseMessages[0] != contextMessage || responseMessages[1] != externalMessage {
+		t.Fatal("expected response filtering not to mutate InvokedContext input")
 	}
 }
 

--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -348,6 +348,10 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 			// processed (non-informational) function calls, preserving the exact
 			// assistant content order the model emitted (e.g. reasoning → text →
 			// tool_calls, or text following a tool_call).
+			processedFCCSet := make(map[*message.FunctionCallContent]struct{}, len(processedFunctionCalls))
+			for _, fcc := range processedFunctionCalls {
+				processedFCCSet[fcc] = struct{}{}
+			}
 			var iterationContents []message.Content
 			for _, u := range updates {
 				iterationContents = append(iterationContents, u.Contents...)
@@ -362,7 +366,7 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 					// Only carry over the non-informational function calls that were
 					// actually processed this iteration, keeping them in their original
 					// position relative to the surrounding text/reasoning.
-					if slices.Contains(processedFunctionCalls, v) {
+					if _, ok := processedFCCSet[v]; ok {
 						assistantContents = append(assistantContents, c)
 					}
 				}
@@ -984,6 +988,9 @@ func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.
 	// - Validate that we have an approval response for each approval request.
 	var anyRemoved bool
 	for i, msg := range msgs {
+		if msg == nil {
+			continue
+		}
 		var keptContents []message.Content
 		for _, c := range msg.Contents {
 			switch c := c.(type) {

--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -144,6 +144,7 @@ func New(cfg Config) agent.Middleware {
 
 func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
+		var messagesCloned bool
 		tools, _ := f.createToolsMap(agent.AllOptions(opts, agent.WithTool))
 
 		// When message injection is enabled, create a MessageInjector and place it on the
@@ -164,6 +165,7 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 		var errCount int
 		if hasAnyApprovalContent(messages) {
 			messages = slices.Clone(messages)
+			messagesCloned = true
 			// We also need a synthetic ID for the function call content for approved function calls
 			// where we don't know what the original message id of the function call was.
 			funcCallFallbackMsgID := f.newID()
@@ -303,6 +305,10 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 				if i < f.maximumIterationsPerRequest && injector != nil && len(functionCallContents) == 0 {
 					if injected := injector.drain(); len(injected) > 0 {
 						opts = updateOptionsForNextIteration(opts)
+						if !messagesCloned {
+							messages = slices.Clone(messages)
+							messagesCloned = true
+						}
 						messages = append(messages, injected...)
 						continue
 					}
@@ -342,10 +348,6 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 			// processed (non-informational) function calls, preserving the exact
 			// assistant content order the model emitted (e.g. reasoning → text →
 			// tool_calls, or text following a tool_call).
-			processedFCCSet := make(map[*message.FunctionCallContent]struct{}, len(processedFunctionCalls))
-			for _, fcc := range processedFunctionCalls {
-				processedFCCSet[fcc] = struct{}{}
-			}
 			var iterationContents []message.Content
 			for _, u := range updates {
 				iterationContents = append(iterationContents, u.Contents...)
@@ -360,7 +362,7 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 					// Only carry over the non-informational function calls that were
 					// actually processed this iteration, keeping them in their original
 					// position relative to the surrounding text/reasoning.
-					if _, ok := processedFCCSet[v]; ok {
+					if slices.Contains(processedFunctionCalls, v) {
 						assistantContents = append(assistantContents, c)
 					}
 				}
@@ -371,6 +373,10 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 			// and the tool results so that the downstream provider receives a well-formed
 			// conversation (user message → assistant tool_calls → tool results).
 			opts = updateOptionsForNextIteration(opts)
+			if !messagesCloned {
+				messages = slices.Clone(messages)
+				messagesCloned = true
+			}
 			messages = append(messages, &message.Message{
 				Role:     message.RoleAssistant,
 				Contents: assistantContents,
@@ -441,18 +447,25 @@ func convertToolResultMsgToUpdate(msg *message.Message, msgID string) *agent.Res
 }
 
 func updateOptionsForNextIteration(opts []agent.Option) []agent.Option {
+	updated := opts
+	var cloned bool
 	if v, ok := agent.GetOption(opts, agent.WithToolMode); ok && v == tool.ToolModeRequired {
 		// We have to reset the tool mode to be non-required after the first iteration,
 		// as otherwise we'll be in an infinite loop.
-		opts = append(opts, agent.WithToolMode(tool.ToolModeAuto))
+		updated = slices.Clone(opts)
+		cloned = true
+		updated = append(updated, agent.WithToolMode(tool.ToolModeAuto))
 	}
 	// Reset the continuation token of a background response operation
 	// to signal the inner client to handle function call result rather
 	// than getting the result of the operation.
 	if _, ok := agent.GetOption(opts, agent.WithContinuationToken); ok {
-		opts = append(opts, agent.WithContinuationToken(""))
+		if !cloned {
+			updated = slices.Clone(opts)
+		}
+		updated = append(updated, agent.WithContinuationToken(""))
 	}
-	return opts
+	return updated
 }
 
 // prepareOptionsForLastIteration prepares options for the last iteration by removing schema tools.
@@ -605,6 +618,7 @@ func markServerHandledFunctionCalls(updates []*agent.ResponseUpdate, functionCal
 }
 
 func hasAnyApprovalContent(msgs []*message.Message) bool {
+	approvalResponseNeedsProcessing := approvalResponseNeedsProcessingByRequestID(msgs)
 	return slices.ContainsFunc(msgs, func(m *message.Message) bool {
 		if m == nil || m.Contents == nil {
 			return false
@@ -612,8 +626,17 @@ func hasAnyApprovalContent(msgs []*message.Message) bool {
 		return slices.ContainsFunc(m.Contents, func(c message.Content) bool {
 			switch c := c.(type) {
 			case *message.ToolApprovalRequestContent:
+				if c == nil {
+					return false
+				}
+				if responseNeedsProcessing, hasResponse := approvalResponseNeedsProcessing[c.RequestID]; hasResponse {
+					return responseNeedsProcessing
+				}
 				return approvalToolCallNeedsProcessing(c.ToolCall)
 			case *message.ToolApprovalResponseContent:
+				if c == nil {
+					return false
+				}
 				return approvalToolCallNeedsProcessing(c.ToolCall)
 			default:
 				return false
@@ -625,6 +648,32 @@ func hasAnyApprovalContent(msgs []*message.Message) bool {
 func approvalToolCallNeedsProcessing(toolCall message.ToolCallContent) bool {
 	fcc, ok := approvalToolCallAsFunctionCall(toolCall)
 	return ok && !fcc.InformationalOnly
+}
+
+// approvalResponseNeedsProcessingByRequestID records whether paired approval
+// responses are actionable. Any actionable duplicate keeps the pair actionable.
+func approvalResponseNeedsProcessingByRequestID(msgs []*message.Message) map[string]bool {
+	var result map[string]bool
+	for _, msg := range msgs {
+		if msg == nil {
+			continue
+		}
+		for _, content := range msg.Contents {
+			response, ok := content.(*message.ToolApprovalResponseContent)
+			if !ok || response == nil {
+				continue
+			}
+			fcc, ok := approvalToolCallAsFunctionCall(response.ToolCall)
+			if !ok {
+				continue
+			}
+			if result == nil {
+				result = make(map[string]bool)
+			}
+			result[response.RequestID] = result[response.RequestID] || !fcc.InformationalOnly
+		}
+	}
+	return result
 }
 
 func (f *autocall) invokeApprovedToolApprovalResponses(ctx context.Context, approvals []toolApprovalResultWithRequestMessage, tools map[string]tool.SchemaTool, errCount int) (*message.Message, int, error) {
@@ -646,16 +695,6 @@ func (f *autocall) invokeApprovedToolApprovalResponses(ctx context.Context, appr
 	newMsg, errCount, err := f.processFunctionCalls(ctx, tools, funcCalls, errCount)
 	if err != nil {
 		return nil, errCount, err
-	}
-
-	// Also mark the request's function call as informational-only to keep serialized
-	// approval request/response pairs consistent when they are separate instances.
-	for _, approval := range approvals {
-		if approval.Request != nil {
-			if fcc, ok := approvalToolCallAsFunctionCall(approval.Request.ToolCall); ok {
-				fcc.InformationalOnly = true
-			}
-		}
 	}
 
 	return newMsg, errCount, nil
@@ -908,13 +947,24 @@ func (f *autocall) processToolApprovalResponses(ctx context.Context, msgs []*mes
 
 type toolApprovalResultWithRequestMessage struct {
 	Response       *message.ToolApprovalResponseContent
-	Request        *message.ToolApprovalRequestContent
 	RequestMessage *message.Message
 }
 
 func approvalToolCallAsFunctionCall(toolCall message.ToolCallContent) (*message.FunctionCallContent, bool) {
 	fcc, ok := toolCall.(*message.FunctionCallContent)
 	return fcc, ok && fcc != nil
+}
+
+func cloneToolApprovalResponseContent(content *message.ToolApprovalResponseContent) *message.ToolApprovalResponseContent {
+	if content == nil {
+		return nil
+	}
+	cloned := *content
+	if functionCall, ok := approvalToolCallAsFunctionCall(content.ToolCall); ok {
+		clonedFunctionCall := *functionCall
+		cloned.ToolCall = &clonedFunctionCall
+	}
+	return &cloned
 }
 
 func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.Context, msgs []*message.Message) (out []*message.Message, approvals, rejections []toolApprovalResultWithRequestMessage, err error) {
@@ -924,6 +974,9 @@ func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.
 		functionResultCallIds       map[string]struct{}
 		allApprovalResponses        []*message.ToolApprovalResponseContent
 	)
+	// A paired response is authoritative because request and response tool calls may
+	// be separate instances after serialization.
+	approvalResponseNeedsProcessing := approvalResponseNeedsProcessingByRequestID(msgs)
 	// 1st iteration, over all messages and content:
 	// - Build a list of all function call ids that are already executed.
 	// - Build a list of all function approval requests and responses.
@@ -936,7 +989,9 @@ func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.
 			switch c := c.(type) {
 			case *message.ToolApprovalRequestContent:
 				fcc, ok := approvalToolCallAsFunctionCall(c.ToolCall)
-				if !ok || fcc.InformationalOnly {
+				responseNeedsProcessing, hasResponse := approvalResponseNeedsProcessing[c.RequestID]
+				requestNeedsProcessing := ok && ((hasResponse && responseNeedsProcessing) || (!hasResponse && !fcc.InformationalOnly))
+				if !requestNeedsProcessing {
 					keptContents = append(keptContents, c)
 					continue
 				}
@@ -948,7 +1003,7 @@ func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.
 				if allApprovalRequestsMessages == nil {
 					allApprovalRequestsMessages = make(map[string]toolApprovalResultWithRequestMessage)
 				}
-				allApprovalRequestsMessages[c.RequestID] = toolApprovalResultWithRequestMessage{Request: c, RequestMessage: msg}
+				allApprovalRequestsMessages[c.RequestID] = toolApprovalResultWithRequestMessage{RequestMessage: msg}
 			case *message.ToolApprovalResponseContent:
 				fcc, ok := approvalToolCallAsFunctionCall(c.ToolCall)
 				if !ok {
@@ -956,7 +1011,6 @@ func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.
 					continue
 				}
 				if fcc.InformationalOnly {
-					delete(approvalRequestCallIDs, fcc.CallID)
 					keptContents = append(keptContents, c)
 					continue
 				}
@@ -1021,8 +1075,7 @@ func (f *autocall) extractAndRemoveToolApprovalRequestsAndResponses(ctx context.
 		request := allApprovalRequestsMessages[approvalResponse.RequestID]
 		// Split the responses into approved and rejected.
 		newMsg := toolApprovalResultWithRequestMessage{
-			Response:       approvalResponse,
-			Request:        request.Request,
+			Response:       cloneToolApprovalResponseContent(approvalResponse),
 			RequestMessage: request.RequestMessage,
 		}
 		if approvalResponse.Approved {
@@ -1133,11 +1186,6 @@ func (f *autocall) generateRejectedFunctionResults(ctx context.Context, rejectio
 		}
 		f.logger.Debug(ctx, "function was rejected", "funcName", fcc.Name, "reason", rej.Response.Reason)
 		fcc.InformationalOnly = true
-		if rej.Request != nil {
-			if requestFCC, ok := approvalToolCallAsFunctionCall(rej.Request.ToolCall); ok {
-				requestFCC.InformationalOnly = true
-			}
-		}
 		result := "Tool call invocation rejected."
 		if strings.TrimSpace(rej.Response.Reason) != "" {
 			result += " " + rej.Response.Reason

--- a/agent/harness/toolautocall/autocall_approval_test.go
+++ b/agent/harness/toolautocall/autocall_approval_test.go
@@ -198,6 +198,127 @@ func TestFunctionInvoking_IgnoresInformationalOnlyApprovalContent(t *testing.T) 
 	invokeAndAssertApproval(t, nil, input, downstreamAgentOutput, expectedOutput, expectedDownstreamAgentInput, nil)
 }
 
+func TestFunctionInvoking_PreservesUnpairedInformationalApprovalRequest(t *testing.T) {
+	input := []*message.Message{
+		message.New(&message.TextContent{Text: "hello"}),
+		{Role: message.RoleAssistant, Contents: []message.Content{
+			&message.ToolApprovalRequestContent{RequestID: "ficc_callId1", ToolCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1", InformationalOnly: true}},
+		}},
+	}
+	downstreamAgentOutput := []*agent.ResponseUpdate{
+		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "world"}}},
+	}
+	expectedOutput := []*agent.ResponseUpdate{
+		{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "world"}}},
+	}
+
+	invokeAndAssertApproval(t, nil, input, downstreamAgentOutput, expectedOutput, input, nil)
+}
+
+func TestFunctionInvoking_UsesResponseInformationalOnlyForApprovalPairs(t *testing.T) {
+	tests := []struct {
+		name                  string
+		requestInformational  bool
+		responseInformational bool
+	}{
+		{name: "informational_response", responseInformational: true},
+		{name: "informational_request", requestInformational: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCall := &message.FunctionCallContent{CallID: "callId1", Name: "Func1", InformationalOnly: tt.requestInformational}
+			responseCall := &message.FunctionCallContent{CallID: "callId1", Name: "Func1", InformationalOnly: tt.responseInformational}
+			input := []*message.Message{
+				message.New(&message.TextContent{Text: "hello"}),
+				{Role: message.RoleAssistant, ID: "resp1", Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "ficc_callId1", ToolCall: requestCall},
+				}},
+				message.New(&message.ToolApprovalResponseContent{RequestID: "ficc_callId1", Approved: true, ToolCall: responseCall}),
+			}
+			if tt.responseInformational {
+				input = append(input,
+					&message.Message{Role: message.RoleAssistant, Contents: []message.Content{
+						&message.FunctionCallContent{CallID: "callId1", Name: "Func1", InformationalOnly: true},
+					}},
+					&message.Message{Role: message.RoleTool, Contents: []message.Content{
+						&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
+					}},
+				)
+			}
+			input = append(input,
+				&message.Message{Role: message.RoleAssistant, ID: "resp2", Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "ficc_callId2", ToolCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func1"}},
+				}},
+				message.New(&message.ToolApprovalResponseContent{RequestID: "ficc_callId2", Approved: true, ToolCall: &message.FunctionCallContent{CallID: "callId2", Name: "Func1"}}),
+			)
+
+			var expectedDownstreamAgentInput []*message.Message
+			var expectedOutput []*agent.ResponseUpdate
+			if tt.responseInformational {
+				expectedDownstreamAgentInput = []*message.Message{
+					message.New(&message.TextContent{Text: "hello"}),
+					{Role: message.RoleAssistant, ID: "resp1", Contents: []message.Content{
+						&message.ToolApprovalRequestContent{RequestID: "ficc_callId1", ToolCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}},
+					}},
+					message.New(&message.ToolApprovalResponseContent{RequestID: "ficc_callId1", Approved: true, ToolCall: &message.FunctionCallContent{CallID: "callId1", Name: "Func1", InformationalOnly: true}}),
+					{Role: message.RoleAssistant, Contents: []message.Content{
+						&message.FunctionCallContent{CallID: "callId1", Name: "Func1", InformationalOnly: true},
+					}},
+					{Role: message.RoleTool, Contents: []message.Content{
+						&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
+					}},
+					{Role: message.RoleTool, Contents: []message.Content{
+						&message.FunctionResultContent{CallID: "callId2", Result: "Result 1"},
+					}},
+				}
+				expectedOutput = []*agent.ResponseUpdate{
+					{MessageID: "resp2", ResponseID: "resp2", Role: message.RoleAssistant, Contents: []message.Content{
+						&message.FunctionCallContent{CallID: "callId2", Name: "Func1"},
+					}},
+					{Role: message.RoleTool, Contents: []message.Content{
+						&message.FunctionResultContent{CallID: "callId2", Result: "Result 1"},
+					}},
+					{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "world"}}},
+				}
+			} else {
+				expectedDownstreamAgentInput = []*message.Message{
+					message.New(&message.TextContent{Text: "hello"}),
+					{Role: message.RoleTool, Contents: []message.Content{
+						&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
+						&message.FunctionResultContent{CallID: "callId2", Result: "Result 1"},
+					}},
+				}
+				expectedOutput = []*agent.ResponseUpdate{
+					{MessageID: "resp1", ResponseID: "resp1", Role: message.RoleAssistant, Contents: []message.Content{
+						&message.FunctionCallContent{CallID: "callId1", Name: "Func1"},
+					}},
+					{MessageID: "resp2", ResponseID: "resp2", Role: message.RoleAssistant, Contents: []message.Content{
+						&message.FunctionCallContent{CallID: "callId2", Name: "Func1"},
+					}},
+					{Role: message.RoleTool, Contents: []message.Content{
+						&message.FunctionResultContent{CallID: "callId1", Result: "Result 1"},
+						&message.FunctionResultContent{CallID: "callId2", Result: "Result 1"},
+					}},
+					{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "world"}}},
+				}
+			}
+			downstreamAgentOutput := []*agent.ResponseUpdate{
+				{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "world"}}},
+			}
+
+			invokeAndAssertApproval(t, []tool.Tool{tool.ApprovalRequiredFunc(createFunc1())}, input, downstreamAgentOutput, expectedOutput, expectedDownstreamAgentInput, nil)
+
+			if requestCall.InformationalOnly != tt.requestInformational {
+				t.Fatal("expected approval request FunctionCallContent to remain unchanged")
+			}
+			if responseCall.InformationalOnly != tt.responseInformational {
+				t.Fatal("expected approval response FunctionCallContent to remain unchanged")
+			}
+		})
+	}
+}
+
 func TestFunctionInvoking_PreservesNilToolCallApprovalContentWhenProcessingOtherApproval(t *testing.T) {
 	tools := []tool.Tool{createFunc1()}
 
@@ -377,7 +498,7 @@ func TestFunctionInvoking_ApprovedApprovalResponsesAreExecuted(t *testing.T) {
 	invokeAndAssertApproval(t, tools, input, downstreamAgentOutput, expectedOutput, expectedDownstreamAgentInput, nil)
 }
 
-func TestFunctionInvoking_ApprovedApprovalResponsesMarkRequestInformationalOnly(t *testing.T) {
+func TestFunctionInvoking_ApprovedApprovalResponsesDoNotMutateInput(t *testing.T) {
 	tools := []tool.Tool{tool.ApprovalRequiredFunc(createFunc1())}
 	requestCall := &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}
 	responseCall := &message.FunctionCallContent{CallID: "callId1", Name: "Func1"}
@@ -401,11 +522,11 @@ func TestFunctionInvoking_ApprovedApprovalResponsesMarkRequestInformationalOnly(
 
 	invokeAndAssertApproval(t, tools, input, downstreamAgentOutput, expectedOutput, nil, nil)
 
-	if !requestCall.InformationalOnly {
-		t.Fatal("expected approval request FunctionCallContent to be informational-only")
+	if requestCall.InformationalOnly {
+		t.Fatal("expected approval request FunctionCallContent to remain unchanged")
 	}
-	if !responseCall.InformationalOnly {
-		t.Fatal("expected approval response FunctionCallContent to be informational-only")
+	if responseCall.InformationalOnly {
+		t.Fatal("expected approval response FunctionCallContent to remain unchanged")
 	}
 }
 

--- a/agent/harness/toolautocall/autocall_log_test.go
+++ b/agent/harness/toolautocall/autocall_log_test.go
@@ -448,11 +448,11 @@ func TestAutocall_LogsApprovalResponseAndRejection(t *testing.T) {
 	if !strings.Contains(output, "not now") {
 		t.Errorf("expected log to contain rejection reason, got: %s", output)
 	}
-	if !requestCall.InformationalOnly {
-		t.Fatal("expected rejected request FunctionCallContent to be informational-only")
+	if requestCall.InformationalOnly {
+		t.Fatal("expected rejected request FunctionCallContent to remain unchanged")
 	}
-	if !responseCall.InformationalOnly {
-		t.Fatal("expected rejected response FunctionCallContent to be informational-only")
+	if responseCall.InformationalOnly {
+		t.Fatal("expected rejected response FunctionCallContent to remain unchanged")
 	}
 }
 

--- a/agent/harness/toolautocall/autocall_test.go
+++ b/agent/harness/toolautocall/autocall_test.go
@@ -127,6 +127,48 @@ func TestFunctionInvoking_MarksProcessedFunctionCallsInformationalOnly(t *testin
 	}
 }
 
+func TestFunctionInvoking_DoesNotMutateInputSliceBackingArrays(t *testing.T) {
+	testTool := functool.MustNew(functool.Config{Name: "Func1"},
+		func(ctx context.Context, args struct{}) (string, error) {
+			return "ok", nil
+		})
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{Role: message.RoleAssistant, Contents: []message.Content{
+				&message.FunctionCallContent{CallID: "callId1", Name: "Func1", Arguments: `{}`},
+			}}).
+			NewTurn().
+			AddText("done").
+			Build(),
+	}
+
+	messages := make([]*message.Message, 1, 3)
+	messages[0] = message.NewText("hello")
+	messageSentinel1 := message.NewText("sentinel-1")
+	messageSentinel2 := message.NewText("sentinel-2")
+	messageBacking := messages[:cap(messages)]
+	messageBacking[1] = messageSentinel1
+	messageBacking[2] = messageSentinel2
+	options := make([]agent.Option, 2, 3)
+	options[0] = agent.WithTool(testTool)
+	options[1] = agent.WithToolMode(tool.ToolModeRequired)
+	optionSentinel := agent.WithInstructions("sentinel")
+	optionBacking := options[:cap(options)]
+	optionBacking[2] = optionSentinel
+
+	for _, err := range toolautocall.New(toolautocall.Config{}).Run(runner.Run, t.Context(), messages, options...) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if messageBacking[1] != messageSentinel1 || messageBacking[2] != messageSentinel2 {
+		t.Fatal("expected autocall not to modify the input message backing array")
+	}
+	if optionBacking[2] != optionSentinel {
+		t.Fatal("expected autocall not to modify the input option backing array")
+	}
+}
+
 func TestFunctionInvoking_PreparesOptionsForLastIteration(t *testing.T) {
 	var capturedTools []tool.Tool
 	var capturedToolMode tool.ToolMode

--- a/agent/history.go
+++ b/agent/history.go
@@ -100,7 +100,7 @@ func (p *defaultHistoryProvider) Invoking(ctx context.Context, invoking Invoking
 	}
 
 	if p.config.ProvideOutputMessageFilter != nil {
-		providedMessages, err = p.config.ProvideOutputMessageFilter(ctx, providedMessages)
+		providedMessages, err = p.config.ProvideOutputMessageFilter(ctx, slices.Clone(providedMessages))
 		if err != nil {
 			return nil, err
 		}
@@ -110,16 +110,18 @@ func (p *defaultHistoryProvider) Invoking(ctx context.Context, invoking Invoking
 		return invoking.Messages, nil
 	}
 
+	outMessages := make([]*message.Message, 0, len(providedMessages)+len(invoking.Messages))
 	source := message.Source{Type: SourceTypeHistoryProvider, ID: p.config.SourceID}
-	for i, msg := range providedMessages {
+	for _, msg := range providedMessages {
 		if msg == nil || msg.Source == source {
+			outMessages = append(outMessages, msg)
 			continue
 		}
 		marked := msg.Clone()
 		marked.Source = source
-		providedMessages[i] = marked
+		outMessages = append(outMessages, marked)
 	}
-	outMessages := append(providedMessages, invoking.Messages...)
+	outMessages = append(outMessages, invoking.Messages...)
 
 	return outMessages, nil
 }
@@ -139,17 +141,16 @@ func (p *defaultHistoryProvider) Invoked(ctx context.Context, invoked InvokedCon
 	if requestFilter == nil {
 		requestFilter = notSourceTypes(SourceTypeHistoryProvider)
 	}
-	responseFilter := p.config.StoreInputResponseMessageFilter
-	if responseFilter == nil {
-		responseFilter = messagefilter.PassThrough
-	}
-	filteredReq, err := requestFilter(ctx, invoked.RequestMessages)
+	filteredReq, err := requestFilter(ctx, slices.Clone(invoked.RequestMessages))
 	if err != nil {
 		return err
 	}
-	filteredResp, err := responseFilter(ctx, invoked.ResponseMessages)
-	if err != nil {
-		return err
+	filteredResp := invoked.ResponseMessages
+	if responseFilter := p.config.StoreInputResponseMessageFilter; responseFilter != nil {
+		filteredResp, err = responseFilter(ctx, slices.Clone(invoked.ResponseMessages))
+		if err != nil {
+			return err
+		}
 	}
 	return p.config.Store(ctx, InvokedContext{RequestMessages: filteredReq, ResponseMessages: filteredResp, Options: invoked.Options, Err: invoked.Err})
 }

--- a/agent/history_test.go
+++ b/agent/history_test.go
@@ -245,6 +245,74 @@ func TestNewInMemoryHistoryProvider_DefaultStoreInputRequestMessageFilter_Exclud
 	}
 }
 
+func TestHistoryProvider_Invoking_DoesNotMutateProvidedMessageSlice(t *testing.T) {
+	provided := message.NewText("provided")
+	filtered := message.NewText("filtered")
+	providedMessages := make([]*message.Message, 1, 2)
+	providedMessages[0] = provided
+	sentinel := message.NewText("sentinel")
+	backing := providedMessages[:cap(providedMessages)]
+	backing[1] = sentinel
+	provider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
+		SourceID: "history",
+		Provide: func(context.Context, agent.InvokingContext) ([]*message.Message, error) {
+			return providedMessages, nil
+		},
+		ProvideOutputMessageFilter: func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
+			messages[0] = filtered
+			return messages, nil
+		},
+	})
+
+	request := message.NewText("request")
+	messages, err := invokeHistoryProvider(provider, t.Context(), []*message.Message{request})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(messages) != 2 || messages[1] != request {
+		t.Fatalf("unexpected history output: %#v", messages)
+	}
+	if messages[0] == provided || messages[0].Source != (message.Source{Type: agent.SourceTypeHistoryProvider, ID: "history"}) {
+		t.Fatal("expected provided message to be cloned and source-stamped")
+	}
+	if providedMessages[0] != provided || backing[1] != sentinel {
+		t.Fatal("expected history provider not to modify the provided message backing array")
+	}
+}
+
+func TestHistoryProvider_Invoked_FiltersDoNotMutateInputSlices(t *testing.T) {
+	historyMessage := message.NewText("history")
+	historyMessage.Source = message.Source{Type: agent.SourceTypeHistoryProvider, ID: "history"}
+	externalMessage := message.NewText("external")
+	requestMessages := []*message.Message{historyMessage, externalMessage}
+	responseMessage := message.NewText("response")
+	replacementResponse := message.NewText("replacement")
+	responseMessages := []*message.Message{responseMessage, replacementResponse}
+	provider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
+		SourceID: "history",
+		StoreInputResponseMessageFilter: func(_ context.Context, messages []*message.Message) ([]*message.Message, error) {
+			messages[0] = replacementResponse
+			return messages[:1], nil
+		},
+		Store: func(_ context.Context, invoked agent.InvokedContext) error {
+			if len(invoked.ResponseMessages) != 1 || invoked.ResponseMessages[0] != replacementResponse {
+				return fmt.Errorf("unexpected filtered response messages")
+			}
+			return nil
+		},
+	})
+
+	if err := invokeHistoryProviderInvoked(provider, t.Context(), requestMessages, responseMessages); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requestMessages[0] != historyMessage || requestMessages[1] != externalMessage {
+		t.Fatal("expected request filtering not to mutate InvokedContext input")
+	}
+	if responseMessages[0] != responseMessage || responseMessages[1] != replacementResponse {
+		t.Fatal("expected response filtering not to mutate InvokedContext input")
+	}
+}
+
 func TestNewInMemoryHistoryProvider_SkipStoreRequestMessages(t *testing.T) {
 	provider := agent.NewInMemoryHistoryProvider(agent.InMemoryHistoryProviderConfig{
 		SourceID: "k",

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -57,9 +57,13 @@ type middlewareRunner struct {
 
 func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
 	next := func(ctx context.Context, outMessages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
+		inputMessages := make(map[*message.Message]struct{}, len(messages))
+		for _, msg := range messages {
+			inputMessages[msg] = struct{}{}
+		}
 		var outMessagesCloned bool
 		for i, msg := range outMessages {
-			if slices.Contains(messages, msg) {
+			if _, ok := inputMessages[msg]; ok {
 				continue
 			}
 			if msg == nil || msg.Source != (message.Source{}) {

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"context"
 	"iter"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/message"
 )
@@ -20,6 +21,10 @@ const SourceTypeMiddleware message.SourceType = "middleware"
 // request/response message hooks exposed by [ContextProvider].
 // Messages passed to next that were not present in the middleware input are
 // marked with [SourceTypeMiddleware] when they do not already carry a source.
+//
+// Middleware implementations must treat input message and option slices, and
+// existing messages, as read-only. To modify the downstream invocation, clone
+// the slices and any message being changed, then pass the derived values to next.
 type Middleware interface {
 	Run(next RunFunc, ctx context.Context, messages []*message.Message, options ...Option) iter.Seq2[*ResponseUpdate, error]
 }
@@ -52,12 +57,9 @@ type middlewareRunner struct {
 
 func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
 	next := func(ctx context.Context, outMessages []*message.Message, opts ...Option) iter.Seq2[*ResponseUpdate, error] {
-		originals := make(map[*message.Message]struct{}, len(messages))
-		for _, msg := range messages {
-			originals[msg] = struct{}{}
-		}
+		var outMessagesCloned bool
 		for i, msg := range outMessages {
-			if _, ok := originals[msg]; ok {
+			if slices.Contains(messages, msg) {
 				continue
 			}
 			if msg == nil || msg.Source != (message.Source{}) {
@@ -65,6 +67,10 @@ func (mr middlewareRunner) Run(ctx context.Context, messages []*message.Message,
 			}
 			marked := msg.Clone()
 			marked.Source = message.Source{Type: SourceTypeMiddleware}
+			if !outMessagesCloned {
+				outMessages = slices.Clone(outMessages)
+				outMessagesCloned = true
+			}
 			outMessages[i] = marked
 		}
 		return mr.next(ctx, outMessages, opts...)

--- a/agent/structuredoutput.go
+++ b/agent/structuredoutput.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/message"
 )
@@ -35,7 +36,7 @@ func (m *structuredOutputMiddleware) Run(next RunFunc, ctx context.Context, mess
 			yield(nil, err)
 			return
 		}
-		options = append(options, WithResponseFormat(format))
+		options = append(slices.Clone(options), WithResponseFormat(format))
 		var data []byte
 		var current structuredOutputMessageKey
 		var sawUpdate bool

--- a/agent/structuredoutput_test.go
+++ b/agent/structuredoutput_test.go
@@ -181,6 +181,37 @@ func TestAgent_StructuredOutput_SuccessfulUnmarshal(t *testing.T) {
 	}
 }
 
+func TestAgent_StructuredOutput_DoesNotMutateInputOptions(t *testing.T) {
+	a := newStructuredOutputTestAgent(
+		func(v any) (agent.ResponseFormat, error) {
+			return agent.ResponseFormat{Kind: "json"}, nil
+		},
+		func(format agent.ResponseFormat, data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		},
+		func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return singleStructuredOutputTestUpdate(`{"name":"Alice"}`)
+		},
+	)
+
+	output := &struct {
+		Name string `json:"name"`
+	}{}
+	options := make([]agent.Option, 2, 3)
+	options[0] = agent.WithStructuredOutput(output)
+	options[1] = agent.WithSession(agenttest.CreateSession())
+	sentinel := agent.WithInstructions("sentinel")
+	backing := options[:cap(options)]
+	backing[2] = sentinel
+
+	if _, err := a.Run(context.Background(), nil, options...).Collect(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backing[2] != sentinel {
+		t.Fatal("expected structured output not to modify the input options backing array")
+	}
+}
+
 func TestAgent_StructuredOutput_UsesLastMessageOnly(t *testing.T) {
 	a := newStructuredOutputTestAgent(
 		func(v any) (agent.ResponseFormat, error) {

--- a/message/message.go
+++ b/message/message.go
@@ -4,6 +4,7 @@ package message
 
 import (
 	"maps"
+	"slices"
 	"time"
 )
 
@@ -74,12 +75,14 @@ func (m *Message) Usage() UsageDetails {
 	return m.Contents.Usage()
 }
 
-// Clone creates a shallow copy of the message.
+// Clone creates a shallow copy of the message, cloning its top-level map and
+// slice containers while sharing their values and content objects.
 func (m *Message) Clone() *Message {
 	if m == nil {
 		return nil
 	}
 	v := *m
 	v.AdditionalProperties = maps.Clone(m.AdditionalProperties)
+	v.Contents = slices.Clone(m.Contents)
 	return &v
 }

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -26,3 +26,18 @@ func TestMessage_Clone_ClonesAdditionalProperties(t *testing.T) {
 		t.Fatalf("expected original additional properties to remain unchanged, got %v", original.AdditionalProperties["k"])
 	}
 }
+
+func TestMessage_Clone_ClonesContentsSlice(t *testing.T) {
+	content := &message.TextContent{Text: "original"}
+	original := message.New(content)
+
+	cloned := original.Clone()
+	if cloned.Contents[0] != content {
+		t.Fatal("expected content values to remain shallow-copied")
+	}
+
+	cloned.Contents[0] = &message.TextContent{Text: "replacement"}
+	if original.Contents[0] != content {
+		t.Fatal("expected replacing cloned contents not to modify the original message")
+	}
+}


### PR DESCRIPTION
## Summary

- Establish a read-only ownership contract for provider run functions, middleware, context/history providers, and provider session creation.
- Move cloning to actual mutation boundaries so caller- and callback-owned message/option slices are preserved while pass-through paths avoid unnecessary copies.
- Make message cloning own top-level slice/map containers and preserve approval replay after serialization by correlating paired responses by request ID.

The primary intent of this PR is to make ownership explicit and consistent: incoming message and option slices, plus existing messages, are borrowed read-only; code that modifies derived input or source attribution must own its copy. Allocation cleanup follows that contract rather than weakening it.