### PR TITLE
Reimplement custom hash maps with Go 1.27 hashers

### DIFF
--- a/internal/concurrent/hashmap.go
+++ b/internal/concurrent/hashmap.go
@@ -79,6 +79,7 @@ func (m *HashMap[K, V]) Delete(key K) (V, bool) {
 
 // Keys returns an iterator over the map keys in unspecified order.
 func (m *HashMap[K, V]) Keys() iter.Seq[K] {
+	_ = m.state
 	return func(yield func(K) bool) {
 		for key := range m.All() {
 			if !yield(key) {
@@ -90,6 +91,7 @@ func (m *HashMap[K, V]) Keys() iter.Seq[K] {
 
 // Values returns an iterator over the map values in unspecified order.
 func (m *HashMap[K, V]) Values() iter.Seq[V] {
+	_ = m.state
 	return func(yield func(V) bool) {
 		for _, value := range m.All() {
 			if !yield(value) {

--- a/internal/concurrent/hashmap.go
+++ b/internal/concurrent/hashmap.go
@@ -5,36 +5,55 @@ package concurrent
 import (
 	"fmt"
 	"iter"
-)
+	"slices"
+	"strings"
+	"sync"
 
-type Hasher[T any] interface {
-	Hash(T) uint64
-	Equal(T, T) bool
-}
+	"github.com/microsoft/agent-framework-go/internal/hashmap"
+	internalmaphash "github.com/microsoft/agent-framework-go/internal/maphash"
+)
 
 type entry[K, V any] struct {
 	key   K
 	value V
 }
 
-// Map is a mapping from keys of type K to values of type V,
-// using key-equivalence relation H.
-type HashMap[K, V any] struct {
-	entries Map[uint64, entry[K, V]]
-	h       Hasher[K]
+type hashMapState[K, V any] struct {
+	mu    sync.RWMutex
+	inner *hashmap.Map[K, V]
 }
 
-// NewMap returns a new mapping.
-func NewHashMap[K, V any](h Hasher[K]) *HashMap[K, V] {
+// HashMap is a synchronized wrapper around [hashmap.Map].
+type HashMap[K, V any] struct {
+	state *hashMapState[K, V]
+}
+
+// NewHashMap returns a new map that uses the specified hash function and
+// key-equivalence relation.
+func NewHashMap[K, V any](hasher internalmaphash.Hasher[K]) *HashMap[K, V] {
 	return &HashMap[K, V]{
-		h: h,
+		state: &hashMapState[K, V]{
+			inner: hashmap.NewMap[K, V](hasher),
+		},
 	}
+}
+
+func (m *HashMap[K, V]) snapshot() []entry[K, V] {
+	m.state.mu.RLock()
+	defer m.state.mu.RUnlock()
+
+	entries := make([]entry[K, V], 0, m.state.inner.Len())
+	for key, value := range m.state.inner.All() {
+		entries = append(entries, entry[K, V]{key: key, value: value})
+	}
+	return entries
 }
 
 // All returns an iterator over the key/value entries of the map in undefined order.
 func (m *HashMap[K, V]) All() iter.Seq2[K, V] {
+	_ = m.state
 	return func(yield func(K, V) bool) {
-		for entry := range m.entries.Values() {
+		for _, entry := range m.snapshot() {
 			if !yield(entry.key, entry.value) {
 				return
 			}
@@ -42,26 +61,27 @@ func (m *HashMap[K, V]) All() iter.Seq2[K, V] {
 	}
 }
 
-// Load returns the map entry for the given key.
-func (m *HashMap[K, V]) Load(key K) (V, bool) {
-	entry, ok := m.entries.Load(m.h.Hash(key))
-	if !ok {
-		var zero V
-		return zero, false
-	}
-	return entry.value, ok
+// Get reports whether the map contains the specified key, and returns the
+// corresponding value if found, or the zero value if not.
+func (m *HashMap[K, V]) Get(key K) (V, bool) {
+	m.state.mu.RLock()
+	defer m.state.mu.RUnlock()
+	return m.state.inner.Get(key)
 }
 
-// Delete removes th//e entry with the given key, if any.
-func (m *HashMap[K, V]) Delete(key K) {
-	m.entries.Delete(m.h.Hash(key))
+// Delete removes the entry with the given key, if present. It reports whether
+// the map changed, and returns the previous value, if any.
+func (m *HashMap[K, V]) Delete(key K) (V, bool) {
+	m.state.mu.Lock()
+	defer m.state.mu.Unlock()
+	return m.state.inner.Delete(key)
 }
 
 // Keys returns an iterator over the map keys in unspecified order.
 func (m *HashMap[K, V]) Keys() iter.Seq[K] {
 	return func(yield func(K) bool) {
-		for entry := range m.entries.Values() {
-			if !yield(entry.key) {
+		for key := range m.All() {
+			if !yield(key) {
 				return
 			}
 		}
@@ -71,41 +91,62 @@ func (m *HashMap[K, V]) Keys() iter.Seq[K] {
 // Values returns an iterator over the map values in unspecified order.
 func (m *HashMap[K, V]) Values() iter.Seq[V] {
 	return func(yield func(V) bool) {
-		for entry := range m.entries.Values() {
-			if !yield(entry.value) {
+		for _, value := range m.All() {
+			if !yield(value) {
 				return
 			}
 		}
 	}
 }
 
-// Swap updates the map entry for key to value, and returns the previous entry, if any.
-func (m *HashMap[K, V]) Swap(key K, value V) (V, bool) {
-	hash := m.h.Hash(key)
-	entry, ok := m.entries.Swap(hash, entry[K, V]{key: key, value: value})
-	if !ok {
-		var zero V
-		return zero, false
-	}
-	return entry.value, ok
+// Set updates the map entry for key to value and returns the previous entry,
+// if any. It reports whether the map size increased.
+func (m *HashMap[K, V]) Set(key K, value V) (prev V, changed bool) {
+	m.state.mu.Lock()
+	defer m.state.mu.Unlock()
+	return m.state.inner.Set(key, value)
 }
 
 func (m *HashMap[K, V]) Clear() {
-	m.entries.Clear()
+	m.state.mu.Lock()
+	defer m.state.mu.Unlock()
+	m.state.inner.Clear()
 }
 
-// String returns a string representation of the map's entries in unspecified order.
-// Values are printed as if by fmt.Sprint.
+// String returns a string representation of the map's entries in an
+// unspecified but deterministic order. Keys and values are printed as if by
+// fmt.Sprint.
 func (m *HashMap[K, V]) String() string {
-	s := "{"
-	first := true
-	for entry := range m.entries.Values() {
-		if !first {
-			s += " "
-		}
-		s += fmt.Sprintf("%v: %v", entry.key, entry.value)
-		first = false
+	type formattedEntry struct {
+		key   string
+		value string
 	}
-	s += "}"
-	return s
+
+	entries := m.snapshot()
+	formatted := make([]formattedEntry, 0, len(entries))
+	for _, entry := range entries {
+		formatted = append(formatted, formattedEntry{
+			key:   fmt.Sprint(entry.key),
+			value: fmt.Sprint(entry.value),
+		})
+	}
+	slices.SortStableFunc(formatted, func(a, b formattedEntry) int {
+		if result := strings.Compare(a.key, b.key); result != 0 {
+			return result
+		}
+		return strings.Compare(a.value, b.value)
+	})
+
+	var buf strings.Builder
+	buf.WriteByte('{')
+	for i, entry := range formatted {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(entry.key)
+		buf.WriteString(": ")
+		buf.WriteString(entry.value)
+	}
+	buf.WriteByte('}')
+	return buf.String()
 }

--- a/internal/concurrent/hashmap_test.go
+++ b/internal/concurrent/hashmap_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package concurrent
+
+import (
+	"hash/maphash"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type collisionHasher struct{}
+
+func (collisionHasher) Hash(*maphash.Hash, string) {}
+
+func (collisionHasher) Equal(x, y string) bool {
+	return strings.EqualFold(x, y)
+}
+
+func TestHashMapCollisions(t *testing.T) {
+	m := NewHashMap[string, int](collisionHasher{})
+
+	if value, ok := m.Get("missing"); ok || value != 0 {
+		t.Errorf("Get() on empty HashMap = %d, %t, want 0, false", value, ok)
+	}
+	if prev, changed := m.Set("two", 2); prev != 0 || !changed {
+		t.Errorf("Set(\"two\") = %d, %t, want 0, true", prev, changed)
+	}
+	m.Set("one", 1)
+
+	for key, want := range map[string]int{"one": 1, "two": 2} {
+		if got, ok := m.Get(key); !ok || got != want {
+			t.Errorf("Get(%q) = %d, %t, want %d, true", key, got, ok, want)
+		}
+	}
+	if prev, changed := m.Set("ONE", 10); prev != 1 || changed {
+		t.Errorf("Set(\"ONE\") = %d, %t, want 1, false", prev, changed)
+	}
+	if prev, removed := m.Delete("oNe"); prev != 10 || !removed {
+		t.Errorf("Delete(\"oNe\") = %d, %t, want 10, true", prev, removed)
+	}
+	if got, ok := m.Get("two"); !ok || got != 2 {
+		t.Errorf("Get(\"two\") after colliding delete = %d, %t, want 2, true", got, ok)
+	}
+
+	m.Set("three", 3)
+	keys := slices.Collect(m.Keys())
+	slices.Sort(keys)
+	if !slices.Equal(keys, []string{"three", "two"}) {
+		t.Errorf("Keys() = %v, want [three two]", keys)
+	}
+	values := slices.Collect(m.Values())
+	slices.Sort(values)
+	if !slices.Equal(values, []int{2, 3}) {
+		t.Errorf("Values() = %v, want [2 3]", values)
+	}
+	if got, want := m.String(), "{three: 3, two: 2}"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+
+	m.Clear()
+	if _, ok := m.Get("two"); ok {
+		t.Error("Get(\"two\") found entry after Clear")
+	}
+}
+
+func TestHashMapConcurrentCollisions(t *testing.T) {
+	m := NewHashMap[string, int](collisionHasher{})
+	keys := []string{"zero", "one", "two", "three", "four", "five", "six", "seven"}
+
+	var wg sync.WaitGroup
+	for value, key := range keys {
+		wg.Go(func() {
+			for range 100 {
+				m.Set(key, value)
+				if _, ok := m.Get(key); !ok {
+					t.Errorf("Get(%q) did not find concurrently stored key", key)
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	for value, key := range keys {
+		if got, ok := m.Get(key); !ok || got != value {
+			t.Errorf("Get(%q) = %d, %t, want %d, true", key, got, ok, value)
+		}
+	}
+}
+
+func TestHashMapMutationDuringIteration(t *testing.T) {
+	m := NewHashMap[string, int](collisionHasher{})
+	m.Set("one", 1)
+	m.Set("two", 2)
+
+	for key := range m.Keys() {
+		m.Set("three", 3)
+		m.Delete(key)
+	}
+}
+
+type reentrantStringer struct {
+	m *HashMap[string, any]
+}
+
+func (s reentrantStringer) String() string {
+	s.m.Set("updated", true)
+	return "value"
+}
+
+func TestHashMapStringFormatsWithoutLock(t *testing.T) {
+	m := NewHashMap[string, any](collisionHasher{})
+	m.Set("key", reentrantStringer{m: m})
+
+	done := make(chan struct{})
+	go func() {
+		_ = m.String()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("String deadlocked while formatting a value that mutated the map")
+	}
+}

--- a/internal/concurrent/hashmap_test.go
+++ b/internal/concurrent/hashmap_test.go
@@ -66,6 +66,27 @@ func TestHashMapCollisions(t *testing.T) {
 	}
 }
 
+func TestNilHashMapIteratorsPanicImmediately(t *testing.T) {
+	var m *HashMap[string, int]
+	for _, test := range []struct {
+		name string
+		call func()
+	}{
+		{name: "All", call: func() { m.All() }},
+		{name: "Keys", call: func() { m.Keys() }},
+		{name: "Values", call: func() { m.Values() }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("call did not panic")
+				}
+			}()
+			test.call()
+		})
+	}
+}
+
 func TestHashMapConcurrentCollisions(t *testing.T) {
 	m := NewHashMap[string, int](collisionHasher{})
 	keys := []string{"zero", "one", "two", "three", "four", "five", "six", "seven"}

--- a/internal/hashmap/hashmap.go
+++ b/internal/hashmap/hashmap.go
@@ -1,70 +1,118 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+// Package hashmap provides a hash table with custom hashing and key equivalence.
+//
+// Map is adapted from the proposed standard library container/hash.Map:
+// https://go.dev/issue/69559.
+//
+// TODO: Replace this package with container/hash once it is available in the
+// minimum Go version supported by this module.
 package hashmap
 
 import (
 	"fmt"
+	"hash/maphash"
 	"iter"
+	"slices"
+	"strings"
+	"sync"
+
+	internalmaphash "github.com/microsoft/agent-framework-go/internal/maphash"
 )
 
-type Hasher[T any] interface {
-	Hash(T) uint64
-	Equal(T, T) bool
-}
-
 type entry[K, V any] struct {
+	used  bool
 	key   K
 	value V
 }
 
 // Map is a mapping from keys of type K to values of type V,
-// using key-equivalence relation H.
+// using the hash function and key-equivalence relation specified at construction.
+// Map values must not be copied.
 type Map[K, V any] struct {
-	entries map[uint64]entry[K, V]
-	h       Hasher[K]
+	seed   maphash.Seed
+	table  map[uint64][]entry[K, V]
+	len    int
+	hasher internalmaphash.Hasher[K]
+
+	_ noCopy
 }
 
 // NewMap returns a new mapping.
-func NewMap[K, V any](h Hasher[K]) *Map[K, V] {
+func NewMap[K, V any](h internalmaphash.Hasher[K]) *Map[K, V] {
 	return &Map[K, V]{
-		entries: make(map[uint64]entry[K, V]),
-		h:       h,
+		seed:   maphash.MakeSeed(),
+		table:  make(map[uint64][]entry[K, V]),
+		hasher: h,
 	}
+}
+
+func (m *Map[K, V]) hash(key K) uint64 {
+	h := hashPool.Get().(*maphash.Hash)
+	h.SetSeed(m.seed)
+	m.hasher.Hash(h, key)
+	sum := h.Sum64()
+	hashPool.Put(h)
+	return sum
+}
+
+var hashPool = sync.Pool{
+	New: func() any { return new(maphash.Hash) },
 }
 
 // All returns an iterator over the key/value entries of the map in undefined order.
 func (m *Map[K, V]) All() iter.Seq2[K, V] {
+	_ = m.len
 	return func(yield func(K, V) bool) {
-		for _, entry := range m.entries {
-			if !yield(entry.key, entry.value) {
-				return
+		for hash := range m.table {
+			for i := 0; i < len(m.table[hash]); i++ {
+				entry := &m.table[hash][i]
+				if entry.used && !yield(entry.key, entry.value) {
+					return
+				}
 			}
 		}
 	}
 }
 
-// Load returns the map entry for the given key.
-func (m *Map[K, V]) Load(key K) (V, bool) {
-	entry, ok := m.entries[m.h.Hash(key)]
-	return entry.value, ok
+// Get reports whether the map contains the specified key, and returns the
+// corresponding value if found, or the zero value if not.
+func (m *Map[K, V]) Get(key K) (V, bool) {
+	for _, entry := range m.table[m.hash(key)] {
+		if entry.used && m.hasher.Equal(key, entry.key) {
+			return entry.value, true
+		}
+	}
+	var zero V
+	return zero, false
 }
 
-// Delete removes th//e entry with the given key, if any. It returns true if the entry was found.
-func (m *Map[K, V]) Delete(key K) bool {
-	hash := m.h.Hash(key)
-	if _, exists := m.entries[hash]; exists {
-		delete(m.entries, hash)
-		return true
+// Delete removes the entry with the given key, if present. It reports whether
+// the map changed, and returns the previous value, if any.
+func (m *Map[K, V]) Delete(key K) (V, bool) {
+	bucket := m.table[m.hash(key)]
+	for i, e := range bucket {
+		if e.used && m.hasher.Equal(key, e.key) {
+			prev := e.value
+			bucket[i] = entry[K, V]{}
+			m.len--
+			return prev, true
+		}
 	}
-	return false
+	var zero V
+	return zero, false
 }
 
 // Keys returns an iterator over the map keys in unspecified order.
 func (m *Map[K, V]) Keys() iter.Seq[K] {
+	_ = m.len
 	return func(yield func(K) bool) {
-		for _, entry := range m.entries {
-			if !yield(entry.key) {
-				return
+		for hash := range m.table {
+			for i := 0; i < len(m.table[hash]); i++ {
+				entry := &m.table[hash][i]
+				if entry.used && !yield(entry.key) {
+					return
+				}
 			}
 		}
 	}
@@ -72,10 +120,14 @@ func (m *Map[K, V]) Keys() iter.Seq[K] {
 
 // Values returns an iterator over the map values in unspecified order.
 func (m *Map[K, V]) Values() iter.Seq[V] {
+	_ = m.len
 	return func(yield func(V) bool) {
-		for _, entry := range m.entries {
-			if !yield(entry.value) {
-				return
+		for hash := range m.table {
+			for i := 0; i < len(m.table[hash]); i++ {
+				entry := &m.table[hash][i]
+				if entry.used && !yield(entry.value) {
+					return
+				}
 			}
 		}
 	}
@@ -83,35 +135,84 @@ func (m *Map[K, V]) Values() iter.Seq[V] {
 
 // Len returns the number of map entries.
 func (m *Map[K, V]) Len() int {
-	return len(m.entries)
+	return m.len
 }
 
-// Set updates the map entry for key to value, and returns the previous entry, if any.
-func (m *Map[K, V]) Set(key K, value V) (prev V) {
-	hash := m.h.Hash(key)
-	if entry, exists := m.entries[hash]; exists {
-		prev = entry.value
+// Set updates the map entry for key to value and returns the previous entry,
+// if any. It reports whether the map size increased.
+func (m *Map[K, V]) Set(key K, value V) (prev V, changed bool) {
+	hash := m.hash(key)
+	bucket := m.table[hash]
+	var hole *entry[K, V]
+	for i := range bucket {
+		entry := &bucket[i]
+		if entry.used {
+			if m.hasher.Equal(key, entry.key) {
+				prev = entry.value
+				entry.value = value
+				return prev, false
+			}
+		} else if hole == nil {
+			hole = entry
+		}
 	}
-	m.entries[hash] = entry[K, V]{key, value}
-	return prev
+	if hole != nil {
+		*hole = entry[K, V]{used: true, key: key, value: value}
+	} else {
+		m.table[hash] = append(bucket, entry[K, V]{used: true, key: key, value: value})
+	}
+	m.len++
+	return prev, true
 }
 
 func (m *Map[K, V]) Clear() {
-	clear(m.entries)
+	clear(m.table)
+	m.len = 0
 }
 
-// String returns a string representation of the map's entries in unspecified order.
-// Values are printed as if by fmt.Sprint.
+// String returns a string representation of the map's entries
+// in an unspecified but deterministic order.
+//
+// Keys and values are printed as if by fmt.Sprint.
 func (m *Map[K, V]) String() string {
-	s := "{"
-	first := true
-	for _, entry := range m.entries {
-		if !first {
-			s += " "
-		}
-		s += fmt.Sprintf("%v: %v", entry.key, entry.value)
-		first = false
+	type formattedEntry struct {
+		key   string
+		value string
 	}
-	s += "}"
-	return s
+
+	var buf strings.Builder
+	buf.WriteByte('{')
+	sorted := make([]formattedEntry, 0, m.len)
+	for _, bucket := range m.table {
+		for _, entry := range bucket {
+			if entry.used {
+				sorted = append(sorted, formattedEntry{
+					key:   fmt.Sprint(entry.key),
+					value: fmt.Sprint(entry.value),
+				})
+			}
+		}
+	}
+	slices.SortStableFunc(sorted, func(a, b formattedEntry) int {
+		if result := strings.Compare(a.key, b.key); result != 0 {
+			return result
+		}
+		return strings.Compare(a.value, b.value)
+	})
+
+	for i, entry := range sorted {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(entry.key)
+		buf.WriteString(": ")
+		buf.WriteString(entry.value)
+	}
+	buf.WriteByte('}')
+	return buf.String()
 }
+
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/internal/hashmap/hashmap_test.go
+++ b/internal/hashmap/hashmap_test.go
@@ -5,7 +5,6 @@ package hashmap
 import (
 	"hash/maphash"
 	"slices"
-	"strings"
 	"testing"
 	"unicode"
 	"unicode/utf8"
@@ -27,7 +26,16 @@ func (caseInsensitive) Hash(h *maphash.Hash, s string) {
 }
 
 func (caseInsensitive) Equal(x, y string) bool {
-	return strings.ToLower(x) == strings.ToLower(y)
+	for len(x) > 0 && len(y) > 0 {
+		xr, xSize := utf8.DecodeRuneInString(x)
+		yr, ySize := utf8.DecodeRuneInString(y)
+		if unicode.ToLower(xr) != unicode.ToLower(yr) {
+			return false
+		}
+		x = x[xSize:]
+		y = y[ySize:]
+	}
+	return len(x) == len(y)
 }
 
 func TestMap(t *testing.T) {

--- a/internal/hashmap/hashmap_test.go
+++ b/internal/hashmap/hashmap_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package hashmap
+
+import (
+	"hash/maphash"
+	"slices"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	internalmaphash "github.com/microsoft/agent-framework-go/internal/maphash"
+)
+
+// caseInsensitive is a string Hasher that ignores letter case.
+type caseInsensitive struct{}
+
+var _ internalmaphash.Hasher[string] = caseInsensitive{}
+
+func (caseInsensitive) Hash(h *maphash.Hash, s string) {
+	var buf [utf8.UTFMax]byte
+	for _, r := range s {
+		n := utf8.EncodeRune(buf[:], unicode.ToLower(r))
+		h.Write(buf[:n])
+	}
+}
+
+func (caseInsensitive) Equal(x, y string) bool {
+	return strings.ToLower(x) == strings.ToLower(y)
+}
+
+func TestMap(t *testing.T) {
+	m := NewMap[string, int](caseInsensitive{})
+
+	if got := m.Len(); got != 0 {
+		t.Errorf("Len() on empty Map: got %d, want 0", got)
+	}
+	if value, ok := m.Get("foo"); ok || value != 0 {
+		t.Errorf("Get() on empty Map: got %v, %v, want 0, false", value, ok)
+	}
+	if _, removed := m.Delete("foo"); removed {
+		t.Error("Delete() on empty Map: got true, want false")
+	}
+
+	if prev, changed := m.Set("Hello", 1); prev != 0 {
+		t.Errorf("Set() on empty Map returned non-zero previous value %d", prev)
+	} else if !changed {
+		t.Error("Set() on empty Map returned changed=false")
+	}
+	if got := m.Len(); got != 1 {
+		t.Errorf("Len(): got %d, want 1", got)
+	}
+	for _, key := range []string{"Hello", "hello", "HELLO"} {
+		if value, ok := m.Get(key); !ok || value != 1 {
+			t.Errorf("Get(%q): got %v, %v, want 1, true", key, value, ok)
+		}
+	}
+
+	if prev, changed := m.Set("HELLO", 2); prev != 1 {
+		t.Errorf("Set(\"HELLO\") previous value: got %d, want 1", prev)
+	} else if changed {
+		t.Error("Set(\"HELLO\") returned changed=true")
+	}
+	if got := m.Len(); got != 1 {
+		t.Errorf("Len() after update: got %d, want 1", got)
+	}
+	if prev, changed := m.Set("World", 3); prev != 0 {
+		t.Errorf("Set(\"World\") previous value: got %d, want 0", prev)
+	} else if !changed {
+		t.Error("Set(\"World\") returned changed=false")
+	}
+
+	if got, want := m.String(), "{Hello: 2, World: 3}"; got != want {
+		t.Errorf("String(): got %s, want %s", got, want)
+	}
+
+	keys := slices.Collect(m.Keys())
+	slices.Sort(keys)
+	if !slices.Equal(keys, []string{"Hello", "World"}) {
+		t.Errorf("Keys(): got %v", keys)
+	}
+
+	values := slices.Collect(m.Values())
+	slices.Sort(values)
+	if !slices.Equal(values, []int{2, 3}) {
+		t.Errorf("Values(): got %v", values)
+	}
+
+	entries := make(map[string]int)
+	for key, value := range m.All() {
+		entries[key] = value
+	}
+	if len(entries) != 2 || entries["Hello"] != 2 || entries["World"] != 3 {
+		t.Errorf("All(): got %v", entries)
+	}
+
+	if prev, removed := m.Delete("hello"); !removed || prev != 2 {
+		t.Errorf("Delete(\"hello\") = %v, %v, want 2, true", prev, removed)
+	}
+	if got := m.Len(); got != 1 {
+		t.Errorf("Len(): got %d, want 1", got)
+	}
+	if _, ok := m.Get("Hello"); ok {
+		t.Error("Get(\"Hello\") found entry after Delete")
+	}
+
+	m.Clear()
+	if got := m.Len(); got != 0 {
+		t.Errorf("Len() after Clear: got %d, want 0", got)
+	}
+	if _, ok := m.Get("World"); ok {
+		t.Error("Get(\"World\") found entry after Clear")
+	}
+}
+
+func TestNilMapPanics(t *testing.T) {
+	panics := func(name string, f func()) {
+		t.Helper()
+		defer func() {
+			if recover() == nil {
+				t.Errorf("expected panic for nil Map.%s", name)
+			}
+		}()
+		f()
+	}
+
+	var m *Map[string, int]
+	panics("Len", func() { m.Len() })
+	panics("All", func() { m.All() })
+	panics("Keys", func() { m.Keys() })
+	panics("Values", func() { m.Values() })
+	panics("Get", func() { m.Get("key") })
+	panics("Set", func() { m.Set("key", 1) })
+	panics("Delete", func() { m.Delete("key") })
+	panics("Clear", func() { m.Clear() })
+	panics("String", func() { _ = m.String() })
+}
+
+type collisionHasher struct{}
+
+func (collisionHasher) Hash(*maphash.Hash, string) {}
+
+func (collisionHasher) Equal(x, y string) bool {
+	return x == y
+}
+
+func TestMapHashCollisions(t *testing.T) {
+	m := NewMap[string, int](collisionHasher{})
+	m.Set("one", 1)
+	m.Set("two", 2)
+
+	if got := m.Len(); got != 2 {
+		t.Fatalf("Len() = %d, want 2", got)
+	}
+	for key, want := range map[string]int{"one": 1, "two": 2} {
+		if got, ok := m.Get(key); !ok || got != want {
+			t.Errorf("Get(%q) = %d, %t, want %d, true", key, got, ok, want)
+		}
+	}
+
+	if prev, changed := m.Set("one", 10); prev != 1 || changed {
+		t.Errorf("Set(%q) returned %d, want 1", "one", prev)
+	}
+	if _, removed := m.Delete("one"); !removed {
+		t.Fatal("Delete(\"one\") = false, want true")
+	}
+	if got, ok := m.Get("two"); !ok || got != 2 {
+		t.Errorf("Get(%q) after colliding delete = %d, %t, want 2, true", "two", got, ok)
+	}
+
+	m.Set("three", 3)
+	if got := m.Len(); got != 2 {
+		t.Fatalf("Len() after reusing deleted slot = %d, want 2", got)
+	}
+	if got, ok := m.Get("three"); !ok || got != 3 {
+		t.Errorf("Get(%q) = %d, %t, want 3, true", "three", got, ok)
+	}
+}
+
+type sameStringKey int
+
+func (sameStringKey) String() string { return "key" }
+
+type sameStringKeyHasher struct{}
+
+func (sameStringKeyHasher) Hash(*maphash.Hash, sameStringKey) {}
+
+func (sameStringKeyHasher) Equal(x, y sameStringKey) bool { return x == y }
+
+func TestMapStringFormattedKeyCollision(t *testing.T) {
+	m := NewMap[sameStringKey, int](sameStringKeyHasher{})
+	m.Set(1, 2)
+	m.Set(2, 1)
+
+	if got, want := m.String(), "{key: 1, key: 2}"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}

--- a/internal/maphash/maphash.go
+++ b/internal/maphash/maphash.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// Package maphash provides temporary hash interfaces used by hash-based containers.
+package maphash
+
+import stdmaphash "hash/maphash"
+
+// TODO: Replace Hasher with hash/maphash.Hasher once Go 1.27 is the minimum supported version.
+
+// Hasher defines a hash function and equivalence relation over values of type T.
+// If Equal(x, y) is true, Hash must write the same representation for x and y.
+type Hasher[T any] interface {
+	Hash(*stdmaphash.Hash, T)
+	Equal(x, y T) bool
+}

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -484,7 +484,7 @@ func (r *runner) checkpoint(ctx context.Context) error {
 		StepNumber:    r.stepTracer.StepNumber(),
 		WorkflowInfo:  workflowInfo,
 		RunnerData:    r.runContext.exportState(),
-		StateData:     *stateData,
+		StateData:     stateData,
 		EdgeStateData: edgeData,
 		Parent:        parent,
 	}

--- a/workflow/internal/checkpoint/checkpoint.go
+++ b/workflow/internal/checkpoint/checkpoint.go
@@ -25,7 +25,7 @@ type Checkpoint struct {
 	StepNumber    int
 	WorkflowInfo  WorkflowInfo
 	RunnerData    RunnerStateData
-	StateData     hashmap.Map[workflow.ScopeKey, workflow.PortableValue]
+	StateData     *hashmap.Map[workflow.ScopeKey, workflow.PortableValue]
 	EdgeStateData map[string]workflow.PortableValue
 	Parent        *workflow.CheckpointInfo
 }

--- a/workflow/internal/checkpoint/checkpoint_json.go
+++ b/workflow/internal/checkpoint/checkpoint_json.go
@@ -7,27 +7,18 @@ import (
 	"hash/maphash"
 
 	"github.com/microsoft/agent-framework-go/internal/hashmap"
+	internalmaphash "github.com/microsoft/agent-framework-go/internal/maphash"
 	"github.com/microsoft/agent-framework-go/workflow"
 )
 
-// scopeKeyHasherImpl implements hashmap.Hasher for workflow.ScopeKey.
+// scopeKeyHasherImpl implements maphash.Hasher for workflow.ScopeKey.
 // This is duplicated here to avoid an import cycle with execution.
 type scopeKeyHasherImpl struct{}
 
-var scopeKeyHasherInstance hashmap.Hasher[workflow.ScopeKey] = scopeKeyHasherImpl{}
+var scopeKeyHasherInstance internalmaphash.Hasher[workflow.ScopeKey] = scopeKeyHasherImpl{}
 
-// scopeKeyHashSeed is a fixed process-wide seed. maphash.Hash's zero value
-// picks a new random seed on first use, so without SetSeed the same key would
-// hash differently on every call — breaking Load/Delete and shared-scope key
-// collapse on a map restored from JSON. state.go seeds its ScopeKey hasher the
-// same way.
-var scopeKeyHashSeed = maphash.MakeSeed()
-
-func (scopeKeyHasherImpl) Hash(s workflow.ScopeKey) uint64 {
-	var h maphash.Hash
-	h.SetSeed(scopeKeyHashSeed)
-	s.Hash(&h)
-	return h.Sum64()
+func (scopeKeyHasherImpl) Hash(h *maphash.Hash, s workflow.ScopeKey) {
+	s.Hash(h)
 }
 
 func (scopeKeyHasherImpl) Equal(a, b workflow.ScopeKey) bool {
@@ -53,8 +44,10 @@ type checkpointJSON struct {
 // MarshalJSON implements [json.Marshaler] for Checkpoint.
 func (c *Checkpoint) MarshalJSON() ([]byte, error) {
 	var entries []scopeKeyEntry
-	for key, value := range c.StateData.All() {
-		entries = append(entries, scopeKeyEntry{Key: key, Value: value})
+	if c.StateData != nil {
+		for key, value := range c.StateData.All() {
+			entries = append(entries, scopeKeyEntry{Key: key, Value: value})
+		}
 	}
 
 	return json.Marshal(checkpointJSON{
@@ -82,7 +75,7 @@ func (c *Checkpoint) UnmarshalJSON(data []byte) error {
 	c.StepNumber = v.StepNumber
 	c.WorkflowInfo = v.WorkflowInfo
 	c.RunnerData = v.RunnerData
-	c.StateData = *stateData
+	c.StateData = stateData
 	c.EdgeStateData = v.EdgeStateData
 	c.Parent = v.Parent
 	return nil

--- a/workflow/internal/checkpoint/checkpoint_json.go
+++ b/workflow/internal/checkpoint/checkpoint_json.go
@@ -11,7 +11,7 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow"
 )
 
-// scopeKeyHasherImpl implements maphash.Hasher for workflow.ScopeKey.
+// scopeKeyHasherImpl implements internalmaphash.Hasher for workflow.ScopeKey.
 // This is duplicated here to avoid an import cycle with execution.
 type scopeKeyHasherImpl struct{}
 

--- a/workflow/internal/checkpoint/json_test.go
+++ b/workflow/internal/checkpoint/json_test.go
@@ -117,10 +117,9 @@ func TestRunnerStateData_JsonRoundtrip(t *testing.T) {
 	}
 }
 
-// A Checkpoint's StateData map is rebuilt from JSON on Unmarshal. Its scope-key
-// hasher must use a fixed seed: a zero-value maphash.Hash picks a new random
-// seed on every call, so Load on a restored map would miss the key it just
-// stored (and shared-scope keys would not collapse).
+// A Checkpoint's StateData map is rebuilt from JSON on Unmarshal. The map must
+// consistently apply its per-instance seed so Get can find keys inserted while
+// restoring the checkpoint.
 func TestCheckpoint_JsonRoundtrip_StateDataRemainsLoadable(t *testing.T) {
 	key := workflow.ScopeKey{ID: workflow.ScopeID{ExecutorID: "exec1"}, Key: "k"}
 	keyJSON, err := json.Marshal(key)
@@ -137,7 +136,7 @@ func TestCheckpoint_JsonRoundtrip_StateDataRemainsLoadable(t *testing.T) {
 	if err := json.Unmarshal(data, &cp); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if _, ok := cp.StateData.Load(key); !ok {
-		t.Fatal("restored StateData.Load(key) = false: the scope-key hasher is not deterministic across calls")
+	if _, ok := cp.StateData.Get(key); !ok {
+		t.Fatal("restored StateData.Get(key) = false: the scope-key hasher is not deterministic across calls")
 	}
 }

--- a/workflow/internal/execution/state.go
+++ b/workflow/internal/execution/state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/microsoft/agent-framework-go/internal/concurrent"
 	"github.com/microsoft/agent-framework-go/internal/hashmap"
+	internalmaphash "github.com/microsoft/agent-framework-go/internal/maphash"
 	"github.com/microsoft/agent-framework-go/workflow"
 	"github.com/microsoft/agent-framework-go/workflow/internal/checkpoint"
 )
@@ -126,17 +127,12 @@ func (s UpdateKey) Hash(h *maphash.Hash) {
 	h.WriteString(s.Key)
 }
 
-var theSeed = maphash.MakeSeed()
-
 type updateKeyHasher struct{}
 
-var UpdateKeyHasher hashmap.Hasher[UpdateKey] = updateKeyHasher{}
+var UpdateKeyHasher internalmaphash.Hasher[UpdateKey] = updateKeyHasher{}
 
-func (updateKeyHasher) Hash(s UpdateKey) uint64 {
-	var mh maphash.Hash
-	mh.SetSeed(theSeed)
-	s.Hash(&mh)
-	return mh.Sum64()
+func (updateKeyHasher) Hash(h *maphash.Hash, s UpdateKey) {
+	s.Hash(h)
 }
 
 func (h updateKeyHasher) Equal(a, b UpdateKey) bool {
@@ -145,13 +141,10 @@ func (h updateKeyHasher) Equal(a, b UpdateKey) bool {
 
 type scopeIDHasher struct{}
 
-var ScopeIDHasher hashmap.Hasher[workflow.ScopeID] = scopeIDHasher{}
+var ScopeIDHasher internalmaphash.Hasher[workflow.ScopeID] = scopeIDHasher{}
 
-func (scopeIDHasher) Hash(s workflow.ScopeID) uint64 {
-	var mh maphash.Hash
-	mh.SetSeed(theSeed)
-	s.Hash(&mh)
-	return mh.Sum64()
+func (scopeIDHasher) Hash(h *maphash.Hash, s workflow.ScopeID) {
+	s.Hash(h)
 }
 
 func (scopeIDHasher) Equal(a, b workflow.ScopeID) bool {
@@ -160,13 +153,10 @@ func (scopeIDHasher) Equal(a, b workflow.ScopeID) bool {
 
 type scopeKeyHasher struct{}
 
-var ScopeKeyHasher hashmap.Hasher[workflow.ScopeKey] = scopeKeyHasher{}
+var ScopeKeyHasher internalmaphash.Hasher[workflow.ScopeKey] = scopeKeyHasher{}
 
-func (scopeKeyHasher) Hash(s workflow.ScopeKey) uint64 {
-	var mh maphash.Hash
-	mh.SetSeed(theSeed)
-	s.Hash(&mh)
-	return mh.Sum64()
+func (scopeKeyHasher) Hash(h *maphash.Hash, s workflow.ScopeKey) {
+	s.Hash(h)
 }
 
 func (scopeKeyHasher) Equal(a, b workflow.ScopeKey) bool {
@@ -189,11 +179,11 @@ func NewStateManager() StateManager {
 
 // getOrCreateScope gets or creates a state scope.
 func (sm *StateManager) getOrCreateScope(scopeID workflow.ScopeID) *StateScope {
-	if scope, ok := sm.scopes.Load(scopeID); ok {
+	if scope, ok := sm.scopes.Get(scopeID); ok {
 		return scope
 	}
 	scope := NewStateScope(scopeID)
-	sm.scopes.Swap(scopeID, scope)
+	sm.scopes.Set(scopeID, scope)
 	return scope
 }
 
@@ -224,22 +214,22 @@ func (sm *StateManager) ClearStateByID(scopeID workflow.ScopeID) error {
 	// into deletes, otherwise a write-then-clear on a fresh scope silently keeps
 	// (and later commits) the write.
 	keysToDelete := map[string]struct{}{}
-	if scope, exists := sm.scopes.Load(scopeID); exists {
+	if scope, exists := sm.scopes.Get(scopeID); exists {
 		keysToDelete = scope.ReadKeys()
 	}
 
 	// Mark existing updates as deletes
 	for updateKey := range sm.getUpdatesForScopeStrict(scopeID) {
-		update, _ := sm.queuedUpdates.Load(updateKey)
+		update, _ := sm.queuedUpdates.Get(updateKey)
 		if !update.IsDelete {
-			sm.queuedUpdates.Swap(updateKey, DeleteStateUpdate(update.Key))
+			sm.queuedUpdates.Set(updateKey, DeleteStateUpdate(update.Key))
 		}
 		delete(keysToDelete, update.Key)
 	}
 
 	// Queue deletes for remaining keys
 	for key := range keysToDelete {
-		sm.queuedUpdates.Swap(UpdateKey{ScopeID: scopeID, Key: key}, DeleteStateUpdate(key))
+		sm.queuedUpdates.Set(UpdateKey{ScopeID: scopeID, Key: key}, DeleteStateUpdate(key))
 	}
 
 	return nil
@@ -248,7 +238,7 @@ func (sm *StateManager) ClearStateByID(scopeID workflow.ScopeID) error {
 // applyUnpublishedUpdates applies queued updates to a set of keys.
 func (sm *StateManager) applyUnpublishedUpdates(scopeID workflow.ScopeID, keys map[string]struct{}) map[string]struct{} {
 	for key := range sm.getUpdatesForScopeStrict(scopeID) {
-		update, _ := sm.queuedUpdates.Load(key)
+		update, _ := sm.queuedUpdates.Get(key)
 		if update.IsDelete || update.Value == nil {
 			delete(keys, update.Key)
 		} else {
@@ -287,7 +277,7 @@ func (sm *StateManager) ReadStateByID(scopeID workflow.ScopeID, key string) (wor
 	stateKey := UpdateKey{ScopeID: scopeID, Key: key}
 
 	// Check queued updates first
-	if update, hasUpdate := sm.queuedUpdates.Load(stateKey); hasUpdate {
+	if update, hasUpdate := sm.queuedUpdates.Get(stateKey); hasUpdate {
 		if update.IsDelete || update.Value == nil {
 			return workflow.PortableValue{}, false, nil
 		}
@@ -343,7 +333,7 @@ func (sm *StateManager) WriteStateByID(scopeID workflow.ScopeID, key string, val
 	}
 
 	stateKey := UpdateKey{ScopeID: scopeID, Key: key}
-	sm.queuedUpdates.Swap(stateKey, UpdateStateUpdate(key, value))
+	sm.queuedUpdates.Set(stateKey, UpdateStateUpdate(key, value))
 
 	return nil
 }
@@ -361,7 +351,7 @@ func (sm *StateManager) ClearStateKeyByID(scopeID workflow.ScopeID, key string) 
 	}
 
 	stateKey := UpdateKey{ScopeID: scopeID, Key: key}
-	sm.queuedUpdates.Swap(stateKey, DeleteStateUpdate(key))
+	sm.queuedUpdates.Set(stateKey, DeleteStateUpdate(key))
 
 	return nil
 }
@@ -372,11 +362,11 @@ func (sm *StateManager) PublishUpdates(tracer StepTracer) error {
 	updatesByScope := hashmap.NewMap[workflow.ScopeID, map[string][]StateUpdate](ScopeIDHasher)
 
 	for key, update := range sm.queuedUpdates.All() {
-		if _, ok := updatesByScope.Load(key.ScopeID); !ok {
+		if _, ok := updatesByScope.Get(key.ScopeID); !ok {
 			updatesByScope.Set(key.ScopeID, make(map[string][]StateUpdate))
 		}
 
-		scopeUpdates, _ := updatesByScope.Load(key.ScopeID)
+		scopeUpdates, _ := updatesByScope.Get(key.ScopeID)
 		scopeUpdates[key.Key] = append(scopeUpdates[key.Key], update)
 	}
 
@@ -428,13 +418,15 @@ func (sm *StateManager) ImportState(cp *checkpoint.Checkpoint) error {
 	sm.queuedUpdates.Clear()
 	sm.scopes.Clear()
 
-	for scopeKey, value := range cp.StateData.All() {
-		scope, ok := sm.scopes.Load(scopeKey.ID)
-		if !ok {
-			scope = NewStateScope(scopeKey.ID)
-			sm.scopes.Swap(scopeKey.ID, scope)
+	if cp.StateData != nil {
+		for scopeKey, value := range cp.StateData.All() {
+			scope, ok := sm.scopes.Get(scopeKey.ID)
+			if !ok {
+				scope = NewStateScope(scopeKey.ID)
+				sm.scopes.Set(scopeKey.ID, scope)
+			}
+			scope.ImportState(scopeKey.Key, value)
 		}
-		scope.ImportState(scopeKey.Key, value)
 	}
 
 	return nil

--- a/workflow/internal/execution/state_test.go
+++ b/workflow/internal/execution/state_test.go
@@ -527,7 +527,7 @@ func TestScopeLoadPortableValueState_AfterSerialization(t *testing.T) {
 	}
 
 	testCheckpoint := &checkpoint.Checkpoint{
-		StateData: *stateData,
+		StateData: stateData,
 	}
 
 	manager = NewStateManager()


### PR DESCRIPTION
## Summary

- reimplement `internal/hashmap.Map` with collision buckets and container-seeded hashing compatible with the proposed Go 1.27 `hash/maphash.Hasher`
- make `internal/concurrent.HashMap` a synchronized wrapper with snapshot-based iteration and formatting
- keep checkpoint map ownership pointer-based and update workflow state call sites

## Bugs fixed

- preserve distinct keys that produce the same hash by resolving collisions with `Hasher.Equal`
- prevent concurrent map deadlocks when iterator callbacks or formatting methods re-enter the map
- make map string output deterministic when distinct keys have identical formatted representations
- keep checkpoint state keys retrievable after JSON round trips
- discard queued writes when clearing a fresh, unpublished workflow scope

## Testing

- `go test ./...`
- `go vet ./...`