### PR TITLE
Harden public API validation and consistency

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -527,7 +527,7 @@ func (a *Agent) prepareRun(ctx context.Context, messages []*message.Message, opt
 		optionsOwned = true
 	}
 
-	if _, ok := GetOption(options, WithSession); !ok {
+	if session, ok := GetOption(options, WithSession); !ok || session == nil {
 		if allowBackgroundResponses, ok := GetOption(options, AllowBackgroundResponses); ok && allowBackgroundResponses {
 			// Background responses require an explicit session to avoid inconsistent
 			// caller experience between initial and follow-up runs.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -118,6 +118,35 @@ func newGenericTestAgent(runFn func(context.Context, []*message.Message, ...agen
 	})
 }
 
+func TestNew_IgnoresNilMiddleware(t *testing.T) {
+	var providerCalls, agentMiddlewareCalls, providerMiddlewareCalls int
+	run := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		providerCalls++
+		return func(func(*agent.ResponseUpdate, error) bool) {}
+	}
+	agentMiddleware := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		agentMiddlewareCalls++
+		return next(ctx, messages, options...)
+	})
+	providerMiddleware := agent.MiddlewareFunc(func(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		providerMiddlewareCalls++
+		return next(ctx, messages, options...)
+	})
+
+	a := agent.New(agent.ProviderConfig{
+		Run:         run,
+		Middlewares: []agent.Middleware{nil, providerMiddleware, nil},
+	}, agent.Config{
+		Middlewares: []agent.Middleware{nil, agentMiddleware, nil},
+	})
+	if _, err := a.RunText(t.Context(), "hello").Collect(); err != nil {
+		t.Fatalf("RunText() error = %v", err)
+	}
+	if providerCalls != 1 || agentMiddlewareCalls != 1 || providerMiddlewareCalls != 1 {
+		t.Fatalf("calls = provider:%d agent middleware:%d provider middleware:%d, want all 1", providerCalls, agentMiddlewareCalls, providerMiddlewareCalls)
+	}
+}
+
 func TestAgent_RunText(t *testing.T) {
 	var capturedMessages []*message.Message
 	responseBuilder := agenttest.NewResponseBuilder(
@@ -389,6 +418,23 @@ func TestAgent_Run_RequiresSessionWhenAllowBackgroundResponsesEnabled(t *testing
 	}
 	if runCalled {
 		t.Fatal("expected run function not to be called when validation fails")
+	}
+}
+
+func TestAgent_Run_RejectsNilSessionWhenAllowBackgroundResponsesEnabled(t *testing.T) {
+	runCalled := false
+	a := agenttest.New(agenttest.NewResponseBuilder(
+		func(context.Context, []*message.Message, ...agent.Option) {
+			runCalled = true
+		},
+	).AddText("response").Build())
+
+	_, err := a.RunText(t.Context(), "test", agent.WithSession(nil), agent.AllowBackgroundResponses(true)).Collect()
+	if err == nil || err.Error() != "a session must be provided when AllowBackgroundResponses is enabled" {
+		t.Fatalf("RunText() error = %v, want session-required error", err)
+	}
+	if runCalled {
+		t.Fatal("run function called with a nil background-response session")
 	}
 }
 

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -25,6 +25,14 @@ func (f strategyFunc) Compact(ctx context.Context, index *compaction.MessageInde
 	return f(ctx, index)
 }
 
+func TestSummarizerFunc_NilReturnsError(t *testing.T) {
+	var summarizer compaction.SummarizerFunc
+	_, err := summarizer.Summarize(t.Context(), nil)
+	if err == nil || err.Error() != "compaction: summarizer function is nil" {
+		t.Fatalf("Summarize() error = %v, want nil-function error", err)
+	}
+}
+
 func TestMessageIndex_GroupsToolCallsAtomically(t *testing.T) {
 	messages := []*message.Message{
 		textMessage(message.RoleSystem, "system"),

--- a/agent/compaction/summarization.go
+++ b/agent/compaction/summarization.go
@@ -32,13 +32,18 @@ type SummarizerFunc func(context.Context, []*message.Message) (string, error)
 
 // Summarize calls f(ctx, messages).
 func (f SummarizerFunc) Summarize(ctx context.Context, messages []*message.Message) (string, error) {
+	if f == nil {
+		return "", errors.New("compaction: summarizer function is nil")
+	}
 	return f(ctx, messages)
 }
 
 // SummarizationStrategy summarizes older groups into a single assistant summary message.
 //
 // The strategy protects system messages and the most recent non-system groups. Older groups are sent
-// to Summarizer, and the resulting summary is inserted as a GroupKindSummary message.
+// to Summarizer, and the resulting summary is inserted as a GroupKindSummary message. Summarizer
+// failures are best effort: excluded groups are restored and Compact reports no change. Context
+// cancellation and deadline errors are restored and returned to the caller.
 type SummarizationStrategy struct {
 	// Trigger controls whether summarization should run.
 	// When nil, summarization always runs.

--- a/agent/context.go
+++ b/agent/context.go
@@ -111,7 +111,12 @@ type defaultContextProvider struct {
 // results as additive, source-stamps provided messages, appends provided
 // messages and options to the original invocation context, filters stored
 // request and response messages, and skips Store when the run fails.
+//
+// It panics if SourceID is empty.
 func NewContextProvider(config ContextProviderConfig) ContextProvider {
+	if config.SourceID == "" {
+		panic("SourceID is required")
+	}
 	return &defaultContextProvider{config: config}
 }
 

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -349,14 +349,13 @@ func (p contextProviderFunc) Invoked(ctx context.Context, invoked agent.InvokedC
 	return p.invoked(ctx, invoked)
 }
 
-func TestContextProvider_Invoking_PanicsWithoutSourceID(t *testing.T) {
-	provider := agent.NewContextProvider(agent.ContextProviderConfig{})
+func TestNewContextProvider_PanicsWithoutSourceID(t *testing.T) {
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected panic")
 		}
 	}()
-	_, _, _ = invokeContextProvider(provider, t.Context(), nil, agent.WithSession(agenttest.CreateSession()))
+	agent.NewContextProvider(agent.ContextProviderConfig{})
 }
 
 func TestContextProvider_Invoking_SourceStampsProvidedMessages(t *testing.T) {
@@ -601,16 +600,6 @@ func TestContextProvider_Invoking_UsesCustomSourceID(t *testing.T) {
 	if messages[0].Source.ID != "CustomContextSource" {
 		t.Fatalf("expected custom source ID, got %q", messages[0].Source.ID)
 	}
-}
-
-func TestContextProvider_Invoked_PanicsWithoutSourceID(t *testing.T) {
-	provider := agent.NewContextProvider(agent.ContextProviderConfig{})
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected panic")
-		}
-	}()
-	_ = invokeContextProviderInvoked(provider, t.Context(), nil, nil, agent.WithSession(agenttest.CreateSession()))
 }
 
 func TestContextProvider_Invoked_CallsStoreAndIncludesExternalRequestMessagesByDefault(t *testing.T) {

--- a/agent/format/jsonformat/encoding_test.go
+++ b/agent/format/jsonformat/encoding_test.go
@@ -21,6 +21,30 @@ func requireFormat(t *testing.T, responseFormat agent.ResponseFormat) *jsonforma
 	return format
 }
 
+func TestNew_NilSchemaIsUnconstrained(t *testing.T) {
+	format := requireFormat(t, jsonformat.New("any", "", nil))
+	value := map[string]any{"status": "ok"}
+
+	data, err := format.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if string(data) != `{"status":"ok"}` {
+		t.Fatalf("Marshal() = %s, want object JSON", data)
+	}
+}
+
+func TestFromResponseFormat_RejectsTypedNilSchema(t *testing.T) {
+	var schema *jsonschema.Schema
+	format, err := jsonformat.FromResponseFormat(agent.ResponseFormat{Kind: "json", Schema: schema})
+	if err == nil || err.Error() != "response format schema cannot be nil" {
+		t.Fatalf("FromResponseFormat() error = %v, want nil-schema error", err)
+	}
+	if format != nil {
+		t.Fatalf("FromResponseFormat() = %#v, want nil", format)
+	}
+}
+
 func TestEncodingRoundtrip(t *testing.T) {
 	tests := []struct {
 		name string

--- a/agent/format/jsonformat/jsonformat.go
+++ b/agent/format/jsonformat/jsonformat.go
@@ -40,8 +40,12 @@ func newFormat(name, description string, schema *jsonschema.Schema) *Format {
 	}
 }
 
-// New creates a new JSON response format with the given name, description, and schema.
+// New creates a new JSON response format with the given name, description, and
+// schema. A nil schema represents an unconstrained JSON value.
 func New(name, description string, schema *jsonschema.Schema) agent.ResponseFormat {
+	if schema == nil {
+		schema = &jsonschema.Schema{}
+	}
 	return newFormat(name, description, schema).ResponseFormat
 }
 
@@ -50,6 +54,9 @@ func FromResponseFormat(format agent.ResponseFormat) (*Format, error) {
 	schema, ok := format.Schema.(*jsonschema.Schema)
 	if !ok {
 		return nil, fmt.Errorf("response format schema has type %T, want *jsonschema.Schema", format.Schema)
+	}
+	if schema == nil {
+		return nil, fmt.Errorf("response format schema cannot be nil")
 	}
 	return newFormat(format.Name, format.Description, schema), nil
 }

--- a/agent/harness/agentmode/agentmode.go
+++ b/agent/harness/agentmode/agentmode.go
@@ -356,7 +356,7 @@ func (p *Provider) SetMode(mode string, opts ...agent.Option) error {
 	mu.Lock()
 	defer mu.Unlock()
 	session, ok := agent.GetOption(opts, agent.WithSession)
-	if !ok {
+	if !ok || session == nil {
 		return fmt.Errorf("agentmode: no session available")
 	}
 	var s state

--- a/agent/harness/agentmode/agentmode_test.go
+++ b/agent/harness/agentmode/agentmode_test.go
@@ -479,6 +479,15 @@ func TestPublicSetMode_InvalidMode_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestPublicSetMode_NilSession_ReturnsError(t *testing.T) {
+	p := agentmode.New(agentmode.Config{})
+
+	err := p.SetMode("execute", agent.WithSession(nil))
+	if err == nil || err.Error() != "agentmode: no session available" {
+		t.Fatalf("SetMode() error = %v, want no-session error", err)
+	}
+}
+
 // 22. PublicSetMode_ReflectedInToolResults
 func TestPublicSetMode_ReflectedInInstructions(t *testing.T) {
 	p := agentmode.New(agentmode.Config{})

--- a/agent/harness/loop/loop.go
+++ b/agent/harness/loop/loop.go
@@ -359,7 +359,7 @@ func snapshotSession(session *agent.Session) ([]byte, error) {
 	}
 	data, err := json.Marshal(session)
 	if err != nil {
-		return nil, errors.New("loop: snapshot session")
+		return nil, fmt.Errorf("loop: snapshot session: %w", err)
 	}
 	return data, nil
 }
@@ -370,7 +370,7 @@ func sessionFromSnapshot(data []byte) (*agent.Session, error) {
 	}
 	var cloned agent.Session
 	if err := json.Unmarshal(data, &cloned); err != nil {
-		return nil, errors.New("loop: restore session snapshot")
+		return nil, fmt.Errorf("loop: restore session snapshot: %w", err)
 	}
 	return &cloned, nil
 }

--- a/agent/harness/loop/loop_test.go
+++ b/agent/harness/loop/loop_test.go
@@ -4,6 +4,7 @@ package loop_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"iter"
 	"slices"
@@ -264,6 +265,34 @@ func TestLoop_FreshContextPerIteration_RecreatesSession(t *testing.T) {
 	}
 	if capture.sessionsPerCall[1] == capture.sessionsPerCall[2] {
 		t.Fatal("second and third call should use different sessions")
+	}
+}
+
+func TestLoop_FreshContextPerIteration_SnapshotErrorPreservesCause(t *testing.T) {
+	capture := newCaptureAgent(func(int, []*message.Message) []*agent.ResponseUpdate {
+		return textUpdates("unused")
+	})
+	a := agent.New(capture.provider(), agent.Config{
+		Middlewares: []agent.Middleware{loop.New(loop.Config{
+			FreshContextPerIteration: true,
+			Evaluators: []loop.Evaluator{loop.EvaluatorFunc(func(context.Context, *loop.Context) (loop.Evaluation, error) {
+				return loop.Stop(), nil
+			})},
+		})},
+	})
+	session := &agent.Session{}
+	session.Set("unsupported", func() {})
+
+	_, err := a.RunText(t.Context(), "go", agent.WithSession(session)).Collect()
+	var unsupported *json.UnsupportedTypeError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("RunText() error = %v, want wrapped json.UnsupportedTypeError", err)
+	}
+	if !strings.Contains(err.Error(), "loop: snapshot session") {
+		t.Fatalf("RunText() error = %v, want snapshot context", err)
+	}
+	if capture.callCount != 0 {
+		t.Fatalf("provider call count = %d, want 0", capture.callCount)
 	}
 }
 

--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -90,7 +90,8 @@ type Config struct {
 	// MaximumIterationsPerRequest is the maximum number of tool-invocation rounds
 	// performed for a single run. When the limit is reached, the middleware makes a
 	// final provider request without schema tools so no more local function calls
-	// are requested. The zero value uses the default of 40.
+	// are requested. The zero value uses the default of 40. Negative values are
+	// invalid.
 	MaximumIterationsPerRequest int
 
 	// NewID generates synthetic IDs for generated tool-result messages and
@@ -144,6 +145,10 @@ func New(cfg Config) agent.Middleware {
 
 func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*message.Message, opts ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
+		if f.maximumIterationsPerRequest < 0 {
+			yield(nil, fmt.Errorf("toolautocall: MaximumIterationsPerRequest must be 0 or greater, got %d", f.maximumIterationsPerRequest))
+			return
+		}
 		var messagesCloned bool
 		tools, _ := f.createToolsMap(agent.AllOptions(opts, agent.WithTool))
 

--- a/agent/harness/toolautocall/autocall_test.go
+++ b/agent/harness/toolautocall/autocall_test.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -631,6 +633,33 @@ func TestFunctionInvoking_FunctionReturningFunctionResultContentWithMismatchedCa
 	}
 	if inner.Result != "Result from function" {
 		t.Fatalf("expected inner result %q, got %v", "Result from function", inner.Result)
+	}
+}
+
+func TestFunctionInvoking_NegativeMaximumIterationsReturnsError(t *testing.T) {
+	invoked := false
+	next := func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		invoked = true
+		return func(func(*agent.ResponseUpdate, error) bool) {}
+	}
+
+	var got error
+	for _, err := range toolautocall.New(toolautocall.Config{MaximumIterationsPerRequest: -1}).Run(
+		next,
+		t.Context(),
+		[]*message.Message{message.NewText("hello")},
+	) {
+		if err != nil {
+			got = err
+			break
+		}
+	}
+
+	if got == nil || !strings.Contains(got.Error(), "MaximumIterationsPerRequest must be 0 or greater") {
+		t.Fatalf("Run() error = %v, want iteration-limit validation error", got)
+	}
+	if invoked {
+		t.Fatal("provider was invoked for invalid configuration")
 	}
 }
 

--- a/agent/history.go
+++ b/agent/history.go
@@ -81,7 +81,12 @@ type defaultHistoryProvider struct {
 // those messages when ProvideOutputMessageFilter is set, source-stamps them,
 // prepends them to caller-provided request messages, filters stored request and
 // response messages, and skips Store when the run fails.
+//
+// It panics if SourceID is empty.
 func NewHistoryProvider(config HistoryProviderConfig) HistoryProvider {
+	if config.SourceID == "" {
+		panic("SourceID is required")
+	}
 	return &defaultHistoryProvider{config: config}
 }
 

--- a/agent/history_test.go
+++ b/agent/history_test.go
@@ -66,6 +66,15 @@ func TestNewInMemoryHistoryProvider_DefaultConfig_RoundTripsHistory(t *testing.T
 	}
 }
 
+func TestNewHistoryProvider_PanicsWithoutSourceID(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	agent.NewHistoryProvider(agent.HistoryProviderConfig{})
+}
+
 // Agent runs may share a conversation session; concurrent stores must preserve
 // every turn without racing on session state. Run with -race.
 func TestNewInMemoryHistoryProvider_ConcurrentStoresOnSameSession_NoDataRace(t *testing.T) {

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -42,6 +42,9 @@ func (mf MiddlewareFunc) Run(next RunFunc, ctx context.Context, messages []*mess
 func compileRunChain(fn RunFunc, middlewares []Middleware) RunFunc {
 	for i := len(middlewares) - 1; i >= 0; i-- {
 		mw := middlewares[i]
+		if mw == nil {
+			continue
+		}
 		fn = middlewareRunner{
 			Middleware: mw,
 			next:       fn,

--- a/agent/options.go
+++ b/agent/options.go
@@ -134,12 +134,12 @@ func WithSession(session *Session) Option {
 // WithContinuationToken sets the continuation token for resuming and getting the result
 // of the agent response identified by this token.
 //
-// This token is used for background responses that can be activated via [AllowBackgroundResponses]
-// if the agent supports them. Streamed background responses, such as those returned by default by [RunStream],
-// can be resumed if interrupted. This means that a continuation token obtained from the [RunResponseUpdate] continuation token
-// of an update just before the interruption occurred can be passed to this function to resume the stream from
-// the point of interruption. Non-streamed background responses, such as those returned by [Run], can be polled for
-// completion by obtaining the token from the [RunResponse] continuation token.
+// This token is used for background responses that can be activated via
+// [AllowBackgroundResponses] if the agent supports them. A streamed background
+// response started with [Stream] can be resumed by passing a token from
+// [ResponseUpdate.ContinuationToken] to a later [Agent.Run]. A non-streamed
+// background response can be polled by passing [Response.ContinuationToken] to
+// a later Agent.Run with no input messages.
 func WithContinuationToken(token string) Option {
 	return continuationTokenOpt(token)
 }

--- a/agent/skills/fsskills/source.go
+++ b/agent/skills/fsskills/source.go
@@ -143,12 +143,19 @@ func FSFromSkill(skill *skills.Skill) (fs.FS, error) {
 }
 
 // NewSource creates a file-based skill source with default options.
+// It panics if any filesystem is nil.
 func NewSource(filesystems ...fs.FS) *Source {
 	return NewSourceOptions(SourceOptions{}, filesystems...)
 }
 
 // NewSourceOptions creates a file-based skill source using the provided options.
+// It panics if any filesystem is nil.
 func NewSourceOptions(opts SourceOptions, filesystems ...fs.FS) *Source {
+	for index, filesystem := range filesystems {
+		if filesystem == nil {
+			panic(fmt.Sprintf("fsskills: filesystem at index %d is nil", index))
+		}
+	}
 	logger := opts.Logger
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)

--- a/agent/skills/fsskills/source_test.go
+++ b/agent/skills/fsskills/source_test.go
@@ -23,6 +23,16 @@ func TestFileSource_EmptyPaths_ReturnsEmptyList(t *testing.T) {
 	}
 }
 
+func TestFileSource_NilFilesystemPanics(t *testing.T) {
+	defer func() {
+		if got := recover(); got != "fsskills: filesystem at index 1 is nil" {
+			t.Fatalf("panic = %v, want indexed nil filesystem message", got)
+		}
+	}()
+
+	fsskills.NewSource(os.DirFS(t.TempDir()), nil)
+}
+
 func TestFileSource_NonExistentPath_ReturnsEmptyList(t *testing.T) {
 	root := t.TempDir()
 	source := fsskills.NewSource(os.DirFS(filepath.Join(root, "does-not-exist")))

--- a/agent/skills/skills.go
+++ b/agent/skills/skills.go
@@ -50,6 +50,9 @@ type Source interface {
 type SourceFunc func(context.Context) ([]*Skill, error)
 
 func (f SourceFunc) Skills(ctx context.Context) ([]*Skill, error) {
+	if f == nil {
+		return nil, fmt.Errorf("skills: source function is nil")
+	}
 	return f(ctx)
 }
 

--- a/agent/skills/skills_test.go
+++ b/agent/skills/skills_test.go
@@ -31,6 +31,14 @@ func createSkillDir(t *testing.T, root, name, description, body string) {
 	}
 }
 
+func TestSourceFunc_NilReturnsError(t *testing.T) {
+	var source skills.SourceFunc
+	_, err := source.Skills(t.Context())
+	if err == nil || err.Error() != "skills: source function is nil" {
+		t.Fatalf("Skills() error = %v, want nil-function error", err)
+	}
+}
+
 func createSkillDirRaw(t *testing.T, root, dirName, rawContent string) {
 	t.Helper()
 	skillDir := filepath.Join(root, dirName)

--- a/message/content.go
+++ b/message/content.go
@@ -165,6 +165,12 @@ type serializedDataContent struct {
 }
 
 func (t *DataContent) MarshalJSON() ([]byte, error) {
+	if !isValidMediaType(t.MediaType) {
+		return nil, fmt.Errorf("invalid media type: %s", t.MediaType)
+	}
+	if !isValidBase64Data(t.Data) {
+		return nil, fmt.Errorf("invalid base64 data")
+	}
 	tmp := serializedDataContent{
 		ContentHeader: t.ContentHeader,
 		Name:          t.Name,
@@ -384,6 +390,7 @@ func (t *FunctionCallContent) UnmarshalJSON(data []byte) error {
 	t.CallID = tmp.CallID
 	t.Name = tmp.Name
 	t.InformationalOnly = tmp.InformationalOnly
+	t.Error = nil
 	if tmp.Error != "" {
 		t.Error = errors.New(tmp.Error)
 	}
@@ -439,6 +446,7 @@ func (t *FunctionResultContent) UnmarshalJSON(data []byte) error {
 	t.ContentHeader = tmp.ContentHeader
 	t.CallID = tmp.CallID
 	t.Result = tmp.Result
+	t.Error = nil
 	if tmp.Error != "" {
 		t.Error = errors.New(tmp.Error)
 	}
@@ -577,7 +585,15 @@ func NewURIContent(uri string, mediaType string) (*URIContent, error) {
 		return nil, err
 	}
 	if mediaType == "" {
-		mediaType = inferMediaTypeFromURI(uri)
+		if strings.HasPrefix(strings.ToLower(uri), dataURIScheme) {
+			parsed, err := parseDataURI(uri)
+			if err != nil {
+				return nil, err
+			}
+			mediaType = parsed.MediaType
+		} else {
+			mediaType = inferMediaTypeFromURI(uri)
+		}
 	} else if !isValidMediaType(mediaType) {
 		return nil, fmt.Errorf("invalid media type: %s", mediaType)
 	}
@@ -1003,7 +1019,14 @@ func CoalesceContents(contents []Content) []Content {
 
 	contents = coalesce(contents, false,
 		func(a, b *DataContent) bool {
-			return strings.EqualFold(a.MediaType, b.MediaType) && a.TopLevelMediaType() == "text" && a.Name == b.Name
+			if !strings.EqualFold(a.MediaType, b.MediaType) || a.TopLevelMediaType() != "text" || a.Name != b.Name {
+				return false
+			}
+			if _, err := a.Bytes(); err != nil {
+				return false
+			}
+			_, err := b.Bytes()
+			return err == nil
 		},
 		func(contents []Content, start, end int) *DataContent {
 			first := contents[start].(*DataContent)

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -223,6 +223,43 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestFunctionContentUnmarshal_ClearsStaleError(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   string
+		target any
+	}{
+		{
+			name:   "function call omitted error",
+			data:   `{"Arguments":"{}","CallID":"call","Name":"tool","InformationalOnly":false,"Type":"functionCall"}`,
+			target: &message.FunctionCallContent{Error: errors.New("stale")},
+		},
+		{
+			name:   "function result empty error",
+			data:   `{"CallID":"call","Error":"","Result":"ok","Type":"functionResult"}`,
+			target: &message.FunctionResultContent{Error: errors.New("stale")},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := json.Unmarshal([]byte(test.data), test.target); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			switch target := test.target.(type) {
+			case *message.FunctionCallContent:
+				if target.Error != nil {
+					t.Fatalf("Error = %v, want nil", target.Error)
+				}
+			case *message.FunctionResultContent:
+				if target.Error != nil {
+					t.Fatalf("Error = %v, want nil", target.Error)
+				}
+			}
+		})
+	}
+}
+
 func TestContentEncoding_PreservesAdditionalProperties(t *testing.T) {
 	original := &message.TextContent{
 		ContentHeader: message.ContentHeader{
@@ -310,6 +347,24 @@ func TestDataContentUnmarshalDefaultsMissingMediaType(t *testing.T) {
 	}
 }
 
+func TestDataContentMarshalRejectsInvalidValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		content *message.DataContent
+	}{
+		{name: "invalid base64", content: &message.DataContent{MediaType: "text/plain", Data: "%%%"}},
+		{name: "invalid media type", content: &message.DataContent{MediaType: "not a media type", Data: "aGVsbG8="}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := json.Marshal(test.content); err == nil {
+				t.Fatal("Marshal() error = nil, want validation error")
+			}
+		})
+	}
+}
+
 func TestDataContentUnmarshalPreservesInvalidPercentEscapes(t *testing.T) {
 	var content message.DataContent
 	if err := json.Unmarshal([]byte(`{"Type":"data","URI":"data:,hello%20%ZZ+there"}`), &content); err != nil {
@@ -339,6 +394,14 @@ func TestNewURIContentInfersMediaType(t *testing.T) {
 	}
 	if content.MediaType != "application/octet-stream" {
 		t.Fatalf("MediaType = %q, want application/octet-stream", content.MediaType)
+	}
+
+	content, err = message.NewURIContent("data:image/png;base64,iVBORw0KGgo=", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.MediaType != "image/png" {
+		t.Fatalf("MediaType = %q, want image/png", content.MediaType)
 	}
 }
 
@@ -1025,5 +1088,15 @@ func TestCoalesceContents(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCoalesceContents_PreservesInvalidDataContent(t *testing.T) {
+	invalid := &message.DataContent{Data: "%%%", MediaType: "text/plain"}
+	valid := &message.DataContent{Data: base64.StdEncoding.EncodeToString([]byte("valid")), MediaType: "text/plain"}
+
+	got := message.CoalesceContents([]message.Content{invalid, valid})
+	if len(got) != 2 || got[0] != invalid || got[1] != valid {
+		t.Fatalf("CoalesceContents() = %#v, want original contents", got)
 	}
 }

--- a/message/datauri.go
+++ b/message/datauri.go
@@ -82,7 +82,7 @@ func DecodeDataURI(uri string) (data []byte, mediaType string, err error) {
 		// unescaped bytes directly instead of round-tripping through base64.
 		unescaped, err := url.PathUnescape(parsed.Data)
 		if err != nil {
-			unescaped = parsed.Data
+			return nil, "", fmt.Errorf("invalid data URI format: failed to decode percent-encoded data: %w", err)
 		}
 		return []byte(unescaped), parsed.MediaType, nil
 	}

--- a/message/datauri_test.go
+++ b/message/datauri_test.go
@@ -39,6 +39,11 @@ func TestDecodeDataURI(t *testing.T) {
 			uri:     "text/plain,hello",
 			wantErr: true,
 		},
+		{
+			name:    "malformed percent escape",
+			uri:     "data:text/plain,%ZZ",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/message/messageworkflow/messageworkflow.go
+++ b/message/messageworkflow/messageworkflow.go
@@ -14,8 +14,8 @@ import (
 )
 
 // Options configures the chat-message workflow behavior applied by Configure.
-// StateKey and TakeTurnHandler are required; Configure panics if StateKey is
-// empty or TakeTurnHandler is nil. The remaining fields are optional.
+// StateKey and TakeTurnHandler are required; Configure panics if options is nil,
+// StateKey is empty, or TakeTurnHandler is nil. The remaining fields are optional.
 type Options struct {
 	// StateKey identifies the accumulated turn state within the workflow.
 	StateKey string
@@ -23,7 +23,7 @@ type Options struct {
 	TakeTurnHandler func(ctx *workflow.Context, token workflow.TurnToken, messages []*message.Message) error
 
 	// StringMessageRole, when set, registers a handler that wraps incoming string messages with this role.
-	StringMessageRole string
+	StringMessageRole message.Role
 	// ScopeName scopes the accumulated turn state; used when constructing a default MessageState.
 	ScopeName string
 	// DisableAutoSendTurnToken suppresses automatically declaring and forwarding the turn token.
@@ -70,12 +70,17 @@ func Configure(executor *workflow.Executor, options *Options) {
 	if executor == nil {
 		panic("messageworkflow: executor is required")
 	}
+	if options == nil {
+		panic("messageworkflow: options are required")
+	}
 	if options.StateKey == "" {
 		panic("stateKey is required")
 	}
 	if options.TakeTurnHandler == nil {
 		panic("TakeTurnHandler is required")
 	}
+	configured := *options
+	options = &configured
 	state := options.MessageState
 	if state == nil {
 		state = NewMessageState(options.StateKey, options.ScopeName)
@@ -90,7 +95,7 @@ func Configure(executor *workflow.Executor, options *Options) {
 				rb.SendsMessageType(reflect.TypeFor[workflow.TurnToken]())
 			}
 			if options.StringMessageRole != "" {
-				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, accumulateStringMessage(state, message.Role(options.StringMessageRole)))
+				rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[string](), nil, accumulateStringMessage(state, options.StringMessageRole))
 			}
 			rb.RouteBuilder.
 				AddHandlerRaw(reflect.TypeFor[*message.Message](), nil, accumulateMessage(state)).

--- a/message/messageworkflow/messageworkflow_test.go
+++ b/message/messageworkflow/messageworkflow_test.go
@@ -207,7 +207,7 @@ func TestExecutor_WithStringRole_ConvertsStringToMessage(t *testing.T) {
 	executor, ctx := createExecutor(&messageworkflow.Options{
 		StateKey:          "test-state",
 		TakeTurnHandler:   te.takeTurn,
-		StringMessageRole: string(message.RoleUser),
+		StringMessageRole: message.RoleUser,
 	})
 
 	if _, err := executor.Execute(ctx, "String message"); err != nil {
@@ -225,6 +225,43 @@ func TestExecutor_WithStringRole_ConvertsStringToMessage(t *testing.T) {
 	}
 	if te.receivedMessages[0].Contents[0].(*message.TextContent).Text != "String message" {
 		t.Errorf("Expected message 'String message'")
+	}
+}
+
+func TestConfigure_RejectsNilOptions(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected Configure to panic for nil options")
+		}
+	}()
+	messageworkflow.Configure(&workflow.Executor{ID: "test-executor"}, nil)
+}
+
+func TestConfigure_SnapshotsOptions(t *testing.T) {
+	var configuredCalls int
+	options := &messageworkflow.Options{
+		StateKey:          "test-state",
+		StringMessageRole: message.RoleUser,
+		TakeTurnHandler: func(_ *workflow.Context, _ workflow.TurnToken, _ []*message.Message) error {
+			configuredCalls++
+			return nil
+		},
+	}
+	executor, ctx := createExecutor(options)
+	options.StringMessageRole = ""
+	options.TakeTurnHandler = func(_ *workflow.Context, _ workflow.TurnToken, _ []*message.Message) error {
+		t.Fatal("Configure retained caller-owned options")
+		return nil
+	}
+
+	if _, err := executor.Execute(ctx, "String message"); err != nil {
+		t.Fatalf("Execute string: %v", err)
+	}
+	if _, err := executor.Execute(ctx, workflow.TurnToken{}); err != nil {
+		t.Fatalf("Execute turn token: %v", err)
+	}
+	if configuredCalls != 1 {
+		t.Fatalf("configured handler calls = %d, want 1", configuredCalls)
 	}
 }
 

--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -40,8 +40,12 @@ type provider struct {
 }
 
 // NewAgent creates a new [agent.Agent] backed by a remote agent that speaks the
-// AG-UI protocol over Server-Sent Events via the AG-UI client.
+// AG-UI protocol over Server-Sent Events via the AG-UI client. It panics if
+// aclient is nil.
 func NewAgent(aclient *aguiSSEClient.Client, config AgentConfig) *agent.Agent {
+	if aclient == nil {
+		panic("aguiprovider: client cannot be nil")
+	}
 	p := &provider{
 		cfg:    config,
 		client: aclient,
@@ -347,7 +351,7 @@ func toAGUIMessage(msg *message.Message) (aguiTypes.Message, bool, error) {
 		out.Content = msg.String()
 		return out, true, nil
 	default:
-		return aguiTypes.Message{}, false, nil
+		return aguiTypes.Message{}, false, fmt.Errorf("aguiprovider: unsupported message role %q", msg.Role)
 	}
 }
 

--- a/provider/aguiprovider/agui_test.go
+++ b/provider/aguiprovider/agui_test.go
@@ -21,6 +21,23 @@ import (
 	"github.com/microsoft/agent-framework-go/tool/functool"
 )
 
+func TestNewAgent_PanicsWithNilClient(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	aguiprovider.NewAgent(nil, aguiprovider.AgentConfig{})
+}
+
+func TestAgent_UnsupportedMessageRoleReturnsError(t *testing.T) {
+	a := aguiprovider.NewAgent(newTestClient("http://127.0.0.1"), aguiprovider.AgentConfig{})
+	_, err := a.Run(t.Context(), []*message.Message{{Role: message.Role("custom")}}).Collect()
+	if err == nil || !strings.Contains(err.Error(), "unsupported message role") {
+		t.Fatalf("Run() error = %v, want unsupported message role", err)
+	}
+}
+
 func TestAGUIAgentRun_AggregatesStreamingText(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -476,7 +476,7 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 				}
 			}
 		default:
-			// Ignore
+			return anthropic.MessageNewParams{}, fmt.Errorf("anthropicprovider: unsupported message role %q", msg.Role)
 		}
 	}
 

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -27,6 +27,20 @@ type testOutput struct {
 	Age  int    `json:"age"`
 }
 
+func TestAgent_UnsupportedMessageRoleReturnsError(t *testing.T) {
+	a := anthropicprovider.NewAgent(
+		anthropic.NewClient(option.WithAPIKey("test")),
+		anthropicprovider.AgentConfig{
+			Model:  "test-model",
+			Config: agent.Config{DisableFuncAutoCall: true},
+		},
+	)
+	_, err := a.Run(t.Context(), []*message.Message{{Role: message.Role("custom")}}).Collect()
+	if err == nil || !strings.Contains(err.Error(), "unsupported message role") {
+		t.Fatalf("Run() error = %v, want unsupported message role", err)
+	}
+}
+
 func newTestClient(t *testing.T, server *httptest.Server) *agent.Agent {
 	t.Helper()
 	return anthropicprovider.NewAgent(

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -48,8 +48,12 @@ type AgentConfig struct {
 	Model string
 }
 
-// NewAgent creates a new [agent.Agent] backed by the Google Gemini API via the genai client.
+// NewAgent creates a new [agent.Agent] backed by the Google Gemini API via the
+// genai client. It panics if gclient is nil.
 func NewAgent(gclient *genai.Client, config AgentConfig) *agent.Agent {
+	if gclient == nil {
+		panic("geminiprovider: client cannot be nil")
+	}
 	c := &client{
 		client: gclient,
 		config: config,
@@ -362,6 +366,8 @@ func (a *client) buildParams(messages []*message.Message, opts []agent.Option) (
 					Parts: parts,
 				})
 			}
+		default:
+			return nil, nil, fmt.Errorf("geminiprovider: unsupported message role %q", msg.Role)
 		}
 	}
 

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -29,6 +29,33 @@ type testOutput struct {
 	Age  int    `json:"age"`
 }
 
+func TestNewAgent_PanicsWithNilClient(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	geminiprovider.NewAgent(nil, geminiprovider.AgentConfig{})
+}
+
+func TestAgent_UnsupportedMessageRoleReturnsError(t *testing.T) {
+	client, err := genai.NewClient(t.Context(), &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		APIKey:  "test",
+	})
+	if err != nil {
+		t.Fatalf("genai.NewClient: %v", err)
+	}
+	a := geminiprovider.NewAgent(client, geminiprovider.AgentConfig{
+		Model:  testModel,
+		Config: agent.Config{DisableFuncAutoCall: true},
+	})
+	_, err = a.Run(t.Context(), []*message.Message{{Role: message.Role("custom")}}).Collect()
+	if err == nil || !strings.Contains(err.Error(), "unsupported message role") {
+		t.Fatalf("Run() error = %v, want unsupported message role", err)
+	}
+}
+
 func newTestClient(t *testing.T, server *httptest.Server) *agent.Agent {
 	t.Helper()
 	client, err := genai.NewClient(t.Context(), &genai.ClientConfig{

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -533,7 +533,7 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 		return messages, nil
 
 	default:
-		panic("unknown message role: " + string(msg.Role))
+		return nil, fmt.Errorf("openaiprovider: unsupported message role %q", msg.Role)
 	}
 }
 

--- a/provider/openaiprovider/chat_test.go
+++ b/provider/openaiprovider/chat_test.go
@@ -47,6 +47,17 @@ func bodyEqual(t *testing.T, got string, want string) {
 	}
 }
 
+func TestChatCompletionsAgent_UnsupportedMessageRoleReturnsError(t *testing.T) {
+	a := openaiprovider.NewChatCompletionsAgent(openai.NewClient(option.WithAPIKey("test")), openaiprovider.AgentConfig{
+		Model:  "test-model",
+		Config: agent.Config{DisableFuncAutoCall: true},
+	})
+	_, err := a.Run(t.Context(), []*message.Message{{Role: message.Role("custom")}}).Collect()
+	if err == nil || !strings.Contains(err.Error(), "unsupported message role") {
+		t.Fatalf("Run() error = %v, want unsupported message role", err)
+	}
+}
+
 func newTestServer(t *testing.T, input string, output string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -782,7 +782,7 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 		}
 
 	default:
-		panic("unknown message role: " + string(msg.Role))
+		return nil, fmt.Errorf("openaiprovider: unsupported message role %q", msg.Role)
 	}
 
 	if len(contents) > 0 {

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -35,6 +35,17 @@ type continuationToken struct {
 	SequenceNumber int64  `json:"sequence_number"`
 }
 
+func TestResponsesAgent_UnsupportedMessageRoleReturnsError(t *testing.T) {
+	a := openaiprovider.NewResponsesAgent(openai.NewClient(option.WithAPIKey("test")), openaiprovider.AgentConfig{
+		Model:  "test-model",
+		Config: agent.Config{DisableFuncAutoCall: true},
+	})
+	_, err := a.Run(t.Context(), []*message.Message{{Role: message.Role("custom")}}).Collect()
+	if err == nil || !strings.Contains(err.Error(), "unsupported message role") {
+		t.Fatalf("Run() error = %v, want unsupported message role", err)
+	}
+}
+
 // Helper functions for responses tests
 func newTestResponsesServer(t *testing.T, input string, output string) *httptest.Server {
 	t.Helper()

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/tool"
@@ -25,10 +26,14 @@ type Config struct {
 	RunOptions []agent.Option
 }
 
-// New creates a new FuncTool that invokes the given agent with the provided configuration.
+// New creates a new FuncTool that invokes the given agent with the provided
+// configuration. It panics if a is nil.
 func New(a *agent.Agent, config Config) tool.FuncTool {
+	if a == nil {
+		panic("agenttool: agent is required")
+	}
 	return functool{
-		opts:  config.RunOptions,
+		opts:  slices.Clone(config.RunOptions),
 		agent: a,
 	}
 }
@@ -39,7 +44,11 @@ type functool struct {
 }
 
 func (t functool) Name() string {
-	return invalidNameChars.ReplaceAllString(t.agent.Name(), "_")
+	name := t.agent.Name()
+	if name == "" {
+		name = t.agent.ID()
+	}
+	return invalidNameChars.ReplaceAllString(name, "_")
 }
 
 func (t functool) Description() string {

--- a/tool/agenttool/agenttool_test.go
+++ b/tool/agenttool/agenttool_test.go
@@ -73,10 +73,52 @@ func TestNew_ExposesAgentMetadataAndSchemas(t *testing.T) {
 	}
 }
 
+func TestNew_PanicsWithNilAgent(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	agenttool.New(nil, agenttool.Config{})
+}
+
+func TestNew_ClonesRunOptions(t *testing.T) {
+	var capturedOptions []agent.Option
+	a := agenttest.New(agenttest.NewResponseBuilder(
+		func(_ context.Context, _ []*message.Message, opts ...agent.Option) {
+			capturedOptions = opts
+		},
+	).AddText("ok").Build())
+	runOptions := []agent.Option{agent.Stream(false)}
+	tl := agenttool.New(a, agenttool.Config{RunOptions: runOptions})
+	runOptions[0] = agent.Stream(true)
+
+	if _, err := tl.Call(t.Context(), `{"query":"hello"}`); err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	stream, ok := agent.GetOption(capturedOptions, agent.Stream)
+	if !ok || stream {
+		t.Fatalf("stream option = %v, %v; want false, true", stream, ok)
+	}
+}
+
 func TestName_SanitizesInvalidCharacters(t *testing.T) {
 	tl := agenttool.New(newNamedAgent("Weather Agent!", "forecasts"), agenttool.Config{})
 
 	if got, want := tl.Name(), "Weather_Agent_"; got != want {
+		t.Fatalf("Name() = %q, want %q", got, want)
+	}
+}
+
+func TestName_FallsBackToAgentID(t *testing.T) {
+	a := agent.New(agent.ProviderConfig{
+		Run: func(context.Context, []*message.Message, ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(func(*agent.ResponseUpdate, error) bool) {}
+		},
+	}, agent.Config{ID: "unnamed-agent"})
+	tl := agenttool.New(a, agenttool.Config{})
+
+	if got, want := tl.Name(), "unnamed_agent"; got != want {
 		t.Fatalf("Name() = %q, want %q", got, want)
 	}
 }

--- a/tool/functool/func.go
+++ b/tool/functool/func.go
@@ -4,6 +4,7 @@ package functool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -51,6 +52,9 @@ func MustNew[In, Out any](cfg Config, h HandlerFor[In, Out]) tool.FuncTool {
 // inputs and validating arguments before invoking h. It returns an error if
 // either schema cannot be constructed.
 func New[In, Out any](cfg Config, h HandlerFor[In, Out]) (tool.FuncTool, error) {
+	if h == nil {
+		return nil, errors.New("functool: handler is required")
+	}
 	t := funcTool{
 		cfg: cfg,
 	}

--- a/tool/functool/func_test.go
+++ b/tool/functool/func_test.go
@@ -68,6 +68,17 @@ func TestFuncTool_MustNew(t *testing.T) {
 	}
 }
 
+func TestFuncTool_NewRejectsNilHandler(t *testing.T) {
+	var handler functool.HandlerFor[struct{}, string]
+	tool, err := functool.New(functool.Config{Name: "nil-handler"}, handler)
+	if err == nil || err.Error() != "functool: handler is required" {
+		t.Fatalf("New() error = %v, want handler required error", err)
+	}
+	if tool != nil {
+		t.Fatalf("New() tool = %T, want nil", tool)
+	}
+}
+
 func TestFuncTool_CallMissingArg0(t *testing.T) {
 	cfg := functool.Config{
 		Name: "test",

--- a/tool/shelltool/environment.go
+++ b/tool/shelltool/environment.go
@@ -118,6 +118,11 @@ func NewEnvironmentProvider(executor Executor, config EnvironmentProviderConfig)
 	if executor == nil {
 		panic("shelltool: executor is required")
 	}
+	switch config.OverrideFamily {
+	case ShellFamilyUnknown, ShellFamilyPOSIX, ShellFamilyPowerShell:
+	default:
+		panic(fmt.Sprintf("shelltool: invalid shell family %d", config.OverrideFamily))
+	}
 	p := &EnvironmentProvider{executor: executor, config: config}
 	sourceID := strings.TrimSpace(config.SourceID)
 	if sourceID == "" {

--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -103,6 +103,12 @@ func (o LocalConfig) maxOutputBytes() int {
 }
 
 func (o LocalConfig) validate() error {
+	if o.Mode != ModePersistent && o.Mode != ModeStateless {
+		return fmt.Errorf("shelltool: invalid Mode %d", o.Mode)
+	}
+	if o.Timeout < 0 {
+		return fmt.Errorf("shelltool: Timeout must be non-negative")
+	}
 	if o.MaxOutputBytes < 0 {
 		return fmt.Errorf("shelltool: MaxOutputBytes must be non-negative")
 	}

--- a/tool/shelltool/shelltool_test.go
+++ b/tool/shelltool/shelltool_test.go
@@ -796,6 +796,39 @@ func TestNewLocal_negativeMaxOutputErrors(t *testing.T) {
 	}
 }
 
+func TestNewLocal_invalidModeErrors(t *testing.T) {
+	_, err := shelltool.NewLocal(shelltool.LocalConfig{
+		AcknowledgeUnsafe: true,
+		Mode:              shelltool.Mode(99),
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid Mode 99") {
+		t.Fatalf("NewLocal() error = %v, want invalid mode error", err)
+	}
+}
+
+func TestNewLocal_negativeTimeoutErrors(t *testing.T) {
+	_, err := shelltool.NewLocal(shelltool.LocalConfig{
+		AcknowledgeUnsafe: true,
+		Timeout:           -time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "Timeout must be non-negative") {
+		t.Fatalf("NewLocal() error = %v, want negative timeout error", err)
+	}
+}
+
+func TestNewEnvironmentProvider_invalidFamilyPanics(t *testing.T) {
+	fake := &environmentTestExecutor{}
+	defer func() {
+		if got := recover(); got != "shelltool: invalid shell family 99" {
+			t.Fatalf("panic = %v, want invalid shell family message", got)
+		}
+	}()
+
+	shelltool.NewEnvironmentProvider(fake, shelltool.EnvironmentProviderConfig{
+		OverrideFamily: shelltool.ShellFamily(99),
+	})
+}
+
 func TestNewLocal_descriptionContainsShellGuidance(t *testing.T) {
 	ft := newLocal(t, shelltool.LocalConfig{AcknowledgeUnsafe: true})
 	desc := ft.Description()

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -41,13 +41,20 @@ func (m ToolMode) Mode() ToolMode {
 // It returns nil unless m was created by RequireTools.
 func (m ToolMode) Required() []string {
 	if strings.HasPrefix(string(m), requiredPrefix) && m != ToolModeRequired {
-		return strings.Split(strings.TrimPrefix(string(m), requiredPrefix), ",")
+		names := strings.TrimPrefix(string(m), requiredPrefix)
+		if names == "" {
+			return nil
+		}
+		return strings.Split(names, ",")
 	}
 	return nil
 }
 
 // RequireTools returns a ToolMode that requires the named tools to be used.
 func RequireTools(name ...string) ToolMode {
+	if len(name) == 0 {
+		return ToolModeRequired
+	}
 	return ToolMode(requiredPrefix + strings.Join(name, ","))
 }
 
@@ -99,6 +106,9 @@ func (approvalRequiredFunc) ApprovalRequired() bool { return true }
 // If the tool already requires approval, it is returned as-is.
 // Not all tools support approval, in which case the original tool is returned.
 func ApprovalRequiredFunc(t FuncTool) FuncTool {
+	if t == nil {
+		return nil
+	}
 	if approval, ok := t.(ApprovalRequiredTool); ok && approval.ApprovalRequired() {
 		return t
 	}

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package tool_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/tool"
+)
+
+func TestRequireTools_WithoutNamesUsesGenericRequiredMode(t *testing.T) {
+	mode := tool.RequireTools()
+	if mode != tool.ToolModeRequired {
+		t.Fatalf("RequireTools() = %q, want %q", mode, tool.ToolModeRequired)
+	}
+	if names := mode.Required(); names != nil {
+		t.Fatalf("Required() = %v, want nil", names)
+	}
+}
+
+func TestToolModeRequired_EmptyEncodedNamesReturnsNil(t *testing.T) {
+	if names := tool.ToolMode("required:").Required(); names != nil {
+		t.Fatalf("Required() = %v, want nil", names)
+	}
+}
+
+func TestApprovalRequiredFunc_NilRemainsNil(t *testing.T) {
+	var input tool.FuncTool
+	if got := tool.ApprovalRequiredFunc(input); got != nil {
+		t.Fatalf("ApprovalRequiredFunc(nil) = %T, want nil", got)
+	}
+}

--- a/workflow/agentworkflow/groupchat.go
+++ b/workflow/agentworkflow/groupchat.go
@@ -304,7 +304,7 @@ func (host *groupChatHostExecutor) executor() *workflow.Executor {
 	messageworkflow.Configure(&executor, &messageworkflow.Options{
 		StateKey:                 groupChatHostBufferedStateKey,
 		TakeTurnHandler:          host.handleTurn,
-		StringMessageRole:        string(message.RoleUser),
+		StringMessageRole:        message.RoleUser,
 		DisableAutoSendTurnToken: true,
 		MessageState:             host.messageState,
 	})

--- a/workflow/agentworkflow/hosting.go
+++ b/workflow/agentworkflow/hosting.go
@@ -111,8 +111,11 @@ type Config struct {
 
 // New creates a workflow [workflow.ExecutorBinding] that hosts the given
 // [agent.Agent] using the supplied [Config]. The zero value of [Config] is a
-// sensible default.
+// sensible default. New panics if a is nil.
 func New(a *agent.Agent, cfg Config) workflow.ExecutorBinding {
+	if a == nil {
+		panic("agentworkflow: agent is required")
+	}
 	id := descriptiveID(a)
 	ports := hostPorts(id)
 	return workflow.ExecutorBinding{
@@ -206,7 +209,7 @@ func (h *hostExecutor) executor() *workflow.Executor {
 	messageworkflow.Configure(&executor, &messageworkflow.Options{
 		StateKey:                 agentBufferedStateKey,
 		TakeTurnHandler:          h.handleTurnToken,
-		StringMessageRole:        string(message.RoleUser),
+		StringMessageRole:        message.RoleUser,
 		DisableAutoSendTurnToken: true,
 		MessageState:             h.messageState,
 	})

--- a/workflow/agentworkflow/hosting_test.go
+++ b/workflow/agentworkflow/hosting_test.go
@@ -71,6 +71,16 @@ func splitWordsKeepSpaces(s string) []string {
 	return words
 }
 
+func TestNewPanicsForNilAgent(t *testing.T) {
+	defer func() {
+		if got := recover(); got != "agentworkflow: agent is required" {
+			t.Fatalf("panic = %v, want agent required message", got)
+		}
+	}()
+
+	agentworkflow.New(nil, agentworkflow.Config{})
+}
+
 // newReplayAgent emits one *ResponseUpdate per word of each non-empty source
 // message, sharing a stable MessageID across all updates from the same source
 // message.

--- a/workflow/agentworkflow/workflow.go
+++ b/workflow/agentworkflow/workflow.go
@@ -42,7 +42,9 @@ type AgentConfig struct {
 	agent.Config
 
 	// Environment is the execution environment used to run the workflow on
-	// each agent turn. Defaults to [inproc.Default] when nil.
+	// each agent turn. When nil, [inproc.Concurrent] is used if every workflow
+	// executor supports concurrent shared execution; otherwise [inproc.OffThread]
+	// is used.
 	Environment *inproc.ExecutionEnvironment
 
 	// IncludeOutputsInResponse, if true, surfaces [workflow.OutputEvent]

--- a/workflow/binding.go
+++ b/workflow/binding.go
@@ -216,8 +216,12 @@ func BindNewExecutorFunc(id string, fn func(sessionID string, executorID string)
 //
 // Calling Bind multiple times on the same port is fine: each returned binding
 // has the same ID and port metadata, and creates request-port executor
-// instances from that port.
+// instances from that port. Bind panics if the port ID is empty or either
+// message type is nil.
 func (p RequestPort) Bind() ExecutorBinding {
+	if err := validateRequestPort(p); err != nil {
+		panic(err.Error())
+	}
 	return ExecutorBinding{
 		ID:               p.ID,
 		ImplementationID: "workflow.RequestPort.Bind",

--- a/workflow/binding_test.go
+++ b/workflow/binding_test.go
@@ -2,7 +2,46 @@
 
 package workflow
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRequestPortBind_PanicsForInvalidPort(t *testing.T) {
+	stringType := reflect.TypeFor[string]()
+	tests := []struct {
+		name string
+		port RequestPort
+		want string
+	}{
+		{
+			name: "empty ID",
+			port: RequestPort{Request: stringType, Response: stringType},
+			want: "workflow: request port ID is required",
+		},
+		{
+			name: "nil request type",
+			port: RequestPort{ID: "port", Response: stringType},
+			want: `workflow: request port "port" request type is required`,
+		},
+		{
+			name: "nil response type",
+			port: RequestPort{ID: "port", Request: stringType},
+			want: `workflow: request port "port" response type is required`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if got := recover(); got != test.want {
+					t.Fatalf("panic = %v, want %q", got, test.want)
+				}
+			}()
+			test.port.Bind()
+		})
+	}
+}
 
 func TestIsAnonymousFuncName(t *testing.T) {
 	tests := []struct {

--- a/workflow/builder.go
+++ b/workflow/builder.go
@@ -180,6 +180,10 @@ func (wb *Builder) AddFanOutEdge(source ExecutorBinding, targets []ExecutorBindi
 	if wb.err != nil {
 		return wb
 	}
+	if len(targets) == 0 {
+		wb.err = fmt.Errorf("fan-out edge requires at least one target")
+		return wb
+	}
 	if !wb.track(source) {
 		return wb
 	}
@@ -204,6 +208,10 @@ func (wb *Builder) AddFanOutEdge(source ExecutorBinding, targets []ExecutorBindi
 // all sources before dispatching to the target.
 func (wb *Builder) AddFanInBarrierEdge(sources []ExecutorBinding, target ExecutorBinding, opts ...EdgeOption) *Builder {
 	if wb.err != nil {
+		return wb
+	}
+	if len(sources) == 0 {
+		wb.err = fmt.Errorf("fan-in barrier edge requires at least one source")
 		return wb
 	}
 	if !wb.track(target) {
@@ -471,11 +479,20 @@ func sendTypeCompatibleWithInput(outType, inType reflect.Type) bool {
 	return outType == inType || outType.AssignableTo(inType) || (inType.Kind() == reflect.Interface && outType.Implements(inType))
 }
 
-func (wb *Builder) trackInputPort(port RequestPort) {
+func (wb *Builder) trackInputPort(port RequestPort) bool {
+	if err := validateRequestPort(port); err != nil {
+		wb.err = err
+		return false
+	}
 	if wb.inputPorts == nil {
 		wb.inputPorts = make(map[string]RequestPort)
 	}
+	if existing, ok := wb.inputPorts[port.ID]; ok && existing != port {
+		wb.err = fmt.Errorf("workflow: request port %q conflicts with an existing definition", port.ID)
+		return false
+	}
 	wb.inputPorts[port.ID] = port
+	return true
 }
 
 func (wb *Builder) track(binding ExecutorBinding) bool {
@@ -523,12 +540,17 @@ func (wb *Builder) track(binding ExecutorBinding) bool {
 		}
 	}
 	for _, port := range binding.Ports {
-		wb.trackInputPort(port)
+		if !wb.trackInputPort(port) {
+			return false
+		}
 	}
 	return true
 }
 
 func validateBinding(binding ExecutorBinding) error {
+	if binding.ID == "" {
+		return fmt.Errorf("cannot bind executor with empty ID")
+	}
 	if binding.RawValue == nil {
 		return nil
 	}
@@ -605,6 +627,9 @@ func (wb *Builder) AddSwitch(source ExecutorBinding) *SwitchBuilder {
 // AddCase adds a case branch matching messages of type T satisfying the
 // predicate. The matched message is routed to all bindings in targets.
 func (s *SwitchBuilder) AddCase(predicate func(msg any) bool, targets ...ExecutorBinding) *SwitchBuilder {
+	if predicate == nil {
+		panic("workflow: switch case predicate cannot be nil")
+	}
 	indices := s.collectTargets(targets)
 	s.cases = append(s.cases, switchCase{predicate: predicate, indices: indices})
 	return s

--- a/workflow/builder_test.go
+++ b/workflow/builder_test.go
@@ -98,6 +98,84 @@ func TestBuilder_InfersEmptyImplementationID(t *testing.T) {
 	}
 }
 
+func TestBuilder_RejectsEmptyExecutorID(t *testing.T) {
+	binding := (&workflow.Executor{ImplementationID: "empty-id"}).Bind()
+
+	_, err := workflow.NewBuilder(binding).Build()
+	if err == nil || !strings.Contains(err.Error(), "cannot bind executor with empty ID") {
+		t.Fatalf("Build() error = %v, want empty executor ID error", err)
+	}
+}
+
+func TestBuilder_ValidatesBindingPorts(t *testing.T) {
+	stringType := reflect.TypeFor[string]()
+	intType := reflect.TypeFor[int]()
+	tests := []struct {
+		name string
+		port workflow.RequestPort
+		want string
+	}{
+		{
+			name: "empty ID",
+			port: workflow.RequestPort{Request: stringType, Response: intType},
+			want: "workflow: request port ID is required",
+		},
+		{
+			name: "nil request type",
+			port: workflow.RequestPort{ID: "port", Response: intType},
+			want: `workflow: request port "port" request type is required`,
+		},
+		{
+			name: "nil response type",
+			port: workflow.RequestPort{ID: "port", Request: stringType},
+			want: `workflow: request port "port" response type is required`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			binding := newNoOpExecutor("start")
+			binding.Ports = []workflow.RequestPort{test.port}
+			wf, err := workflow.NewBuilder(binding).Build()
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("Build() error = %v, want %q", err, test.want)
+			}
+			if wf != nil {
+				t.Fatalf("Build() workflow = %#v, want nil", wf)
+			}
+		})
+	}
+}
+
+func TestBuilder_RejectsConflictingBindingPorts(t *testing.T) {
+	stringType := reflect.TypeFor[string]()
+	port := workflow.RequestPort{ID: "shared-port", Request: stringType, Response: reflect.TypeFor[int]()}
+	source := newNoOpExecutor("source")
+	source.Ports = []workflow.RequestPort{port}
+	target := newNoOpExecutor("target")
+	target.Ports = []workflow.RequestPort{{ID: port.ID, Request: stringType, Response: reflect.TypeFor[bool]()}}
+
+	wf, err := workflow.NewBuilder(source).AddEdge(source, target).Build()
+	if err == nil || err.Error() != `workflow: request port "shared-port" conflicts with an existing definition` {
+		t.Fatalf("Build() error = %v, want conflicting port error", err)
+	}
+	if wf != nil {
+		t.Fatalf("Build() workflow = %#v, want nil", wf)
+	}
+}
+
+func TestBuilder_AllowsIdenticalBindingPorts(t *testing.T) {
+	port := workflow.RequestPort{ID: "shared-port", Request: reflect.TypeFor[string](), Response: reflect.TypeFor[int]()}
+	source := newNoOpExecutor("source")
+	source.Ports = []workflow.RequestPort{port}
+	target := newNoOpExecutor("target")
+	target.Ports = []workflow.RequestPort{port}
+
+	if _, err := workflow.NewBuilder(source).AddEdge(source, target).Build(); err != nil {
+		t.Fatalf("Build() error = %v, want nil", err)
+	}
+}
+
 func TestBuilder_Validation_FailsWhenUnboundExecutors(t *testing.T) {
 	_, err := workflow.NewBuilder(newPlaceholder("start")).
 		AddEdge(newNoOpExecutor("start"), newPlaceholder("unbound")).
@@ -368,6 +446,43 @@ func TestAddChain_RejectsRepetitionByDefault(t *testing.T) {
 	}
 }
 
+func TestBuilder_RejectsEmptyFanEdgeEndpoints(t *testing.T) {
+	source := newNoOpExecutor("source")
+	target := newNoOpExecutor("target")
+	tests := []struct {
+		name  string
+		build func() (*workflow.Workflow, error)
+		want  string
+	}{
+		{
+			name: "fan out without targets",
+			build: func() (*workflow.Workflow, error) {
+				return workflow.NewBuilder(source).AddFanOutEdge(source, nil).Build()
+			},
+			want: "fan-out edge requires at least one target",
+		},
+		{
+			name: "fan in without sources",
+			build: func() (*workflow.Workflow, error) {
+				return workflow.NewBuilder(target).AddFanInBarrierEdge(nil, target).Build()
+			},
+			want: "fan-in barrier edge requires at least one source",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wf, err := test.build()
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("Build() error = %v, want %q", err, test.want)
+			}
+			if wf != nil {
+				t.Fatalf("Build() workflow = %#v, want nil", wf)
+			}
+		})
+	}
+}
+
 func TestAddSwitch_RoutesToMatchingCase(t *testing.T) {
 	var trace []string
 	src := recordingBinding("src", &trace)
@@ -410,6 +525,18 @@ func TestAddSwitch_RoutesToMatchingCase(t *testing.T) {
 			t.Errorf("expected odd branch not to receive even-length string; trace=%v", trace)
 		}
 	}
+}
+
+func TestAddSwitch_RejectsNilPredicate(t *testing.T) {
+	src := recordingBinding("src", new([]string))
+	target := recordingBinding("target", new([]string))
+	defer func() {
+		if got := recover(); got != "workflow: switch case predicate cannot be nil" {
+			t.Fatalf("panic = %v, want nil-predicate message", got)
+		}
+	}()
+
+	workflow.NewBuilder(src).AddSwitch(src).AddCase(nil, target)
 }
 
 func TestAddSwitch_FallsBackToDefault(t *testing.T) {

--- a/workflow/checkpoint/manager.go
+++ b/workflow/checkpoint/manager.go
@@ -152,7 +152,7 @@ func (s *jsonManager) Lookup(ctx context.Context, sessionID string, checkpointIn
 		return nil, fmt.Errorf("checkpoint: sessionID cannot be empty")
 	}
 	if err := validateManagerCheckpointInfo(sessionID, checkpointInfo); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("checkpoint: invalid checkpoint info: %w", err)
 	}
 	v, err := s.store.RetrieveCheckpoint(ctx, sessionID, checkpointInfo)
 	if err != nil {

--- a/workflow/checkpoint/manager.go
+++ b/workflow/checkpoint/manager.go
@@ -123,18 +123,37 @@ type jsonManager struct {
 func (s *jsonManager) internal() {}
 
 func (s *jsonManager) Commit(ctx context.Context, sessionID string, checkpoint *checkpoint.Checkpoint) (workflow.CheckpointInfo, error) {
+	if sessionID == "" {
+		return workflow.CheckpointInfo{}, fmt.Errorf("checkpoint: sessionID cannot be empty")
+	}
 	if checkpoint == nil {
 		return workflow.CheckpointInfo{}, fmt.Errorf("checkpoint: checkpoint cannot be nil")
+	}
+	if checkpoint.Parent != nil && checkpoint.Parent.SessionID != sessionID {
+		return workflow.CheckpointInfo{}, fmt.Errorf("checkpoint: parent sessionID %q does not match sessionID %q", checkpoint.Parent.SessionID, sessionID)
 	}
 	v, err := json.Marshal(checkpoint)
 	if err != nil {
 		return workflow.CheckpointInfo{}, fmt.Errorf("failed to serialize checkpoint: %w", err)
 	}
 
-	return s.store.CreateCheckpoint(ctx, sessionID, v, checkpoint.Parent)
+	info, err := s.store.CreateCheckpoint(ctx, sessionID, v, checkpoint.Parent)
+	if err != nil {
+		return workflow.CheckpointInfo{}, err
+	}
+	if err := validateManagerCheckpointInfo(sessionID, info); err != nil {
+		return workflow.CheckpointInfo{}, fmt.Errorf("checkpoint: store returned invalid checkpoint info: %w", err)
+	}
+	return info, nil
 }
 
 func (s *jsonManager) Lookup(ctx context.Context, sessionID string, checkpointInfo workflow.CheckpointInfo) (*checkpoint.Checkpoint, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("checkpoint: sessionID cannot be empty")
+	}
+	if err := validateManagerCheckpointInfo(sessionID, checkpointInfo); err != nil {
+		return nil, err
+	}
 	v, err := s.store.RetrieveCheckpoint(ctx, sessionID, checkpointInfo)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve checkpoint with ID %s for session %s: %w", checkpointInfo.CheckpointID, sessionID, err)
@@ -147,5 +166,35 @@ func (s *jsonManager) Lookup(ctx context.Context, sessionID string, checkpointIn
 }
 
 func (s *jsonManager) RetrieveIndex(ctx context.Context, sessionID string, withParent *workflow.CheckpointInfo) ([]workflow.CheckpointInfo, error) {
-	return s.store.RetrieveIndex(ctx, sessionID, withParent)
+	if sessionID == "" {
+		return nil, fmt.Errorf("checkpoint: sessionID cannot be empty")
+	}
+	if withParent != nil && *withParent != (workflow.CheckpointInfo{}) {
+		if err := validateManagerCheckpointInfo(sessionID, *withParent); err != nil {
+			return nil, fmt.Errorf("checkpoint: invalid parent checkpoint info: %w", err)
+		}
+	}
+	index, err := s.store.RetrieveIndex(ctx, sessionID, withParent)
+	if err != nil {
+		return nil, err
+	}
+	for _, info := range index {
+		if err := validateManagerCheckpointInfo(sessionID, info); err != nil {
+			return nil, fmt.Errorf("checkpoint: store returned invalid checkpoint info: %w", err)
+		}
+	}
+	return index, nil
+}
+
+func validateManagerCheckpointInfo(sessionID string, info workflow.CheckpointInfo) error {
+	if info.SessionID == "" {
+		return fmt.Errorf("checkpoint sessionID cannot be empty")
+	}
+	if info.CheckpointID == "" {
+		return fmt.Errorf("checkpointID cannot be empty")
+	}
+	if info.SessionID != sessionID {
+		return fmt.Errorf("checkpoint sessionID %q does not match sessionID %q", info.SessionID, sessionID)
+	}
+	return nil
 }

--- a/workflow/checkpoint/manager_test.go
+++ b/workflow/checkpoint/manager_test.go
@@ -4,12 +4,31 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
 
+	"github.com/microsoft/agent-framework-go/workflow"
 	icheckpoint "github.com/microsoft/agent-framework-go/workflow/internal/checkpoint"
 )
+
+type managerTestStore struct {
+	createInfo workflow.CheckpointInfo
+	index      []workflow.CheckpointInfo
+}
+
+func (s *managerTestStore) CreateCheckpoint(context.Context, string, json.RawMessage, *workflow.CheckpointInfo) (workflow.CheckpointInfo, error) {
+	return s.createInfo, nil
+}
+
+func (*managerTestStore) RetrieveCheckpoint(context.Context, string, workflow.CheckpointInfo) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+func (s *managerTestStore) RetrieveIndex(context.Context, string, *workflow.CheckpointInfo) ([]workflow.CheckpointInfo, error) {
+	return s.index, nil
+}
 
 func TestNewJSONManagerNilStorePanics(t *testing.T) {
 	defer func() {
@@ -19,6 +38,49 @@ func TestNewJSONManagerNilStorePanics(t *testing.T) {
 	}()
 
 	_ = NewJSONManager(nil)
+}
+
+func TestJSONManager_ValidatesInputs(t *testing.T) {
+	manager := NewJSONManager(&managerTestStore{}).(*jsonManager)
+	checkpoint := &icheckpoint.Checkpoint{}
+
+	if _, err := manager.Commit(t.Context(), "", checkpoint); err == nil {
+		t.Fatal("Commit() error = nil for empty session ID")
+	}
+	checkpoint.Parent = &workflow.CheckpointInfo{SessionID: "other", CheckpointID: "parent"}
+	if _, err := manager.Commit(t.Context(), "session", checkpoint); err == nil {
+		t.Fatal("Commit() error = nil for mismatched parent session")
+	}
+	if _, err := manager.Lookup(t.Context(), "session", workflow.CheckpointInfo{SessionID: "session"}); err == nil {
+		t.Fatal("Lookup() error = nil for empty checkpoint ID")
+	}
+	if _, err := manager.RetrieveIndex(t.Context(), "", nil); err == nil {
+		t.Fatal("RetrieveIndex() error = nil for empty session ID")
+	}
+}
+
+func TestJSONManager_RejectsInvalidStoreMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		info workflow.CheckpointInfo
+	}{
+		{name: "empty info", info: workflow.CheckpointInfo{}},
+		{name: "wrong session", info: workflow.CheckpointInfo{SessionID: "other", CheckpointID: "checkpoint"}},
+		{name: "empty checkpoint ID", info: workflow.CheckpointInfo{SessionID: "session"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &managerTestStore{createInfo: test.info, index: []workflow.CheckpointInfo{test.info}}
+			manager := NewJSONManager(store).(*jsonManager)
+			if _, err := manager.Commit(t.Context(), "session", &icheckpoint.Checkpoint{}); err == nil {
+				t.Fatal("Commit() error = nil for invalid store metadata")
+			}
+			if _, err := manager.RetrieveIndex(t.Context(), "session", nil); err == nil {
+				t.Fatal("RetrieveIndex() error = nil for invalid store metadata")
+			}
+		})
+	}
 }
 
 // The in-memory manager is keyed by session ID, so a single manager can be

--- a/workflow/checkpoint/manager_test.go
+++ b/workflow/checkpoint/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -53,6 +54,8 @@ func TestJSONManager_ValidatesInputs(t *testing.T) {
 	}
 	if _, err := manager.Lookup(t.Context(), "session", workflow.CheckpointInfo{SessionID: "session"}); err == nil {
 		t.Fatal("Lookup() error = nil for empty checkpoint ID")
+	} else if !strings.Contains(err.Error(), "checkpoint: invalid checkpoint info: checkpointID cannot be empty") {
+		t.Fatalf("Lookup() error = %v, want scoped checkpoint info error", err)
 	}
 	if _, err := manager.RetrieveIndex(t.Context(), "", nil); err == nil {
 		t.Fatal("RetrieveIndex() error = nil for empty session ID")

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -435,10 +435,12 @@ func (e *Executor) describeProtocol() (ProtocolDescriptor, error) {
 	return protocol.describe(), nil
 }
 
+// DescribeProtocol returns the executor's accepted, sent, and yielded message
+// types. It panics if the executor's protocol configuration is invalid.
 func (e *Executor) DescribeProtocol() ProtocolDescriptor {
 	protocol, err := e.describeProtocol()
 	if err != nil {
-		return ProtocolDescriptor{}
+		panic(err)
 	}
 	return protocol
 }
@@ -794,7 +796,7 @@ func hasAnonymousFuncOrdinal(s string) bool {
 //     significant; _ is recommended for marker-only fields.
 //
 // NewExecutor panics for nil values, nil functions, unsupported function
-// signatures, or mismatched IDs.
+// signatures, factory failures, or mismatched IDs.
 func NewExecutor(id string, v any) *Executor {
 	if v == nil {
 		panic("workflow: cannot create Executor from nil value")
@@ -805,7 +807,7 @@ func NewExecutor(id string, v any) *Executor {
 			panic("workflow: cannot create Executor from nil *Executor")
 		}
 		if id != "" && v.ID != id {
-			panic(fmt.Sprintf("workflow: executor ID %q does not match provided ID %q", v.ID, id))
+			panic(fmt.Errorf("workflow: executor ID %q does not match provided ID %q", v.ID, id))
 		}
 		return v
 	case RequestPort:
@@ -817,11 +819,11 @@ func NewExecutor(id string, v any) *Executor {
 		return newRequestPortExecutor(*v)
 	case ExecutorBinding:
 		if id != "" && v.ID != id {
-			panic(fmt.Sprintf("workflow: binding ID %q does not match provided ID %q", v.ID, id))
+			panic(fmt.Errorf("workflow: binding ID %q does not match provided ID %q", v.ID, id))
 		}
 		executor, err := v.CreateInstance(v.ID)
 		if err != nil {
-			panic(fmt.Sprintf("workflow: error creating Executor from binding for ID %q: %v", v.ID, err))
+			panic(fmt.Errorf("workflow: error creating Executor from binding for ID %q: %w", v.ID, err))
 		}
 		return executor
 	default:
@@ -844,9 +846,9 @@ func NewExecutor(id string, v any) *Executor {
 			if ok {
 				return executor
 			}
-			panic(fmt.Sprintf("workflow: cannot create Executor from value of type %T", v))
+			panic(fmt.Errorf("workflow: cannot create Executor from value of type %T", v))
 		default:
-			panic(fmt.Sprintf("workflow: cannot create Executor from value of type %T", v))
+			panic(fmt.Errorf("workflow: cannot create Executor from value of type %T", v))
 		}
 	}
 }

--- a/workflow/executor_test.go
+++ b/workflow/executor_test.go
@@ -598,6 +598,23 @@ func TestExecutorDescribeProtocol_IncludesExplicitSendAndYieldTypes(t *testing.T
 	}
 }
 
+func TestExecutorDescribeProtocol_PanicsOnConfigurationError(t *testing.T) {
+	want := errors.New("invalid protocol")
+	executor := &workflow.Executor{
+		ConfigureProtocol: func(*workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
+			return nil, want
+		},
+	}
+	defer func() {
+		got, ok := recover().(error)
+		if !ok || !errors.Is(got, want) {
+			t.Fatalf("panic = %v, want %v", got, want)
+		}
+	}()
+
+	executor.DescribeProtocol()
+}
+
 func TestExecutorDescribeProtocol_ValueReturnIsAllocFreeAfterBuild(t *testing.T) {
 	executor := executorWithSendTypes(reflect.TypeFor[protocolSent]())
 	_ = executor.DescribeProtocol()

--- a/workflow/info.go
+++ b/workflow/info.go
@@ -24,8 +24,12 @@ type CheckpointInfo struct {
 // NewCheckpointInfo creates checkpoint metadata for sessionID.
 //
 // The generated checkpoint ID is a UUID string without hyphen separators so it
-// can be used safely in checkpoint indexes and file names.
+// can be used safely in checkpoint indexes and file names. NewCheckpointInfo
+// panics if sessionID is empty.
 func NewCheckpointInfo(sessionID string) CheckpointInfo {
+	if sessionID == "" {
+		panic("workflow: checkpoint session ID is required")
+	}
 	return CheckpointInfo{
 		SessionID:    sessionID,
 		CheckpointID: strings.ReplaceAll(uuid.NewString(), "-", ""),

--- a/workflow/info_test.go
+++ b/workflow/info_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow"
 )
 
+func TestNewCheckpointInfo_PanicsWithEmptySessionID(t *testing.T) {
+	defer func() {
+		if got := recover(); got != "workflow: checkpoint session ID is required" {
+			t.Fatalf("panic = %v, want checkpoint session ID message", got)
+		}
+	}()
+
+	workflow.NewCheckpointInfo("")
+}
+
 func source(i int) string { return "Source/" + itoa(i) }
 func sink(i int) string   { return "Sink/" + itoa(i) }
 

--- a/workflow/inproc/external_request_test.go
+++ b/workflow/inproc/external_request_test.go
@@ -562,6 +562,43 @@ func TestExternalRequest_NewRequest_TypeValidation(t *testing.T) {
 	}
 }
 
+func TestExternalRequest_NewRequest_RejectsInvalidPort(t *testing.T) {
+	stringType := reflect.TypeFor[string]()
+	tests := []struct {
+		name string
+		port workflow.RequestPort
+		want string
+	}{
+		{
+			name: "empty ID",
+			port: workflow.RequestPort{Request: stringType, Response: stringType},
+			want: "workflow: request port ID is required",
+		},
+		{
+			name: "nil request type",
+			port: workflow.RequestPort{ID: "port", Response: stringType},
+			want: `workflow: request port "port" request type is required`,
+		},
+		{
+			name: "nil response type",
+			port: workflow.RequestPort{ID: "port", Request: stringType},
+			want: `workflow: request port "port" response type is required`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := workflow.NewExternalRequest("request", test.port, "payload")
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("NewExternalRequest() error = %v, want %q", err, test.want)
+			}
+			if request != nil {
+				t.Fatalf("NewExternalRequest() = %#v, want nil", request)
+			}
+		})
+	}
+}
+
 func TestExternalRequest_NewRequest_RejectsNil(t *testing.T) {
 	port := workflow.RequestPort{
 		ID:       "p",

--- a/workflow/inproc/run.go
+++ b/workflow/inproc/run.go
@@ -69,10 +69,9 @@ func (run *Run) NewEventCount() int {
 }
 
 // NewEvents returns an iterator over the events accumulated since the previous
-// call to NewEvents. The internal bookmark is advanced to the current end of the
-// event sink as soon as iteration begins, so every event returned here is
-// consumed even if the caller stops iterating early; a subsequent call will only
-// yield events accumulated after this call.
+// call to NewEvents. The internal bookmark advances as each event is yielded,
+// so stopping iteration early leaves unread events available to a subsequent
+// call.
 func (run *Run) NewEvents() iter.Seq[workflow.Event] {
 	return func(yield func(workflow.Event) bool) {
 		// Advance the read bookmark as each event is delivered so that stopping

--- a/workflow/json_test.go
+++ b/workflow/json_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/microsoft/agent-framework-go/workflow"
 )
 
+func TestOutputTag_JSONRoundtrip(t *testing.T) {
+	data, err := json.Marshal(workflow.OutputTagIntermediate)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var got workflow.OutputTag
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got != workflow.OutputTagIntermediate {
+		t.Fatalf("roundtrip = %q, want %q", got, workflow.OutputTagIntermediate)
+	}
+}
+
+func TestOutputTag_RejectsEmptyJSON(t *testing.T) {
+	if _, err := json.Marshal(workflow.OutputTag("")); err == nil {
+		t.Fatal("Marshal() error = nil, want empty-tag error")
+	}
+	var tag workflow.OutputTag
+	if err := json.Unmarshal([]byte(`""`), &tag); err == nil {
+		t.Fatal("Unmarshal() error = nil, want empty-tag error")
+	}
+}
+
 func TestEdgeConnection_JsonRoundtrip(t *testing.T) {
 	cases := []workflow.EdgeConnection{
 		{SourceIDs: []string{"a"}, SinkIDs: []string{"b"}},

--- a/workflow/outputtag.go
+++ b/workflow/outputtag.go
@@ -27,6 +27,9 @@ func (t OutputTag) String() string {
 
 // MarshalJSON implements [json.Marshaler].
 func (t OutputTag) MarshalJSON() ([]byte, error) {
+	if t == "" {
+		return nil, fmt.Errorf("workflow: output tag value cannot be empty")
+	}
 	return json.Marshal(string(t))
 }
 

--- a/workflow/portable.go
+++ b/workflow/portable.go
@@ -3,6 +3,7 @@
 package workflow
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -26,10 +27,16 @@ type PortableValue struct {
 func AnyPortableValue(v any) PortableValue {
 	switch val := v.(type) {
 	case PortableValue:
+		if !val.valid() {
+			panic("workflow: PortableValue cannot wrap zero value")
+		}
 		return val
 	case *PortableValue:
 		if val == nil {
 			panic("workflow: PortableValue cannot wrap nil")
+		}
+		if !val.valid() {
+			panic("workflow: PortableValue cannot wrap zero value")
 		}
 		return *val
 	default:
@@ -38,6 +45,10 @@ func AnyPortableValue(v any) PortableValue {
 		}
 		return PortableValue{any: v, TypeID: NewTypeID(reflect.TypeOf(v))}
 	}
+}
+
+func (v PortableValue) valid() bool {
+	return v.any != nil
 }
 
 // PortableValueAs attempts to convert the supplied [PortableValue] to the requested type T.
@@ -146,7 +157,7 @@ func decodePortableJSON[T any](raw json.RawMessage) (any, bool) {
 // If the value is stored in a delayed deserialized form, it will attempt to
 // deserialize it to the requested type.
 func (v *PortableValue) Is(typ reflect.Type) bool {
-	if v == nil {
+	if v == nil || typ == nil {
 		return false
 	}
 	if typ == reflect.TypeFor[PortableValue]() {
@@ -195,7 +206,7 @@ func (v *PortableValue) Delayed() bool {
 }
 
 func (v PortableValue) MarshalJSON() ([]byte, error) {
-	if v.any == nil {
+	if !v.valid() {
 		return nil, errors.New("cannot marshal zero PortableValue")
 	}
 	// Preserve the original wire bytes for a delayed value that was never read.
@@ -221,12 +232,19 @@ func (v PortableValue) MarshalJSON() ([]byte, error) {
 }
 
 func (v *PortableValue) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
 		return errors.New("cannot unmarshal null PortableValue")
 	}
 	var wire portableValueJSON
 	if err := json.Unmarshal(data, &wire); err != nil {
 		return err
+	}
+	raw := bytes.TrimSpace(wire.Value)
+	if len(raw) == 0 {
+		return errors.New("cannot unmarshal PortableValue without a non-null value")
+	}
+	if bytes.Equal(raw, []byte("null")) && wire.TypeID == (TypeID{}) {
+		return errors.New("cannot unmarshal untyped null PortableValue")
 	}
 	*v = PortableValue{any: wire.Value, TypeID: wire.TypeID}
 	return nil

--- a/workflow/portable_test.go
+++ b/workflow/portable_test.go
@@ -207,13 +207,65 @@ func TestPortableValue_RejectsNil(t *testing.T) {
 	_ = workflow.AnyPortableValue(nil)
 }
 
+func TestAnyPortableValue_RejectsInvalidValues(t *testing.T) {
+	zero := workflow.PortableValue{}
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "zero value", value: zero},
+		{name: "zero value pointer", value: &zero},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected panic")
+				}
+			}()
+			workflow.AnyPortableValue(test.value)
+		})
+	}
+}
+
+func TestPortableValue_TypedNilRoundTrip(t *testing.T) {
+	var input *int
+	data, err := json.Marshal(workflow.AnyPortableValue(input))
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var decoded workflow.PortableValue
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	got, ok := workflow.PortableValueAs[*int](decoded)
+	if !ok || got != nil {
+		t.Fatalf("PortableValueAs[*int]() = (%v, %v), want (nil, true)", got, ok)
+	}
+}
+
+func TestPortableValue_NilTypeDoesNotMatch(t *testing.T) {
+	value := workflow.AnyPortableValue("value")
+	if value.Is(nil) {
+		t.Fatal("Is(nil) = true, want false")
+	}
+	if got, ok := value.As(nil); ok || got != nil {
+		t.Fatalf("As(nil) = (%v, %v), want (nil, false)", got, ok)
+	}
+}
+
 func TestPortableValue_RejectsZeroJSON(t *testing.T) {
 	if _, err := json.Marshal(workflow.PortableValue{}); err == nil {
 		t.Fatal("expected marshal error for zero PortableValue")
 	}
-	var got workflow.PortableValue
-	if err := json.Unmarshal([]byte("null"), &got); err == nil {
-		t.Fatal("expected unmarshal error for null PortableValue")
+	for _, data := range []string{"null", `{}`, `{"Value":null}`} {
+		t.Run(data, func(t *testing.T) {
+			var got workflow.PortableValue
+			if err := json.Unmarshal([]byte(data), &got); err == nil {
+				t.Fatalf("expected unmarshal error for %s", data)
+			}
+		})
 	}
 }
 

--- a/workflow/requestport.go
+++ b/workflow/requestport.go
@@ -52,9 +52,12 @@ type ExternalRequest struct {
 // id is an optional unique identifier for this request instance. If id is empty,
 // a UUID will be generated.
 //
-// NewExternalRequest returns an error when data does not match the expected
-// request type.
+// NewExternalRequest returns an error when the port is invalid or data does
+// not match the expected request type.
 func NewExternalRequest(id string, port RequestPort, data any) (*ExternalRequest, error) {
+	if err := validateRequestPort(port); err != nil {
+		return nil, err
+	}
 	if id == "" {
 		id = uuid.New().String()
 	}
@@ -67,6 +70,19 @@ func NewExternalRequest(id string, port RequestPort, data any) (*ExternalRequest
 		RequestID: id,
 		Data:      AnyPortableValue(data),
 	}, nil
+}
+
+func validateRequestPort(port RequestPort) error {
+	if port.ID == "" {
+		return fmt.Errorf("workflow: request port ID is required")
+	}
+	if port.Request == nil {
+		return fmt.Errorf("workflow: request port %q request type is required", port.ID)
+	}
+	if port.Response == nil {
+		return fmt.Errorf("workflow: request port %q response type is required", port.ID)
+	}
+	return nil
 }
 
 // CreateResponse creates a new [ExternalResponse] corresponding to r, with the

--- a/workflow/route.go
+++ b/workflow/route.go
@@ -142,6 +142,10 @@ func (rb *RouteBuilder) AddCatchAll(handler func(*Context, PortableValue) (any, 
 	if rb.err != nil {
 		return rb
 	}
+	if rb.catchAll == nil && addHandlerOptions.overwrite {
+		rb.err = errors.New("cannot overwrite unregistered catch-all handler")
+		return rb
+	}
 	if rb.catchAll != nil && !addHandlerOptions.overwrite {
 		rb.err = errors.New("catch-all handler is already registered")
 		return rb

--- a/workflow/route_test.go
+++ b/workflow/route_test.go
@@ -19,6 +19,44 @@ type routeTestConcrete struct {
 
 func (m routeTestConcrete) routeMarker() string { return m.value }
 
+func TestRouteBuilder_OverwriteRequiresRegisteredHandler(t *testing.T) {
+	tests := []struct {
+		name string
+		add  func(*RouteBuilder)
+		want string
+	}{
+		{
+			name: "typed handler",
+			add: func(rb *RouteBuilder) {
+				rb.AddHandlerRaw(reflect.TypeFor[string](), nil, func(*Context, any) (any, error) {
+					return nil, nil
+				}, WithHandlerOverwrite(true))
+			},
+			want: "cannot overwrite handler for unregistered type string",
+		},
+		{
+			name: "catch-all handler",
+			add: func(rb *RouteBuilder) {
+				rb.AddCatchAll(func(*Context, PortableValue) (any, error) {
+					return nil, nil
+				}, WithHandlerOverwrite(true))
+			},
+			want: "cannot overwrite unregistered catch-all handler",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var rb RouteBuilder
+			test.add(&rb)
+			_, err := rb.build()
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("build() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestMessageRouterRoutesAssignableInterfaceHandler(t *testing.T) {
 	var rb RouteBuilder
 	rb.AddHandlerRaw(reflect.TypeFor[routeTestMessage](), nil, func(_ *Context, msg any) (any, error) {


### PR DESCRIPTION
## Summary
- tighten constructor, option, and workflow validation across agent, tool, message, provider, and workflow APIs
- make unsupported inputs and invalid serialized state fail consistently at public boundaries
- preserve established API choices while aligning provider behavior and documentation
- add focused regression coverage for the hardened contracts

## Testing
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`