### PR TITLE
Prevent duplicate Agent Framework user agents

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -57,12 +57,7 @@ func PrependAgentFrameworkToUserAgent(headers map[string]string) map[string]stri
 	if headers == nil {
 		headers = map[string]string{}
 	}
-	userAgent := userAgent()
-	if existing := headers[userAgentKey]; existing != "" {
-		headers[userAgentKey] = userAgent + " " + existing
-	} else {
-		headers[userAgentKey] = userAgent
-	}
+	headers[userAgentKey] = prependUserAgent(headers[userAgentKey])
 	return headers
 }
 
@@ -74,13 +69,48 @@ func PrependAgentFrameworkToHTTPHeader(headers http.Header) http.Header {
 	if headers == nil {
 		headers = http.Header{}
 	}
-	userAgent := userAgent()
-	if existing := headers.Get(userAgentKey); existing != "" {
-		headers.Set(userAgentKey, userAgent+" "+existing)
-	} else {
-		headers.Set(userAgentKey, userAgent)
-	}
+	headers.Set(userAgentKey, prependUserAgent(headers.Get(userAgentKey)))
 	return headers
+}
+
+func prependUserAgent(existing string) string {
+	frameworkUserAgent := userAgent()
+	products := strings.Fields(existing)
+	frameworkProductCount := 0
+	hasCurrentFrameworkProduct := false
+	for _, product := range products {
+		if isAgentFrameworkUserAgent(product) {
+			frameworkProductCount++
+			hasCurrentFrameworkProduct = hasCurrentFrameworkProduct || product == frameworkUserAgent
+		}
+	}
+	if frameworkProductCount == 1 && hasCurrentFrameworkProduct {
+		return existing
+	}
+	if frameworkProductCount > 0 {
+		normalized := make([]string, 0, len(products)-frameworkProductCount+1)
+		frameworkProductAdded := false
+		for _, product := range products {
+			if isAgentFrameworkUserAgent(product) {
+				if !frameworkProductAdded {
+					normalized = append(normalized, frameworkUserAgent)
+					frameworkProductAdded = true
+				}
+				continue
+			}
+			normalized = append(normalized, product)
+		}
+		return strings.Join(normalized, " ")
+	}
+	if existing == "" {
+		return frameworkUserAgent
+	}
+	return frameworkUserAgent + " " + existing
+}
+
+func isAgentFrameworkUserAgent(product string) bool {
+	return strings.HasPrefix(product, httpUserAgent+"/") ||
+		strings.Contains(product, "/"+httpUserAgent+"/")
 }
 
 func userAgentPrefixList() []string {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -36,6 +36,14 @@ func TestPrependAgentFrameworkToUserAgent(t *testing.T) {
 	}
 }
 
+func TestPrependAgentFrameworkToUserAgentIsIdempotent(t *testing.T) {
+	got := runHelper(t, "prepend-map-twice", userAgentTelemetryDisabledEnvVar+"=")
+	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=") + " my-app/1.0"
+	if got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
 func TestPrependAgentFrameworkToUserAgentWithNilHeaders(t *testing.T) {
 	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=")
 	if got := runHelper(t, "prepend-nil", userAgentTelemetryDisabledEnvVar+"="); got != want {
@@ -54,6 +62,22 @@ func TestPrependAgentFrameworkToUserAgentDisabled(t *testing.T) {
 func TestPrependAgentFrameworkToHTTPHeader(t *testing.T) {
 	got := runHelper(t, "prepend-http", userAgentTelemetryDisabledEnvVar+"=")
 	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=") + " my-app/1.0"
+	if got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestPrependAgentFrameworkToHTTPHeaderIsIdempotent(t *testing.T) {
+	got := runHelper(t, "prepend-http-twice", userAgentTelemetryDisabledEnvVar+"=")
+	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=", userAgentTelemetryDisabledEnvVar+"=") + " my-app/1.0"
+	if got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestPrependAgentFrameworkToHTTPHeaderHostedReplacesBareProduct(t *testing.T) {
+	got := runHelper(t, "prepend-http-hosted-over-bare", foundryHostingEnvVar+"=1", userAgentTelemetryDisabledEnvVar+"=")
+	want := runHelper(t, "user-agent", foundryHostingEnvVar+"=1", userAgentTelemetryDisabledEnvVar+"=") + " my-app/1.0"
 	if got != want {
 		t.Fatalf("User-Agent = %q, want %q", got, want)
 	}
@@ -99,6 +123,10 @@ func TestHelperProcess(t *testing.T) {
 	case "prepend-map":
 		headers := telemetry.PrependAgentFrameworkToUserAgent(map[string]string{"User-Agent": "my-app/1.0"})
 		fmt.Print(headers[userAgentKey])
+	case "prepend-map-twice":
+		headers := telemetry.PrependAgentFrameworkToUserAgent(map[string]string{"User-Agent": "my-app/1.0"})
+		headers = telemetry.PrependAgentFrameworkToUserAgent(headers)
+		fmt.Print(headers[userAgentKey])
 	case "prepend-nil":
 		headers := telemetry.PrependAgentFrameworkToUserAgent(nil)
 		fmt.Print(headers[userAgentKey])
@@ -109,6 +137,15 @@ func TestHelperProcess(t *testing.T) {
 		fmt.Print(telemetry.PrependAgentFrameworkToHTTPHeader(nil) == nil)
 	case "prepend-http":
 		headers := telemetry.PrependAgentFrameworkToHTTPHeader(http.Header{"User-Agent": []string{"my-app/1.0"}})
+		fmt.Print(headers.Get(userAgentKey))
+	case "prepend-http-twice":
+		headers := telemetry.PrependAgentFrameworkToHTTPHeader(http.Header{"User-Agent": []string{"my-app/1.0"}})
+		headers = telemetry.PrependAgentFrameworkToHTTPHeader(headers)
+		fmt.Print(headers.Get(userAgentKey))
+	case "prepend-http-hosted-over-bare":
+		headers := telemetry.PrependAgentFrameworkToHTTPHeader(nil)
+		bareUserAgent := strings.TrimPrefix(headers.Get(userAgentKey), "foundry-hosting/")
+		headers = telemetry.PrependAgentFrameworkToHTTPHeader(http.Header{"User-Agent": []string{bareUserAgent + " my-app/1.0"}})
 		fmt.Print(headers.Get(userAgentKey))
 	case "telemetry-enabled-cached":
 		fmt.Println(telemetry.PrependAgentFrameworkToUserAgent(nil) != nil)


### PR DESCRIPTION
## Summary

- make Agent Framework User-Agent stamping idempotent
- normalize bare, hosted, stale, and duplicate `agent-framework-go` products to one current product
- add regression coverage for map headers, HTTP headers, and hosted upgrades

## Testing

- `go test -count=1 ./internal/telemetry ./provider/openaiprovider ./provider/foundryprovider`