### PR TITLE
[dotnet-code] Consolidate concurrent end executor state

### DIFF
--- a/workflow/agentworkflow/concurrent.go
+++ b/workflow/agentworkflow/concurrent.go
@@ -170,26 +170,17 @@ func newConcurrentEndBinding(expectedInputs int, aggregator MessageAggregator) w
 		ID:                                concurrentEndExecutorID,
 		SupportsConcurrentSharedExecution: true,
 		NewExecutorFunc: func(_ string) (*workflow.Executor, error) {
-			allResults := make([][]*message.Message, 0, expectedInputs)
-			remaining := expectedInputs
-			reset := func() {
-				allResults = make([][]*message.Message, 0, expectedInputs)
-				remaining = expectedInputs
-			}
+			state := newConcurrentEndState(expectedInputs)
 			return &workflow.Executor{
 				ID: concurrentEndExecutorID,
 				ResetFunc: func() error {
-					reset()
+					state.reset()
 					return nil
 				},
 				ConfigureProtocol: func(rb *workflow.ProtocolBuilder) (*workflow.ProtocolBuilder, error) {
 					rb.YieldsOutputType(reflect.TypeFor[[]*message.Message]())
 					rb.RouteBuilder.AddHandlerRaw(reflect.TypeFor[[]*message.Message](), nil, func(ctx *workflow.Context, msg any) (any, error) {
-						allResults = append(allResults, msg.([]*message.Message))
-						remaining--
-						if remaining == 0 {
-							results := allResults
-							reset()
+						if results, done := state.add(msg.([]*message.Message)); done {
 							if err := ctx.YieldOutput(aggregator(ctx, results)); err != nil {
 								return nil, err
 							}
@@ -201,6 +192,34 @@ func newConcurrentEndBinding(expectedInputs int, aggregator MessageAggregator) w
 			}, nil
 		},
 	}
+}
+
+type concurrentEndState struct {
+	expectedInputs int
+	allResults     [][]*message.Message
+	remaining      int
+}
+
+func newConcurrentEndState(expectedInputs int) *concurrentEndState {
+	state := &concurrentEndState{expectedInputs: expectedInputs}
+	state.reset()
+	return state
+}
+
+func (state *concurrentEndState) reset() {
+	state.allResults = make([][]*message.Message, 0, state.expectedInputs)
+	state.remaining = state.expectedInputs
+}
+
+func (state *concurrentEndState) add(messages []*message.Message) ([][]*message.Message, bool) {
+	state.allResults = append(state.allResults, messages)
+	state.remaining--
+	if state.remaining != 0 {
+		return nil, false
+	}
+	results := state.allResults
+	state.reset()
+	return results, true
 }
 
 func defaultConcurrentMessageAggregator(_ context.Context, lists [][]*message.Message) []*message.Message {


### PR DESCRIPTION
## Summary

Refactored the concurrent workflow end executor to keep its per-turn aggregation bookkeeping in a small unexported `concurrentEndState` helper. This makes the Go implementation structurally closer to the .NET resettable `ConcurrentEndExecutor` fields while preserving the same aggregation and reset behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/ConcurrentEndExecutor.cs` - resettable concurrent end executor tracks expected inputs, collected message batches, and remaining inputs before yielding aggregated output.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow/agentworkflow`

## Notes

Rejected candidates from the random sample:

- `dotnet/src/Microsoft.Agents.AI/Compaction/SummarizationCompactionStrategy.cs` / Go compaction internals: existing Go helpers already consolidate the relevant grouping/counting logic, and recent `[dotnet-code]` compaction PRs cover nearby cleanup.
- `dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs` / Go skills provider: existing `resolveSkillItem` already centralizes resource/script lookup shape, with nearby closed `[dotnet-code]` skills cleanup already present.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/ConcurrentEndExecutor.cs` / Go concurrent workflow: selected for this small state-helper refactor.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32424552422) · gpt55 · 68.6 AIC · ⌖ 19.4 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 32424552422, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32424552422 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #880