### PR TITLE
[dotnet-code] Consolidate compaction group exclusion helper

### DIFF
--- a/agent/compaction/group.go
+++ b/agent/compaction/group.go
@@ -75,6 +75,11 @@ func (group *MessageGroup) isIncludedNonSystem() bool {
 	return group.isIncluded() && group.Kind != GroupKindSystem
 }
 
+func (group *MessageGroup) exclude(reason string) {
+	group.IsExcluded = true
+	group.ExcludeReason = reason
+}
+
 func (group *MessageGroup) isRaw() bool {
 	return group.Kind != GroupKindSummary
 }

--- a/agent/compaction/slidingwindow.go
+++ b/agent/compaction/slidingwindow.go
@@ -61,9 +61,7 @@ func (strategy *SlidingWindowStrategy) Compact(_ context.Context, index *Message
 			continue
 		}
 		for _, groupIndex := range turnGroups[turnIndex] {
-			group := index.Groups[groupIndex]
-			group.IsExcluded = true
-			group.ExcludeReason = "excluded by SlidingWindowStrategy"
+			index.Groups[groupIndex].exclude("excluded by SlidingWindowStrategy")
 		}
 		compacted = true
 		if target(index) {

--- a/agent/compaction/toolresult.go
+++ b/agent/compaction/toolresult.go
@@ -73,8 +73,7 @@ func (strategy *ToolResultStrategy) Compact(_ context.Context, index *MessageInd
 		group := index.Groups[idx]
 		summary := formatter(group)
 
-		group.IsExcluded = true
-		group.ExcludeReason = "collapsed by ToolResultStrategy"
+		group.exclude("collapsed by ToolResultStrategy")
 
 		summaryMessage := &message.Message{
 			Role: message.RoleAssistant,

--- a/agent/compaction/truncation.go
+++ b/agent/compaction/truncation.go
@@ -50,8 +50,7 @@ func (strategy *TruncationStrategy) Compact(_ context.Context, index *MessageInd
 		if !group.isIncludedNonSystem() {
 			continue
 		}
-		group.IsExcluded = true
-		group.ExcludeReason = "truncated by TruncationStrategy"
+		group.exclude("truncated by TruncationStrategy")
 		removed++
 		compacted = true
 		if target(index) {


### PR DESCRIPTION
## Summary

Consolidates the repeated internal compaction-group exclusion assignment into a single unexported `MessageGroup.exclude` helper. This keeps truncation, sliding-window, and tool-result compaction strategies aligned around the same structural operation, making future .NET-to-Go ports easier to compare while preserving existing behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Compaction/TruncationCompactionStrategy.cs` - truncation marks groups excluded and records an exclusion reason as the core strategy operation.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/compaction`

## Notes

Rejected candidates from the random .NET sample:

- `dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Interpreter/WorkflowModelBuilder.cs` - workflow/builder internals were inspected, but existing open `[dotnet-code]` PRs such as https://github.com/microsoft/agent-framework-go/pull/860 and https://github.com/microsoft/agent-framework-go/pull/858 already cover nearby workflow/route cleanup areas.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ResponsesMessageItemParamConverter.cs` - inspected, but the sampled role-based converter did not map to a comparably narrow Go internal converter cleanup.
- `dotnet/src/Microsoft.Agents.AI.Mcp/Skills/Loaders/ArchiveFormat.cs` from the sample was skipped because skills internals are already covered by https://github.com/microsoft/agent-framework-go/pull/859.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32192997578) · gpt55 · 58.7 AIC · ⌖ 47.2 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 32192997578, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32192997578 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #865