### PR TITLE
[dotnet-port-fixes] Align A2A streaming artifact updates with .NET

### DIFF
--- a/provider/a2aprovider/artifact_stream.go
+++ b/provider/a2aprovider/artifact_stream.go
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package a2aprovider
+
+import (
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/microsoft/agent-framework-go/agent"
+)
+
+type artifactStreamWriter struct {
+	infoProvider      a2a.TaskInfoProvider
+	usedArtifactIDs   map[a2a.ArtifactID]struct{}
+	currentMessageID  string
+	currentArtifactID a2a.ArtifactID
+	bufferedUpdate    *agent.ResponseUpdate
+	shouldAppend      bool
+}
+
+func newArtifactStreamWriter(infoProvider a2a.TaskInfoProvider) *artifactStreamWriter {
+	return &artifactStreamWriter{
+		infoProvider:    infoProvider,
+		usedArtifactIDs: make(map[a2a.ArtifactID]struct{}),
+	}
+}
+
+func (w *artifactStreamWriter) Write(update *agent.ResponseUpdate) ([]*a2a.TaskArtifactUpdateEvent, error) {
+	if update == nil {
+		return nil, nil
+	}
+
+	events := make([]*a2a.TaskArtifactUpdateEvent, 0, 2)
+	if w.currentArtifactID == "" {
+		w.startArtifact(update.MessageID)
+	} else if w.isNewMessage(update.MessageID) {
+		evt, err := w.flushBuffered(true)
+		if err != nil {
+			return nil, err
+		}
+		if evt != nil {
+			events = append(events, evt)
+		}
+		w.startArtifact(update.MessageID)
+	}
+
+	parts, err := contentsToParts(update.Contents, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) == 0 {
+		return events, nil
+	}
+
+	evt, err := w.flushBuffered(false)
+	if err != nil {
+		return nil, err
+	}
+	if evt != nil {
+		events = append(events, evt)
+	}
+	w.bufferedUpdate = update
+	return events, nil
+}
+
+func (w *artifactStreamWriter) Complete() (*a2a.TaskArtifactUpdateEvent, error) {
+	return w.flushBuffered(true)
+}
+
+func (w *artifactStreamWriter) flushBuffered(lastChunk bool) (*a2a.TaskArtifactUpdateEvent, error) {
+	if w.bufferedUpdate == nil {
+		return nil, nil
+	}
+
+	evt, err := responseUpdateToArtifactEventWithOptions(
+		w.infoProvider,
+		w.currentArtifactID,
+		w.shouldAppend,
+		lastChunk,
+		w.bufferedUpdate,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	w.bufferedUpdate = nil
+	w.shouldAppend = true
+	return evt, nil
+}
+
+func (w *artifactStreamWriter) isNewMessage(messageID string) bool {
+	return messageID != "" && messageID != w.currentMessageID
+}
+
+func (w *artifactStreamWriter) startArtifact(messageID string) {
+	groupKey := messageID
+	if groupKey == "" {
+		groupKey = string(a2a.NewArtifactID())
+	}
+
+	w.currentMessageID = groupKey
+	artifactID := a2a.ArtifactID(groupKey)
+	if _, used := w.usedArtifactIDs[artifactID]; !used {
+		w.currentArtifactID = artifactID
+		w.usedArtifactIDs[artifactID] = struct{}{}
+	} else {
+		w.currentArtifactID = a2a.NewArtifactID()
+		w.usedArtifactIDs[w.currentArtifactID] = struct{}{}
+	}
+	w.shouldAppend = false
+}

--- a/provider/a2aprovider/artifact_stream.go
+++ b/provider/a2aprovider/artifact_stream.go
@@ -3,6 +3,8 @@
 package a2aprovider
 
 import (
+	"cmp"
+
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/microsoft/agent-framework-go/agent"
 )
@@ -30,21 +32,24 @@ func (w *artifactStreamWriter) Write(update *agent.ResponseUpdate) ([]*a2a.TaskA
 
 	events := make([]*a2a.TaskArtifactUpdateEvent, 0, 2)
 	if w.currentArtifactID == "" {
-		w.startArtifact(update.MessageID)
+		w.startArtifact(update.MessageID, update.ResponseID)
 	} else if w.isNewMessage(update.MessageID) {
 		evt, err := w.flushBuffered(true)
 		if err != nil {
-			return nil, err
+			return events, err
 		}
 		if evt != nil {
 			events = append(events, evt)
 		}
-		w.startArtifact(update.MessageID)
+		w.startArtifact(update.MessageID, update.ResponseID)
 	}
 
 	parts, err := contentsToParts(update.Contents, nil)
 	if err != nil {
-		return nil, err
+		if flushEvt, flushErr := w.flushBuffered(true); flushErr == nil && flushEvt != nil {
+			events = append(events, flushEvt)
+		}
+		return events, err
 	}
 	if len(parts) == 0 {
 		return events, nil
@@ -52,7 +57,7 @@ func (w *artifactStreamWriter) Write(update *agent.ResponseUpdate) ([]*a2a.TaskA
 
 	evt, err := w.flushBuffered(false)
 	if err != nil {
-		return nil, err
+		return events, err
 	}
 	if evt != nil {
 		events = append(events, evt)
@@ -90,14 +95,15 @@ func (w *artifactStreamWriter) isNewMessage(messageID string) bool {
 	return messageID != "" && messageID != w.currentMessageID
 }
 
-func (w *artifactStreamWriter) startArtifact(messageID string) {
-	groupKey := messageID
-	if groupKey == "" {
-		groupKey = string(a2a.NewArtifactID())
+func (w *artifactStreamWriter) startArtifact(messageID, responseID string) {
+	w.currentMessageID = messageID
+
+	idSource := cmp.Or(messageID, responseID)
+	if idSource == "" {
+		idSource = string(a2a.NewArtifactID())
 	}
 
-	w.currentMessageID = groupKey
-	artifactID := a2a.ArtifactID(groupKey)
+	artifactID := a2a.ArtifactID(idSource)
 	if _, used := w.usedArtifactIDs[artifactID]; !used {
 		w.currentArtifactID = artifactID
 		w.usedArtifactIDs[artifactID] = struct{}{}

--- a/provider/a2aprovider/artifact_stream_test.go
+++ b/provider/a2aprovider/artifact_stream_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package a2aprovider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+func artifactText(evt *a2a.TaskArtifactUpdateEvent) string {
+	if evt == nil || evt.Artifact == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range evt.Artifact.Parts {
+		if part == nil {
+			continue
+		}
+		sb.WriteString(part.Text())
+	}
+	return sb.String()
+}
+
+func TestArtifactStreamWriter_MissingMessageIDFallsBackToResponseID(t *testing.T) {
+	w := newArtifactStreamWriter(testTaskInfoProvider{})
+
+	events, err := w.Write(&agent.ResponseUpdate{
+		ResponseID: "resp-1",
+		Role:       message.RoleAssistant,
+		Contents:   message.Contents{&message.TextContent{Text: "reply"}},
+	})
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("event count = %d, want 0 (should stay buffered until Complete)", len(events))
+	}
+
+	evt, err := w.Complete()
+	if err != nil {
+		t.Fatalf("Complete returned error: %v", err)
+	}
+	if evt == nil {
+		t.Fatal("expected a flushed artifact event")
+	}
+	if evt.Artifact.ID != "resp-1" {
+		t.Fatalf("artifact id = %q, want %q", evt.Artifact.ID, "resp-1")
+	}
+}
+
+func TestArtifactStreamWriter_WriteFlushesBufferedArtifactOnConversionError(t *testing.T) {
+	w := newArtifactStreamWriter(testTaskInfoProvider{})
+
+	events, err := w.Write(&agent.ResponseUpdate{
+		MessageID: "msg-1",
+		Role:      message.RoleAssistant,
+		Contents:  message.Contents{&message.TextContent{Text: "partial"}},
+	})
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("event count = %d, want 0 (should stay buffered)", len(events))
+	}
+
+	events, err = w.Write(&agent.ResponseUpdate{
+		MessageID: "msg-1",
+		Role:      message.RoleAssistant,
+		Contents:  message.Contents{&message.DataContent{Data: "not-valid-base64!!!", MediaType: "application/octet-stream"}},
+	})
+	if err == nil {
+		t.Fatal("expected a conversion error")
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1 (buffered artifact should be flushed before the error)", len(events))
+	}
+	if got := artifactText(events[0]); got != "partial" {
+		t.Fatalf("artifact text = %q, want %q", got, "partial")
+	}
+	if !events[0].LastChunk {
+		t.Fatal("expected flushed artifact to be closed as the last chunk")
+	}
+}

--- a/provider/a2aprovider/executor.go
+++ b/provider/a2aprovider/executor.go
@@ -153,10 +153,26 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 		return nil
 	}
 
-	var artifactID a2a.ArtifactID
+	artifactWriter := newArtifactStreamWriter(execCtx)
 	var yieldedWorking bool
 	for update, runErr := range e.agent.Run(ctx, messagesIn, runOptions...) {
 		if runErr != nil {
+			artifact, err := artifactWriter.Complete()
+			if err != nil {
+				return err
+			}
+			if artifact != nil {
+				if !yieldedWorking {
+					if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
+						return nil
+					}
+					yieldedWorking = true
+				}
+				if !yield(artifact, nil) {
+					return nil
+				}
+			}
+
 			statusMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(runErr.Error()))
 			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed, statusMsg), nil) {
 				return nil
@@ -167,6 +183,22 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 			continue
 		}
 		if update.ContinuationToken != "" {
+			artifact, err := artifactWriter.Complete()
+			if err != nil {
+				return err
+			}
+			if artifact != nil {
+				if !yieldedWorking {
+					if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
+						return nil
+					}
+					yieldedWorking = true
+				}
+				if !yield(artifact, nil) {
+					return nil
+				}
+			}
+
 			working, err := responseUpdateToWorkingStatusEvent(execCtx, update)
 			if err != nil {
 				return err
@@ -177,20 +209,38 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 			return nil
 		}
 
-		artifact, nextArtifactID, err := responseUpdateToArtifactEvent(execCtx, artifactID, update)
+		artifacts, err := artifactWriter.Write(update)
 		if err != nil {
 			return err
 		}
-		if artifact == nil {
-			continue
+
+		for _, artifact := range artifacts {
+			if artifact == nil {
+				continue
+			}
+			if !yieldedWorking {
+				if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
+					return nil
+				}
+				yieldedWorking = true
+			}
+			if !yield(artifact, nil) {
+				return nil
+			}
 		}
+	}
+
+	artifact, err := artifactWriter.Complete()
+	if err != nil {
+		return err
+	}
+	if artifact != nil {
 		if !yieldedWorking {
 			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
 				return nil
 			}
 			yieldedWorking = true
 		}
-		artifactID = nextArtifactID
 		if !yield(artifact, nil) {
 			return nil
 		}

--- a/provider/a2aprovider/executor.go
+++ b/provider/a2aprovider/executor.go
@@ -166,7 +166,6 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 					if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
 						return nil
 					}
-					yieldedWorking = true
 				}
 				if !yield(artifact, nil) {
 					return nil
@@ -187,17 +186,6 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 			if err != nil {
 				return err
 			}
-			if artifact != nil {
-				if !yieldedWorking {
-					if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
-						return nil
-					}
-					yieldedWorking = true
-				}
-				if !yield(artifact, nil) {
-					return nil
-				}
-			}
 
 			working, err := responseUpdateToWorkingStatusEvent(execCtx, update)
 			if err != nil {
@@ -206,13 +194,16 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 			if !yield(working, nil) {
 				return nil
 			}
+
+			if artifact != nil {
+				if !yield(artifact, nil) {
+					return nil
+				}
+			}
 			return nil
 		}
 
-		artifacts, err := artifactWriter.Write(update)
-		if err != nil {
-			return err
-		}
+		artifacts, writeErr := artifactWriter.Write(update)
 
 		for _, artifact := range artifacts {
 			if artifact == nil {
@@ -228,6 +219,10 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 				return nil
 			}
 		}
+
+		if writeErr != nil {
+			return writeErr
+		}
 	}
 
 	artifact, err := artifactWriter.Complete()
@@ -239,7 +234,6 @@ func (e *executor) executeNewMessageStreaming(ctx context.Context, execCtx *a2as
 			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
 				return nil
 			}
-			yieldedWorking = true
 		}
 		if !yield(artifact, nil) {
 			return nil

--- a/provider/a2aprovider/hosting_convert.go
+++ b/provider/a2aprovider/hosting_convert.go
@@ -153,7 +153,7 @@ func responseToArtifactEvent(infoProvider a2a.TaskInfoProvider, resp *agent.Resp
 func responseUpdateToArtifactEventWithOptions(
 	infoProvider a2a.TaskInfoProvider,
 	artifactID a2a.ArtifactID,
-	append bool,
+	appendChunk bool,
 	lastChunk bool,
 	update *agent.ResponseUpdate,
 ) (*a2a.TaskArtifactUpdateEvent, error) {
@@ -174,7 +174,7 @@ func responseUpdateToArtifactEventWithOptions(
 	if evt.Artifact.ID == "" {
 		evt.Artifact.ID = a2a.NewArtifactID()
 	}
-	evt.Append = append
+	evt.Append = appendChunk
 	evt.LastChunk = lastChunk
 	evt.Metadata = maps.Clone(update.AdditionalProperties)
 	return evt, nil

--- a/provider/a2aprovider/hosting_convert.go
+++ b/provider/a2aprovider/hosting_convert.go
@@ -106,14 +106,6 @@ func responseUpdateToArtifactEvent(infoProvider a2a.TaskInfoProvider, artifactID
 		return nil, artifactID, nil
 	}
 
-	parts, err := contentsToParts(update.Contents, nil)
-	if err != nil {
-		return nil, artifactID, err
-	}
-	if len(parts) == 0 {
-		return nil, artifactID, nil
-	}
-
 	nextArtifactID := artifactID
 	stableID := cmp.Or(update.ResponseID, update.MessageID)
 	if stableID != "" {
@@ -123,11 +115,19 @@ func responseUpdateToArtifactEvent(infoProvider a2a.TaskInfoProvider, artifactID
 		nextArtifactID = a2a.NewArtifactID()
 	}
 
-	evt := a2a.NewArtifactEvent(infoProvider, parts...)
-	evt.Artifact.ID = nextArtifactID
-	evt.Append = artifactID != "" && artifactID == nextArtifactID
-	evt.LastChunk = false
-	evt.Metadata = maps.Clone(update.AdditionalProperties)
+	evt, err := responseUpdateToArtifactEventWithOptions(
+		infoProvider,
+		nextArtifactID,
+		artifactID != "" && artifactID == nextArtifactID,
+		false,
+		update,
+	)
+	if err != nil {
+		return nil, artifactID, err
+	}
+	if evt == nil {
+		return nil, artifactID, nil
+	}
 	return evt, nextArtifactID, nil
 }
 
@@ -147,5 +147,35 @@ func responseToArtifactEvent(infoProvider a2a.TaskInfoProvider, resp *agent.Resp
 	if resp != nil {
 		evt.Metadata = maps.Clone(resp.AdditionalProperties)
 	}
+	return evt, nil
+}
+
+func responseUpdateToArtifactEventWithOptions(
+	infoProvider a2a.TaskInfoProvider,
+	artifactID a2a.ArtifactID,
+	append bool,
+	lastChunk bool,
+	update *agent.ResponseUpdate,
+) (*a2a.TaskArtifactUpdateEvent, error) {
+	if update == nil {
+		return nil, nil
+	}
+
+	parts, err := contentsToParts(update.Contents, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) == 0 {
+		return nil, nil
+	}
+
+	evt := a2a.NewArtifactEvent(infoProvider, parts...)
+	evt.Artifact.ID = artifactID
+	if evt.Artifact.ID == "" {
+		evt.Artifact.ID = a2a.NewArtifactID()
+	}
+	evt.Append = append
+	evt.LastChunk = lastChunk
+	evt.Metadata = maps.Clone(update.AdditionalProperties)
 	return evt, nil
 }

--- a/provider/a2aprovider/hosting_test.go
+++ b/provider/a2aprovider/hosting_test.go
@@ -322,6 +322,116 @@ func TestRequestHandler_OnSendMessageStream_UsesTaskLifecycleAndArtifacts(t *tes
 	if got := a2aArtifactText(artifacts[1]); got != "chunk 2" {
 		t.Fatalf("second streamed artifact text = %q, want %q", got, "chunk 2")
 	}
+	if artifacts[0].Artifact.ID == "" {
+		t.Fatal("expected first streamed artifact id")
+	}
+	if artifacts[1].Artifact.ID != artifacts[0].Artifact.ID {
+		t.Fatalf("artifact ids = %q, %q, want identical ids", artifacts[0].Artifact.ID, artifacts[1].Artifact.ID)
+	}
+	if artifacts[0].Append {
+		t.Fatal("expected first streamed artifact update to start a new artifact")
+	}
+	if artifacts[0].LastChunk {
+		t.Fatal("expected first streamed artifact update to remain open")
+	}
+	if !artifacts[1].Append {
+		t.Fatal("expected second streamed artifact update to append to the same artifact")
+	}
+	if !artifacts[1].LastChunk {
+		t.Fatal("expected second streamed artifact update to close the artifact")
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_ReusedMessageIDGetsNewArtifactID(t *testing.T) {
+	a := newHostedTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			if !yield(&agent.ResponseUpdate{
+				MessageID: "msg-1",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.TextContent{Text: "first"}},
+			}, nil) {
+				return
+			}
+			if !yield(&agent.ResponseUpdate{
+				MessageID: "msg-2",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.TextContent{Text: "second"}},
+			}, nil) {
+				return
+			}
+			yield(&agent.ResponseUpdate{
+				MessageID: "msg-1",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.TextContent{Text: "third"}},
+			}, nil)
+		}
+	})
+
+	h := newRequestHandler(a, a2aprovider.ExecutorConfig{})
+	artifacts := collectStreamingArtifacts(collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	})))
+
+	if len(artifacts) != 3 {
+		t.Fatalf("artifact event count = %d, want 3", len(artifacts))
+	}
+	if artifacts[0].Artifact.ID != "msg-1" {
+		t.Fatalf("first artifact id = %q, want %q", artifacts[0].Artifact.ID, "msg-1")
+	}
+	if artifacts[1].Artifact.ID != "msg-2" {
+		t.Fatalf("second artifact id = %q, want %q", artifacts[1].Artifact.ID, "msg-2")
+	}
+	if artifacts[2].Artifact.ID == "" || artifacts[2].Artifact.ID == "msg-1" {
+		t.Fatalf("third artifact id = %q, want generated id distinct from %q", artifacts[2].Artifact.ID, "msg-1")
+	}
+	if !artifacts[0].LastChunk || !artifacts[1].LastChunk || !artifacts[2].LastChunk {
+		t.Fatalf("expected each single-update artifact to be closed: %#v %#v %#v", artifacts[0].LastChunk, artifacts[1].LastChunk, artifacts[2].LastChunk)
+	}
+}
+
+func TestRequestHandler_OnSendMessageStream_FlushesBufferedArtifactBeforeFailure(t *testing.T) {
+	a := newHostedTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			if !yield(&agent.ResponseUpdate{
+				MessageID: "msg-1",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.TextContent{Text: "partial"}},
+			}, nil) {
+				return
+			}
+			yield(nil, assertErr("boom"))
+		}
+	})
+
+	h := newRequestHandler(a, a2aprovider.ExecutorConfig{})
+	events := collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	}))
+
+	artifacts := collectStreamingArtifacts(events)
+	if len(artifacts) != 1 {
+		t.Fatalf("artifact event count = %d, want 1", len(artifacts))
+	}
+	if got := a2aArtifactText(artifacts[0]); got != "partial" {
+		t.Fatalf("artifact text = %q, want %q", got, "partial")
+	}
+	if artifacts[0].Append {
+		t.Fatal("expected failure artifact flush to start a new artifact")
+	}
+	if !artifacts[0].LastChunk {
+		t.Fatal("expected failure artifact flush to close the artifact")
+	}
+
+	statuses := collectStreamingStatuses(events)
+	if len(statuses) != 3 {
+		t.Fatalf("status event count = %d, want 3", len(statuses))
+	}
+	if statuses[0].Status.State != a2a.TaskStateSubmitted || statuses[1].Status.State != a2a.TaskStateWorking || statuses[2].Status.State != a2a.TaskStateFailed {
+		t.Fatalf("unexpected status sequence: %q, %q, %q", statuses[0].Status.State, statuses[1].Status.State, statuses[2].Status.State)
+	}
+	if statuses[2].Status.Message == nil || statuses[2].Status.Message.Parts[0].Text() != "boom" {
+		t.Fatalf("failed status message = %#v, want %q", statuses[2].Status.Message, "boom")
+	}
 }
 
 func TestRequestHandler_OnSendMessageStream_UsesProvidedContextID(t *testing.T) {

--- a/provider/a2aprovider/hosting_test.go
+++ b/provider/a2aprovider/hosting_test.go
@@ -389,6 +389,30 @@ func TestRequestHandler_OnSendMessageStream_ReusedMessageIDGetsNewArtifactID(t *
 	}
 }
 
+func TestRequestHandler_OnSendMessageStream_MissingMessageIDFallsBackToResponseIDForArtifactID(t *testing.T) {
+	a := newHostedTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				ResponseID: "resp-1",
+				Role:       message.RoleAssistant,
+				Contents:   message.Contents{&message.TextContent{Text: "reply"}},
+			}, nil)
+		}
+	})
+
+	h := newRequestHandler(a, a2aprovider.ExecutorConfig{})
+	artifacts := collectStreamingArtifacts(collectStreamingEvents(t, h.SendStreamingMessage(context.Background(), &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	})))
+
+	if len(artifacts) != 1 {
+		t.Fatalf("artifact event count = %d, want 1", len(artifacts))
+	}
+	if artifacts[0].Artifact.ID != "resp-1" {
+		t.Fatalf("artifact id = %q, want %q", artifacts[0].Artifact.ID, "resp-1")
+	}
+}
+
 func TestRequestHandler_OnSendMessageStream_FlushesBufferedArtifactBeforeFailure(t *testing.T) {
 	a := newHostedTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {


### PR DESCRIPTION
## Summary

Aligned hosted A2A streaming task artifact updates with the upstream .NET fix from commit `d29e7be7fd7277f15e37ddda5b6bf154c9ef428b` (`microsoft/agent-framework#7722`). The Go A2A provider now buffers streaming chunks so contiguous updates stay on the same artifact, closes the final chunk correctly, flushes the buffered artifact before failed/background handoff states, and assigns a fresh artifact ID when a message ID reappears later in the stream.

## Ported .NET PRs

- microsoft/agent-framework#7722 - Fix A2A streaming artifact updates

## Breaking Changes

No. The change preserves the existing Go API and only corrects hosted A2A streaming task artifact behavior to match the upstream contract.

## Tests and Examples

- Added hosted A2A streaming regression coverage for append/last-chunk behavior, repeated message IDs, and failure flushing in `provider/a2aprovider/hosting_test.go`
- Ran `go test ./provider/a2aprovider`

## Notes

Scoped to the task-lifecycle artifact streaming parity fix from the upstream change set. No exported Go symbols changed, and the feature-comparison document did not require an update for this behavior-only alignment.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32684158103) · gpt54 · 223.4 AIC · ⌖ 14.7 AIC · ⊞ 24.4K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 32684158103, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32684158103 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #892