### PR TITLE
[dotnet-port-fixes] Disengage history storage for service-managed sessions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -486,17 +486,23 @@ func (a *Agent) shouldStoreHistoryProvider(provider HistoryProvider, session *Se
 	if provider == nil {
 		return false
 	}
-	if !a.hasDefaultHistoryProvider {
-		return true
-	}
 	if a.providerDoesNotManageHistory {
 		// Provider never uses server-side history; always persist locally.
+		return true
+	}
+	if session != nil && session.ServiceID() != "" {
+		// Once the provider service owns the conversation history, no history
+		// provider should persist the run locally, even if a configured provider
+		// remains attached for future local sessions.
+		return false
+	}
+	if !a.hasDefaultHistoryProvider {
 		return true
 	}
 
 	// A provider can promote a local session to a service-managed one during the
 	// run. Once that happens, the default in-memory provider should stop storing.
-	return session != nil && session.ServiceID() == ""
+	return session != nil
 }
 
 func (a *Agent) handleHistoryProviderConflict(ctx context.Context, provider HistoryProvider, session *Session) (bool, error) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1538,7 +1538,7 @@ func TestAgent_Run_HistoryProvider_ClearsWhenThrowDisabledAndClearEnabled(t *tes
 	}
 }
 
-func TestAgent_Run_HistoryProvider_KeepsWhenThrowAndClearDisabled(t *testing.T) {
+func TestAgent_Run_HistoryProvider_KeepsReferenceButSkipsStoreWhenThrowAndClearDisabled(t *testing.T) {
 	provideCalls := 0
 	storeCalls := 0
 	historyProvider := agent.NewHistoryProvider(agent.HistoryProviderConfig{
@@ -1575,14 +1575,14 @@ func TestAgent_Run_HistoryProvider_KeepsWhenThrowAndClearDisabled(t *testing.T) 
 	if _, err := a.RunText(t.Context(), "input", agent.WithSession(agenttest.CreateSession())).Collect(); err != nil {
 		t.Fatalf("unexpected first run error: %v", err)
 	}
-	if provideCalls != 1 || storeCalls != 1 {
-		t.Fatalf("after first run provide/store = %d/%d, want 1/1", provideCalls, storeCalls)
+	if provideCalls != 1 || storeCalls != 0 {
+		t.Fatalf("after first run provide/store = %d/%d, want 1/0", provideCalls, storeCalls)
 	}
 	if _, err := a.RunText(t.Context(), "next", agent.WithSession(agenttest.CreateSession())).Collect(); err != nil {
 		t.Fatalf("unexpected second run error: %v", err)
 	}
-	if provideCalls != 2 || storeCalls != 2 {
-		t.Fatalf("after second run provide/store = %d/%d, want 2/2", provideCalls, storeCalls)
+	if provideCalls != 2 || storeCalls != 1 {
+		t.Fatalf("after second run provide/store = %d/%d, want 2/1", provideCalls, storeCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Align the Go agent runtime with microsoft/agent-framework#7284 by stopping history-provider persistence once a run is promoted to a service-managed session. The change keeps configured history providers attached for future local sessions, but skips storing the conflicting run when the provider service returns a session/service ID.

## Ported .NET PRs

- microsoft/agent-framework#7284 - stop persisting chat history locally once the service owns conversation history (`c59a65da5eaff014951a4732e7132793d2cd174e`)

## Breaking Changes

No. This changes internal history persistence behavior under the existing API so service-managed sessions no longer duplicate history into configured local providers.

## Tests and Examples

- `go test ./agent ./provider/aguiprovider`
- Updated the agent history conflict regression test to verify the configured provider reference is preserved while the service-managed run is not stored locally

## Notes

Skipped the later AGUI-specific follow-up in microsoft/agent-framework#7741 to keep this PR limited to the narrow parity fix from #7284. The chat-history comparison doc already reflects this area as partial, so no doc status change was needed.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32440990079) · gpt54 · 174.4 AIC · ⌖ 14 AIC · ⊞ 24.4K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 32440990079, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32440990079 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #884