### PR TITLE
[dotnet-port-fixes] Add tool approval no-session parity test

### DIFF
--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -227,6 +227,85 @@ func TestToolApproval_AlwaysApproveToolCreatesRule(t *testing.T) {
 	}
 }
 
+func TestToolApproval_AutoApprovalWithoutSessionPreservesOriginalMessages(t *testing.T) {
+	fcc := &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`}
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder().
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc},
+				},
+			}).
+			NewTurn(func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+				if len(messages) != 2 {
+					t.Fatalf("expected original user message plus injected approval response, got %d messages", len(messages))
+				}
+
+				if messages[0].Role != message.RoleUser {
+					t.Fatalf("first message role = %q, want %q", messages[0].Role, message.RoleUser)
+				}
+				text, ok := messages[0].Contents[0].(*message.TextContent)
+				if !ok || text.Text != "go" {
+					t.Fatalf("first message contents = %#v, want original user text", messages[0].Contents)
+				}
+
+				if messages[1].Role != message.RoleUser {
+					t.Fatalf("second message role = %q, want %q", messages[1].Role, message.RoleUser)
+				}
+				if len(messages[1].Contents) != 1 {
+					t.Fatalf("second message contents count = %d, want 1", len(messages[1].Contents))
+				}
+				resp, ok := messages[1].Contents[0].(*message.ToolApprovalResponseContent)
+				if !ok {
+					t.Fatalf("second message contents = %#v, want approval response", messages[1].Contents)
+				}
+				if !resp.Approved {
+					t.Fatal("expected injected approval response to approve the tool call")
+				}
+				if resp.RequestID != "r1" {
+					t.Fatalf("approval response request ID = %q, want %q", resp.RequestID, "r1")
+				}
+			}).
+			AddText("done").
+			Build(),
+	}
+
+	ruleCalls := 0
+	mw := toolapproval.New(toolapproval.Config{
+		AutoApprovalRules: []func(context.Context, *message.FunctionCallContent) (bool, error){
+			func(_ context.Context, call *message.FunctionCallContent) (bool, error) {
+				ruleCalls++
+				if call != fcc {
+					t.Fatalf("auto-approval rule received tool call %#v, want %#v", call, fcc)
+				}
+				return true, nil
+			},
+		},
+	})
+
+	updates := collectUpdates(t, mw, runner.Run, []*message.Message{
+		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}},
+	})
+
+	if ruleCalls != 1 {
+		t.Fatalf("auto-approval rule called %d times, want 1", ruleCalls)
+	}
+
+	var gotDone bool
+	for _, u := range updates {
+		for _, c := range u.Contents {
+			if tc, ok := c.(*message.TextContent); ok && tc.Text == "done" {
+				gotDone = true
+			}
+		}
+	}
+	if !gotDone {
+		t.Fatal("expected done text after auto-approved re-invocation without a session")
+	}
+}
+
 func TestToolApproval_QueuedRequestsSurfacedOneAtATime(t *testing.T) {
 	fcc1 := &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`}
 	fcc2 := &message.FunctionCallContent{CallID: "c2", Name: "restart", Arguments: `{}`}


### PR DESCRIPTION
## Summary

Add a regression test in `agent/harness/toolapproval/toolapproval_test.go` that ports the intent of the upstream .NET no-session tool-approval fix. The Go middleware already preserves the original user message when an approval request is auto-approved and the inner agent is re-invoked in the same run, so this change locks that behavior in with explicit parity coverage rather than changing the implementation.

Upstream reference: microsoft/agent-framework#7310 and commit [`28e02d466997972d51c0a435b133a875f7444976`](https://github.com/microsoft/agent-framework/commit/28e02d466997972d51c0a435b133a875f7444976).

## Ported .NET PRs

- microsoft/agent-framework#7310 - create and thread a session for tool approval when none is supplied; in Go the equivalent behavior is already satisfied by re-invoking with the original messages plus injected approval responses, so this PR ports the regression-test intent.

## Breaking Changes

No.

## Tests and Examples

- `go test ./agent/harness/toolapproval`
- Added `TestToolApproval_AutoApprovalWithoutSessionPreservesOriginalMessages`
- No examples changed

## Notes

The broader recent `dotnet/` inspection did not produce a smaller behavior fix that was both unported and in scope for `[dotnet-port-fixes]`. This PR keeps the nightly change narrow by adding parity coverage for the remaining applicable tool-approval regression path instead of changing public or internal behavior that is already aligned.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32325539284) · gpt54 · 182.5 AIC · ⌖ 12 AIC · ⊞ 24.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 32325539284, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32325539284 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #874