### PR TITLE
[dotnet-port-fixes] Cover implicit tool approval sessions

### DIFF
--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -30,6 +30,15 @@ func collectUpdates(t *testing.T, mw agent.Middleware, next agent.RunFunc, messa
 	return updates
 }
 
+func sessionFromOptions(t *testing.T, opts ...agent.Option) *agent.Session {
+	t.Helper()
+	session, ok := agent.GetOption(opts, agent.WithSession)
+	if !ok || session == nil {
+		t.Fatal("expected run options to include a non-nil session")
+	}
+	return session
+}
+
 func TestToolApproval_PassthroughWithoutApprovalRequests(t *testing.T) {
 	runner := &agenttest.Runner{
 		Responses: agenttest.NewResponseBuilder().AddText("hello").Build(),
@@ -144,6 +153,134 @@ func TestToolApproval_SurfacesFirstApprovalRequest(t *testing.T) {
 	}
 	if approvalReqs[0].RequestID != "r1" {
 		t.Errorf("expected request ID 'r1', got %q", approvalReqs[0].RequestID)
+	}
+}
+
+func TestToolApproval_AutoApprovalRuleWithoutExplicitSessionThreadsImplicitSession(t *testing.T) {
+	fcc := &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`}
+
+	var createdSession *agent.Session
+	createSessionCalls := 0
+	capturedSessions := []*agent.Session{}
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder(
+			func(_ context.Context, _ []*message.Message, opts ...agent.Option) {
+				capturedSessions = append(capturedSessions, sessionFromOptions(t, opts...))
+			},
+		).
+			Add(&agent.ResponseUpdate{
+				Role: message.RoleAssistant,
+				Contents: []message.Content{
+					&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: fcc},
+				},
+			}).
+			NewTurn(func(_ context.Context, messages []*message.Message, opts ...agent.Option) {
+				capturedSessions = append(capturedSessions, sessionFromOptions(t, opts...))
+
+				var sawApprovalResponse bool
+				for _, msg := range messages {
+					for _, c := range msg.Contents {
+						resp, ok := c.(*message.ToolApprovalResponseContent)
+						if !ok {
+							continue
+						}
+						sawApprovalResponse = true
+						if !resp.Approved {
+							t.Fatal("expected auto-approved tool response on re-entry")
+						}
+					}
+				}
+				if !sawApprovalResponse {
+					t.Fatal("expected auto-approval response to be forwarded on re-entry")
+				}
+			}).
+			AddText("done").
+			Build(),
+	}
+
+	a := agent.New(agent.ProviderConfig{
+		Run: runner.Run,
+		CreateSession: func(_ context.Context, session *agent.Session, _ ...agent.Option) error {
+			createSessionCalls++
+			createdSession = session
+			return nil
+		},
+		Middlewares: []agent.Middleware{toolapproval.New(toolapproval.Config{
+			AutoApprovalRules: []func(context.Context, *message.FunctionCallContent) (bool, error){
+				func(_ context.Context, call *message.FunctionCallContent) (bool, error) {
+					if call.Name != "deploy" {
+						t.Fatalf("auto-approval rule saw tool %q, want deploy", call.Name)
+					}
+					return true, nil
+				},
+			},
+		})},
+	}, agent.Config{ID: "test-agent", Name: "test-agent"})
+
+	resp, err := a.RunText(t.Context(), "go").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := resp.String(); got != "done" {
+		t.Fatalf("response text = %q, want done", got)
+	}
+	if createSessionCalls != 1 {
+		t.Fatalf("CreateSession called %d times, want 1", createSessionCalls)
+	}
+	if createdSession == nil {
+		t.Fatal("expected CreateSession to receive a session")
+	}
+	if len(capturedSessions) != 2 {
+		t.Fatalf("captured %d provider sessions, want 2", len(capturedSessions))
+	}
+	for i, session := range capturedSessions {
+		if session != createdSession {
+			t.Fatalf("provider call %d received session %p, want %p", i+1, session, createdSession)
+		}
+	}
+}
+
+func TestToolApproval_NoApprovalRequestWithoutExplicitSessionCreatesSingleImplicitSession(t *testing.T) {
+	var createdSession *agent.Session
+	createSessionCalls := 0
+	var capturedSession *agent.Session
+
+	runner := &agenttest.Runner{
+		Responses: agenttest.NewResponseBuilder(
+			func(_ context.Context, _ []*message.Message, opts ...agent.Option) {
+				capturedSession = sessionFromOptions(t, opts...)
+			},
+		).
+			AddText("done").
+			Build(),
+	}
+
+	a := agent.New(agent.ProviderConfig{
+		Run: runner.Run,
+		CreateSession: func(_ context.Context, session *agent.Session, _ ...agent.Option) error {
+			createSessionCalls++
+			createdSession = session
+			return nil
+		},
+		Middlewares: []agent.Middleware{toolapproval.New(toolapproval.Config{})},
+	}, agent.Config{ID: "test-agent", Name: "test-agent"})
+
+	resp, err := a.RunText(t.Context(), "go").Collect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := resp.String(); got != "done" {
+		t.Fatalf("response text = %q, want done", got)
+	}
+	if createSessionCalls != 1 {
+		t.Fatalf("CreateSession called %d times, want 1", createSessionCalls)
+	}
+	if createdSession == nil {
+		t.Fatal("expected CreateSession to receive a session")
+	}
+	if capturedSession != createdSession {
+		t.Fatalf("provider run received session %p, want %p", capturedSession, createdSession)
 	}
 }
 


### PR DESCRIPTION
## Summary

Added regression coverage for the .NET tool-approval no-session fix by exercising Go's existing implicit-session behavior through a real agent run. The new tests verify that `agent.prepareRun` creates exactly one implicit session, threads it through tool-approval auto-approval re-entry, and still provides that session on a no-approval pass-through run.

## Ported .NET PRs

- microsoft/agent-framework#7310 - create and thread a session for tool approval when the caller does not supply one
- Upstream commit: `28e02d466997972d51c0a435b133a875f7444976` ([link](https://github.com/microsoft/agent-framework/commit/28e02d466997972d51c0a435b133a875f7444976))

## Breaking Changes

No. This is a test-only parity update for behavior the Go SDK already implements.

## Tests and Examples

- `go test ./agent/harness/toolapproval`
- Added focused tests for implicit session threading during tool-approval auto-approval re-entry and for single implicit-session creation when no approval request is returned

## Notes

Go already aligned the runtime behavior before this change because `agent.prepareRun` injects an implicit session before middleware executes. This PR ports the upstream regression coverage so that alignment stays protected. Go uses a single streamed run path, so separate .NET non-streaming and streaming coverage collapses into these focused tests.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32209527810) · gpt54 · 229.6 AIC · ⌖ 11.7 AIC · ⊞ 24.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 32209527810, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32209527810 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #866