### PR TITLE
Update minimum Go version to 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25', '1.26']
+        go-version: ['1.26', '1.27']
         target:
         - name: linux
           runner: ubuntu-latest

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -129,7 +129,7 @@ func TestTruncationStrategy_ExcludesOldestGroups(t *testing.T) {
 	index := compaction.CreateMessageIndex(turnMessages(3), nil)
 	strategy := &compaction.TruncationStrategy{
 		Trigger:                compaction.GroupsExceed(2),
-		MinimumPreservedGroups: ptr(2),
+		MinimumPreservedGroups: new(2),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -156,7 +156,7 @@ func TestTruncationStrategy_SkipsPreExcludedAndSystemGroups(t *testing.T) {
 	}, nil)
 	index.Groups[1].IsExcluded = true
 	strategy := &compaction.TruncationStrategy{
-		MinimumPreservedGroups: ptr(1),
+		MinimumPreservedGroups: new(1),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -201,7 +201,7 @@ func TestSlidingWindowStrategy_ExcludesOldestTurns(t *testing.T) {
 	index := compaction.CreateMessageIndex(turnMessages(3), nil)
 	strategy := &compaction.SlidingWindowStrategy{
 		Trigger:               compaction.TurnsExceed(1),
-		MinimumPreservedTurns: ptr(1),
+		MinimumPreservedTurns: new(1),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -229,7 +229,7 @@ func TestSlidingWindowStrategy_PreservesTurnZeroGroups(t *testing.T) {
 	}, nil)
 	strategy := &compaction.SlidingWindowStrategy{
 		Trigger:               compaction.TurnsExceed(1),
-		MinimumPreservedTurns: ptr(1),
+		MinimumPreservedTurns: new(1),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -256,7 +256,7 @@ func TestTruncationStrategy_ExplicitZeroPreservesNone(t *testing.T) {
 		textMessage(message.RoleAssistant, "g4"),
 		textMessage(message.RoleAssistant, "g5"),
 	}, nil)
-	strategy := &compaction.TruncationStrategy{MinimumPreservedGroups: ptr(0)}
+	strategy := &compaction.TruncationStrategy{MinimumPreservedGroups: new(0)}
 
 	compacted, err := strategy.Compact(t.Context(), index)
 	if err != nil {
@@ -275,7 +275,7 @@ func TestTruncationStrategy_ExplicitZeroPreservesNone(t *testing.T) {
 
 func TestSlidingWindowStrategy_NegativeMinimumClampsToZero(t *testing.T) {
 	index := compaction.CreateMessageIndex(turnMessages(3), nil)
-	strategy := &compaction.SlidingWindowStrategy{MinimumPreservedTurns: ptr(-5)}
+	strategy := &compaction.SlidingWindowStrategy{MinimumPreservedTurns: new(-5)}
 
 	compacted, err := strategy.Compact(t.Context(), index)
 	if err != nil {
@@ -329,7 +329,7 @@ func TestToolResultStrategy_CollapsesOldToolGroups(t *testing.T) {
 	index := compaction.CreateMessageIndex(messages, nil)
 	strategy := &compaction.ToolResultStrategy{
 		Trigger:                compaction.HasToolCalls(),
-		MinimumPreservedGroups: ptr(2),
+		MinimumPreservedGroups: new(2),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -432,7 +432,7 @@ func TestSummarizationStrategy_InsertsSummaryAndPreservesRecentGroups(t *testing
 	strategy := &compaction.SummarizationStrategy{
 		Trigger:                compaction.GroupsExceed(2),
 		Summarizer:             summarizer,
-		MinimumPreservedGroups: ptr(2),
+		MinimumPreservedGroups: new(2),
 		SummarizationPrompt:    "summarize",
 	}
 
@@ -504,7 +504,7 @@ func TestSummarizationStrategy_RestoresGroupsWhenSummarizerFails(t *testing.T) {
 	strategy := &compaction.SummarizationStrategy{
 		Trigger:                compaction.GroupsExceed(2),
 		Summarizer:             compaction.SummarizerFunc(func(context.Context, []*message.Message) (string, error) { return "", expected }),
-		MinimumPreservedGroups: ptr(1),
+		MinimumPreservedGroups: new(1),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -524,7 +524,7 @@ func TestSummarizationStrategy_PropagatesCancellation(t *testing.T) {
 	strategy := &compaction.SummarizationStrategy{
 		Trigger:                compaction.GroupsExceed(2),
 		Summarizer:             compaction.SummarizerFunc(func(context.Context, []*message.Message) (string, error) { return "", context.Canceled }),
-		MinimumPreservedGroups: ptr(1),
+		MinimumPreservedGroups: new(1),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -544,7 +544,7 @@ func TestNewProvider_CompactsAndPersistsIndex(t *testing.T) {
 	provider := compaction.NewContextProvider(compaction.ContextProviderConfig{
 		Strategy: &compaction.TruncationStrategy{
 			Trigger:                compaction.GroupsExceed(2),
-			MinimumPreservedGroups: ptr(2),
+			MinimumPreservedGroups: new(2),
 		},
 		SourceID: "compaction-test",
 	})
@@ -581,7 +581,7 @@ func TestNewProvider_SourceStampsGeneratedMessages(t *testing.T) {
 		Strategy: &compaction.SummarizationStrategy{
 			Trigger:                compaction.GroupsExceed(2),
 			Summarizer:             compaction.SummarizerFunc(func(context.Context, []*message.Message) (string, error) { return "older context", nil }),
-			MinimumPreservedGroups: ptr(2),
+			MinimumPreservedGroups: new(2),
 		},
 		SourceID: "compaction-test",
 	})
@@ -631,7 +631,7 @@ func TestNewProvider_CompactsWithoutSession(t *testing.T) {
 	provider := compaction.NewContextProvider(compaction.ContextProviderConfig{
 		Strategy: &compaction.TruncationStrategy{
 			Trigger:                compaction.GroupsExceed(2),
-			MinimumPreservedGroups: ptr(2),
+			MinimumPreservedGroups: new(2),
 		},
 	})
 
@@ -696,5 +696,3 @@ func messageTexts(messages []*message.Message) []string {
 	}
 	return texts
 }
-
-func ptr[T any](value T) *T { return &value }

--- a/agent/compaction/index_test.go
+++ b/agent/compaction/index_test.go
@@ -84,7 +84,7 @@ func TestMessageIndex_ClassifiesStrategySummaryMessages(t *testing.T) {
 	strategy := &compaction.SummarizationStrategy{
 		Trigger:                compaction.GroupsExceed(2),
 		Summarizer:             compaction.SummarizerFunc(func(context.Context, []*message.Message) (string, error) { return "older context", nil }),
-		MinimumPreservedGroups: ptr(1),
+		MinimumPreservedGroups: new(1),
 	}
 
 	compacted, err := strategy.Compact(t.Context(), index)
@@ -183,7 +183,7 @@ func TestMessageIndex_UpdatePreservesStateFromCompactedProjection(t *testing.T) 
 	strategy := &compaction.SummarizationStrategy{
 		Trigger:                compaction.GroupsExceed(2),
 		Summarizer:             compaction.SummarizerFunc(func(context.Context, []*message.Message) (string, error) { return "older context", nil }),
-		MinimumPreservedGroups: ptr(2),
+		MinimumPreservedGroups: new(2),
 		SummarizationPrompt:    "summarize",
 	}
 

--- a/agent/harness/loop/loop_test.go
+++ b/agent/harness/loop/loop_test.go
@@ -284,8 +284,7 @@ func TestLoop_FreshContextPerIteration_SnapshotErrorPreservesCause(t *testing.T)
 	session.Set("unsupported", func() {})
 
 	_, err := a.RunText(t.Context(), "go", agent.WithSession(session)).Collect()
-	var unsupported *json.UnsupportedTypeError
-	if !errors.As(err, &unsupported) {
+	if _, ok := errors.AsType[*json.UnsupportedTypeError](err); !ok {
 		t.Fatalf("RunText() error = %v, want wrapped json.UnsupportedTypeError", err)
 	}
 	if !strings.Contains(err.Error(), "loop: snapshot session") {

--- a/cmd/verifyexamples/runner.go
+++ b/cmd/verifyexamples/runner.go
@@ -60,8 +60,7 @@ func runExample(ctx context.Context, projectPath string, timeout time.Duration, 
 
 	exitCode := 0
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
 			exitCode = -1

--- a/examples/02-agents/agents/step18_compaction_pipeline/main.go
+++ b/examples/02-agents/agents/step18_compaction_pipeline/main.go
@@ -58,23 +58,23 @@ func main() {
 			// 1. Gentle: collapse old tool-call groups into short summaries.
 			&compaction.ToolResultStrategy{
 				Trigger:                compaction.MessagesExceed(7),
-				MinimumPreservedGroups: ptr(4),
+				MinimumPreservedGroups: new(4),
 			},
 			// 2. Moderate: use an LLM to summarize older conversation spans into a concise message.
 			&compaction.SummarizationStrategy{
 				Trigger:                compaction.TokensExceed(0x500),
 				Summarizer:             summarizer,
-				MinimumPreservedGroups: ptr(4),
+				MinimumPreservedGroups: new(4),
 			},
 			// 3. Aggressive: keep only the last N user turns and their responses.
 			&compaction.SlidingWindowStrategy{
 				Trigger:               compaction.TurnsExceed(4),
-				MinimumPreservedTurns: ptr(4),
+				MinimumPreservedTurns: new(4),
 			},
 			// 4. Emergency: drop oldest groups until under the token budget.
 			&compaction.TruncationStrategy{
 				Trigger:                compaction.TokensExceed(0x8000),
-				MinimumPreservedGroups: ptr(8),
+				MinimumPreservedGroups: new(8),
 			},
 		},
 	}
@@ -125,9 +125,6 @@ When responding, be extra descriptive and use as many words as possible without 
 		demo.Response(resp, err)
 	}
 }
-
-func ptr[T any](value T) *T { return &value }
-
 func lookupPrice(_ context.Context, productName string) (string, error) {
 	switch strings.ToUpper(productName) {
 	case "LAPTOP":

--- a/examples/02-agents/agents/step18_compaction_pipeline/main.go
+++ b/examples/02-agents/agents/step18_compaction_pipeline/main.go
@@ -125,6 +125,7 @@ When responding, be extra descriptive and use as many words as possible without 
 		demo.Response(resp, err)
 	}
 }
+
 func lookupPrice(_ context.Context, productName string) (string, error) {
 	switch strings.ToUpper(productName) {
 	case "LAPTOP":

--- a/examples/02-agents/agents/step22_foundry_memory/main.go
+++ b/examples/02-agents/agents/step22_foundry_memory/main.go
@@ -91,10 +91,6 @@ func main() {
 	demo.Response(resp, err)
 }
 
-func stringPtr(value string) *string {
-	return &value
-}
-
 // setupFoundryMemoryStore prepares a sample memory store so the demo can run
 // repeatedly. Regular apps should provision Foundry resources outside the app;
 // this helper uses Agent Framework's temporary internal Foundry SDK for setup.
@@ -108,8 +104,8 @@ func setupFoundryMemoryStore(ctx context.Context, foundryEndpoint string, token 
 	// Ensure the memory store exists (creates it with the specified models if needed).
 	if _, err := client.GetMemoryStore(ctx, memoryStoreName, nil); err != nil {
 		demo.Assistant("Setting up Foundry memory store")
-		var responseErr *azcore.ResponseError
-		if !errors.As(err, &responseErr) || responseErr.StatusCode != 404 {
+		responseErr, ok := errors.AsType[*azcore.ResponseError](err)
+		if !ok || responseErr.StatusCode != 404 {
 			demo.Panicf("failed to get memory store: %v", err)
 		}
 
@@ -117,7 +113,7 @@ func setupFoundryMemoryStore(ctx context.Context, foundryEndpoint string, token 
 			ChatModel:      &chatDeployment,
 			EmbeddingModel: &embeddingDeployment,
 		}, &azaiprojects.MemoryStoresClientCreateMemoryStoreOptions{
-			Description: stringPtr("Sample memory store for travel assistant"),
+			Description: new("Sample memory store for travel assistant"),
 		})
 		if err != nil {
 			demo.Panicf("failed to create memory store with chat deployment %q and embedding deployment %q: %v", chatDeployment, embeddingDeployment, err)
@@ -126,8 +122,8 @@ func setupFoundryMemoryStore(ctx context.Context, foundryEndpoint string, token 
 
 	// Clear any existing memories for this scope to demonstrate fresh behavior.
 	if _, err := client.DeleteScope(ctx, memoryStoreName, memoryScope, nil); err != nil {
-		var responseErr *azcore.ResponseError
-		if !errors.As(err, &responseErr) || responseErr.StatusCode != 404 {
+		responseErr, ok := errors.AsType[*azcore.ResponseError](err)
+		if !ok || responseErr.StatusCode != 404 {
 			demo.Panicf("failed to clear stored memories: %v", err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/agent-framework-go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0

--- a/message/messageworkflow/messageforwarding_test.go
+++ b/message/messageworkflow/messageforwarding_test.go
@@ -196,7 +196,7 @@ func TestConfigureForwarding_ForwardsMessageSequenceAsSlice(t *testing.T) {
 }
 
 func TestConfigureForwarding_ForwardsTurnTokenUnmodified(t *testing.T) {
-	for _, emitEvents := range []*bool{nil, boolPtr(false), boolPtr(true)} {
+	for _, emitEvents := range []*bool{nil, new(false), new(true)} {
 		executor := newForwardingExecutorForTest(nil)
 		token := workflow.TurnToken{EmitEvents: emitEvents}
 
@@ -209,5 +209,3 @@ func TestConfigureForwarding_ForwardsTurnTokenUnmodified(t *testing.T) {
 		}
 	}
 }
-
-func boolPtr(value bool) *bool { return &value }

--- a/provider/foundryprovider/memory.go
+++ b/provider/foundryprovider/memory.go
@@ -127,8 +127,8 @@ func newMemoryProvider(client *azaiprojects.MemoryStoresClient, memoryStoreName 
 // returned unchanged.
 func (p *MemoryProvider) EnsureMemoryStoreCreated(ctx context.Context, chatModel, embeddingModel string, description *string) error {
 	if _, err := p.client.GetMemoryStore(ctx, p.memoryStoreName, nil); err != nil {
-		var respErr *azcore.ResponseError
-		if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusNotFound {
+		respErr, ok := errors.AsType[*azcore.ResponseError](err)
+		if !ok || respErr.StatusCode != http.StatusNotFound {
 			return err
 		}
 		def := &azaiprojects.MemoryStoreDefaultDefinition{
@@ -142,7 +142,7 @@ func (p *MemoryProvider) EnsureMemoryStoreCreated(ctx context.Context, chatModel
 		if _, err = p.client.CreateMemoryStore(ctx, p.memoryStoreName, def, options); err != nil {
 			// Tolerate a concurrent create: if another process created the store after the
 			// GET returned 404, CreateMemoryStore reports a conflict. Treat it as a no-op.
-			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusConflict {
+			if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok && respErr.StatusCode == http.StatusConflict {
 				return nil
 			}
 			return err
@@ -172,8 +172,7 @@ func (p *MemoryProvider) Invoked(ctx context.Context, invoked agent.InvokedConte
 func (p *MemoryProvider) EnsureStoredMemoriesDeleted(ctx context.Context, session *agent.Session) error {
 	scope := p.scope(session)
 	if _, err := p.client.DeleteScope(ctx, p.memoryStoreName, scope, nil); err != nil {
-		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok && respErr.StatusCode == http.StatusNotFound {
 			p.log(ctx, slog.LevelInfo, "foundrymemory: no stored memories to delete", "memory_store", p.memoryStoreName)
 			return nil
 		}

--- a/provider/foundryprovider/memory_test.go
+++ b/provider/foundryprovider/memory_test.go
@@ -457,8 +457,8 @@ func TestMemoryProviderEnsureStoredMemoriesDeletedSurfacesOtherErrors(t *testing
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	var respErr *azcore.ResponseError
-	if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusInternalServerError {
+	respErr, ok := errors.AsType[*azcore.ResponseError](err)
+	if !ok || respErr.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/tool/functool/func.go
+++ b/tool/functool/func.go
@@ -75,7 +75,7 @@ func New[In, Out any](cfg Config, h HandlerFor[In, Out]) (tool.FuncTool, error) 
 	// that case, mirroring the MCP go-sdk's HandlerFor behavior.
 	var elemZero Out
 	outType := reflect.TypeFor[Out]()
-	hasPointerOut := outType != nil && outType.Kind() == reflect.Pointer
+	hasPointerOut := outType.Kind() == reflect.Pointer
 	if hasPointerOut {
 		// Convert to outType before asserting: for a named pointer type
 		// (e.g. type P *T), reflect.New yields an unnamed *T that is not

--- a/tool/shelltool/localshell.go
+++ b/tool/shelltool/localshell.go
@@ -386,8 +386,7 @@ func runStateless(ctx context.Context, opts LocalConfig, command string) (Result
 	if timedOut {
 		exitCode = exitCodeTimedOut
 	} else if runErr != nil {
-		var exitErr *exec.ExitError
-		if errors.As(runErr, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](runErr); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
 			return Result{}, fmt.Errorf("%w: shelltool: run: %w", errCommandIO, runErr)

--- a/workflow/agentworkflow/hosting_test.go
+++ b/workflow/agentworkflow/hosting_test.go
@@ -349,9 +349,6 @@ func runHostedAgent(t *testing.T, a *agent.Agent, cfg agentworkflow.Config, toke
 	return events
 }
 
-// boolPtr is a tiny helper for *bool literals.
-func boolPtr(b bool) *bool { return &b }
-
 // TestHostedAgent_EmitsStreamingUpdatesIfConfigured exercises the matrix
 // (executorSetting × turnSetting) for streaming response update output emission. The rule:
 // the TurnToken's EmitEvents flag overrides the executor's EmitUpdateEvents
@@ -362,14 +359,14 @@ func TestHostedAgent_EmitsStreamingUpdatesIfConfigured(t *testing.T) {
 		turnSetting     *bool
 	}{
 		{nil, nil},
-		{nil, boolPtr(true)},
-		{nil, boolPtr(false)},
-		{boolPtr(true), nil},
-		{boolPtr(true), boolPtr(true)},
-		{boolPtr(true), boolPtr(false)},
-		{boolPtr(false), nil},
-		{boolPtr(false), boolPtr(true)},
-		{boolPtr(false), boolPtr(false)},
+		{nil, new(true)},
+		{nil, new(false)},
+		{new(true), nil},
+		{new(true), new(true)},
+		{new(true), new(false)},
+		{new(false), nil},
+		{new(false), new(true)},
+		{new(false), new(false)},
 	}
 
 	expectedContents := expectedReplayUpdateContents()

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -946,8 +946,8 @@ func handleMethodValue(value reflect.Value) reflect.Value {
 }
 
 func executorAttrTypes(structType reflect.Type) (sendTypes []reflect.Type, yieldTypes []reflect.Type) {
-	for i := 0; i < structType.NumField(); i++ {
-		fieldType := structType.Field(i).Type
+	for field := range structType.Fields() {
+		fieldType := field.Type
 		if typ, ok := executorAttrType(fieldType, "AttrSendsMessage"); ok {
 			sendTypes = appendUniqueTypes(sendTypes, typ)
 		}

--- a/workflow/inproc/runner.go
+++ b/workflow/inproc/runner.go
@@ -302,15 +302,11 @@ func (r *runner) Checkpoints() []workflow.CheckpointInfo {
 	return slices.Clone(r.checkpoints)
 }
 
-func checkpointInfoPtr(info workflow.CheckpointInfo) *workflow.CheckpointInfo {
-	return &info
-}
-
 func cloneCheckpointInfoPtr(info *workflow.CheckpointInfo) *workflow.CheckpointInfo {
 	if info == nil {
 		return nil
 	}
-	return checkpointInfoPtr(*info)
+	return new(*info)
 }
 
 // RestoreCheckpoint restores the workflow state from a checkpoint.
@@ -363,7 +359,7 @@ func (r *runner) restoreCheckpointCore(ctx context.Context, checkpointInfo workf
 	}
 	r.checkpointMu.Lock()
 	r.checkpoints = index
-	r.lastCheckpointInfo = checkpointInfoPtr(checkpointInfo)
+	r.lastCheckpointInfo = new(checkpointInfo)
 	r.checkpointMu.Unlock()
 	r.stepTracer.Reload(cp.StepNumber)
 	return nil
@@ -495,7 +491,7 @@ func (r *runner) checkpoint(ctx context.Context) error {
 	r.stepTracer.TraceCheckpointCreated(info)
 	r.checkpointMu.Lock()
 	r.checkpoints = append(r.checkpoints, info)
-	r.lastCheckpointInfo = checkpointInfoPtr(info)
+	r.lastCheckpointInfo = new(info)
 	r.checkpointMu.Unlock()
 	return nil
 }

--- a/workflow/internal/execution/edgerunner.go
+++ b/workflow/internal/execution/edgerunner.go
@@ -216,7 +216,7 @@ func (em *EdgeRunner) PrepareDeliveryForEdge(ctx context.Context, edge workflow.
 		// Stateful edge - track source messages.
 		state, ok := em.statefulEdges[edge.Index]
 		if !ok {
-			return nil, fmt.Errorf("edge state for %q not found", edge.Index)
+			return nil, fmt.Errorf("edge state for %d not found", edge.Index)
 		}
 		envelopes = state.processMessage(envelope.SourceID, envelope)
 		if len(envelopes) == 0 {

--- a/workflow/internal/execution/edgerunner_observability_test.go
+++ b/workflow/internal/execution/edgerunner_observability_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPrepareDeliveryForDirectEdge(t *testing.T) {
-	bools := []*bool{nil, ptr(true), ptr(false)}
+	bools := []*bool{nil, new(true), new(false)}
 	for _, conditionMatch := range bools {
 		for _, targetMatch := range bools {
 			name := fmt.Sprintf("condition=%v/target=%v", boolName(conditionMatch), boolName(targetMatch))
@@ -68,7 +68,7 @@ func TestPrepareDeliveryForDirectEdge(t *testing.T) {
 }
 
 func TestPrepareDeliveryForFanOutEdge(t *testing.T) {
-	bools := []*bool{nil, ptr(true), ptr(false)}
+	bools := []*bool{nil, new(true), new(false)}
 	for _, assignerSelectsEmpty := range bools {
 		for _, targetMatch := range bools {
 			name := fmt.Sprintf("assignerEmpty=%v/target=%v", boolName(assignerSelectsEmpty), boolName(targetMatch))
@@ -417,10 +417,6 @@ func sameStringSet(left []string, right []string) bool {
 		}
 	}
 	return true
-}
-
-func ptr(value bool) *bool {
-	return &value
 }
 
 func boolName(value *bool) string {


### PR DESCRIPTION
## Summary
- raise the module's minimum Go version from 1.25 to 1.26
- update CI to test the supported Go 1.26 and 1.27 releases
- adopt Go 1.26's `new(expression)`, `errors.AsType`, and reflection iterators, and fix a stricter `printf` diagnostic

## Testing
- `GOTOOLCHAIN=local go test ./...` (Go 1.26.1)
- `GOTOOLCHAIN=go1.27.0 go test ./...`