### PR TITLE
Emit GenAI metrics from OTel middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,9 @@ require (
 	github.com/openai/openai-go/v3 v3.52.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.45.0
+	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
+	go.opentelemetry.io/otel/sdk/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/sync v0.22.0
 	google.golang.org/genai v1.69.0
@@ -58,7 +60,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.45.0 h1:lsA/S1bxgdbyFGk
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.45.0/go.mod h1:L7u+MirGoB1bjeLH66+xDykF4RC8C3RN7lIFpBiewUo=
 go.opentelemetry.io/otel/metric v1.45.0 h1:7Eg1uH7CJ5cXv9is6tnBe1FI6rj1nwUdbFypRm3br/M=
 go.opentelemetry.io/otel/metric v1.45.0/go.mod h1:HAPbm1nd3p1PmFH7v2dR+6BjXxw+Lq4a2+pndMAm08s=
+go.opentelemetry.io/otel/metric/x v0.67.0 h1:PcicCNZFkZ4bXfSooXdo3WN7RBOVOtjVdo1wD358Uns=
+go.opentelemetry.io/otel/metric/x v0.67.0/go.mod h1:FBjCWZe6wgcqxcMtjdGiClDKXb2YxxXii0CXftE4QtI=
 go.opentelemetry.io/otel/sdk v1.45.0 h1:4VVSMgQ83dUgW2aoX5f6JgLvHwIvzcuLnF9lUdCSpCw=
 go.opentelemetry.io/otel/sdk v1.45.0/go.mod h1:Sr40LgXV7DsKMMJMKOhUWOgMWTfAaqvm2kF0g7ilwuA=
 go.opentelemetry.io/otel/sdk/metric v1.45.0 h1:oVFszMfyj1Am6s24Vtc7wBb8BKLcwepJjNEYILuiE3o=

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -242,10 +242,11 @@ func mapStopReason(reason anthropic.StopReason) string {
 }
 
 func toUsageDetails(usage anthropic.Usage) message.UsageDetails {
+	inputTokens := usage.InputTokens + usage.CacheCreationInputTokens + usage.CacheReadInputTokens
 	details := message.UsageDetails{
-		InputTokenCount:       usage.InputTokens,
+		InputTokenCount:       inputTokens,
 		OutputTokenCount:      usage.OutputTokens,
-		TotalTokenCount:       usage.InputTokens + usage.OutputTokens,
+		TotalTokenCount:       inputTokens + usage.OutputTokens,
 		CachedInputTokenCount: usage.CacheReadInputTokens,
 	}
 	if usage.CacheCreationInputTokens != 0 {

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -248,6 +248,7 @@ func toUsageDetails(usage anthropic.Usage) message.UsageDetails {
 		OutputTokenCount:      usage.OutputTokens,
 		TotalTokenCount:       inputTokens + usage.OutputTokens,
 		CachedInputTokenCount: usage.CacheReadInputTokens,
+		ReasoningTokenCount:   usage.OutputTokensDetails.ThinkingTokens,
 	}
 	if usage.CacheCreationInputTokens != 0 {
 		if details.AdditionalCounts == nil {
@@ -264,6 +265,7 @@ func toUsageDetailsDelta(usage anthropic.MessageDeltaUsage) message.UsageDetails
 		OutputTokens:             usage.OutputTokens,
 		CacheCreationInputTokens: usage.CacheCreationInputTokens,
 		CacheReadInputTokens:     usage.CacheReadInputTokens,
+		OutputTokensDetails:      usage.OutputTokensDetails,
 	})
 }
 

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -129,7 +129,7 @@ func minimalMessageResponse(payload string) string {
 func TestStreamingUsage_DoesNotDoubleCountOutputTokens(t *testing.T) {
 	output := "" +
 		"event: message_start\n" +
-		`data: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1,"cache_creation_input_tokens":3,"cache_read_input_tokens":7}}}` + "\n\n" +
+		`data: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1,"cache_creation_input_tokens":3,"cache_read_input_tokens":7,"output_tokens_details":{"thinking_tokens":1}}}}` + "\n\n" +
 		"event: content_block_start\n" +
 		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
 		"event: content_block_delta\n" +
@@ -137,7 +137,7 @@ func TestStreamingUsage_DoesNotDoubleCountOutputTokens(t *testing.T) {
 		"event: content_block_stop\n" +
 		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
 		"event: message_delta\n" +
-		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}` + "\n\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5,"output_tokens_details":{"thinking_tokens":3}}}` + "\n\n" +
 		"event: message_stop\n" +
 		`data: {"type":"message_stop"}` + "\n\n"
 
@@ -165,6 +165,9 @@ func TestStreamingUsage_DoesNotDoubleCountOutputTokens(t *testing.T) {
 	}
 	if usage.Details.OutputTokenCount != 5 {
 		t.Errorf("OutputTokenCount = %d, want 5 (message_delta final count, not 1+5)", usage.Details.OutputTokenCount)
+	}
+	if usage.Details.ReasoningTokenCount != 3 {
+		t.Errorf("ReasoningTokenCount = %d, want 3", usage.Details.ReasoningTokenCount)
 	}
 	if usage.Details.InputTokenCount != 20 {
 		t.Errorf("InputTokenCount = %d, want 20 (uncached + cache creation + cache read)", usage.Details.InputTokenCount)

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -129,7 +129,7 @@ func minimalMessageResponse(payload string) string {
 func TestStreamingUsage_DoesNotDoubleCountOutputTokens(t *testing.T) {
 	output := "" +
 		"event: message_start\n" +
-		`data: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}` + "\n\n" +
+		`data: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1,"cache_creation_input_tokens":3,"cache_read_input_tokens":7}}}` + "\n\n" +
 		"event: content_block_start\n" +
 		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
 		"event: content_block_delta\n" +
@@ -166,11 +166,17 @@ func TestStreamingUsage_DoesNotDoubleCountOutputTokens(t *testing.T) {
 	if usage.Details.OutputTokenCount != 5 {
 		t.Errorf("OutputTokenCount = %d, want 5 (message_delta final count, not 1+5)", usage.Details.OutputTokenCount)
 	}
-	if usage.Details.InputTokenCount != 10 {
-		t.Errorf("InputTokenCount = %d, want 10", usage.Details.InputTokenCount)
+	if usage.Details.InputTokenCount != 20 {
+		t.Errorf("InputTokenCount = %d, want 20 (uncached + cache creation + cache read)", usage.Details.InputTokenCount)
 	}
-	if usage.Details.TotalTokenCount != 15 {
-		t.Errorf("TotalTokenCount = %d, want 15", usage.Details.TotalTokenCount)
+	if usage.Details.TotalTokenCount != 25 {
+		t.Errorf("TotalTokenCount = %d, want 25", usage.Details.TotalTokenCount)
+	}
+	if usage.Details.CachedInputTokenCount != 7 {
+		t.Errorf("CachedInputTokenCount = %d, want 7", usage.Details.CachedInputTokenCount)
+	}
+	if got := usage.Details.AdditionalCounts["cache_creation_input_tokens"]; got != 3 {
+		t.Errorf("cache_creation_input_tokens = %d, want 3", got)
 	}
 }
 

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -70,7 +70,7 @@ func NewAgent(gclient *genai.Client, config AgentConfig) *agent.Agent {
 	}
 	return agent.New(agent.ProviderConfig{
 		Run:          c.run,
-		ProviderName: "gemini",
+		ProviderName: "gcp.gemini",
 		Middlewares:  providerMiddlewares,
 		Format:       c.formatOf,
 		Unmarshal:    c.unmarshal,

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -38,6 +38,21 @@ func TestNewAgent_PanicsWithNilClient(t *testing.T) {
 	geminiprovider.NewAgent(nil, geminiprovider.AgentConfig{})
 }
 
+func TestNewAgent_UsesCanonicalProviderName(t *testing.T) {
+	client, err := genai.NewClient(t.Context(), &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		APIKey:  "test",
+	})
+	if err != nil {
+		t.Fatalf("genai.NewClient: %v", err)
+	}
+	a := geminiprovider.NewAgent(client, geminiprovider.AgentConfig{})
+
+	if got := a.ProviderName(); got != "gcp.gemini" {
+		t.Errorf("ProviderName() = %q, want %q", got, "gcp.gemini")
+	}
+}
+
 func TestAgent_UnsupportedMessageRoleReturnsError(t *testing.T) {
 	client, err := genai.NewClient(t.Context(), &genai.ClientConfig{
 		Backend: genai.BackendGeminiAPI,

--- a/provider/otelprovider/otel.go
+++ b/provider/otelprovider/otel.go
@@ -15,6 +15,9 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	"go.opentelemetry.io/otel/semconv/v1.41.0/genaiconv"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -23,48 +26,42 @@ type MiddlewareConfig struct {
 	SourceName string
 }
 
-// NewMiddleware creates a new middleware that adds OpenTelemetry tracing to agent runs.
+// NewMiddleware creates a new middleware that adds OpenTelemetry tracing and metrics to agent runs.
 func NewMiddleware(cfg MiddlewareConfig) agent.Middleware {
-	tracer := otel.Tracer(cmp.Or(cfg.SourceName, "github.com/microsoft/agent-framework-go"))
-	return &mw{
-		tracer: tracer,
+	name := cmp.Or(cfg.SourceName, "github.com/microsoft/agent-framework-go")
+	m := &mw{
+		tracer: otel.Tracer(name),
 	}
+	meter := otel.Meter(name)
+	operationDuration, err := genaiconv.NewClientOperationDuration(
+		meter,
+		metric.WithExplicitBucketBoundaries(0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92),
+	)
+	if err != nil {
+		otel.Handle(err)
+	}
+	m.operationDuration = operationDuration
+	tokenUsage, err := genaiconv.NewClientTokenUsage(
+		meter,
+		metric.WithExplicitBucketBoundaries(1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864),
+	)
+	if err != nil {
+		otel.Handle(err)
+	}
+	m.tokenUsage = tokenUsage
+	return m
 }
 
-const (
-	opInvoke = "invoke_agent"
-
-	attrKeyProviderName  = "gen_ai.provider.name"
-	attrKeyAgentID       = "gen_ai.agent.id"
-	attrKeyAgentName     = "gen_ai.agent.name"
-	attrKeyAgentDesc     = "gen_ai.agent.description"
-	attrKeyOperationName = "gen_ai.operation.name"
-	attrKeyErrorType     = "error.type"
-
-	// Token usage, per the OpenTelemetry GenAI semantic conventions.
-	//
-	// Providers already emit message.UsageContent into the response stream (see
-	// provider/anthropicprovider/agent.go), and this middleware already iterates that
-	// stream -- so the numbers pass through here on their way to the caller and were
-	// simply never recorded. Token count is cost, and cost is the main reason to trace
-	// an agent at all.
-	//
-	// Names are the exact ids from the GenAI semantic-conventions registry. The registry
-	// namespaces the cache/reasoning counters (they are not `<x>_tokens`) and defines no
-	// total; do not infer these from the input/output shape.
-	attrKeyUsageInputTokens     = "gen_ai.usage.input_tokens"
-	attrKeyUsageOutputTokens    = "gen_ai.usage.output_tokens"
-	attrKeyUsageCacheReadTokens = "gen_ai.usage.cache_read.input_tokens"
-	attrKeyUsageReasoningTokens = "gen_ai.usage.reasoning.output_tokens"
-)
-
 type mw struct {
-	tracer trace.Tracer
+	tracer            trace.Tracer
+	operationDuration genaiconv.ClientOperationDuration
+	tokenUsage        genaiconv.ClientTokenUsage
 }
 
 func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		a, _ := agent.AgentFromContext(ctx)
+		start := time.Now()
 		// GenAI conventions name the span "<operation> <target>", mirroring the sibling
 		// execute_tool span (see startToolSpan). Fall back to the agent id when it has no
 		// name so the span still carries a target, matching .NET/Python. Default the id to
@@ -72,32 +69,40 @@ func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Me
 		// and gen_ai.agent.id is never an empty string, even when the middleware runs
 		// without an agent in context.
 		id := cmp.Or(a.ID(), "unknown")
-		name := opInvoke + " " + cmp.Or(a.Name(), id)
+		name := string(genaiconv.OperationNameInvokeAgent) + " " + cmp.Or(a.Name(), id)
 		// Only include name/description when present: .NET and Python omit these attributes
 		// for an unnamed/undescribed agent rather than emitting empty strings.
 		attrs := []attribute.KeyValue{
-			attribute.String(attrKeyOperationName, opInvoke),
-			attribute.String(attrKeyProviderName, cmp.Or(a.ProviderName(), "unknown")),
-			attribute.String(attrKeyAgentID, id),
+			semconv.GenAIOperationNameInvokeAgent,
+			semconv.GenAIProviderNameKey.String(cmp.Or(a.ProviderName(), "unknown")),
+			semconv.GenAIAgentID(id),
 		}
 		if a.Name() != "" {
-			attrs = append(attrs, attribute.String(attrKeyAgentName, a.Name()))
+			attrs = append(attrs, semconv.GenAIAgentName(a.Name()))
 		}
 		if a.Description() != "" {
-			attrs = append(attrs, attribute.String(attrKeyAgentDesc, a.Description()))
+			attrs = append(attrs, semconv.GenAIAgentDescription(a.Description()))
 		}
-		ctx, span := m.tracer.Start(ctx, name, trace.WithAttributes(attrs...))
+		ctx, span := m.tracer.Start(ctx, name, trace.WithTimestamp(start), trace.WithAttributes(attrs...))
 		ctx = otelx.WithTracer(ctx, m.tracer)
-		defer span.End()
 
 		// Accumulated across the whole run. An agent that makes several LLM round-trips
 		// emits one UsageContent per round-trip, so summing them gives the true cost of
 		// the agent rather than the cost of its final call.
 		var usage message.UsageDetails
+		var errorType string
+		defer func() {
+			end := time.Now()
+			setUsage(span, usage)
+			m.recordOperationDuration(ctx, a, end.Sub(start), errorType)
+			m.recordTokenUsage(ctx, a, usage)
+			span.End(trace.WithTimestamp(end))
+		}()
 
 		for update, err := range next(ctx, messages, options...) {
 			if err != nil {
-				span.SetAttributes(attribute.String(attrKeyErrorType, otelx.ErrorTypeName(err)))
+				errorType = otelx.ErrorTypeName(err)
+				span.SetAttributes(semconv.ErrorTypeKey.String(errorType))
 				span.RecordError(err, trace.WithTimestamp(time.Now()))
 				span.SetStatus(codes.Error, err.Error())
 			}
@@ -105,16 +110,34 @@ func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Me
 			// its total into the run rather than iterating Contents by hand.
 			usage.Add(update.Usage())
 			if !yield(update, err) {
-				// Set what we have before bailing. A caller that stops reading early
-				// still ran (and paid for) the tokens counted so far, and a span that
-				// silently reports none of them understates real spend.
-				setUsage(span, usage)
 				return
 			}
 		}
-
-		setUsage(span, usage)
 	}
+}
+
+func (m *mw) recordOperationDuration(ctx context.Context, a *agent.Agent, duration time.Duration, errorType string) {
+	var attrs []attribute.KeyValue
+	if errorType != "" {
+		attrs = append(attrs, m.operationDuration.AttrErrorType(genaiconv.ErrorTypeAttr(errorType)))
+	}
+	m.operationDuration.Record(
+		ctx,
+		duration.Seconds(),
+		genaiconv.OperationNameInvokeAgent,
+		genaiconv.ProviderNameAttr(cmp.Or(a.ProviderName(), "unknown")),
+		attrs...,
+	)
+}
+
+func (m *mw) recordTokenUsage(ctx context.Context, a *agent.Agent, usage message.UsageDetails) {
+	if !hasTokenUsage(usage) {
+		return
+	}
+
+	providerName := genaiconv.ProviderNameAttr(cmp.Or(a.ProviderName(), "unknown"))
+	m.tokenUsage.Record(ctx, usage.InputTokenCount, genaiconv.OperationNameInvokeAgent, providerName, genaiconv.TokenTypeInput)
+	m.tokenUsage.Record(ctx, usage.OutputTokenCount, genaiconv.OperationNameInvokeAgent, providerName, genaiconv.TokenTypeOutput)
 }
 
 // setUsage records token counts on the span. Zero-valued optional counters are left
@@ -122,10 +145,6 @@ func (m *mw) Run(next agent.RunFunc, ctx context.Context, messages []*message.Me
 // tokens should be distinguishable from one that reports none, and an attribute that
 // is always present but always zero trains people to ignore it.
 func setUsage(span trace.Span, usage message.UsageDetails) {
-	// "Did we observe ANY usage?" -- and that must consider every counter, not just the
-	// three required ones. Guarding on input/output/total alone would silently drop the
-	// whole attribute set for a provider that reported only cached or reasoning tokens,
-	// which is the exact silent-drop this function exists to avoid.
 	if !hasUsage(usage) {
 		return
 	}
@@ -134,25 +153,27 @@ func setUsage(span trace.Span, usage message.UsageDetails) {
 	// total); cache_read is a subset of input and reasoning a subset of output, so
 	// consumers sum rather than reading a provider-side total.
 	attrs := []attribute.KeyValue{
-		attribute.Int64(attrKeyUsageInputTokens, usage.InputTokenCount),
-		attribute.Int64(attrKeyUsageOutputTokens, usage.OutputTokenCount),
+		semconv.GenAIUsageInputTokensKey.Int64(usage.InputTokenCount),
+		semconv.GenAIUsageOutputTokensKey.Int64(usage.OutputTokenCount),
 	}
 	if usage.CachedInputTokenCount > 0 {
-		attrs = append(attrs, attribute.Int64(attrKeyUsageCacheReadTokens, usage.CachedInputTokenCount))
+		attrs = append(attrs, semconv.GenAIUsageCacheReadInputTokensKey.Int64(usage.CachedInputTokenCount))
 	}
 	if usage.ReasoningTokenCount > 0 {
-		attrs = append(attrs, attribute.Int64(attrKeyUsageReasoningTokens, usage.ReasoningTokenCount))
+		attrs = append(attrs, semconv.GenAIUsageReasoningOutputTokensKey.Int64(usage.ReasoningTokenCount))
 	}
 	span.SetAttributes(attrs...)
 }
 
-// hasUsage reports whether any counter was populated. UsageDetails carries a map
-// (AdditionalCounts) so it is not comparable with ==; the fields are checked directly.
-func hasUsage(u message.UsageDetails) bool {
-	return u.InputTokenCount != 0 ||
-		u.OutputTokenCount != 0 ||
-		u.TotalTokenCount != 0 ||
-		u.CachedInputTokenCount != 0 ||
-		u.ReasoningTokenCount != 0 ||
-		len(u.AdditionalCounts) > 0
+func hasTokenUsage(usage message.UsageDetails) bool {
+	return usage.InputTokenCount != 0 || usage.OutputTokenCount != 0
+}
+
+func hasUsage(usage message.UsageDetails) bool {
+	return usage.InputTokenCount != 0 ||
+		usage.OutputTokenCount != 0 ||
+		usage.TotalTokenCount != 0 ||
+		usage.CachedInputTokenCount != 0 ||
+		usage.ReasoningTokenCount != 0 ||
+		len(usage.AdditionalCounts) > 0
 }

--- a/provider/otelprovider/otel_test.go
+++ b/provider/otelprovider/otel_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"slices"
 	"strings"
 	"testing"
 
@@ -17,6 +18,9 @@ import (
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/functool"
 
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -38,6 +42,312 @@ func setupTracer(t *testing.T) *tracetest.InMemoryExporter {
 		otellib.SetTracerProvider(originalProvider)
 	})
 	return exporter
+}
+
+func setupMeter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	originalProvider := otellib.GetMeterProvider()
+	otellib.SetMeterProvider(provider)
+
+	t.Cleanup(func() {
+		_ = provider.Shutdown(t.Context())
+		otellib.SetMeterProvider(originalProvider)
+	})
+	return reader
+}
+
+func collectMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Aggregation {
+	t.Helper()
+	resourceMetrics := collectMetrics(t, reader)
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			if m.Name == name {
+				return m.Data
+			}
+		}
+	}
+	t.Fatalf("metric %q was not recorded", name)
+	return nil
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var resourceMetrics metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &resourceMetrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	return resourceMetrics
+}
+
+func hasMetric(resourceMetrics metricdata.ResourceMetrics, name string) bool {
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			if m.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func metricAttribute(set attribute.Set, key string) (string, bool) {
+	value, ok := set.Value(attribute.Key(key))
+	return value.AsString(), ok
+}
+
+func TestOtel_Run_RecordsOperationDurationMetric(t *testing.T) {
+	exporter := setupTracer(t)
+	reader := setupMeter(t)
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	a := agent.New(agent.ProviderConfig{
+		ProviderName: "test-provider",
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{MessageID: "test-1"}, nil)
+			}
+		},
+	}, agent.Config{Name: "test-agent", Middlewares: []agent.Middleware{mw}})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	var resourceMetrics metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &resourceMetrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			if m.Name == "gen_ai.client.operation.duration" {
+				histogram, ok := m.Data.(metricdata.Histogram[float64])
+				if !ok {
+					t.Fatalf("operation duration metric has type %T, want float64 histogram", m.Data)
+				}
+				if len(histogram.DataPoints) != 1 {
+					t.Fatalf("operation duration data points = %d, want 1", len(histogram.DataPoints))
+				}
+				dataPoint := histogram.DataPoints[0]
+				wantBounds := []float64{0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92}
+				if !slices.Equal(dataPoint.Bounds, wantBounds) {
+					t.Errorf("operation duration bounds = %v, want %v", dataPoint.Bounds, wantBounds)
+				}
+				if operation, _ := metricAttribute(dataPoint.Attributes, "gen_ai.operation.name"); operation != "invoke_agent" {
+					t.Errorf("gen_ai.operation.name = %q, want invoke_agent", operation)
+				}
+				if provider, _ := metricAttribute(dataPoint.Attributes, "gen_ai.provider.name"); provider != "test-provider" {
+					t.Errorf("gen_ai.provider.name = %q, want test-provider", provider)
+				}
+				for _, key := range []string{"gen_ai.agent.name", "gen_ai.agent.id"} {
+					if _, ok := metricAttribute(dataPoint.Attributes, key); ok {
+						t.Errorf("operation duration data point unexpectedly contains %s", key)
+					}
+				}
+				spans := exporter.GetSpans()
+				if len(spans) != 1 {
+					t.Fatalf("spans = %d, want 1", len(spans))
+				}
+				if want := spans[0].EndTime.Sub(spans[0].StartTime).Seconds(); dataPoint.Sum != want {
+					t.Errorf("operation duration metric = %v, span duration = %v", dataPoint.Sum, want)
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("gen_ai.client.operation.duration metric was not recorded")
+}
+
+func TestOtel_Run_RecordsTokenUsageMetric(t *testing.T) {
+	reader := setupMeter(t)
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	a := agent.New(agent.ProviderConfig{
+		ProviderName: "test-provider",
+		Run: func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+			return func(yield func(*agent.ResponseUpdate, error) bool) {
+				yield(&agent.ResponseUpdate{Contents: []message.Content{&message.UsageContent{
+					Details: message.UsageDetails{InputTokenCount: 100, OutputTokenCount: 10},
+				}}}, nil)
+				yield(&agent.ResponseUpdate{Contents: []message.Content{&message.UsageContent{
+					Details: message.UsageDetails{InputTokenCount: 200, OutputTokenCount: 20},
+				}}}, nil)
+			}
+		},
+	}, agent.Config{Name: "test-agent", Middlewares: []agent.Middleware{mw}})
+
+	_, _ = a.RunMessage(t.Context(), message.NewText("test")).Collect()
+
+	data := collectMetric(t, reader, "gen_ai.client.token.usage")
+	histogram, ok := data.(metricdata.Histogram[int64])
+	if !ok {
+		t.Fatalf("token usage metric has type %T, want int64 histogram", data)
+	}
+	if len(histogram.DataPoints) != 2 {
+		t.Fatalf("token usage data points = %d, want 2", len(histogram.DataPoints))
+	}
+	counts := make(map[string]int64, 2)
+	for _, dataPoint := range histogram.DataPoints {
+		wantBounds := []float64{1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864}
+		if !slices.Equal(dataPoint.Bounds, wantBounds) {
+			t.Errorf("token usage bounds = %v, want %v", dataPoint.Bounds, wantBounds)
+		}
+		tokenType, ok := metricAttribute(dataPoint.Attributes, "gen_ai.token.type")
+		if !ok {
+			t.Fatal("token usage data point is missing gen_ai.token.type")
+		}
+		counts[tokenType] = dataPoint.Sum
+		if operation, _ := metricAttribute(dataPoint.Attributes, "gen_ai.operation.name"); operation != "invoke_agent" {
+			t.Errorf("gen_ai.operation.name = %q, want invoke_agent", operation)
+		}
+		if provider, _ := metricAttribute(dataPoint.Attributes, "gen_ai.provider.name"); provider != "test-provider" {
+			t.Errorf("gen_ai.provider.name = %q, want test-provider", provider)
+		}
+		if _, ok := metricAttribute(dataPoint.Attributes, "gen_ai.agent.name"); ok {
+			t.Error("token usage data point unexpectedly contains gen_ai.agent.name")
+		}
+	}
+	if counts["input"] != 300 {
+		t.Errorf("input token usage = %d, want 300", counts["input"])
+	}
+	if counts["output"] != 30 {
+		t.Errorf("output token usage = %d, want 30", counts["output"])
+	}
+}
+
+func TestOtel_Run_DoesNotRecordUnreportedTokenUsage(t *testing.T) {
+	reader := setupMeter(t)
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	next := func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{MessageID: "no-usage"}, nil)
+		}
+	}
+
+	for range mw.Run(next, t.Context(), nil) {
+	}
+
+	resourceMetrics := collectMetrics(t, reader)
+	if hasMetric(resourceMetrics, "gen_ai.client.token.usage") {
+		t.Error("token usage metric was recorded when the provider reported no usage")
+	}
+	if !hasMetric(resourceMetrics, "gen_ai.client.operation.duration") {
+		t.Error("operation duration metric was not recorded")
+	}
+}
+
+func TestOtel_Run_DoesNotRecordEmptyUsageContent(t *testing.T) {
+	reader := setupMeter(t)
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	next := func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Contents: []message.Content{&message.UsageContent{}}}, nil)
+		}
+	}
+
+	for range mw.Run(next, t.Context(), nil) {
+	}
+
+	resourceMetrics := collectMetrics(t, reader)
+	if hasMetric(resourceMetrics, "gen_ai.client.token.usage") {
+		t.Error("token usage metric was recorded for an empty usage payload")
+	}
+	if !hasMetric(resourceMetrics, "gen_ai.client.operation.duration") {
+		t.Error("operation duration metric was not recorded")
+	}
+}
+
+func TestOtel_Run_DoesNotRecordTokenMetricForOptionalCountersOnly(t *testing.T) {
+	reader := setupMeter(t)
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	next := func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Contents: []message.Content{&message.UsageContent{
+				Details: message.UsageDetails{CachedInputTokenCount: 42},
+			}}}, nil)
+		}
+	}
+
+	for range mw.Run(next, t.Context(), nil) {
+	}
+
+	resourceMetrics := collectMetrics(t, reader)
+	if hasMetric(resourceMetrics, "gen_ai.client.token.usage") {
+		t.Error("token usage metric was recorded without input or output counts")
+	}
+}
+
+func TestOtel_Run_MetricErrorAttributes(t *testing.T) {
+	reader := setupMeter(t)
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	testErr := errors.New("boom")
+	next := func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{Contents: []message.Content{&message.UsageContent{
+				Details: message.UsageDetails{InputTokenCount: 10, OutputTokenCount: 5},
+			}}}, testErr)
+		}
+	}
+
+	for range mw.Run(next, t.Context(), nil) {
+	}
+
+	resourceMetrics := collectMetrics(t, reader)
+	var duration, usage metricdata.Aggregation
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			switch m.Name {
+			case "gen_ai.client.operation.duration":
+				duration = m.Data
+			case "gen_ai.client.token.usage":
+				usage = m.Data
+			}
+		}
+	}
+	durationHistogram, ok := duration.(metricdata.Histogram[float64])
+	if !ok || len(durationHistogram.DataPoints) != 1 {
+		t.Fatalf("operation duration metric = %T with %d data points, want one float64 histogram data point", duration, len(durationHistogram.DataPoints))
+	}
+	if errorType, ok := metricAttribute(durationHistogram.DataPoints[0].Attributes, "error.type"); !ok || errorType != "errorString" {
+		t.Errorf("duration error.type = %q, %v; want errorString, true", errorType, ok)
+	}
+	if operation, _ := metricAttribute(durationHistogram.DataPoints[0].Attributes, "gen_ai.operation.name"); operation != "invoke_agent" {
+		t.Errorf("duration gen_ai.operation.name = %q, want invoke_agent", operation)
+	}
+	usageHistogram, ok := usage.(metricdata.Histogram[int64])
+	if !ok {
+		t.Fatalf("token usage metric has type %T, want int64 histogram", usage)
+	}
+	for _, dataPoint := range usageHistogram.DataPoints {
+		if _, ok := metricAttribute(dataPoint.Attributes, "error.type"); ok {
+			t.Error("token usage data point unexpectedly contains error.type")
+		}
+	}
+}
+
+func TestOtel_Run_RecordsMetricsOnEarlyBreak(t *testing.T) {
+	reader := setupMeter(t)
+	mw := otelprovider.NewMiddleware(otelprovider.MiddlewareConfig{})
+	next := func(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			for range 3 {
+				if !yield(&agent.ResponseUpdate{Contents: []message.Content{&message.UsageContent{
+					Details: message.UsageDetails{InputTokenCount: 10, OutputTokenCount: 5},
+				}}}, nil) {
+					return
+				}
+			}
+		}
+	}
+
+	for range mw.Run(next, t.Context(), nil) {
+		break
+	}
+
+	resourceMetrics := collectMetrics(t, reader)
+	if !hasMetric(resourceMetrics, "gen_ai.client.operation.duration") {
+		t.Error("operation duration metric was not recorded after an early break")
+	}
+	if !hasMetric(resourceMetrics, "gen_ai.client.token.usage") {
+		t.Error("token usage metric was not recorded after an early break")
+	}
 }
 
 func TestOtel_Run_CreatesSpan(t *testing.T) {


### PR DESCRIPTION
## Summary
- emit `gen_ai.client.operation.duration` and `gen_ai.client.token.usage` from the agent OpenTelemetry middleware using the generated v1.41 `genaiconv` instruments and recommended explicit bucket boundaries
- aggregate streamed token usage across the full invocation and record duration/error metrics on normal completion and early consumer termination
- normalize Anthropic cached-token totals and the Gemini provider identifier (`gcp.gemini`) so metric values and dimensions follow the semantic conventions

## Cross-SDK alignment
- use the client metric names and histogram shapes emitted by the Python and .NET SDKs
- retain `invoke_agent` as the operation dimension for the Go agent middleware boundary

## Validation
- `go test ./... -count=1`
- `go vet ./provider/anthropicprovider/... ./provider/geminiprovider/... ./provider/otelprovider/...`
