### PR TITLE
[dotnet-code] Extract agent tool name sanitizer

### DIFF
--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -48,7 +48,7 @@ func (t functool) Name() string {
 	if name == "" {
 		name = t.agent.ID()
 	}
-	return invalidNameChars.ReplaceAllString(name, "_")
+	return sanitizeAgentName(name)
 }
 
 func (t functool) Description() string {
@@ -56,6 +56,10 @@ func (t functool) Description() string {
 		return d
 	}
 	return defaultDescription
+}
+
+func sanitizeAgentName(name string) string {
+	return invalidNameChars.ReplaceAllString(name, "_")
 }
 
 func (t functool) Schema() any {


### PR DESCRIPTION
## Summary

Extracted agent-tool name sanitization into an unexported `sanitizeAgentName` helper. This keeps existing behavior while making the Go internals structurally closer to the .NET `SanitizeAgentName` helper used when exposing agents as function tools.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs` - `SanitizeAgentName` helper used by `AsAIFunction` metadata generation.
- `dotnet/src/Microsoft.Agents.AI/FunctionInvocationDelegatingAgent.cs` - sampled agent/function invocation area; rejected because Go already has separate tool auto-call middleware and this PR focuses on the safer agent-tool metadata shape.
- `dotnet/src/Microsoft.Agents.AI.Workflows/AgentResponseUpdateEvent.cs` - sampled workflow response-update event area; rejected because the Go workflow event model does not have a similarly narrow internal cleanup.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Models/ChatCompletionRequestMessage.cs` - sampled provider message conversion area; rejected to avoid provider serialization churn.
- `dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsSourceContext.cs` - sampled skills context area; rejected because the Go skills source shape is already minimal and changing it would risk API surface changes.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./tool/agenttool`

Existing agent-tool tests continue to cover sanitized names, fallback-to-ID behavior, default descriptions, and invocation behavior.

## Notes

Checked for open `[dotnet-code]` PRs before editing. Exact searches for `agenttool` and `SanitizeAgentName` found no candidate-specific open PR; one broader low-integrity result was filtered by policy and could not be inspected, so the change was kept narrowly scoped to the exact helper extraction.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/33023321534) · gpt55 · 90.4 AIC · ⌖ 14.3 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 33023321534, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/33023321534 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #918