### PR TITLE
[dotnet-code] Cache agent mode display internals

### DIFF
--- a/agent/harness/agentmode/agentmode.go
+++ b/agent/harness/agentmode/agentmode.go
@@ -130,6 +130,7 @@ func New(cfg Config) *Provider {
 
 	// Validate modes: no empty names, no duplicates.
 	validModes := make(map[string]struct{}, len(modes))
+	modeNames := make([]string, 0, len(modes))
 	for i, m := range modes {
 		if strings.TrimSpace(m.Name) == "" {
 			panic(fmt.Sprintf("agentmode: mode at index %d has an empty name", i))
@@ -138,16 +139,18 @@ func New(cfg Config) *Provider {
 			panic(fmt.Sprintf("agentmode: duplicate mode name %q", m.Name))
 		}
 		validModes[m.Name] = struct{}{}
+		modeNames = append(modeNames, m.Name)
 	}
 	if _, ok := validModes[defaultMode]; !ok {
 		panic(fmt.Sprintf("agentmode: default mode %q is not in the configured modes list", defaultMode))
 	}
 
 	p := &Provider{
-		modes:        modes,
-		defaultMode:  defaultMode,
-		instructions: instructions,
-		validModes:   validModes,
+		modes:            modes,
+		defaultMode:      defaultMode,
+		instructions:     instructions,
+		validModes:       validModes,
+		modeNamesDisplay: strings.Join(modeNames, "\", \""),
 	}
 
 	p.provider = agent.NewContextProvider(agent.ContextProviderConfig{
@@ -160,11 +163,12 @@ func New(cfg Config) *Provider {
 // Provider is an agent mode context provider.
 // Use [New] to create. Provider can be used directly in agent configuration.
 type Provider struct {
-	provider     agent.ContextProvider
-	modes        []Mode
-	defaultMode  string
-	instructions string
-	validModes   map[string]struct{}
+	provider         agent.ContextProvider
+	modes            []Mode
+	defaultMode      string
+	instructions     string
+	validModes       map[string]struct{}
+	modeNamesDisplay string
 
 	sessionLocks    sync.Map // map[weak.Pointer[agent.Session]]*sync.Mutex
 	nullSessionLock sync.Mutex
@@ -286,20 +290,14 @@ func (p *Provider) buildInstructions(currentMode string) string {
 }
 
 func (p *Provider) createTools(opts []agent.Option) []tool.FuncTool {
-	modeNames := make([]string, len(p.modes))
-	for i, m := range p.modes {
-		modeNames[i] = m.Name
-	}
-	modeNamesDisplay := strings.Join(modeNames, "\", \"")
-
 	setTool := functool.MustNew(
 		functool.Config{
 			Name:        "mode_set",
-			Description: fmt.Sprintf("Switch the agent's operating mode. Supported modes: \"%s\".", modeNamesDisplay),
+			Description: fmt.Sprintf("Switch the agent's operating mode. Supported modes: \"%s\".", p.modeNamesDisplay),
 		},
 		func(ctx context.Context, mode string) (string, error) {
 			if _, ok := p.validModes[mode]; !ok {
-				return "", fmt.Errorf("invalid mode: %q. Supported modes: \"%s\"", mode, modeNamesDisplay)
+				return "", fmt.Errorf("invalid mode: %q. Supported modes: \"%s\"", mode, p.modeNamesDisplay)
 			}
 			mu := p.getSessionLock(opts)
 			mu.Lock()


### PR DESCRIPTION
## Summary

Cache the agent-mode provider's supported-mode display string during construction instead of rebuilding it each time tools are created. This mirrors the .NET provider's stored mode-name display field and keeps future .NET-to-Go ports structurally easier to compare without changing public APIs or behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeProvider.cs` - stores `_modeNamesDisplay` during provider construction and reuses it in tool descriptions and validation errors.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./agent/harness/agentmode`

## Notes

Rejected candidates:
- `dotnet/src/Microsoft.Agents.AI.Abstractions/AgentSessionStateBagValue.cs` overlapped with the existing open PR https://github.com/microsoft/agent-framework-go/pull/900.
- `dotnet/src/Microsoft.Agents.AI.Workflows/HandoffToolCallFilteringBehavior.cs` has no matching Go implementation; adding it would be a feature.
- `dotnet/src/Microsoft.Agents.AI.Workflows/Configured.cs` did not expose a similarly small, behavior-preserving Go cleanup after comparison with workflow executor internals.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32906461702) · gpt55 · 78.8 AIC · ⌖ 15.8 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 32906461702, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32906461702 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #911