### PR TITLE
[dotnet-code] Consolidate workflow idle status helper

### DIFF
--- a/workflow/internal/execution/eventstream.go
+++ b/workflow/internal/execution/eventstream.go
@@ -233,11 +233,7 @@ func (s *streamingRunEventStream) runLoop() {
 		}
 
 		// Update status based on what's waiting
-		if s.stepRunner.HasUnservicedRequests() {
-			s.setStatus(RunStatusPendingRequests)
-		} else {
-			s.setStatus(RunStatusIdle)
-		}
+		s.setStatus(idleOrPendingRequestsStatus(s.stepRunner))
 
 		// Signal completion to consumer so they can check status and decide whether to continue
 		// Increment epoch so next consumer iteration gets a new completion signal
@@ -492,11 +488,7 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 
 		defer func() {
 			// Update status
-			if l.stepRunner.HasUnservicedRequests() {
-				l.setStatus(RunStatusPendingRequests)
-			} else {
-				l.setStatus(RunStatusIdle)
-			}
+			l.setStatus(idleOrPendingRequestsStatus(l.stepRunner))
 		}()
 
 		l.setStatus(RunStatusRunning)
@@ -547,11 +539,7 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 			}
 
 			// Update status
-			if l.stepRunner.HasUnservicedRequests() {
-				l.setStatus(RunStatusPendingRequests)
-			} else {
-				l.setStatus(RunStatusIdle)
-			}
+			l.setStatus(idleOrPendingRequestsStatus(l.stepRunner))
 
 			// Check if we should break
 			status := l.getStatus()
@@ -579,11 +567,7 @@ func (l *lockstepRunEventStream) TakeEventStream(ctx context.Context, blockOnPen
 					// No work yet: the run may have progressed to a terminal
 					// state (e.g. requests serviced elsewhere). Re-evaluate and
 					// stop if there is nothing left to wait for.
-					if l.stepRunner.HasUnservicedRequests() {
-						l.setStatus(RunStatusPendingRequests)
-					} else {
-						l.setStatus(RunStatusIdle)
-					}
+					l.setStatus(idleOrPendingRequestsStatus(l.stepRunner))
 					status = l.getStatus()
 					if l.shouldBreak(status, blockOnPendingRequest, linkedCtx) {
 						return
@@ -643,6 +627,13 @@ func (l *lockstepRunEventStream) shouldBreak(status RunStatus, blockOnPendingReq
 		return true
 	}
 	return false
+}
+
+func idleOrPendingRequestsStatus(stepRunner SuperStepRunner) RunStatus {
+	if stepRunner.HasUnservicedRequests() {
+		return RunStatusPendingRequests
+	}
+	return RunStatusIdle
 }
 
 // SignalInput signals that new input has been provided and the run loop should continue processing.


### PR DESCRIPTION
## Summary

Consolidates the internal workflow execution status decision that maps unserviced requests to `PendingRequests` and otherwise to `Idle`. This mirrors the compact .NET `HasUnservicedRequests ? PendingRequests : Idle` shape and reduces duplicated status-transition logic for future ports.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/LockstepRunEventStream.cs` - uses a single pending-request status expression in the lockstep run stream.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow/internal/execution`

## Notes

Rejected candidates inspected from the random sample:

- `dotnet/src/Microsoft.Agents.AI.Abstractions/AgentResponse.cs` / `agent/response.go` - Go response text and update aggregation were already closely aligned; further changes risked churn.
- `dotnet/src/Microsoft.Agents.AI.Workflows/RequestInfoEvent.cs` / `workflow/event.go` - event wrapper shape was already minimal and equivalent.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Models/MessageContentPart.cs` / `message/content.go` - provider/content model differences did not reveal a safe small internal cleanup.

Open `[dotnet-code]` PRs checked before editing; none appeared to cover the workflow idle-status candidate.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32784964025) · gpt55 · 71.6 AIC · ⌖ 13.1 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 32784964025, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32784964025 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #906