### PR TITLE
[dotnet-port-fixes] Prevent workflow telemetry serialization panics

### DIFF
--- a/workflow/inproc/observability_test.go
+++ b/workflow/inproc/observability_test.go
@@ -24,6 +24,14 @@ func (unserializablePayload) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("marshal failed")
 }
 
+type panicPayload struct {
+	Value string
+}
+
+func (panicPayload) MarshalJSON() ([]byte, error) {
+	panic("marshal panic")
+}
+
 func TestObservability_CreatesWorkflowEndToEndSpans(t *testing.T) {
 	tracer := workflowtest.NewRecordingTracer()
 	wf := newTelemetryWorkflow(t, tracer, workflow.TelemetryOptions{})
@@ -242,6 +250,49 @@ func TestObservability_UnserializableSensitiveDataDoesNotFailWorkflow(t *testing
 	}
 
 	wantFallback := fmt.Sprintf("[Unserializable: %T]", unserializablePayload{})
+	messageSpan := workflowtest.FindSpanWithPrefix(t, tracer.Spans(), "message.send")
+	messageSpan.RequireAttributeValue(t, internalobservability.TagMessageContent, wantFallback)
+	sinkSpan := workflowtest.FindSpanWithPrefix(t, tracer.Spans(), "executor.process sink")
+	sinkSpan.RequireAttributeValue(t, internalobservability.TagExecutorInput, wantFallback)
+}
+
+func TestObservability_PanickingSensitiveDataDoesNotFailWorkflow(t *testing.T) {
+	tracer := workflowtest.NewRecordingTracer()
+	var received []panicPayload
+	start := workflow.NewExecutor("start", func(input string) panicPayload {
+		return panicPayload{Value: strings.ToUpper(input)}
+	}).Bind()
+	sink := workflow.NewExecutor("sink", func(msg panicPayload) string {
+		received = append(received, msg)
+		return "done"
+	}).Bind()
+
+	wf, err := workflow.NewBuilder(start).
+		AddEdge(start, sink).
+		WithOutputFrom(sink).
+		WithTelemetry(tracer, workflow.TelemetryOptions{EnableSensitiveData: true}).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	run, err := inproc.Default.Run(context.Background(), wf, "hello")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	outputs := collectOutputValues(run.OutgoingEvents())
+	if err := run.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if len(outputs) != 1 || outputs[0] != "done" {
+		t.Fatalf("outputs = %#v, want []string{\"done\"}", outputs)
+	}
+	if len(received) != 1 || received[0].Value != "HELLO" {
+		t.Fatalf("received = %#v, want one delivered payload with value HELLO", received)
+	}
+
+	wantFallback := fmt.Sprintf("[Unserializable: %T]", panicPayload{})
 	messageSpan := workflowtest.FindSpanWithPrefix(t, tracer.Spans(), "message.send")
 	messageSpan.RequireAttributeValue(t, internalobservability.TagMessageContent, wantFallback)
 	sinkSpan := workflowtest.FindSpanWithPrefix(t, tracer.Spans(), "executor.process sink")

--- a/workflow/internal/observability/observability.go
+++ b/workflow/internal/observability/observability.go
@@ -317,15 +317,24 @@ func setWorkflowAttributes(span *Activity, metadata WorkflowMetadata) {
 	span.SetAttributes(attrs...)
 }
 
-func serialize(value any) string {
+func serialize(value any) (serialized string) {
 	if value == nil {
 		return ""
 	}
+	defer func() {
+		if recover() != nil {
+			serialized = fallbackSerializedValue(value)
+		}
+	}()
 	data, err := json.Marshal(value)
 	if err != nil {
-		return fmt.Sprintf("[Unserializable: %T]", value)
+		return fallbackSerializedValue(value)
 	}
 	return string(data)
+}
+
+func fallbackSerializedValue(value any) string {
+	return fmt.Sprintf("[Unserializable: %T]", value)
 }
 
 type contextKey struct{}

--- a/workflow/internal/observability/observability_test.go
+++ b/workflow/internal/observability/observability_test.go
@@ -19,6 +19,12 @@ func (unserializableValue) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("marshal failed")
 }
 
+type panicSerializableValue struct{}
+
+func (panicSerializableValue) MarshalJSON() ([]byte, error) {
+	panic("marshal panic")
+}
+
 func attributeValue(t *testing.T, attrs []workflowobservability.Attribute, key string) string {
 	t.Helper()
 	for _, attr := range attrs {
@@ -131,6 +137,18 @@ func TestSerializedAttributeUsesFallbackForMarshalErrors(t *testing.T) {
 	}
 }
 
+func TestSerializedAttributeUsesFallbackForMarshalPanics(t *testing.T) {
+	attr := observability.SerializedAttribute("message.content", panicSerializableValue{})
+	value, ok := attr.Value.(string)
+	if !ok {
+		t.Fatalf("attribute value type = %T, want string", attr.Value)
+	}
+	want := "[Unserializable: observability_test.panicSerializableValue]"
+	if value != want {
+		t.Fatalf("attribute value = %q, want %q", value, want)
+	}
+}
+
 func TestSensitiveDataUsesFallbackForExecutorInputAndOutput(t *testing.T) {
 	span := &fakeSpan{}
 	telemetry := observability.New(observability.Options{
@@ -146,6 +164,29 @@ func TestSensitiveDataUsesFallbackForExecutorInputAndOutput(t *testing.T) {
 	telemetry.SetExecutorOutput(activity, message)
 
 	want := "[Unserializable: observability_test.unserializableValue]"
+	if got := attributeValue(t, span.attrs, observability.TagExecutorInput); got != want {
+		t.Fatalf("executor.input = %q, want %q", got, want)
+	}
+	if got := attributeValue(t, span.attrs, observability.TagExecutorOutput); got != want {
+		t.Fatalf("executor.output = %q, want %q", got, want)
+	}
+}
+
+func TestSensitiveDataUsesFallbackForExecutorInputAndOutputPanics(t *testing.T) {
+	span := &fakeSpan{}
+	telemetry := observability.New(observability.Options{
+		Tracer:              &fakeTracer{span: span},
+		EnableSensitiveData: true,
+	})
+
+	message := panicSerializableValue{}
+	_, activity := telemetry.StartExecutorProcess(context.Background(), "exec1", "pkg.Type", "message", message, nil)
+	if activity == nil {
+		t.Fatal("expected an activity span")
+	}
+	telemetry.SetExecutorOutput(activity, message)
+
+	want := "[Unserializable: observability_test.panicSerializableValue]"
 	if got := attributeValue(t, span.attrs, observability.TagExecutorInput); got != want {
 		t.Fatalf("executor.input = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

Prevent workflow telemetry serialization from failing execution when sensitive-data attributes hit panic-style JSON serialization failures. The Go port now falls back to the existing `[Unserializable: ...]` marker for both ordinary marshal errors and panics, and adds regression coverage for direct observability helpers and in-process workflow execution.

## Ported .NET PRs

- [microsoft/agent-framework#7612](https://github.com/microsoft/agent-framework/pull/7612) - prevent telemetry serialization failures from failing workflows. Upstream commit: [`8a0731ad92560d7eb5c181682d9501a82a6b4a70`](https://github.com/microsoft/agent-framework/commit/8a0731ad92560d7eb5c181682d9501a82a6b4a70).

## Breaking Changes

No. This keeps the existing public Go API and only hardens internal telemetry serialization so workflow execution continues when telemetry-only serialization panics.

## Tests and Examples

- `go test ./workflow/internal/observability ./workflow/inproc`
- Added panic-path observability regression tests for serialized attributes, executor input/output telemetry, and end-to-end in-process workflow delivery
- No example changes were needed for this internal parity fix

## Notes

This is the remaining narrow parity gap after earlier observability fallback coverage: Go already handled `json.Marshal` error returns, but custom `MarshalJSON` panics could still escape through telemetry serialization.


<!-- gh-aw-tracker-id: dotnet-port-fixes-nightly -->




> Generated by [.NET to Go Fixes and Test Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32802456066) · gpt54 · 255.6 AIC · ⌖ 14 AIC · ⊞ 24.4K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-fixes-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go Fixes and Test Porting Agent, gh-aw-tracker-id: dotnet-port-fixes-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 32802456066, workflow_id: dotnet-port-fixes-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32802456066 -->

<!-- gh-aw-workflow-id: dotnet-port-fixes-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-fixes-nightly -->

Closes #909