### PR TITLE
Keep retained history Source when compaction runs across turns

### DIFF
--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -729,7 +729,12 @@ func TestNewProvider_KeepsRetainedHistorySourceAcrossTurns(t *testing.T) {
 	cp := message.Source{Type: agent.SourceTypeContextProvider, ID: "compaction-test"}
 	for i, msg := range out {
 		if msg.Source == cp {
-			t.Errorf("message %d (%q) mislabeled as context-provider generated; genuine history must keep its original Source", i, msg.String())
+			t.Errorf("message %d (%q) mislabeled as context-provider generated; genuine history must not be attributed to the provider", i, msg.String())
 		}
+	}
+	// Retained prior-turn history restored from compaction state is attributed as
+	// chat history (matching .NET), not context-provider generated.
+	if len(out) < 2 || out[0].Source.Type != agent.SourceTypeHistoryProvider || out[1].Source.Type != agent.SourceTypeHistoryProvider {
+		t.Errorf("retained history should be marked as chat history, got %#v and %#v", out[0].Source, out[1].Source)
 	}
 }

--- a/agent/compaction/compaction_test.go
+++ b/agent/compaction/compaction_test.go
@@ -696,3 +696,40 @@ func messageTexts(messages []*message.Message) []string {
 	}
 	return texts
 }
+
+func TestNewProvider_KeepsRetainedHistorySourceAcrossTurns(t *testing.T) {
+	// A compaction provider generates only summary messages; genuine prior-turn
+	// history returned from the persisted index must keep its original Source.
+	// Across turns the index is rebuilt from persisted groups whose message
+	// pointers differ from this turn's input, so identity-based attribution
+	// wrongly stamps real history as context-provider generated.
+	provider := compaction.NewContextProvider(compaction.ContextProviderConfig{
+		Strategy: &compaction.TruncationStrategy{Trigger: compaction.Never()},
+		SourceID: "compaction-test",
+	})
+	session := agenttest.CreateSession()
+
+	if _, _, err := invokeProvider(provider, t.Context(), []*message.Message{
+		textMessage(message.RoleUser, "u1"),
+		textMessage(message.RoleAssistant, "a1"),
+	}, agent.WithSession(session)); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+
+	out, _, err := invokeProvider(provider, t.Context(), []*message.Message{
+		textMessage(message.RoleUser, "u1"),
+		textMessage(message.RoleAssistant, "a1"),
+		textMessage(message.RoleUser, "u2"),
+		textMessage(message.RoleAssistant, "a2"),
+	}, agent.WithSession(session))
+	if err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+
+	cp := message.Source{Type: agent.SourceTypeContextProvider, ID: "compaction-test"}
+	for i, msg := range out {
+		if msg.Source == cp {
+			t.Errorf("message %d (%q) mislabeled as context-provider generated; genuine history must keep its original Source", i, msg.String())
+		}
+	}
+}

--- a/agent/compaction/provider.go
+++ b/agent/compaction/provider.go
@@ -128,16 +128,17 @@ func (p *contextProvider) markGeneratedMessages(messages, inputMessages []*messa
 	if len(messages) == 0 {
 		return messages
 	}
-	originals := make(map[*message.Message]struct{}, len(inputMessages))
-	for _, msg := range inputMessages {
-		originals[msg] = struct{}{}
-	}
 	source := message.Source{Type: agent.SourceTypeContextProvider, ID: p.sourceID}
 	for i, msg := range messages {
-		if _, ok := originals[msg]; ok {
+		if msg == nil || msg.Source == source {
 			continue
 		}
-		if msg == nil || msg.Source == source {
+		// A message is provider-generated only when it is not one of this turn's
+		// input messages. Compare by content, not pointer identity: with a session
+		// the index is rebuilt from persisted groups whose message pointers differ
+		// from the incoming messages, so an identity check would wrongly stamp
+		// genuine prior-turn history as context-provider generated.
+		if containsMessageByContent(inputMessages, msg) {
 			continue
 		}
 		marked := msg.Clone()
@@ -145,4 +146,13 @@ func (p *contextProvider) markGeneratedMessages(messages, inputMessages []*messa
 		messages[i] = marked
 	}
 	return messages
+}
+
+func containsMessageByContent(messages []*message.Message, target *message.Message) bool {
+	for _, candidate := range messages {
+		if messageContentEqual(candidate, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/compaction/provider.go
+++ b/agent/compaction/provider.go
@@ -98,6 +98,11 @@ func (p *contextProvider) Invoking(ctx context.Context, invoking agent.InvokingC
 	var index *MessageIndex
 	if len(state.MessageGroups) > 0 {
 		index = NewMessageIndex(state.MessageGroups, p.tokenCounter)
+		// Treat every message restored from persisted compaction state as chat
+		// history before folding in this turn's input (matching .NET). This keeps
+		// markGeneratedMessages from re-attributing restored history and prevents
+		// those messages from being re-stored as new messages at the end of the run.
+		p.markRestoredMessagesAsHistory(index)
 		index.Update(messages)
 	} else {
 		index = CreateMessageIndex(messages, p.tokenCounter)
@@ -130,7 +135,7 @@ func (p *contextProvider) markGeneratedMessages(messages, inputMessages []*messa
 	}
 	source := message.Source{Type: agent.SourceTypeContextProvider, ID: p.sourceID}
 	for i, msg := range messages {
-		if msg == nil || msg.Source == source {
+		if msg == nil || msg.Source == source || msg.Source.Type == agent.SourceTypeHistoryProvider {
 			continue
 		}
 		// A message is provider-generated only when it is not one of this turn's
@@ -146,6 +151,20 @@ func (p *contextProvider) markGeneratedMessages(messages, inputMessages []*messa
 		messages[i] = marked
 	}
 	return messages
+}
+
+// markRestoredMessagesAsHistory stamps every message restored from persisted
+// compaction state with the history source so it is not later re-attributed as
+// provider-generated or re-stored as a new message.
+func (p *contextProvider) markRestoredMessagesAsHistory(index *MessageIndex) {
+	source := message.Source{Type: agent.SourceTypeHistoryProvider, ID: p.sourceID}
+	for _, group := range index.Groups {
+		for _, msg := range group.Messages {
+			if msg != nil {
+				msg.Source = source
+			}
+		}
+	}
 }
 
 func containsMessageByContent(messages []*message.Message, target *message.Message) bool {


### PR DESCRIPTION
## Problem

`markGeneratedMessages` (in `agent/compaction/provider.go`) tells provider-generated messages apart from the caller's original input by **`*message.Message` pointer identity**. That invariant only holds on the first, session-less turn.

With a session, on every subsequent turn the index is rebuilt from persisted `state.MessageGroups` (`NewMessageIndex(...)` + `index.Update(messages)`) — or from a deserialized session — whose retained-history messages are **different pointers** from this turn's incoming `messages`. Each retained history message therefore fails the identity check and is stamped `Source = {SourceTypeContextProvider, sourceID}`.

`Source.Type` is load-bearing: the default history provider's store filter (`notSourceTypes(SourceTypeHistoryProvider)`) and context-provider attribution key on it, so this relabels genuine user/assistant history as provider-generated on **every multi-turn run** (and after any session serialize/deserialize round-trip).

## Fix

Identify provider-generated messages by comparing against this turn's input **by content** (`messageContentEqual`) rather than by pointer identity. Retained prior-turn history content-matches the incoming messages and keeps its original `Source`; only the summary messages compaction actually generates (which never match an input message) get stamped.

## Test

`TestNewProvider_KeepsRetainedHistorySourceAcrossTurns` drives two turns against one session and asserts the retained first-turn messages keep their original `Source`. Fails before the fix (prior-turn messages stamped `context-provider`), passes after. Existing source-stamping tests stay green.