### PR TITLE
Surface hosted URIContent as text over AG-UI instead of dropping it

### DIFF
--- a/provider/aguiprovider/hosting_events.go
+++ b/provider/aguiprovider/hosting_events.go
@@ -201,6 +201,10 @@ func hasTextLikeContent(contents message.Contents) bool {
 		if ok && shouldEmitDataContentAsText(dc) {
 			return true
 		}
+		uc, ok := c.(*message.URIContent)
+		if ok && uc.URI != "" {
+			return true
+		}
 	}
 	return false
 }
@@ -249,6 +253,15 @@ func contentToEvents(content message.Content, messageID string) ([]aguiEvents.Ev
 		// message ID. MEAI batches all results under a shared MessageId, which
 		// collapses them in FE reconciliation when the same id is reused.
 		return []aguiEvents.Event{aguiEvents.NewToolCallResultEvent("result-"+callID, callID, contentStr)}, nil
+	case *message.URIContent:
+		// AG-UI has no native reference/attachment event; surface the URI as
+		// text so it is not silently dropped (mirrors the DataContent fallback
+		// and the A2A hosting path, which never drop unknown content). Gemini,
+		// for example, emits URIContent for generated files.
+		if c.URI == "" {
+			return nil, nil
+		}
+		return []aguiEvents.Event{aguiEvents.NewTextMessageContentEvent(messageID, c.URI)}, nil
 	case *message.DataContent:
 		return dataContentToEvents(c, messageID)
 	default:

--- a/provider/aguiprovider/hosting_test.go
+++ b/provider/aguiprovider/hosting_test.go
@@ -617,3 +617,28 @@ func TestHandler_MidStreamError_ClientObservesErrorContent(t *testing.T) {
 		t.Fatalf("expected client to observe an *message.ErrorContent from RUN_ERROR, got messages %#v", resp.Messages)
 	}
 }
+
+func TestHandler_URIContentEmittedAsText(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				MessageID: "msg-1",
+				Role:      message.RoleAssistant,
+				Contents:  message.Contents{&message.URIContent{URI: "https://example.com/generated.png", MediaType: "image/png"}},
+			}, nil)
+		}
+	})
+	h := aguiprovider.NewJSONHTTPHandler(a, aguiprovider.HandlerConfig{})
+
+	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if content := rr.Body.String(); !strings.Contains(content, "https://example.com/generated.png") {
+		t.Fatalf("expected URIContent URI surfaced in SSE payload, got %q", content)
+	}
+}


### PR DESCRIPTION
## Problem

In `provider/aguiprovider/hosting_events.go`, `contentToEvents` handles `TextContent`, `FunctionCallContent`, `FunctionResultContent` and `DataContent`; anything else hits `default: return nil, nil`. `hasTextLikeContent` likewise ignores it, so no `TEXT_MESSAGE_START` is emitted either. A hosted agent that yields a `message.URIContent` therefore produces **no SSE event at all** — the content is silently lost.

This is a real path: the Gemini provider emits `URIContent` for generated file responses, so hosting a Gemini agent behind AG-UI drops them.

## Fix

Add a `*message.URIContent` case that emits the URI as a text-message-content event, mirroring the `DataContent` default fallback (`dataContentToEvents` emits unknown media as text) and the sibling A2A hosting path (`contentsToParts` JSON-marshals unknown content rather than dropping it). `URIContent` is also counted in `hasTextLikeContent` so the `TEXT_MESSAGE_START`/`END` framing is produced.

## Test

`TestHandler_URIContentEmittedAsText` hosts an agent yielding a `URIContent` and asserts the URI appears in the SSE body. Fails before the fix (only RUN_STARTED/RUN_FINISHED are emitted), passes after.