### PR TITLE
Surface AG-UI REASONING_MESSAGE_CHUNK events as reasoning content

### DIFF
--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -381,6 +381,10 @@ type toolCallAccumulator struct {
 	// TextMessageChunkEvent that carried one. Chunks that omit MessageID
 	// continue that message.
 	lastChunkMessageID string
+	// lastReasoningChunkMessageID is the same for ReasoningMessageChunkEvent,
+	// kept separate from lastChunkMessageID so interleaved text and reasoning
+	// chunks that omit MessageID do not inherit each other's message.
+	lastReasoningChunkMessageID string
 }
 
 func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUpdate, error) {
@@ -452,13 +456,14 @@ func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUp
 			return nil, nil
 		}
 		// A chunk may omit MessageID to continue the current reasoning message;
-		// reuse the last seen chunk MessageID, mirroring the text-chunk handling.
+		// reuse the last reasoning chunk MessageID (kept separate from the text
+		// chunk MessageID so interleaved text/reasoning chunks do not cross).
 		if id := deref(e.MessageID); id != "" {
-			a.lastChunkMessageID = id
+			a.lastReasoningChunkMessageID = id
 		}
 		return []*agent.ResponseUpdate{{
 			Role:      message.RoleAssistant,
-			MessageID: a.lastChunkMessageID,
+			MessageID: a.lastReasoningChunkMessageID,
 			CreatedAt: eventTime(evt),
 			Contents:  message.Contents{&message.TextReasoningContent{Text: delta}},
 		}}, nil

--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -446,6 +446,22 @@ func (a *toolCallAccumulator) onEvent(evt aguiEvents.Event) ([]*agent.ResponseUp
 			CreatedAt: eventTime(evt),
 			Contents:  message.Contents{&message.TextContent{Text: delta}},
 		}}, nil
+	case *aguiEvents.ReasoningMessageChunkEvent:
+		delta := deref(e.Delta)
+		if delta == "" {
+			return nil, nil
+		}
+		// A chunk may omit MessageID to continue the current reasoning message;
+		// reuse the last seen chunk MessageID, mirroring the text-chunk handling.
+		if id := deref(e.MessageID); id != "" {
+			a.lastChunkMessageID = id
+		}
+		return []*agent.ResponseUpdate{{
+			Role:      message.RoleAssistant,
+			MessageID: a.lastChunkMessageID,
+			CreatedAt: eventTime(evt),
+			Contents:  message.Contents{&message.TextReasoningContent{Text: delta}},
+		}}, nil
 	case *aguiEvents.ReasoningMessageContentEvent:
 		return []*agent.ResponseUpdate{{
 			Role:      message.RoleAssistant,

--- a/provider/aguiprovider/agui_test.go
+++ b/provider/aguiprovider/agui_test.go
@@ -713,3 +713,30 @@ func writeSSE(t *testing.T, w http.ResponseWriter, evt aguiEvents.Event) {
 func newTestClient(endpoint string) *aguiSSEClient.Client {
 	return aguiSSEClient.NewClient(aguiSSEClient.Config{Endpoint: endpoint})
 }
+
+func TestAGUIAgentRun_SurfacesReasoningMessageChunkEvents(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent("thread-1", "run-1"))
+		writeSSE(t, w, aguiEvents.NewReasoningMessageChunkEvent(strPtr("r1"), strPtr("think")))
+		writeSSE(t, w, aguiEvents.NewReasoningMessageChunkEvent(strPtr("r1"), strPtr("ing")))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent("thread-1", "run-1"))
+	}))
+	defer server.Close()
+
+	a := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := a.RunText(context.Background(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var reasoning string
+	for content := range resp.Contents() {
+		if rc, ok := content.(*message.TextReasoningContent); ok {
+			reasoning += rc.Text
+		}
+	}
+	if reasoning != "thinking" {
+		t.Fatalf("reasoning text = %q, want %q", reasoning, "thinking")
+	}
+}

--- a/provider/aguiprovider/agui_test.go
+++ b/provider/aguiprovider/agui_test.go
@@ -740,3 +740,52 @@ func TestAGUIAgentRun_SurfacesReasoningMessageChunkEvents(t *testing.T) {
 		t.Fatalf("reasoning text = %q, want %q", reasoning, "thinking")
 	}
 }
+
+func TestAGUIAgentRun_ReasoningChunkContinuationIsSeparateFromTextChunk(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(t, w, aguiEvents.NewRunStartedEvent("thread-1", "run-1"))
+		writeSSE(t, w, aguiEvents.NewReasoningMessageChunkEvent(strPtr("r1"), strPtr("think")))
+		writeSSE(t, w, aguiEvents.NewTextMessageChunkEvent(strPtr("t1"), strPtr("assistant"), strPtr("hello")))
+		// A reasoning chunk that omits MessageID must continue the reasoning
+		// message (r1), not inherit the last text chunk's MessageID (t1).
+		writeSSE(t, w, aguiEvents.NewReasoningMessageChunkEvent(nil, strPtr("ing")))
+		writeSSE(t, w, aguiEvents.NewRunFinishedEvent("thread-1", "run-1"))
+	}))
+	defer server.Close()
+
+	a := aguiprovider.NewAgent(newTestClient(server.URL), aguiprovider.AgentConfig{})
+	resp, err := a.RunText(context.Background(), "hi").Collect()
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	var r1Reasoning, t1Text, t1Reasoning string
+	for _, m := range resp.Messages {
+		for _, c := range m.Contents {
+			switch cc := c.(type) {
+			case *message.TextReasoningContent:
+				switch m.ID {
+				case "r1":
+					r1Reasoning += cc.Text
+				case "t1":
+					t1Reasoning += cc.Text
+				}
+			case *message.TextContent:
+				if m.ID == "t1" {
+					t1Text += cc.Text
+				}
+			}
+		}
+	}
+	if r1Reasoning != "thinking" {
+		t.Errorf("reasoning message r1 = %q, want %q", r1Reasoning, "thinking")
+	}
+	if t1Text != "hello" {
+		t.Errorf("text message t1 = %q, want %q", t1Text, "hello")
+	}
+	if t1Reasoning != "" {
+		t.Errorf("reasoning leaked into text message t1: %q", t1Reasoning)
+	}
+}


### PR DESCRIPTION
## Problem

The AG-UI client's `onEvent` switch (`provider/aguiprovider/agui.go`) handles `ReasoningMessageContentEvent` and `TextMessageChunkEvent`, but has no case for `ReasoningMessageChunkEvent` — the chunk-form encoding of reasoning that the AG-UI decoder also produces (`decoder.go` case `EventTypeReasoningMessageChunk`). A server that streams reasoning as `REASONING_MESSAGE_CHUNK` events therefore has its reasoning **silently dropped** (falls through to the default).

This is the reasoning counterpart of the already-handled `TEXT_MESSAGE_CHUNK` case.

## Fix

Add a `*aguiEvents.ReasoningMessageChunkEvent` case that emits a `message.TextReasoningContent` from the chunk delta, reusing the last seen chunk `MessageID` when a chunk omits it — mirroring the existing `TextMessageChunkEvent` handling and the `ReasoningMessageContentEvent` mapping.

## Test

`TestAGUIAgentRun_SurfacesReasoningMessageChunkEvents` streams two `REASONING_MESSAGE_CHUNK` events and asserts the concatenated reasoning is surfaced as `TextReasoningContent`. Fails before the fix (empty), passes after.

Note: `TOOL_CALL_CHUNK` is intentionally not addressed here — the AG-UI Go decoder has no case for it, so it never reaches the client.