### PR TITLE
Do not block a second consumer on an already-drained halt signal

### DIFF
--- a/workflow/inproc/binding_test.go
+++ b/workflow/inproc/binding_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/message"
@@ -1150,5 +1151,33 @@ func TestRequestPortBind_ForwardsExternalRequestAndRestoresOriginalResponse(t *t
 	value, ok := workflow.PortableValueAs[int](gotResponse.Data)
 	if !ok || value != 42 {
 		t.Fatalf("restored response data = %d, %v; want 42, true", value, ok)
+	}
+}
+
+func TestRun_SecondRunToNextHaltOnHaltedRunReturns(t *testing.T) {
+	// Environment.Run already drives one RunToNextHalt internally. A caller that
+	// polls RunToNextHalt again on an already-Idle run must return promptly
+	// rather than block forever on a halt signal that was already consumed.
+	binding := workflow.NewExecutor("fn", func(in textMessage) dataMessage {
+		return dataMessage{Bytes: []byte(in.Text)}
+	}).Bind()
+	wf, err := workflow.NewBuilder(binding).WithOutputFrom(binding).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	run, err := inproc.OffThread.Run(context.Background(), wf, textMessage{Text: "abc"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = run.RunToNextHalt(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second RunToNextHalt on an already-halted run blocked")
 	}
 }

--- a/workflow/internal/execution/eventstream.go
+++ b/workflow/internal/execution/eventstream.go
@@ -332,6 +332,45 @@ func (s *streamingRunEventStream) TakeEventStream(ctx context.Context, blockOnPe
 	}
 
 	return func(yield func(workflow.Event, error) bool) {
+		// Fast path: the run has already halted and there is no fresh work. The
+		// halt signal is a one-shot queue item, so a prior consumer may have
+		// already drained it for this epoch; blocking in nextEvent would then wait
+		// forever for a signal that is never re-emitted (the run loop is parked
+		// awaiting input). Drain whatever is still queued and stop at the
+		// terminal/pending halt instead, mirroring the lockstep stream. The
+		// blockOnPendingRequest path still falls through to block for serviced input.
+		if !expectingFreshWork {
+			for {
+				evt, ok := s.eventQueue.Dequeue()
+				if !ok {
+					break
+				}
+				if signal, ok := evt.(*internalHaltSignal); ok {
+					if signal.epoch < myEpoch {
+						continue
+					}
+					if signal.status == RunStatusIdle || signal.status == RunStatusEnded {
+						return
+					}
+					if !blockOnPendingRequest && signal.status == RunStatusPendingRequests {
+						return
+					}
+					continue
+				}
+				if !yield(evt, nil) {
+					return
+				}
+			}
+			switch s.getStatus() {
+			case RunStatusIdle, RunStatusEnded:
+				return
+			case RunStatusPendingRequests:
+				if !blockOnPendingRequest {
+					return
+				}
+			}
+		}
+
 		for {
 			evt, ok := s.nextEvent(ctx)
 			if !ok {


### PR DESCRIPTION
## Problem

The off-thread streaming run loop (`workflow/internal/execution/eventstream.go`) emits a **single one-shot `internalHaltSignal` per completion epoch**, then parks in `waitForInput`. In `TakeEventStream`, a consumer that isn't expecting fresh work targets that already-emitted halt (`myEpoch = currentEpoch`). If a **prior** consumer already dequeued that one-shot signal, a later consumer blocks in `nextEvent` forever — the run loop is parked and never re-emits it.

This is a deadlock reachable through the public API:
- `Environment.Run` already drives one `RunToNextHalt` internally, so calling `Run.RunToNextHalt(ctx)` **again** on the returned (already-Idle) run hangs.
- Draining `StreamingRun.WatchUntilHalt` once (to Idle) then again with no new input hangs.

The sibling **lockstep** `RunEventStream` returns promptly in the exact same scenario; only the off-thread/default stream hangs. The stream is explicitly designed to be re-taken (`RunHandle` resets `isEventStreamTaken` after each consumer), so re-consuming a terminal state is a supported operation.

## Fix

When `TakeEventStream` is not expecting fresh work (the run has already halted), drain any still-queued events non-blockingly and stop at the terminal (`Idle`/`Ended`) halt — or, when `blockOnPendingRequest` is false, the pending-request halt — instead of blocking on a signal that will never be re-emitted. The `blockOnPendingRequest` path still falls through to the blocking read so it can await serviced input.

## Test

`TestRun_SecondRunToNextHaltOnHaltedRunReturns` calls `RunToNextHalt` a second time on an already-Idle run under a watchdog; it hangs before the fix and returns promptly after. Validated against the full `./workflow/...` suite under `-race -shuffle` (no regressions).