### PR TITLE
fix: preserve AG-UI reasoning message lifecycle

### DIFF
--- a/provider/aguiprovider/hosting_events.go
+++ b/provider/aguiprovider/hosting_events.go
@@ -73,7 +73,51 @@ func updatesToAGUIEvents(
 		}
 
 		var currentMessageID string
+		var currentMessageSourceID string
 		var currentReasoningMsgID string
+		var currentReasoningSourceID string
+		usedMessageIDs := map[string]struct{}{}
+		allocateMessageID := func(preferred string) string {
+			if preferred != "" {
+				if _, used := usedMessageIDs[preferred]; !used {
+					usedMessageIDs[preferred] = struct{}{}
+					return preferred
+				}
+			}
+			for {
+				generated := aguiEvents.GenerateMessageID()
+				if _, used := usedMessageIDs[generated]; used {
+					continue
+				}
+				usedMessageIDs[generated] = struct{}{}
+				return generated
+			}
+		}
+		closeReasoning := func() bool {
+			if currentReasoningMsgID == "" {
+				return true
+			}
+			if !yield(aguiEvents.NewReasoningMessageEndEvent(currentReasoningMsgID), nil) {
+				return false
+			}
+			if !yield(aguiEvents.NewReasoningEndEvent(currentReasoningMsgID), nil) {
+				return false
+			}
+			currentReasoningMsgID = ""
+			currentReasoningSourceID = ""
+			return true
+		}
+		closeText := func() bool {
+			if currentMessageID == "" {
+				return true
+			}
+			if !yield(aguiEvents.NewTextMessageEndEvent(currentMessageID), nil) {
+				return false
+			}
+			currentMessageID = ""
+			currentMessageSourceID = ""
+			return true
+		}
 		suppressedCallIDs := map[string]struct{}{}
 		for update, err := range updates {
 			if err != nil {
@@ -98,47 +142,7 @@ func updatesToAGUIEvents(
 				continue
 			}
 
-			msgID := update.MessageID
-			if msgID == "" {
-				msgID = aguiEvents.GenerateMessageID()
-			}
-
-			if currentReasoningMsgID != "" && currentReasoningMsgID != msgID {
-				if !yield(aguiEvents.NewReasoningMessageEndEvent(currentReasoningMsgID), nil) {
-					return
-				}
-				currentReasoningMsgID = ""
-			}
-
-			hasText := hasTextLikeContent(update.Contents)
-			if hasText && currentMessageID != msgID {
-				if currentMessageID != "" {
-					if !yield(aguiEvents.NewTextMessageEndEvent(currentMessageID), nil) {
-						return
-					}
-				}
-				role := string(update.Role)
-				if role == "" {
-					role = string(message.RoleAssistant)
-				}
-				if !yield(aguiEvents.NewTextMessageStartEvent(msgID, aguiEvents.WithRole(role)), nil) {
-					return
-				}
-				currentMessageID = msgID
-			}
-
-			hasReasoning := hasReasoningContent(update.Contents)
-			if hasReasoning && currentReasoningMsgID != msgID {
-				if currentReasoningMsgID != "" {
-					if !yield(aguiEvents.NewReasoningMessageEndEvent(currentReasoningMsgID), nil) {
-						return
-					}
-				}
-				if !yield(aguiEvents.NewReasoningMessageStartEvent(msgID, string(aguiTypes.RoleReasoning)), nil) {
-					return
-				}
-				currentReasoningMsgID = msgID
-			}
+			mixedReasoningAndText := hasReasoningContent(update.Contents) && hasTextLikeContent(update.Contents)
 
 			for _, c := range update.Contents {
 				if frc, ok := c.(*message.FunctionResultContent); ok {
@@ -147,6 +151,27 @@ func updatesToAGUIEvents(
 					}
 				}
 				if rc, ok := c.(*message.TextReasoningContent); ok {
+					if rc.Text == "" && rc.ProtectedData == "" {
+						continue
+					}
+					sourceIDChanged := update.MessageID != "" && currentReasoningSourceID != update.MessageID
+					if currentReasoningMsgID == "" || sourceIDChanged {
+						if !closeReasoning() {
+							return
+						}
+						preferredID := update.MessageID
+						if mixedReasoningAndText {
+							preferredID = ""
+						}
+						currentReasoningMsgID = allocateMessageID(preferredID)
+						currentReasoningSourceID = update.MessageID
+						if !yield(aguiEvents.NewReasoningStartEvent(currentReasoningMsgID), nil) {
+							return
+						}
+						if !yield(aguiEvents.NewReasoningMessageStartEvent(currentReasoningMsgID, string(aguiTypes.RoleReasoning)), nil) {
+							return
+						}
+					}
 					if rc.Text != "" {
 						if !yield(aguiEvents.NewReasoningMessageContentEvent(currentReasoningMsgID, rc.Text), nil) {
 							return
@@ -159,7 +184,32 @@ func updatesToAGUIEvents(
 					}
 					continue
 				}
-				events, convErr := contentToEvents(c, msgID)
+
+				if !closeReasoning() {
+					return
+				}
+
+				eventMessageID := update.MessageID
+				if isTextLikeContent(c) {
+					sourceIDChanged := update.MessageID != "" && currentMessageSourceID != update.MessageID
+					if currentMessageID == "" || sourceIDChanged {
+						if !closeText() {
+							return
+						}
+						currentMessageID = allocateMessageID(update.MessageID)
+						currentMessageSourceID = update.MessageID
+						role := string(update.Role)
+						if role == "" {
+							role = string(message.RoleAssistant)
+						}
+						if !yield(aguiEvents.NewTextMessageStartEvent(currentMessageID, aguiEvents.WithRole(role)), nil) {
+							return
+						}
+					}
+					eventMessageID = currentMessageID
+				}
+
+				events, convErr := contentToEvents(c, eventMessageID)
 				if convErr != nil {
 					if !yield(aguiEvents.NewRunErrorEvent(convErr.Error(), aguiEvents.WithRunID(runID)), convErr) {
 						return
@@ -174,32 +224,32 @@ func updatesToAGUIEvents(
 			}
 		}
 
-		if currentReasoningMsgID != "" {
-			if !yield(aguiEvents.NewReasoningMessageEndEvent(currentReasoningMsgID), nil) {
-				return
-			}
+		if !closeReasoning() {
+			return
 		}
-		if currentMessageID != "" {
-			if !yield(aguiEvents.NewTextMessageEndEvent(currentMessageID), nil) {
-				return
-			}
+		if !closeText() {
+			return
 		}
 		yield(aguiEvents.NewRunFinishedEvent(threadID, runID), nil)
 	}
 }
 
+func isTextLikeContent(content message.Content) bool {
+	switch c := content.(type) {
+	case *message.TextContent:
+		return c.Text != ""
+	case *message.DataContent:
+		return shouldEmitDataContentAsText(c)
+	case *message.URIContent:
+		return c.URI != ""
+	default:
+		return false
+	}
+}
+
 func hasTextLikeContent(contents message.Contents) bool {
 	for _, c := range contents {
-		text, ok := c.(*message.TextContent)
-		if ok && text.Text != "" {
-			return true
-		}
-		dc, ok := c.(*message.DataContent)
-		if ok && shouldEmitDataContentAsText(dc) {
-			return true
-		}
-		uc, ok := c.(*message.URIContent)
-		if ok && uc.URI != "" {
+		if isTextLikeContent(c) {
 			return true
 		}
 	}

--- a/provider/aguiprovider/hosting_test.go
+++ b/provider/aguiprovider/hosting_test.go
@@ -24,6 +24,68 @@ func newTestAgent(runFn func(context.Context, []*message.Message, ...agent.Optio
 	return agent.New(agent.ProviderConfig{Run: runFn}, agent.Config{Name: "test-agent", ID: "test-agent-id"})
 }
 
+type sseEvent struct {
+	Type      string `json:"type"`
+	MessageID string `json:"messageId"`
+	Role      string `json:"role"`
+}
+
+func decodeSSEEvents(t *testing.T, body string) []sseEvent {
+	t.Helper()
+	var events []sseEvent
+	for _, line := range strings.Split(body, "\n") {
+		payload, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			continue
+		}
+		var event sseEvent
+		if err := json.Unmarshal([]byte(payload), &event); err != nil {
+			t.Fatalf("decode SSE event: %v", err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func eventsWithPrefixes(events []sseEvent, prefixes ...string) []sseEvent {
+	var filtered []sseEvent
+	for _, event := range events {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(event.Type, prefix) {
+				filtered = append(filtered, event)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+func assertEventTypes(t *testing.T, events []sseEvent, want []string) {
+	t.Helper()
+	if len(events) != len(want) {
+		t.Fatalf("event count = %d, want %d; events=%+v", len(events), len(want), events)
+	}
+	for i, wantType := range want {
+		if events[i].Type != wantType {
+			t.Fatalf("events[%d].type = %q, want %q; events=%+v", i, events[i].Type, wantType, events)
+		}
+	}
+}
+
+func assertSharedMessageID(t *testing.T, events []sseEvent) string {
+	t.Helper()
+	if len(events) == 0 || events[0].MessageID == "" {
+		t.Fatalf("events must have a non-empty message ID: %+v", events)
+	}
+	messageID := events[0].MessageID
+	for _, event := range events[1:] {
+		if event.MessageID != messageID {
+			t.Fatalf("event %q messageId = %q, want %q", event.Type, event.MessageID, messageID)
+		}
+	}
+	return messageID
+}
+
 func TestHandler_MethodNotAllowed(t *testing.T) {
 	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {}
@@ -252,6 +314,124 @@ func TestHandler_ReasoningContent_EmitsReasoningEvents(t *testing.T) {
 	if !strings.Contains(content, "TEXT_MESSAGE_START") || !strings.Contains(content, "final answer") {
 		t.Fatalf("expected text message events after reasoning, got %q", content)
 	}
+}
+
+func TestHandler_MixedReasoningAndText_UsesDistinctOrderedLifecycles(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				MessageID: "msg-shared",
+				Role:      message.RoleAssistant,
+				Contents: message.Contents{
+					&message.TextReasoningContent{Text: "thinking"},
+					&message.TextContent{Text: "final answer"},
+				},
+			}, nil)
+		}
+	})
+	h := aguiprovider.NewJSONHTTPHandler(a, aguiprovider.HandlerConfig{})
+
+	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	lifecycle := eventsWithPrefixes(decodeSSEEvents(t, rr.Body.String()), "REASONING_", "TEXT_MESSAGE_")
+	wantTypes := []string{
+		"REASONING_START",
+		"REASONING_MESSAGE_START",
+		"REASONING_MESSAGE_CONTENT",
+		"REASONING_MESSAGE_END",
+		"REASONING_END",
+		"TEXT_MESSAGE_START",
+		"TEXT_MESSAGE_CONTENT",
+		"TEXT_MESSAGE_END",
+	}
+	assertEventTypes(t, lifecycle, wantTypes)
+	reasoningID := assertSharedMessageID(t, lifecycle[:5])
+	textID := assertSharedMessageID(t, lifecycle[5:])
+	if reasoningID == textID {
+		t.Fatalf("reasoning and text IDs must differ, both were %q", reasoningID)
+	}
+	if lifecycle[1].Role != "reasoning" {
+		t.Fatalf("reasoning role = %q, want %q", lifecycle[1].Role, "reasoning")
+	}
+}
+
+func TestHandler_ReasoningDeltasWithoutMessageID_ShareLifecycle(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: message.Contents{&message.TextReasoningContent{Text: "Think "}},
+			}, nil)
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: message.Contents{&message.TextReasoningContent{Text: "carefully."}},
+			}, nil)
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: message.Contents{&message.TextContent{Text: "Answer."}},
+			}, nil)
+		}
+	})
+	h := aguiprovider.NewJSONHTTPHandler(a, aguiprovider.HandlerConfig{})
+
+	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	events := decodeSSEEvents(t, rr.Body.String())
+	reasoning := eventsWithPrefixes(events, "REASONING_")
+	textEvents := eventsWithPrefixes(events, "TEXT_MESSAGE_")
+	wantReasoningTypes := []string{
+		"REASONING_START",
+		"REASONING_MESSAGE_START",
+		"REASONING_MESSAGE_CONTENT",
+		"REASONING_MESSAGE_CONTENT",
+		"REASONING_MESSAGE_END",
+		"REASONING_END",
+	}
+	assertEventTypes(t, reasoning, wantReasoningTypes)
+	reasoningID := assertSharedMessageID(t, reasoning)
+	wantTextTypes := []string{"TEXT_MESSAGE_START", "TEXT_MESSAGE_CONTENT", "TEXT_MESSAGE_END"}
+	assertEventTypes(t, textEvents, wantTextTypes)
+	textID := assertSharedMessageID(t, textEvents)
+	if reasoningID == textID {
+		t.Fatalf("reasoning and text IDs must differ, both were %q", reasoningID)
+	}
+}
+
+func TestHandler_TextDeltasWithoutMessageID_ShareLifecycle(t *testing.T) {
+	a := newTestAgent(func(_ context.Context, _ []*message.Message, _ ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+		return func(yield func(*agent.ResponseUpdate, error) bool) {
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: message.Contents{&message.TextContent{Text: "Hello "}},
+			}, nil)
+			yield(&agent.ResponseUpdate{
+				Role:     message.RoleAssistant,
+				Contents: message.Contents{&message.TextContent{Text: "world."}},
+			}, nil)
+		}
+	})
+	h := aguiprovider.NewJSONHTTPHandler(a, aguiprovider.HandlerConfig{})
+
+	body := `{"threadId":"thread-1","runId":"run-1","messages":[{"id":"u1","role":"user","content":"ping"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	textEvents := eventsWithPrefixes(decodeSSEEvents(t, rr.Body.String()), "TEXT_MESSAGE_")
+	wantTypes := []string{
+		"TEXT_MESSAGE_START",
+		"TEXT_MESSAGE_CONTENT",
+		"TEXT_MESSAGE_CONTENT",
+		"TEXT_MESSAGE_END",
+	}
+	assertEventTypes(t, textEvents, wantTypes)
+	assertSharedMessageID(t, textEvents)
 }
 
 func TestHandler_ReasoningContent_WithEncryptedValue(t *testing.T) {


### PR DESCRIPTION
## Summary

- keep one stable AG-UI message ID across streaming deltas that do not carry `ResponseUpdate.MessageID`
- give reasoning and assistant text distinct message IDs when one update contains both content types
- close the reasoning block before starting text and emit the complete `REASONING_START` / `REASONING_END` lifecycle

## Why

Responses providers can produce a single update containing both `TextReasoningContent` and `TextContent` under one upstream message ID. The previous converter pre-opened both AG-UI messages with that same ID, so clients keyed by message ID could merge visible reasoning into the assistant answer. Updates without a message ID also received a fresh ID per delta, fragmenting a single stream into many messages.

The converter now tracks reasoning and text as separate logical streams and processes content in emission order, matching the Python Agent Framework AG-UI adapter behavior.

## Testing

- `go test ./provider/aguiprovider`
- `go vet ./provider/aguiprovider`
- `go test ./...`

Added handler-level regressions for mixed reasoning/text updates and no-ID reasoning/text deltas.