### PR TITLE
[dotnet-port-api] Port feature-usage user-agent telemetry

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -3,13 +3,18 @@
 package telemetry
 
 import (
+	"context"
 	"maps"
 	"net/http"
+	"net/url"
 	"os"
 	"runtime/debug"
 	"slices"
 	"strings"
 	"sync"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	publictelemetry "github.com/microsoft/agent-framework-go/telemetry"
 )
 
 const (
@@ -21,11 +26,35 @@ const (
 	hostedUserAgentPrefix            = "foundry-hosting"
 )
 
+type BaseUserAgentScope int
+
+const (
+	BaseUserAgentScopeApprovedOrigins BaseUserAgentScope = iota
+	BaseUserAgentScopeAllRequests
+)
+
+type FeatureUsageConfig struct {
+	Index                int
+	BaseUserAgentScope   BaseUserAgentScope
+	ApprovedHostSuffixes []string
+}
+
+type featureUsageOpt struct{ FeatureUsageConfig }
+
+func (o featureUsageOpt) MAFValue() any { return o.FeatureUsageConfig }
+
+func WithFeatureUsage(config FeatureUsageConfig) agent.Option {
+	config.ApprovedHostSuffixes = slices.Clone(config.ApprovedHostSuffixes)
+	return featureUsageOpt{config}
+}
+
 var (
 	version                 = detectVersion()
 	agentFrameworkUserAgent = httpUserAgent + "/" + version
 	userAgentPrefixes       = map[string]struct{}{}
 )
+
+type featureUsageContextKey struct{}
 
 var userAgentTelemetryEnabled = sync.OnceValue(func() bool {
 	switch strings.ToLower(os.Getenv(userAgentTelemetryDisabledEnvVar)) {
@@ -49,6 +78,27 @@ var userAgent = sync.OnceValue(func() string {
 	return strings.Join(prefixes, "/") + "/" + agentFrameworkUserAgent
 })
 
+func ConfigureRequestContext(ctx context.Context, options []agent.Option) context.Context {
+	config, ok := agent.GetOption(options, WithFeatureUsage)
+	if !ok {
+		return ctx
+	}
+	publictelemetry.FeatureUsage.MarkUsed(config.Index)
+	return context.WithValue(ctx, featureUsageContextKey{}, config)
+}
+
+func ApplyToRequest(req *http.Request) {
+	if req == nil || !userAgentTelemetryEnabled() {
+		return
+	}
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+
+	config, _ := req.Context().Value(featureUsageContextKey{}).(FeatureUsageConfig)
+	updateHTTPUserAgent(req.Header, applyRequestUserAgent(req.Header.Get(userAgentKey), config, req.URL))
+}
+
 // PrependAgentFrameworkToUserAgent prepends the Agent Framework user-agent value to headers.
 func PrependAgentFrameworkToUserAgent(headers map[string]string) map[string]string {
 	if !userAgentTelemetryEnabled() {
@@ -57,12 +107,7 @@ func PrependAgentFrameworkToUserAgent(headers map[string]string) map[string]stri
 	if headers == nil {
 		headers = map[string]string{}
 	}
-	userAgent := userAgent()
-	if existing := headers[userAgentKey]; existing != "" {
-		headers[userAgentKey] = userAgent + " " + existing
-	} else {
-		headers[userAgentKey] = userAgent
-	}
+	headers[userAgentKey] = prependUserAgent(headers[userAgentKey])
 	return headers
 }
 
@@ -74,13 +119,55 @@ func PrependAgentFrameworkToHTTPHeader(headers http.Header) http.Header {
 	if headers == nil {
 		headers = http.Header{}
 	}
-	userAgent := userAgent()
-	if existing := headers.Get(userAgentKey); existing != "" {
-		headers.Set(userAgentKey, userAgent+" "+existing)
-	} else {
-		headers.Set(userAgentKey, userAgent)
-	}
+	headers.Set(userAgentKey, prependUserAgent(headers.Get(userAgentKey)))
 	return headers
+}
+
+func prependUserAgent(existing string) string {
+	existing = publictelemetry.FeatureUsage.ApplyToUserAgent(existing)
+	if existing == "" {
+		return userAgent()
+	}
+	return userAgent() + " " + existing
+}
+
+func applyRequestUserAgent(existing string, config FeatureUsageConfig, requestURL *url.URL) string {
+	approved := isApprovedOrigin(requestURL, config.ApprovedHostSuffixes)
+	updated := publictelemetry.FeatureUsage.ApplyToUserAgent(existing, approved)
+
+	if config.BaseUserAgentScope == BaseUserAgentScopeAllRequests || approved {
+		if updated == "" {
+			return userAgent()
+		}
+		return userAgent() + " " + updated
+	}
+
+	return updated
+}
+
+func updateHTTPUserAgent(headers http.Header, value string) {
+	if value == "" {
+		headers.Del(userAgentKey)
+		return
+	}
+	headers.Set(userAgentKey, value)
+}
+
+func isApprovedOrigin(requestURL *url.URL, approvedHostSuffixes []string) bool {
+	if requestURL == nil || !strings.EqualFold(requestURL.Scheme, "https") {
+		return false
+	}
+
+	host := strings.TrimRight(requestURL.Hostname(), ".")
+	if host == "" {
+		return false
+	}
+	for _, suffix := range approvedHostSuffixes {
+		if strings.EqualFold(host, suffix) || strings.HasSuffix(strings.ToLower(host), "."+strings.ToLower(suffix)) {
+			return true
+		}
+	}
+	return false
 }
 
 func userAgentPrefixList() []string {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -3,13 +3,16 @@
 package telemetry_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
 
+	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/internal/telemetry"
 )
 
@@ -83,6 +86,39 @@ func TestUserAgentHostedEnvironmentDetectionCached(t *testing.T) {
 	}
 }
 
+func TestApplyToRequestApprovedOpenAIOriginIncludesFeatureToken(t *testing.T) {
+	got := runHelper(t, "request-approved", userAgentTelemetryDisabledEnvVar+"=")
+	if !strings.HasPrefix(got, "agent-framework-go/") {
+		t.Fatalf("User-Agent = %q, want agent-framework-go prefix", got)
+	}
+	if !strings.Contains(got, "OpenAI/Go") {
+		t.Fatalf("User-Agent = %q, want OpenAI/Go token", got)
+	}
+	if !strings.Contains(got, "(feat=v1.") {
+		t.Fatalf("User-Agent = %q, want feature token", got)
+	}
+}
+
+func TestApplyToRequestUnapprovedOpenAIOriginOmitsAgentFrameworkUserAgent(t *testing.T) {
+	got := runHelper(t, "request-unapproved", userAgentTelemetryDisabledEnvVar+"=")
+	if got != "OpenAI/Go" {
+		t.Fatalf("User-Agent = %q, want OpenAI/Go", got)
+	}
+}
+
+func TestApplyToRequestAllRequestsRetainsBaseUserAgentAndStripsStaleFeatureToken(t *testing.T) {
+	got := runHelper(t, "request-all-requests", userAgentTelemetryDisabledEnvVar+"=")
+	if !strings.HasPrefix(got, "agent-framework-go/") {
+		t.Fatalf("User-Agent = %q, want agent-framework-go prefix", got)
+	}
+	if strings.Contains(got, "(feat=") {
+		t.Fatalf("User-Agent = %q, want stale feature token removed", got)
+	}
+	if !strings.Contains(got, "OpenAI/Go") {
+		t.Fatalf("User-Agent = %q, want OpenAI/Go token", got)
+	}
+}
+
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv(helperProcessEnv) != "1" {
 		return
@@ -123,6 +159,71 @@ func TestHelperProcess(t *testing.T) {
 		_ = os.Setenv(foundryHostingEnvVar, "1")
 		headers = telemetry.PrependAgentFrameworkToUserAgent(nil)
 		fmt.Print(headers[userAgentKey])
+	case "request-approved":
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://resource.openai.azure.com/v1/chat/completions", nil)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		req.Header.Set(userAgentKey, "OpenAI/Go")
+		ctx := telemetry.ConfigureRequestContext(req.Context(), []agent.Option{
+			telemetry.WithFeatureUsage(telemetry.FeatureUsageConfig{
+				Index:              54,
+				BaseUserAgentScope: telemetry.BaseUserAgentScopeApprovedOrigins,
+				ApprovedHostSuffixes: []string{
+					"cognitiveservices.azure.com",
+					"openai.azure.com",
+					"services.ai.azure.com",
+				},
+			}),
+		})
+		req = req.WithContext(ctx)
+		telemetry.ApplyToRequest(req)
+		fmt.Print(req.Header.Get(userAgentKey))
+	case "request-unapproved":
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://api.openai.com/v1/chat/completions", nil)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		req.Header.Set(userAgentKey, "OpenAI/Go (feat=v1.ff)")
+		ctx := telemetry.ConfigureRequestContext(req.Context(), []agent.Option{
+			telemetry.WithFeatureUsage(telemetry.FeatureUsageConfig{
+				Index:              54,
+				BaseUserAgentScope: telemetry.BaseUserAgentScopeApprovedOrigins,
+				ApprovedHostSuffixes: []string{
+					"cognitiveservices.azure.com",
+					"openai.azure.com",
+					"services.ai.azure.com",
+				},
+			}),
+		})
+		req = req.WithContext(ctx)
+		telemetry.ApplyToRequest(req)
+		fmt.Print(req.Header.Get(userAgentKey))
+	case "request-all-requests":
+		requestURL, err := url.Parse("https://example.test/v1/responses")
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(2)
+		}
+		req := (&http.Request{
+			Method: http.MethodGet,
+			URL:    requestURL,
+			Header: http.Header{},
+		}).WithContext(telemetry.ConfigureRequestContext(context.Background(), []agent.Option{
+			telemetry.WithFeatureUsage(telemetry.FeatureUsageConfig{
+				Index:              49,
+				BaseUserAgentScope: telemetry.BaseUserAgentScopeAllRequests,
+				ApprovedHostSuffixes: []string{
+					"services.ai.azure.com",
+					"inference.ai.azure.com",
+				},
+			}),
+		}))
+		req.Header.Set(userAgentKey, "OpenAI/Go (feat=v1.ff)")
+		telemetry.ApplyToRequest(req)
+		fmt.Print(req.Header.Get(userAgentKey))
 	default:
 		fmt.Fprintf(os.Stderr, "unknown helper %q", helperName)
 		os.Exit(2)

--- a/provider/foundryprovider/agent.go
+++ b/provider/foundryprovider/agent.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/internal/telemetry"
 	"github.com/microsoft/agent-framework-go/provider/openaiprovider"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/azure"
@@ -19,6 +20,15 @@ const (
 	azureAIResourceScope       = "https://ai.azure.com/.default"
 	foundryDataPlaneAPIVersion = "v1"
 )
+
+var foundryFeatureUsageConfig = telemetry.FeatureUsageConfig{
+	Index:              49,
+	BaseUserAgentScope: telemetry.BaseUserAgentScopeAllRequests,
+	ApprovedHostSuffixes: []string{
+		"services.ai.azure.com",
+		"inference.ai.azure.com",
+	},
+}
 
 // AgentConfig contains configuration for Foundry-backed agents.
 type AgentConfig struct {
@@ -130,6 +140,7 @@ func newFoundryAgent(credential azcore.TokenCredential, config AgentConfig, mode
 	openAIOptions = append(openAIOptions, clientHeadersRequestOption())
 	openAIOptions = append(openAIOptions, servedModelRequestOption())
 	config.Middlewares = append([]agent.Middleware{clientHeadersMiddleware{}, servedModelMiddleware{}}, config.Middlewares...)
+	config.RunOptions = append(config.RunOptions, telemetry.WithFeatureUsage(foundryFeatureUsageConfig))
 
 	return openaiprovider.NewResponsesAgent(openai.NewClient(openAIOptions...), openaiprovider.AgentConfig{
 		Config:             config.Config,

--- a/provider/foundryprovider/agent_test.go
+++ b/provider/foundryprovider/agent_test.go
@@ -129,6 +129,30 @@ func TestNewAgentRunsAgainstFoundryAgentEndpoint(t *testing.T) {
 	}
 }
 
+func TestNewAgentIncludesFeatureUsageForApprovedFoundryOrigin(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); !strings.HasPrefix(got, "agent-framework-go/") {
+			t.Fatalf("User-Agent = %q", got)
+		} else if !strings.Contains(got, "(feat=v1.") {
+			t.Fatalf("User-Agent = %q, want feature token", got)
+		}
+		writeResponsesOK(w)
+	}))
+	defer server.Close()
+
+	foundryAgent := newFoundryAgentAtEndpoint(
+		t,
+		"https://project.services.ai.azure.com/projects/proj",
+		server,
+		foundryprovider.ModelDeployment("gpt-4o-mini"),
+		foundryprovider.AgentConfig{Config: agent.Config{DisableFuncAutoCall: true}},
+	)
+
+	if _, err := foundryAgent.RunText(t.Context(), "hello").Collect(); err != nil {
+		t.Fatalf("RunText error = %v", err)
+	}
+}
+
 func TestNewAgentEscapesServerAgentNameInEndpoint(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.EscapedPath(); got != "/projects/proj/agents/my%2Fagent/endpoint/protocols/openai/responses" {

--- a/provider/foundryprovider/helpers_test.go
+++ b/provider/foundryprovider/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -53,6 +54,47 @@ func newFoundryAgent(t *testing.T, server *httptest.Server, target foundryprovid
 	t.Helper()
 	config.OpenAIOptions = append(config.OpenAIOptions, option.WithHTTPClient(server.Client()))
 	return foundryprovider.NewAgent(server.URL+"/projects/proj", validCredential, target, config)
+}
+
+func newFoundryAgentAtEndpoint(t *testing.T, endpoint string, server *httptest.Server, target foundryprovider.AgentTarget, config foundryprovider.AgentConfig) *agent.Agent {
+	t.Helper()
+	config.OpenAIOptions = append(config.OpenAIOptions, option.WithHTTPClient(newRewrittenHTTPClient(t, server)))
+	return foundryprovider.NewAgent(endpoint, validCredential, target, config)
+}
+
+type rewriteFoundryBaseURLTransport struct {
+	targetBaseURL *url.URL
+	inner         http.RoundTripper
+}
+
+func (transport rewriteFoundryBaseURLTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	cloneURL := *clone.URL
+	clone.URL = &cloneURL
+	clone.URL.Scheme = transport.targetBaseURL.Scheme
+	clone.URL.Host = transport.targetBaseURL.Host
+	clone.Host = transport.targetBaseURL.Host
+	return transport.inner.RoundTrip(clone)
+}
+
+func newRewrittenHTTPClient(t *testing.T, server *httptest.Server) *http.Client {
+	t.Helper()
+
+	targetBaseURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(server.URL) failed: %v", err)
+	}
+
+	client := *server.Client()
+	inner := client.Transport
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	client.Transport = rewriteFoundryBaseURLTransport{
+		targetBaseURL: targetBaseURL,
+		inner:         inner,
+	}
+	return &client
 }
 
 func mustReadBody(t *testing.T, r *http.Request) string {

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -27,8 +27,18 @@ import (
 	"github.com/openai/openai-go/v3/shared"
 )
 
+var openAIFeatureUsageConfig = telemetry.FeatureUsageConfig{
+	Index:              54,
+	BaseUserAgentScope: telemetry.BaseUserAgentScopeApprovedOrigins,
+	ApprovedHostSuffixes: []string{
+		"cognitiveservices.azure.com",
+		"openai.azure.com",
+		"services.ai.azure.com",
+	},
+}
+
 var telemetryRequestOption = option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-	req.Header = telemetry.PrependAgentFrameworkToHTTPHeader(req.Header)
+	telemetry.ApplyToRequest(req)
 	return next(req)
 })
 
@@ -66,6 +76,7 @@ type AgentConfig struct {
 
 // NewChatCompletionsAgent creates an agent backed by the OpenAI Chat Completions API.
 func NewChatCompletionsAgent(oclient openai.Client, config AgentConfig) *agent.Agent {
+	ensureFeatureUsageRunOption(&config)
 	c := &chatClient{
 		client: oclient,
 		config: config,
@@ -102,6 +113,7 @@ func (a *chatClient) unmarshal(format agent.ResponseFormat, data []byte, v any) 
 }
 
 func (a *chatClient) run(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+	ctx = telemetry.ConfigureRequestContext(ctx, options)
 	body, err := buildCompletionParams(a.config.Model, messages, options)
 	if err != nil {
 		return func(yield func(*agent.ResponseUpdate, error) bool) {
@@ -218,6 +230,13 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 			yield(nil, stream.Err())
 		}
 	}
+}
+
+func ensureFeatureUsageRunOption(config *AgentConfig) {
+	if _, ok := agent.GetOption(config.RunOptions, telemetry.WithFeatureUsage); ok {
+		return
+	}
+	config.RunOptions = append(config.RunOptions, telemetry.WithFeatureUsage(openAIFeatureUsageConfig))
 }
 
 func mapRole(r string) message.Role {

--- a/provider/openaiprovider/chat_test.go
+++ b/provider/openaiprovider/chat_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -72,11 +73,87 @@ func newTestClient(server *httptest.Server) *agent.Agent {
 	)
 }
 
-func TestChatRequestIncludesAgentFrameworkUserAgent(t *testing.T) {
+type rewriteBaseURLTransport struct {
+	targetBaseURL *url.URL
+	inner         http.RoundTripper
+}
+
+func (transport rewriteBaseURLTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	cloneURL := *clone.URL
+	clone.URL = &cloneURL
+	clone.URL.Scheme = transport.targetBaseURL.Scheme
+	clone.URL.Host = transport.targetBaseURL.Host
+	clone.Host = transport.targetBaseURL.Host
+	return transport.inner.RoundTrip(clone)
+}
+
+func newApprovedOriginHTTPClient(t *testing.T, server *httptest.Server) *http.Client {
+	t.Helper()
+
+	targetBaseURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(server.URL) failed: %v", err)
+	}
+
+	client := *server.Client()
+	inner := client.Transport
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	client.Transport = rewriteBaseURLTransport{
+		targetBaseURL: targetBaseURL,
+		inner:         inner,
+	}
+	return &client
+}
+
+func TestChatRequestIncludesAgentFrameworkUserAgentForApprovedAzureOrigin(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userAgent := r.Header.Get("User-Agent")
 		if !strings.HasPrefix(userAgent, "agent-framework-go/") {
 			t.Fatalf("User-Agent = %q, want agent-framework-go prefix", userAgent)
+		}
+		if !strings.Contains(userAgent, "(feat=v1.") {
+			t.Fatalf("User-Agent = %q, want feature token", userAgent)
+		}
+		if !strings.Contains(userAgent, "OpenAI/Go") {
+			t.Fatalf("User-Agent = %q, want OpenAI SDK token", userAgent)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":1727888631,
+			"model":"gpt-4o-mini",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer server.Close()
+
+	a := openaiprovider.NewChatCompletionsAgent(
+		openai.NewClient(
+			option.WithBaseURL("https://resource.openai.azure.com"),
+			option.WithHTTPClient(newApprovedOriginHTTPClient(t, server)),
+		),
+		openaiprovider.AgentConfig{
+			Model:  "gpt-4o-mini",
+			Config: agent.Config{DisableFuncAutoCall: true},
+		},
+	)
+	if _, err := a.RunText(t.Context(), "hello").Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestChatRequestOmitsAgentFrameworkUserAgentForUnapprovedOrigin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		if strings.Contains(userAgent, "agent-framework-go/") {
+			t.Fatalf("User-Agent = %q, want no agent-framework-go prefix", userAgent)
+		}
+		if strings.Contains(userAgent, "(feat=") {
+			t.Fatalf("User-Agent = %q, want no feature token", userAgent)
 		}
 		if !strings.Contains(userAgent, "OpenAI/Go") {
 			t.Fatalf("User-Agent = %q, want OpenAI SDK token", userAgent)

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -20,6 +20,7 @@ import (
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/format/jsonformat"
 	"github.com/microsoft/agent-framework-go/agent/harness/toolautocall"
+	"github.com/microsoft/agent-framework-go/internal/telemetry"
 	"github.com/microsoft/agent-framework-go/message"
 	"github.com/microsoft/agent-framework-go/tool"
 	"github.com/microsoft/agent-framework-go/tool/hostedtool"
@@ -38,6 +39,7 @@ func NewAgent(oclient openai.Client, config AgentConfig) *agent.Agent {
 
 // NewResponsesAgent creates an agent backed by the OpenAI Responses API.
 func NewResponsesAgent(oclient openai.Client, config AgentConfig) *agent.Agent {
+	ensureFeatureUsageRunOption(&config)
 	c := &responsesClient{
 		client: oclient,
 		config: config,
@@ -92,6 +94,7 @@ func (a *responsesClient) unmarshal(format agent.ResponseFormat, data []byte, v 
 }
 
 func (a *responsesClient) run(ctx context.Context, messages []*message.Message, options ...agent.Option) iter.Seq2[*agent.ResponseUpdate, error] {
+	ctx = telemetry.ConfigureRequestContext(ctx, options)
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		stream, _ := agent.GetOption(options, agent.Stream)
 

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -76,11 +76,55 @@ func newTestResponsesClient(server *httptest.Server, model string) *agent.Agent 
 	)
 }
 
-func TestResponsesRequestIncludesAgentFrameworkUserAgent(t *testing.T) {
+func TestResponsesRequestIncludesAgentFrameworkUserAgentForApprovedAzureOrigin(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userAgent := r.Header.Get("User-Agent")
 		if !strings.HasPrefix(userAgent, "agent-framework-go/") {
 			t.Fatalf("User-Agent = %q, want agent-framework-go prefix", userAgent)
+		}
+		if !strings.Contains(userAgent, "(feat=v1.") {
+			t.Fatalf("User-Agent = %q, want feature token", userAgent)
+		}
+		if !strings.Contains(userAgent, "OpenAI/Go") {
+			t.Fatalf("User-Agent = %q, want OpenAI SDK token", userAgent)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"resp_test",
+			"object":"response",
+			"created_at":1741891428,
+			"status":"completed",
+			"error":null,
+			"incomplete_details":null,
+			"model":"gpt-4o-mini",
+			"output":[{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"hello","annotations":[]}]}]
+		}`)
+	}))
+	defer server.Close()
+
+	a := openaiprovider.NewResponsesAgent(
+		openai.NewClient(
+			option.WithBaseURL("https://resource.openai.azure.com"),
+			option.WithHTTPClient(newApprovedOriginHTTPClient(t, server)),
+		),
+		openaiprovider.AgentConfig{
+			Model:  "gpt-4o-mini",
+			Config: agent.Config{DisableFuncAutoCall: true},
+		},
+	)
+	if _, err := a.RunText(t.Context(), "hello").Collect(); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestResponsesRequestOmitsAgentFrameworkUserAgentForUnapprovedOrigin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		if strings.Contains(userAgent, "agent-framework-go/") {
+			t.Fatalf("User-Agent = %q, want no agent-framework-go prefix", userAgent)
+		}
+		if strings.Contains(userAgent, "(feat=") {
+			t.Fatalf("User-Agent = %q, want no feature token", userAgent)
 		}
 		if !strings.Contains(userAgent, "OpenAI/Go") {
 			t.Fatalf("User-Agent = %q, want OpenAI SDK token", userAgent)

--- a/telemetry/feature_usage.go
+++ b/telemetry/feature_usage.go
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package telemetry
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	featureMaskDisabledEnvVar = "AGENT_FRAMEWORK_FEATURE_MASK_DISABLED"
+	featureRegistryVersion    = 1
+)
+
+// FeatureUsage provides process-wide tracking for Agent Framework feature usage.
+//
+// It supports framework integrations and is not intended for direct use by applications.
+var FeatureUsage featureUsage
+
+type featureUsage struct{}
+
+var (
+	featureUsageLowMask  atomic.Uint64
+	featureUsageHighMask atomic.Uint64
+	featureMaskDisabled  = sync.OnceValue(func() bool {
+		switch strings.ToLower(os.Getenv(featureMaskDisabledEnvVar)) {
+		case "true", "1":
+			return true
+		default:
+			return false
+		}
+	})
+)
+
+// MarkUsed marks a registered Agent Framework feature as used in the current process.
+func (featureUsage) MarkUsed(index int) {
+	if featureMaskDisabled() {
+		return
+	}
+	if index < 0 || index >= 128 {
+		panic(fmt.Sprintf("feature index %d must be in the range 0 through 127", index))
+	}
+
+	var mask *atomic.Uint64
+	bit := uint64(1) << uint(index&63)
+	if index < 64 {
+		mask = &featureUsageLowMask
+	} else {
+		mask = &featureUsageHighMask
+	}
+	atomicOr(mask, bit)
+}
+
+// ApplyToUserAgent appends or removes the current feature-usage token from a User-Agent value.
+func (featureUsage) ApplyToUserAgent(userAgent string, includeFeatureToken ...bool) string {
+	include := true
+	if len(includeFeatureToken) > 0 {
+		include = includeFeatureToken[0]
+	}
+
+	baseUserAgent := removeFeatureComments(userAgent)
+	token := ""
+	if include {
+		token = currentFeatureToken()
+	}
+	if token == "" {
+		return baseUserAgent
+	}
+	if baseUserAgent == "" {
+		return "(feat=" + token + ")"
+	}
+	return baseUserAgent + " (feat=" + token + ")"
+}
+
+func currentFeatureToken() string {
+	if featureMaskDisabled() {
+		return ""
+	}
+
+	low := featureUsageLowMask.Load()
+	high := featureUsageHighMask.Load()
+	if low == 0 && high == 0 {
+		return ""
+	}
+	if high == 0 {
+		return fmt.Sprintf("v%d.%x", featureRegistryVersion, low)
+	}
+	return fmt.Sprintf("v%d.%x%016x", featureRegistryVersion, high, low)
+}
+
+func atomicOr(target *atomic.Uint64, bit uint64) {
+	for {
+		current := target.Load()
+		if current&bit != 0 {
+			return
+		}
+		if target.CompareAndSwap(current, current|bit) {
+			return
+		}
+	}
+}
+
+func removeFeatureComments(userAgent string) string {
+	start, end, ok := findFeatureComment(userAgent, 0)
+	if !ok {
+		return userAgent
+	}
+
+	var b strings.Builder
+	b.Grow(len(userAgent))
+	copyFrom := 0
+	for ok {
+		removeFrom := start
+		removeThrough := end
+
+		if removeFrom > copyFrom && isWhitespace(userAgent[removeFrom-1]) {
+			removeFrom--
+		} else if removeFrom == copyFrom && removeThrough < len(userAgent) && isWhitespace(userAgent[removeThrough]) {
+			removeThrough++
+		}
+
+		b.WriteString(userAgent[copyFrom:removeFrom])
+		copyFrom = removeThrough
+		start, end, ok = findFeatureComment(userAgent, end)
+	}
+
+	b.WriteString(userAgent[copyFrom:])
+	return b.String()
+}
+
+func findFeatureComment(userAgent string, searchFrom int) (start int, end int, ok bool) {
+	const prefix = "(feat=v"
+
+	for {
+		index := strings.Index(userAgent[searchFrom:], prefix)
+		if index < 0 {
+			return -1, -1, false
+		}
+		start = searchFrom + index
+		if start > 0 && !isWhitespace(userAgent[start-1]) {
+			searchFrom = start + len(prefix)
+			continue
+		}
+
+		cursor := start + len(prefix)
+		versionStart := cursor
+		for cursor < len(userAgent) && userAgent[cursor] >= '0' && userAgent[cursor] <= '9' {
+			cursor++
+		}
+		if cursor == versionStart || cursor >= len(userAgent) || userAgent[cursor] != '.' {
+			searchFrom = start + len(prefix)
+			continue
+		}
+
+		cursor++
+		maskStart := cursor
+		for cursor < len(userAgent) && isHexDigit(userAgent[cursor]) {
+			cursor++
+		}
+		if cursor == maskStart || cursor >= len(userAgent) || userAgent[cursor] != ')' {
+			searchFrom = start + len(prefix)
+			continue
+		}
+
+		end = cursor + 1
+		if end == len(userAgent) || isWhitespace(userAgent[end]) {
+			return start, end, true
+		}
+
+		searchFrom = start + len(prefix)
+	}
+}
+
+func isHexDigit(value byte) bool {
+	return value >= '0' && value <= '9' ||
+		value >= 'a' && value <= 'f' ||
+		value >= 'A' && value <= 'F'
+}
+
+func isWhitespace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\n' || value == '\r' || value == '\f' || value == '\v'
+}

--- a/telemetry/feature_usage_test.go
+++ b/telemetry/feature_usage_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package telemetry_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	maftelemetry "github.com/microsoft/agent-framework-go/telemetry"
+)
+
+const featureUsageHelperEnv = "AGENT_FRAMEWORK_FEATURE_USAGE_TEST_HELPER"
+
+func TestFeatureUsageMarkUsedAndApplyToUserAgent(t *testing.T) {
+	got := runFeatureUsageHelper(t, "mark-openai")
+	if got != "app/1.0 (feat=v1.40000000000000)" {
+		t.Fatalf("ApplyToUserAgent = %q, want app/1.0 (feat=v1.40000000000000)", got)
+	}
+}
+
+func TestFeatureUsageApplyToUserAgentRemovesStaleComments(t *testing.T) {
+	got := runFeatureUsageHelper(t, "strip-stale")
+	if got != "vendor/2.0 app/1.0" {
+		t.Fatalf("ApplyToUserAgent = %q, want vendor/2.0 app/1.0", got)
+	}
+}
+
+func TestFeatureUsageMarkUsedRejectsInvalidIndex(t *testing.T) {
+	got := runFeatureUsageHelper(t, "invalid-index")
+	if got != "panic" {
+		t.Fatalf("helper output = %q, want panic", got)
+	}
+}
+
+func TestFeatureUsageDisabledSkipsMarksAndStripsTokens(t *testing.T) {
+	got := runFeatureUsageHelper(t, "disabled", "AGENT_FRAMEWORK_FEATURE_MASK_DISABLED=1")
+	if got != "app/1.0" {
+		t.Fatalf("ApplyToUserAgent = %q, want app/1.0", got)
+	}
+}
+
+func TestFeatureUsageHelperProcess(t *testing.T) {
+	if os.Getenv(featureUsageHelperEnv) != "1" {
+		return
+	}
+
+	_, helperName, ok := strings.Cut(strings.Join(os.Args, "\x00"), "\x00--\x00")
+	if !ok {
+		fmt.Fprint(os.Stderr, "missing helper name")
+		os.Exit(2)
+	}
+
+	switch strings.Trim(helperName, "\x00") {
+	case "mark-openai":
+		maftelemetry.FeatureUsage.MarkUsed(54)
+		fmt.Print(maftelemetry.FeatureUsage.ApplyToUserAgent("app/1.0"))
+	case "strip-stale":
+		fmt.Print(maftelemetry.FeatureUsage.ApplyToUserAgent("vendor/2.0 (feat=v1.ff) app/1.0 (feat=v1.1)", false))
+	case "invalid-index":
+		defer func() {
+			if recover() != nil {
+				fmt.Print("panic")
+				os.Exit(0)
+			}
+			fmt.Print("no-panic")
+			os.Exit(0)
+		}()
+		maftelemetry.FeatureUsage.MarkUsed(128)
+	case "disabled":
+		maftelemetry.FeatureUsage.MarkUsed(54)
+		fmt.Print(maftelemetry.FeatureUsage.ApplyToUserAgent("app/1.0 (feat=v1.ff)"))
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper %q", helperName)
+		os.Exit(2)
+	}
+
+	os.Exit(0)
+}
+
+func runFeatureUsageHelper(t *testing.T, name string, env ...string) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() failed: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=^TestFeatureUsageHelperProcess$", "--", name)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(cmd.Env, featureUsageHelperEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper %q failed: %v\n%s", name, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}


### PR DESCRIPTION
## Summary

Ported the .NET feature-usage User-Agent telemetry from microsoft/agent-framework#7709 (commit 43b3ce6027c49bdbcd422dc3959e0bbe28cb833f) into the Go SDK. This adds a public `telemetry.FeatureUsage` API for process-wide feature tracking, threads feature-usage configuration through the OpenAI and Foundry providers, and aligns provider User-Agent behavior so approved Azure OpenAI and Foundry requests can emit the `(feat=v1...)` token while stale feature tokens are stripped when they should not be sent.

## Ported .NET PRs

- microsoft/agent-framework#7709 - Add feature-usage bitmask and User-Agent feature telemetry

## Breaking Changes

Yes. The OpenAI provider previously prepended `agent-framework-go/...` to requests sent to any configured endpoint. It now only emits the Agent Framework User-Agent prefix and feature token for approved Azure OpenAI origins, matching the upstream .NET behavior; unapproved/custom OpenAI origins keep the OpenAI SDK User-Agent without the Agent Framework prefix. This is acceptable in the beta Go SDK because it improves parity with the upstream contract and narrows telemetry to the intended destinations.

## Tests and Examples

- `go test ./telemetry ./internal/telemetry ./provider/openaiprovider ./provider/foundryprovider`
- Added feature-usage API tests plus OpenAI and Foundry User-Agent coverage for approved and unapproved origins

## Notes

- This PR intentionally keeps the port narrow: it adds the public feature-usage API and wires the existing Go OpenAI/Foundry User-Agent surfaces that correspond to the selected upstream change.
- Broader feature-index adoption across additional Go packages can follow separately if maintainers want the full .NET registry coverage beyond the currently affected providers.


<!-- gh-aw-tracker-id: dotnet-port-api-nightly -->




> Generated by [.NET to Go API Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32693857818) · gpt54 · 378.4 AIC · ⌖ 21.2 AIC · ⊞ 24.4K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-api-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go API Porting Agent, gh-aw-tracker-id: dotnet-port-api-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 32693857818, workflow_id: dotnet-port-api-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32693857818 -->

<!-- gh-aw-workflow-id: dotnet-port-api-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-api-nightly -->

Closes #893