### PR TITLE
[dotnet-port-api] Expose concurrent tool invocation opt-in

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -77,6 +77,11 @@ type Config struct {
 	// DisableFuncAutoCall tells provider constructors not to add automatic function-tool calling middleware.
 	DisableFuncAutoCall bool
 
+	// AllowConcurrentToolInvocations lets provider constructors opt the default
+	// automatic function-tool calling middleware into invoking multiple tool calls
+	// from the same model response concurrently. The default is false.
+	AllowConcurrentToolInvocations bool
+
 	// Logger receives run, middleware, and provider diagnostics.
 	Logger *slog.Logger
 

--- a/provider/aguiprovider/agui.go
+++ b/provider/aguiprovider/agui.go
@@ -57,8 +57,9 @@ func NewAgent(aclient *aguiSSEClient.Client, config AgentConfig) *agent.Agent {
 	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
 		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
-			Logger:           config.Logger,
-			LogSensitiveData: config.LogSensitiveData,
+			Logger:                     config.Logger,
+			LogSensitiveData:           config.LogSensitiveData,
+			AllowConcurrentInvocations: config.AllowConcurrentToolInvocations,
 		}))
 	}
 	return agent.New(agent.ProviderConfig{

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -58,8 +58,9 @@ func NewAgent(aclient anthropic.Client, config AgentConfig) *agent.Agent {
 	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
 		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
-			Logger:           config.Logger,
-			LogSensitiveData: config.LogSensitiveData,
+			Logger:                     config.Logger,
+			LogSensitiveData:           config.LogSensitiveData,
+			AllowConcurrentInvocations: config.AllowConcurrentToolInvocations,
 		}))
 	}
 	return agent.New(agent.ProviderConfig{

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -59,8 +59,9 @@ func NewAgent(gclient *genai.Client, config AgentConfig) *agent.Agent {
 	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
 		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
-			Logger:           config.Logger,
-			LogSensitiveData: config.LogSensitiveData,
+			Logger:                     config.Logger,
+			LogSensitiveData:           config.LogSensitiveData,
+			AllowConcurrentInvocations: config.AllowConcurrentToolInvocations,
 		}))
 	}
 	return agent.New(agent.ProviderConfig{

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -75,8 +75,9 @@ func NewChatCompletionsAgent(oclient openai.Client, config AgentConfig) *agent.A
 	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
 		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
-			Logger:           config.Logger,
-			LogSensitiveData: config.LogSensitiveData,
+			Logger:                     config.Logger,
+			LogSensitiveData:           config.LogSensitiveData,
+			AllowConcurrentInvocations: config.AllowConcurrentToolInvocations,
 		}))
 	}
 	return agent.New(agent.ProviderConfig{

--- a/provider/openaiprovider/concurrent_autocall_test.go
+++ b/provider/openaiprovider/concurrent_autocall_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package openaiprovider_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/provider/openaiprovider"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestChatConfigAllowConcurrentToolInvocations_EnablesParallelAutoCall(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount.Add(1) {
+		case 1:
+			_, _ = io.WriteString(w, `{
+				"id":"chatcmpl-first",
+				"object":"chat.completion",
+				"created":1727888631,
+				"model":"gpt-4o-mini",
+				"choices":[{
+					"index":0,
+					"message":{
+						"role":"assistant",
+						"tool_calls":[
+							{"id":"call_first","type":"function","function":{"name":"FirstTool","arguments":"{}"}},
+							{"id":"call_second","type":"function","function":{"name":"SecondTool","arguments":"{}"}}
+						]
+					},
+					"finish_reason":"tool_calls"
+				}]
+			}`)
+		default:
+			_, _ = io.WriteString(w, `{
+				"id":"chatcmpl-second",
+				"object":"chat.completion",
+				"created":1727888632,
+				"model":"gpt-4o-mini",
+				"choices":[{
+					"index":0,
+					"message":{"role":"assistant","content":"done"},
+					"finish_reason":"stop"
+				}]
+			}`)
+		}
+	}))
+	defer server.Close()
+
+	a := openaiprovider.NewChatCompletionsAgent(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiprovider.AgentConfig{
+			Model: "gpt-4o-mini",
+			Config: agent.Config{
+				AllowConcurrentToolInvocations: true,
+			},
+		},
+	)
+
+	assertConcurrentAutoCall(t, a)
+}
+
+func TestResponsesConfigAllowConcurrentToolInvocations_EnablesParallelAutoCall(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount.Add(1) {
+		case 1:
+			_, _ = io.WriteString(w, `{
+				"id":"resp_first",
+				"object":"response",
+				"created_at":1741891428,
+				"status":"completed",
+				"model":"gpt-4o-mini",
+				"output":[
+					{"type":"function_call","id":"call_first","name":"FirstTool","arguments":"{}"},
+					{"type":"function_call","id":"call_second","name":"SecondTool","arguments":"{}"}
+				]
+			}`)
+		default:
+			_, _ = io.WriteString(w, `{
+				"id":"resp_second",
+				"object":"response",
+				"created_at":1741891429,
+				"status":"completed",
+				"model":"gpt-4o-mini",
+				"output":[
+					{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"done","annotations":[]}]}
+				]
+			}`)
+		}
+	}))
+	defer server.Close()
+
+	a := openaiprovider.NewResponsesAgent(
+		openai.NewClient(option.WithBaseURL(server.URL)),
+		openaiprovider.AgentConfig{
+			Model: "gpt-4o-mini",
+			Config: agent.Config{
+				AllowConcurrentToolInvocations: true,
+			},
+		},
+	)
+
+	assertConcurrentAutoCall(t, a)
+}
+
+func assertConcurrentAutoCall(t *testing.T, a *agent.Agent) {
+	t.Helper()
+
+	type emptyInput struct{}
+
+	var started atomic.Int32
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+
+	firstTool := functool.MustNew(functool.Config{
+		Name:        "FirstTool",
+		Description: "Waits until both tools have started.",
+	}, func(ctx context.Context, _ emptyInput) (string, error) {
+		if started.Add(1) == 2 {
+			releaseOnce.Do(func() { close(release) })
+		}
+
+		select {
+		case <-release:
+			return "first", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	})
+
+	secondTool := functool.MustNew(functool.Config{
+		Name:        "SecondTool",
+		Description: "Waits until both tools have started.",
+	}, func(context.Context, emptyInput) (string, error) {
+		if started.Add(1) == 2 {
+			releaseOnce.Do(func() { close(release) })
+		}
+		<-release
+		return "second", nil
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	if _, err := a.RunText(ctx, "run tools", agent.WithTool(firstTool), agent.WithTool(secondTool)).Collect(); err != nil {
+		t.Fatalf("RunText error = %v", err)
+	}
+	if got := started.Load(); got != 2 {
+		t.Fatalf("started tool invocations = %d, want 2", got)
+	}
+}

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -48,8 +48,9 @@ func NewResponsesAgent(oclient openai.Client, config AgentConfig) *agent.Agent {
 	var providerMiddlewares []agent.Middleware
 	if !config.DisableFuncAutoCall {
 		providerMiddlewares = append(providerMiddlewares, toolautocall.New(toolautocall.Config{
-			Logger:           config.Logger,
-			LogSensitiveData: config.LogSensitiveData,
+			Logger:                     config.Logger,
+			LogSensitiveData:           config.LogSensitiveData,
+			AllowConcurrentInvocations: config.AllowConcurrentToolInvocations,
 		}))
 	}
 	return agent.New(


### PR DESCRIPTION
## Summary

Expose a public Go agent config opt-in for concurrent tool invocation and thread it through the providers that install default tool auto-calling middleware. This ports the .NET agent-level concurrency option from microsoft/agent-framework#7650 using the existing Go `toolautocall` capability, which was previously only configurable at the middleware layer.

## Ported .NET PRs

- microsoft/agent-framework#7650 - allow agents to opt into concurrent tool invocation
- Upstream commit: `047ec7eaffab0d85306d85d7771cdfbc87d66e18`

## Breaking Changes

No. This adds a new optional `agent.Config.AllowConcurrentToolInvocations` setting and preserves the existing default serial behavior.

## Tests and Examples

- `go test ./agent ./provider/openaiprovider ./provider/anthropicprovider ./provider/geminiprovider ./provider/aguiprovider`
- Added focused OpenAI chat/responses tests that verify the public config enables concurrent auto-called tool execution

## Notes

Skipped larger recent upstream changes such as microsoft/agent-framework#7641 (session-persisted routing) and #7602 (background session release API) to keep this PR narrow and API-focused. The shared config is wired through OpenAI, Anthropic, Gemini, and AG-UI providers because they all install the default tool auto-calling middleware from the embedded `agent.Config`.


<!-- gh-aw-tracker-id: dotnet-port-api-nightly -->




> Generated by [.NET to Go API Porting Agent](https://github.com/microsoft/agent-framework-go/actions/runs/32219676001) · gpt54 · 237.5 AIC · ⌖ 12.7 AIC · ⊞ 24.1K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-port-api-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET to Go API Porting Agent, gh-aw-tracker-id: dotnet-port-api-nightly, engine: copilot, version: 1.0.75, model: gpt-5.4, id: 32219676001, workflow_id: dotnet-port-api-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/32219676001 -->

<!-- gh-aw-workflow-id: dotnet-port-api-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-port-api-nightly -->

Closes #867