### PR TITLE
Group go-infra Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       codeql-action:
         patterns:
           - github/codeql-action/*
+      microsoft-go-infra:
+        patterns:
+          - microsoft/go-infra/*
     ignore:
       - dependency-name: github/gh-aw-actions* # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
     exclude-paths:


### PR DESCRIPTION
## Summary
- group microsoft/go-infra/* GitHub Actions updates into a single Dependabot pull request

## Testing
- YAML diagnostics pass