### PR TITLE
[dotnet-code] Extract MCP embedded resource conversion helper

### DIFF
--- a/tool/mcptool/mcp.go
+++ b/tool/mcptool/mcp.go
@@ -164,28 +164,7 @@ func mcpContentToAgentContentWithRaw(mcpContents []mcp.Content, rawOverride any)
 			})
 
 		case *mcp.EmbeddedResource:
-			if contentValue.Resource == nil {
-				result = append(result, &message.TextContent{
-					ContentHeader: mcpContentHeader(raw),
-					Text:          "[MCP embedded resource missing resource data]",
-				})
-				continue
-			}
-			header := mcpContentHeader(raw)
-			if contentValue.Resource.Text != "" {
-				result = append(result, &message.TextContent{
-					ContentHeader: header,
-					Text:          contentValue.Resource.Text,
-				})
-			} else {
-				data, mediaType := mcpDataContent(contentValue.Resource.Blob, contentValue.Resource.MIMEType, "application/octet-stream")
-				result = append(result, &message.DataContent{
-					ContentHeader: header,
-					Data:          data,
-					MediaType:     mediaType,
-					Name:          contentValue.Resource.URI,
-				})
-			}
+			result = append(result, mcpEmbeddedResourceToAgentContent(contentValue, raw))
 
 		case *mcp.ToolUseContent: //nolint:staticcheck // ToolUseContent is deprecated per SEP-2577 but remains functional during the deprecation window.
 			result = append(result, &message.TextContent{
@@ -213,6 +192,31 @@ func mcpContentToAgentContentWithRaw(mcpContents []mcp.Content, rawOverride any)
 	}
 
 	return result
+}
+
+func mcpEmbeddedResourceToAgentContent(contentValue *mcp.EmbeddedResource, raw any) message.Content {
+	if contentValue.Resource == nil {
+		return &message.TextContent{
+			ContentHeader: mcpContentHeader(raw),
+			Text:          "[MCP embedded resource missing resource data]",
+		}
+	}
+
+	header := mcpContentHeader(raw)
+	if contentValue.Resource.Text != "" {
+		return &message.TextContent{
+			ContentHeader: header,
+			Text:          contentValue.Resource.Text,
+		}
+	}
+
+	data, mediaType := mcpDataContent(contentValue.Resource.Blob, contentValue.Resource.MIMEType, "application/octet-stream")
+	return &message.DataContent{
+		ContentHeader: header,
+		Data:          data,
+		MediaType:     mediaType,
+		Name:          contentValue.Resource.URI,
+	}
 }
 
 func mcpContentHeader(raw any) message.ContentHeader {


### PR DESCRIPTION
## Summary

Extracted MCP embedded-resource to agent-content conversion into a focused unexported helper. This keeps the existing conversion behavior intact while making the Go MCP internals easier to compare with the .NET MCP resource wrapper, where resource content extraction is isolated from the broader tool flow.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Mcp/Skills/AgentMcpSkillResource.cs` - isolates MCP resource content extraction from skill resource reading.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./tool/mcptool`

## Notes

Rejected candidates from the random sample:

- `dotnet/src/Microsoft.Agents.AI.A2A/A2AContinuationToken.cs` / Go A2A continuation handling: existing Go continuation tokens are string task IDs in provider flow; aligning further risked public behavior/API churn.
- `dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/ToolResultCompactionStrategyTests.cs` / Go compaction tests: useful comparison area, but changes would likely be test-only or broader than this small production cleanup.
- `dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Converters/ChatClientAgentRunOptionsConverter.cs`: no clear corresponding Go hosting converter cleanup found in the sampled pass.

Open PR check found existing `[dotnet-port-api]` PRs, including an MCP tasks gap PR, but none covering this MCP embedded-resource conversion helper cleanup.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/33566212811) · gpt55 · 63.5 AIC · ⌖ 12.4 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 33566212811, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/33566212811 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #970