### PR TITLE
[dotnet-code] Simplify message merger singleton selection

### DIFF
--- a/workflow/agentworkflow/message_merger.go
+++ b/workflow/agentworkflow/message_merger.go
@@ -75,16 +75,8 @@ func (m *messageMerger) ComputeMerged(primaryResponseID string, primaryAgentID s
 		Messages:             messages,
 		AdditionalProperties: additionalProperties,
 	}
-	if primaryAgentID != "" {
-		response.AgentID = primaryAgentID
-	} else if primaryAgentName != "" {
-		response.AgentID = primaryAgentName
-	} else if len(agentIDs) == 1 {
-		response.AgentID = slices.Collect(maps.Keys(agentIDs))[0]
-	}
-	if len(finishReasons) == 1 {
-		response.FinishReason = slices.Collect(maps.Keys(finishReasons))[0]
-	}
+	response.AgentID = cmp.Or(primaryAgentID, primaryAgentName, singleString(agentIDs))
+	response.FinishReason = singleString(finishReasons)
 	return response
 }
 
@@ -277,6 +269,16 @@ func mergeProperties(current, incoming map[string]any) map[string]any {
 	merged := maps.Clone(current)
 	maps.Copy(merged, incoming)
 	return merged
+}
+
+func singleString(values map[string]struct{}) string {
+	if len(values) != 1 {
+		return ""
+	}
+	for value := range values {
+		return value
+	}
+	return ""
 }
 
 func cleanupMergedMessages(messages []*message.Message) []*message.Message {


### PR DESCRIPTION
## Summary

Extracted the internal single-value set selection used by the workflow message merger when assigning merged agent IDs and finish reasons. This keeps the Go implementation closer to the .NET MessageMerger shape, where these fields are set only when their collected sets contain exactly one value, without changing public APIs or intended behavior.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/MessageMerger.cs` - computes merged response metadata from collected agent ID and finish-reason sets.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow/agentworkflow`

## Notes

Rejected candidates:
- `dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeMap.cs` - Go edge routing internals differ structurally enough that a tiny alignment would have been higher churn.
- `dotnet/src/Microsoft.Agents.AI/Compaction/PipelineCompactionStrategy.cs` - Go pipeline compaction was already closely aligned and covered by existing preservation tests.
- `dotnet/src/Microsoft.Agents.AI/Skills/Decorators/CachingAgentSkillsSource.cs` - no matching Go skills cache implementation was present to safely align.

No open approved `[dotnet-code]` PR found covering `MessageMerger`.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/33446196079) · gpt55 · 70.5 AIC · ⌖ 13.6 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 33446196079, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/33446196079 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #953