### PR TITLE
[dotnet-code] Clarify workflow ownership internals

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -182,6 +182,30 @@ func sameOwnershipToken(left any, right any) bool {
 	return leftOK && rightOK && leftType == rightType && leftPtr == rightPtr
 }
 
+func (w *Workflow) hasResettableExecutors() bool {
+	for _, binding := range w.executorBindings {
+		if binding.ResetFunc != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func ownershipConflictError(subworkflow bool, owner *workflowOwner) error {
+	switch {
+	case subworkflow && owner.subworkflow:
+		return errors.New("cannot use a Workflow as a subworkflow of multiple parent workflows")
+	case subworkflow && !owner.subworkflow:
+		return errors.New("cannot use a running Workflow as a subworkflow")
+	case !subworkflow && owner.subworkflow:
+		return errors.New("cannot directly run a Workflow that is a subworkflow of another workflow")
+	case !subworkflow && !owner.subworkflow:
+		return errors.New("cannot use a Workflow that is already owned by another runner or parent workflow")
+	default:
+		panic("unreachable")
+	}
+}
+
 // Name returns the optional human-readable workflow name.
 func (w *Workflow) Name() string {
 	if w == nil {
@@ -337,12 +361,7 @@ func (w *Workflow) describeOutputYields() ([]reflect.Type, error) {
 // HasResettableExecutors reports whether any executor binding can reset shared
 // resources between workflow runs.
 func (w *Workflow) HasResettableExecutors() bool {
-	for _, binding := range w.executorBindings {
-		if binding.ResetFunc != nil {
-			return true
-		}
-	}
-	return false
+	return w.hasResettableExecutors()
 }
 
 // ContextWithTelemetry returns ctx annotated with the workflow's telemetry
@@ -368,7 +387,7 @@ func (w *Workflow) AllowConcurrent() bool {
 // TryReset attempts to reset all shared executor bindings that require reset
 // support before workflow reuse.
 func (w *Workflow) TryReset() bool {
-	if !w.HasResettableExecutors() {
+	if !w.hasResettableExecutors() {
 		return false
 	}
 	for _, er := range w.executorBindings {
@@ -429,22 +448,11 @@ func (w *Workflow) TakeOwnership(token any, newToken any, subworkflow bool) erro
 		}
 
 		// Someone else owns the workflow
-		switch {
-		case subworkflow && owner.subworkflow:
-			return errors.New("cannot use a Workflow as a subworkflow of multiple parent workflows")
-		case subworkflow && !owner.subworkflow:
-			return errors.New("cannot use a running Workflow as a subworkflow")
-		case !subworkflow && owner.subworkflow:
-			return errors.New("cannot directly run a Workflow that is a subworkflow of another workflow")
-		case !subworkflow && !owner.subworkflow:
-			return errors.New("cannot use a Workflow that is already owned by another runner or parent workflow")
-		default:
-			panic("unreachable")
-		}
+		return ownershipConflictError(subworkflow, owner)
 	}
 
 	// Successfully took ownership (or was already owned by us)
-	w.needsReset.Store(w.HasResettableExecutors())
+	w.needsReset.Store(w.hasResettableExecutors())
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Extracted unexported workflow helpers for resettable-executor detection and ownership-conflict errors. This keeps the Go ownership/reset flow structurally closer to the .NET `Workflow` implementation, where resettable detection and ownership conflict handling are separated from the main ownership transition path.

## .NET Reference

- `dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs` - workflow ownership, resettable executor checks, and conflict error selection.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- `go test ./workflow/...`

## Notes

Rejected candidates from the random .NET sample:

- `dotnet/src/Microsoft.Agents.AI.Workflows/DirectEdgeData.cs` - Go already centralizes direct-edge connection construction; adding matching source/sink fields would change the public `Edge` shape.
- `dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DeduplicatingAgentSkillsSource.cs` - Go already has a narrow `deduplicateSkillsByName` helper with matching first-wins behavior.
- `dotnet/src/Microsoft.Agents.AI.Abstractions/AgentSessionStateBag.cs` - closest Go session state changes would touch public session semantics, so this was left unchanged.

Checked open `[dotnet-code]` PRs before editing; the readable existing PR was unrelated, and no open PR matched workflow ownership/resettable internals.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->




> Generated by [.NET-to-Go Code Portability Refactoring Agent](https://github.com/microsoft/agent-framework-go/actions/runs/33216879685) · gpt55 · 81.7 AIC · ⌖ 19.2 AIC · ⊞ 23.2K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fagent-framework-go+%22gh-aw-workflow-id%3A+dotnet-code-portability-nightly%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: .NET-to-Go Code Portability Refactoring Agent, gh-aw-tracker-id: dotnet-code-portability-nightly, engine: copilot, version: 1.0.75, model: gpt-5.5, id: 33216879685, workflow_id: dotnet-code-portability-nightly, run: https://github.com/microsoft/agent-framework-go/actions/runs/33216879685 -->

<!-- gh-aw-workflow-id: dotnet-code-portability-nightly -->
<!-- gh-aw-workflow-call-id: microsoft/agent-framework-go/dotnet-code-portability-nightly -->

Closes #940