### PR TITLE
Byte-account hosted tool-call/result content in compaction sizing

### DIFF
--- a/agent/compaction/index.go
+++ b/agent/compaction/index.go
@@ -399,6 +399,26 @@ func computeContentByteCount(content message.Content) int {
 		return stringByteCount(typed.Message) + stringByteCount(typed.ErrorCode) + stringByteCount(typed.Details)
 	case *message.HostedFileContent:
 		return stringByteCount(typed.FileID) + stringByteCount(typed.MediaType) + stringByteCount(typed.Name)
+	case *message.MCPServerToolCallContent:
+		return stringByteCount(typed.CallID) + stringByteCount(typed.Name) + stringByteCount(typed.ServerName) + stringByteCount(typed.Arguments)
+	case *message.MCPServerToolResultContent:
+		total := stringByteCount(typed.CallID) + stringByteCount(typed.Name) + stringByteCount(typed.ServerName) + stringByteCount(typed.Error)
+		for _, output := range typed.Outputs {
+			total += computeContentByteCount(output)
+		}
+		return total
+	case *message.CodeInterpreterToolCallContent:
+		total := stringByteCount(typed.CallID)
+		for _, input := range typed.Inputs {
+			total += computeContentByteCount(input)
+		}
+		return total
+	case *message.CodeInterpreterToolResultContent:
+		total := stringByteCount(typed.CallID)
+		for _, output := range typed.Outputs {
+			total += computeContentByteCount(output)
+		}
+		return total
 	default:
 		return 0
 	}

--- a/agent/compaction/index_test.go
+++ b/agent/compaction/index_test.go
@@ -5,6 +5,7 @@ package compaction_test
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/agent-framework-go/agent/compaction"
@@ -368,5 +369,33 @@ func TestMessageIndex_Update_RepeatedContentDoesNotDropMessages(t *testing.T) {
 	index.Update(turn2)
 	if got, want := messageTexts(index.AllMessages()), []string{"hi", "hello", "continue", "sure", "continue"}; !slices.Equal(got, want) {
 		t.Fatalf("after turn 2 (repeated \"continue\"): got %v, want %v — appended turns were dropped", got, want)
+	}
+}
+
+func TestMessageIndex_CountsHostedToolResultBytes(t *testing.T) {
+	big := strings.Repeat("x", 10000)
+	// A hosted tool result carrying 10k bytes of Outputs must be byte-accounted
+	// like the equivalent FunctionResultContent, so token/byte-based compaction
+	// triggers see the payload that most needs compacting.
+	fnMsg := &message.Message{Role: message.RoleTool, Contents: message.Contents{
+		&message.FunctionResultContent{CallID: "c1", Result: big},
+	}}
+	mcpMsg := &message.Message{Role: message.RoleTool, Contents: message.Contents{
+		&message.MCPServerToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: big}}},
+	}}
+	ciMsg := &message.Message{Role: message.RoleTool, Contents: message.Contents{
+		&message.CodeInterpreterToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: big}}},
+	}}
+	prefix := textMessage(message.RoleUser, "hi")
+
+	fnBytes := compaction.CreateMessageIndex([]*message.Message{prefix, fnMsg}, nil).TotalByteCount()
+	mcpBytes := compaction.CreateMessageIndex([]*message.Message{prefix, mcpMsg}, nil).TotalByteCount()
+	ciBytes := compaction.CreateMessageIndex([]*message.Message{prefix, ciMsg}, nil).TotalByteCount()
+
+	if mcpBytes < fnBytes {
+		t.Errorf("MCP tool-result bytes = %d, want >= FunctionResult bytes %d (Outputs undercounted)", mcpBytes, fnBytes)
+	}
+	if ciBytes < fnBytes {
+		t.Errorf("code-interpreter result bytes = %d, want >= FunctionResult bytes %d (Outputs undercounted)", ciBytes, fnBytes)
 	}
 }


### PR DESCRIPTION
## Problem

`computeContentByteCount` (`agent/compaction/index.go`) computes each group's `ByteCount` and, via `computeTokenCount`'s default branch (`… / 4`), the token estimate for non-text content. It accounts `FunctionResultContent` (`fmt.Sprint(Result)`) and `DataContent` (`len(Data)`), but `MCPServerToolResultContent` / `CodeInterpreterToolResultContent` (and the call variants) hit `default: return 0`.

So a `MCPServerToolResultContent`/`CodeInterpreterToolResultContent` carrying 10,000 bytes of `Outputs` contributes only ~2 bytes (just the CallID), whereas the equivalent `FunctionResultContent` contributes 10,004. Byte/token-based triggers (`TokensExceed`, and therefore `ContextWindowStrategy`) **under-count** history dominated by hosted code-interpreter / MCP outputs — precisely the large content that most needs compaction — so compaction can fail to fire when it should.

## Fix

Account the hosted tool-call/result types by recursing into their `Outputs`/`Inputs` (summing `computeContentByteCount`) and counting their identity strings, mirroring the function-call/result cases. `default` stays `0` for genuinely unknown types.

## Test

`TestMessageIndex_CountsHostedToolResultBytes` builds an MCP result and a code-interpreter result each carrying a 10k-byte `Outputs` text and asserts their `TotalByteCount` is at least that of the equivalent `FunctionResultContent`. Fails before the fix (2 bytes vs 10004), passes after.