### PR TITLE
Surface Copilot model citations as CitationAnnotations

### DIFF
--- a/provider/copilotprovider/copilot.go
+++ b/provider/copilotprovider/copilot.go
@@ -668,10 +668,23 @@ func (p *provider) assistantMessageUpdate(event copilot.SessionEvent, data *copi
 			ContentHeader: message.ContentHeader{RawRepresentation: event},
 		}}
 	} else {
-		update.Contents = []message.Content{&message.TextContent{
+		textContent := &message.TextContent{
 			ContentHeader: message.ContentHeader{RawRepresentation: event},
 			Text:          data.Content,
-		}}
+		}
+		// Surface native model citations (enabled via AgentConfig.EnableCitations)
+		// as CitationAnnotations, mirroring the OpenAI chat/Responses providers.
+		if data.Citations != nil {
+			for _, source := range data.Citations.Sources {
+				textContent.Annotations = append(textContent.Annotations, &message.CitationAnnotation{
+					FileID:            derefString(source.Path),
+					Title:             derefString(source.Title),
+					URL:               derefString(source.URL),
+					RawRepresentation: source,
+				})
+			}
+		}
+		update.Contents = []message.Content{textContent}
 		if data.ReasoningText != nil {
 			update.Contents = append(update.Contents, &message.TextReasoningContent{
 				ContentHeader: message.ContentHeader{RawRepresentation: event},
@@ -833,6 +846,13 @@ func additionalUsageCounts(data *copilot.AssistantUsageData) map[string]int64 {
 func int64Value(value *int64) int64 {
 	if value == nil {
 		return 0
+	}
+	return *value
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
 	}
 	return *value
 }

--- a/provider/copilotprovider/copilot_test.go
+++ b/provider/copilotprovider/copilot_test.go
@@ -1264,3 +1264,43 @@ func assertStringSlice(t *testing.T, got any, want []string, name string) {
 		}
 	}
 }
+
+func TestConvertToAgentResponseUpdate_AssistantMessageSurfacesCitations(t *testing.T) {
+	runtime := newFakeRuntime(t,
+		sessionEvent("assistant.message", map[string]any{
+			"messageId": "msg-cite",
+			"content":   "The sky is blue.",
+			"citations": map[string]any{
+				"sources": []any{
+					map[string]any{
+						"id":       "s1",
+						"provider": "openai",
+						"title":    "Sky facts",
+						"url":      "https://example.com/sky",
+					},
+				},
+				"spans": []any{},
+			},
+		}),
+		idleEvent(),
+	)
+	agent := copilotprovider.NewAgent(runtime.client(), copilotprovider.AgentConfig{})
+
+	response, err := runText(t, agent, "why is the sky blue?", agentpkg.Stream(false))
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	text := firstContent[*message.TextContent](t, response)
+	var citation *message.CitationAnnotation
+	for _, ann := range text.Annotations {
+		if c, ok := ann.(*message.CitationAnnotation); ok {
+			citation = c
+		}
+	}
+	if citation == nil {
+		t.Fatalf("expected a CitationAnnotation on the assistant text, got %#v", text.Annotations)
+	}
+	if citation.Title != "Sky facts" || citation.URL != "https://example.com/sky" {
+		t.Errorf("citation = %#v, want Title=%q URL=%q", citation, "Sky facts", "https://example.com/sky")
+	}
+}


### PR DESCRIPTION
## Problem

The Copilot provider already plumbs `AgentConfig.EnableCitations` into the session config (`copilot.go`), so a citation-capable model returns citations on `AssistantMessageData.Citations`. But `assistantMessageUpdate` only reads `Content` and `ReasoningText` — it never looks at `Citations`, so every returned citation is **silently dropped**. This is a one-sided gap: the request opts in, the response data is discarded.

## Fix

When `data.Citations` is present on the non-streaming assistant message, map each `CitationSource` onto the assistant `TextContent`'s `Annotations` as a `message.CitationAnnotation` (title / URL / file path). This mirrors how the OpenAI chat (`populateChatAnnotations`) and Responses providers surface `url_citation` annotations onto text content.

## Test

`TestConvertToAgentResponseUpdate_AssistantMessageSurfacesCitations` emits an `assistant.message` event carrying a citation source and asserts the resulting `TextContent` has a `CitationAnnotation` with the source's title and URL. Fails before the fix (no annotations), passes after.

Note: this maps the deduplicated citation **sources**; span-to-text-region mapping (`Citations.Spans` → `AnnotatedRegions`) can follow as an enhancement.