### PR TITLE
Align stable message content with Microsoft.Extensions.AI

### DIFF
--- a/agent/compaction/equality.go
+++ b/agent/compaction/equality.go
@@ -4,6 +4,7 @@ package compaction
 
 import (
 	"reflect"
+	"slices"
 
 	"github.com/microsoft/agent-framework-go/message"
 )
@@ -69,7 +70,50 @@ func contentEqual(left, right message.Content) bool {
 			errorsEqual(leftContent.Error, rightContent.Error)
 	case *message.HostedFileContent:
 		rightContent := right.(*message.HostedFileContent)
-		return leftContent.FileID == rightContent.FileID && leftContent.MediaType == rightContent.MediaType && leftContent.Name == rightContent.Name
+		return leftContent.FileID == rightContent.FileID && leftContent.MediaType == rightContent.MediaType && leftContent.Name == rightContent.Name &&
+			reflect.DeepEqual(leftContent.SizeInBytes, rightContent.SizeInBytes) && reflect.DeepEqual(leftContent.CreatedAt, rightContent.CreatedAt)
+	case *message.HostedVectorStoreContent:
+		return leftContent.VectorStoreID == right.(*message.HostedVectorStoreContent).VectorStoreID
+	case *message.MCPServerToolCallContent:
+		rightContent := right.(*message.MCPServerToolCallContent)
+		return leftContent.CallID == rightContent.CallID && leftContent.Name == rightContent.Name &&
+			leftContent.ServerName == rightContent.ServerName && leftContent.Arguments == rightContent.Arguments
+	case *message.MCPServerToolResultContent:
+		rightContent := right.(*message.MCPServerToolResultContent)
+		return leftContent.CallID == rightContent.CallID && contentsEqual(leftContent.Outputs, rightContent.Outputs)
+	case *message.CodeInterpreterToolCallContent:
+		rightContent := right.(*message.CodeInterpreterToolCallContent)
+		return leftContent.CallID == rightContent.CallID && contentsEqual(leftContent.Inputs, rightContent.Inputs)
+	case *message.CodeInterpreterToolResultContent:
+		rightContent := right.(*message.CodeInterpreterToolResultContent)
+		return leftContent.CallID == rightContent.CallID && contentsEqual(leftContent.Outputs, rightContent.Outputs)
+	case *message.ImageGenerationToolCallContent:
+		return leftContent.CallID == right.(*message.ImageGenerationToolCallContent).CallID
+	case *message.ImageGenerationToolResultContent:
+		rightContent := right.(*message.ImageGenerationToolResultContent)
+		return leftContent.CallID == rightContent.CallID && contentsEqual(leftContent.Outputs, rightContent.Outputs)
+	case *message.WebSearchToolCallContent:
+		rightContent := right.(*message.WebSearchToolCallContent)
+		return leftContent.CallID == rightContent.CallID && slices.Equal(leftContent.Queries, rightContent.Queries)
+	case *message.WebSearchToolResultContent:
+		rightContent := right.(*message.WebSearchToolResultContent)
+		return leftContent.CallID == rightContent.CallID && contentsEqual(leftContent.Outputs, rightContent.Outputs)
+	case *message.UsageContent:
+		return reflect.DeepEqual(leftContent.Details, right.(*message.UsageContent).Details)
+	case *message.ToolApprovalRequestContent:
+		rightContent := right.(*message.ToolApprovalRequestContent)
+		return leftContent.RequestID == rightContent.RequestID && contentEqual(leftContent.ToolCall, rightContent.ToolCall)
+	case *message.ToolApprovalResponseContent:
+		rightContent := right.(*message.ToolApprovalResponseContent)
+		return leftContent.RequestID == rightContent.RequestID && leftContent.Approved == rightContent.Approved &&
+			leftContent.Reason == rightContent.Reason && contentEqual(leftContent.ToolCall, rightContent.ToolCall)
+	case *message.AlwaysApproveToolApprovalResponseContent:
+		rightContent := right.(*message.AlwaysApproveToolApprovalResponseContent)
+		return leftContent.AlwaysApproveTool == rightContent.AlwaysApproveTool &&
+			leftContent.AlwaysApproveToolWithArguments == rightContent.AlwaysApproveToolWithArguments &&
+			contentEqual(leftContent.InnerResponse, rightContent.InnerResponse)
+	case *message.RawContent:
+		return reflect.DeepEqual(leftContent.RawRepresentation, right.(*message.RawContent).RawRepresentation)
 	default:
 		return true
 	}

--- a/agent/compaction/equality_test.go
+++ b/agent/compaction/equality_test.go
@@ -5,6 +5,7 @@ package compaction_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/microsoft/agent-framework-go/agent/compaction"
 	"github.com/microsoft/agent-framework-go/message"
@@ -68,6 +69,20 @@ func TestMessageIndexUpdate_MatchesKnownContentTypes(t *testing.T) {
 		{name: "function result", original: &message.FunctionResultContent{CallID: "c1", Result: "sunny"}, replacement: &message.FunctionResultContent{CallID: "c1", Result: "rainy"}, matches: false},
 		{name: "function result error", original: &message.FunctionResultContent{CallID: "c1", Result: "sunny"}, replacement: &message.FunctionResultContent{CallID: "c1", Result: "sunny", Error: errors.New("boom")}, matches: false},
 		{name: "hosted file", original: &message.HostedFileContent{FileID: "file-1", MediaType: "text/csv", Name: "a.csv"}, replacement: &message.HostedFileContent{FileID: "file-1", MediaType: "text/csv", Name: "a.csv"}, matches: true},
+		{name: "hosted file size", original: &message.HostedFileContent{FileID: "file-1", SizeInBytes: ptr(int64(1))}, replacement: &message.HostedFileContent{FileID: "file-1", SizeInBytes: ptr(int64(2))}, matches: false},
+		{name: "hosted file creation", original: &message.HostedFileContent{FileID: "file-1", CreatedAt: ptr(time.Unix(1, 0))}, replacement: &message.HostedFileContent{FileID: "file-1", CreatedAt: ptr(time.Unix(2, 0))}, matches: false},
+		{name: "vector store", original: &message.HostedVectorStoreContent{VectorStoreID: "store-1"}, replacement: &message.HostedVectorStoreContent{VectorStoreID: "store-2"}, matches: false},
+		{name: "MCP call", original: &message.MCPServerToolCallContent{CallID: "c1", Name: "search", Arguments: `{}`}, replacement: &message.MCPServerToolCallContent{CallID: "c1", Name: "delete", Arguments: `{}`}, matches: false},
+		{name: "MCP result", original: &message.MCPServerToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: "a"}}}, replacement: &message.MCPServerToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: "b"}}}, matches: false},
+		{name: "code interpreter call", original: &message.CodeInterpreterToolCallContent{CallID: "c1", Inputs: message.Contents{&message.TextContent{Text: "a"}}}, replacement: &message.CodeInterpreterToolCallContent{CallID: "c1", Inputs: message.Contents{&message.TextContent{Text: "b"}}}, matches: false},
+		{name: "code interpreter result", original: &message.CodeInterpreterToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: "a"}}}, replacement: &message.CodeInterpreterToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: "b"}}}, matches: false},
+		{name: "image generation call", original: &message.ImageGenerationToolCallContent{CallID: "c1"}, replacement: &message.ImageGenerationToolCallContent{CallID: "c2"}, matches: false},
+		{name: "image generation result", original: &message.ImageGenerationToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: "a"}}}, replacement: &message.ImageGenerationToolResultContent{CallID: "c1", Outputs: message.Contents{&message.TextContent{Text: "b"}}}, matches: false},
+		{name: "web search call", original: &message.WebSearchToolCallContent{CallID: "c1", Queries: []string{"a"}}, replacement: &message.WebSearchToolCallContent{CallID: "c1", Queries: []string{"b"}}, matches: false},
+		{name: "web search result", original: &message.WebSearchToolResultContent{CallID: "c1", Outputs: message.Contents{&message.URIContent{URI: "https://a"}}}, replacement: &message.WebSearchToolResultContent{CallID: "c1", Outputs: message.Contents{&message.URIContent{URI: "https://b"}}}, matches: false},
+		{name: "usage", original: &message.UsageContent{Details: message.UsageDetails{TotalTokenCount: 1}}, replacement: &message.UsageContent{Details: message.UsageDetails{TotalTokenCount: 2}}, matches: false},
+		{name: "approval request", original: &message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: &message.FunctionCallContent{CallID: "c1"}}, replacement: &message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: &message.FunctionCallContent{CallID: "c2"}}, matches: false},
+		{name: "approval response", original: &message.ToolApprovalResponseContent{RequestID: "r1", Approved: true, ToolCall: &message.FunctionCallContent{CallID: "c1"}}, replacement: &message.ToolApprovalResponseContent{RequestID: "r1", Approved: false, ToolCall: &message.FunctionCallContent{CallID: "c1"}}, matches: false},
 	}
 
 	for _, tt := range tests {
@@ -80,6 +95,8 @@ func TestMessageIndexUpdate_MatchesKnownContentTypes(t *testing.T) {
 		})
 	}
 }
+
+func ptr[T any](value T) *T { return &value }
 
 func TestMessageIndexUpdate_UsesContentListStructureForMatching(t *testing.T) {
 	original := &message.Message{Role: message.RoleAssistant, Contents: []message.Content{&message.TextContent{Text: "reply"}, &message.FunctionCallContent{CallID: "c1", Name: "fn"}}}

--- a/agent/compaction/index.go
+++ b/agent/compaction/index.go
@@ -399,9 +399,45 @@ func computeContentByteCount(content message.Content) int {
 		return stringByteCount(typed.Message) + stringByteCount(typed.ErrorCode) + stringByteCount(typed.Details)
 	case *message.HostedFileContent:
 		return stringByteCount(typed.FileID) + stringByteCount(typed.MediaType) + stringByteCount(typed.Name)
+	case *message.HostedVectorStoreContent:
+		return stringByteCount(typed.VectorStoreID)
+	case *message.MCPServerToolCallContent:
+		return stringByteCount(typed.CallID) + stringByteCount(typed.Name) + stringByteCount(typed.ServerName) + stringByteCount(typed.Arguments)
+	case *message.MCPServerToolResultContent:
+		return stringByteCount(typed.CallID) + contentsByteCount(typed.Outputs)
+	case *message.CodeInterpreterToolCallContent:
+		return stringByteCount(typed.CallID) + contentsByteCount(typed.Inputs)
+	case *message.CodeInterpreterToolResultContent:
+		return stringByteCount(typed.CallID) + contentsByteCount(typed.Outputs)
+	case *message.ImageGenerationToolCallContent:
+		return stringByteCount(typed.CallID)
+	case *message.ImageGenerationToolResultContent:
+		return stringByteCount(typed.CallID) + contentsByteCount(typed.Outputs)
+	case *message.WebSearchToolCallContent:
+		total := stringByteCount(typed.CallID)
+		for _, query := range typed.Queries {
+			total += stringByteCount(query)
+		}
+		return total
+	case *message.WebSearchToolResultContent:
+		return stringByteCount(typed.CallID) + contentsByteCount(typed.Outputs)
+	case *message.ToolApprovalRequestContent:
+		return stringByteCount(typed.RequestID) + computeContentByteCount(typed.ToolCall)
+	case *message.ToolApprovalResponseContent:
+		return stringByteCount(typed.RequestID) + stringByteCount(typed.Reason) + computeContentByteCount(typed.ToolCall)
+	case *message.AlwaysApproveToolApprovalResponseContent:
+		return computeContentByteCount(typed.InnerResponse)
 	default:
 		return 0
 	}
+}
+
+func contentsByteCount(contents message.Contents) int {
+	var total int
+	for _, content := range contents {
+		total += computeContentByteCount(content)
+	}
+	return total
 }
 
 func stringByteCount(value string) int { return len(value) }

--- a/agent/compaction/index_test.go
+++ b/agent/compaction/index_test.go
@@ -35,6 +35,34 @@ func TestMessageIndex_CreateBasicGroups(t *testing.T) {
 	}
 }
 
+func TestMessageIndex_CountsStableToolContent(t *testing.T) {
+	msg := &message.Message{
+		Role: message.RoleUser,
+		Contents: message.Contents{
+			&message.HostedVectorStoreContent{VectorStoreID: "store"},
+			&message.ImageGenerationToolResultContent{
+				CallID:  "img",
+				Outputs: message.Contents{&message.TextContent{Text: "pixels"}},
+			},
+			&message.WebSearchToolCallContent{CallID: "web", Queries: []string{"one", "two"}},
+			&message.MCPServerToolResultContent{
+				CallID:  "mcp",
+				Outputs: message.Contents{&message.ErrorContent{Message: "bad"}},
+			},
+			&message.CodeInterpreterToolCallContent{
+				CallID: "code",
+				Inputs: message.Contents{&message.TextContent{Text: "x"}},
+			},
+			&message.RawContent{ContentHeader: message.ContentHeader{RawRepresentation: map[string]any{"opaque": "ignored"}}},
+		},
+	}
+
+	index := compaction.CreateMessageIndex([]*message.Message{msg}, nil)
+	if got, want := index.Groups[0].ByteCount, 34; got != want {
+		t.Fatalf("ByteCount = %d, want %d", got, want)
+	}
+}
+
 func TestMessageIndex_CreateMixedConversationGroupsCorrectly(t *testing.T) {
 	index := compaction.CreateMessageIndex([]*message.Message{
 		textMessage(message.RoleSystem, "system"),

--- a/agent/harness/toolapproval/toolapproval.go
+++ b/agent/harness/toolapproval/toolapproval.go
@@ -246,6 +246,10 @@ func run(cfg Config, next agent.RunFunc, ctx context.Context, messages []*messag
 					yield(nil, err)
 					return
 				}
+				req = snapshotToolApprovalRequest(req)
+				if req == nil {
+					continue
+				}
 				if approved {
 					autoApproved = append(autoApproved, req.CreateResponse(true, ""))
 				} else {
@@ -443,6 +447,10 @@ func drainAutoApprovable(ctx context.Context, cfg Config, st *state, requestMess
 		if err != nil {
 			return err
 		}
+		req = snapshotToolApprovalRequest(req)
+		if req == nil {
+			continue
+		}
 		if approved {
 			st.CollectedApprovalResponses = append(st.CollectedApprovalResponses, req.CreateResponse(true, ""))
 		} else {
@@ -602,6 +610,29 @@ func cloneToolCallContent(content message.ToolCallContent) message.ToolCallConte
 		}
 		cloned := *content
 		cloned.ContentHeader = cloneContentHeader(content.ContentHeader)
+		return &cloned
+	case *message.CodeInterpreterToolCallContent:
+		if content == nil {
+			return nil
+		}
+		cloned := *content
+		cloned.ContentHeader = cloneContentHeader(content.ContentHeader)
+		cloned.Inputs = slices.Clone(content.Inputs)
+		return &cloned
+	case *message.ImageGenerationToolCallContent:
+		if content == nil {
+			return nil
+		}
+		cloned := *content
+		cloned.ContentHeader = cloneContentHeader(content.ContentHeader)
+		return &cloned
+	case *message.WebSearchToolCallContent:
+		if content == nil {
+			return nil
+		}
+		cloned := *content
+		cloned.ContentHeader = cloneContentHeader(content.ContentHeader)
+		cloned.Queries = slices.Clone(content.Queries)
 		return &cloned
 	default:
 		return content

--- a/agent/harness/toolapproval/toolapproval_test.go
+++ b/agent/harness/toolapproval/toolapproval_test.go
@@ -1684,69 +1684,140 @@ func approvalResponsesFromMessages(messages []*message.Message) []*message.ToolA
 }
 
 func TestToolApproval_BindsResponseToSurfacedRequestSnapshot(t *testing.T) {
-	var innerCallMessages []*message.Message
-	runner := &agenttest.Runner{
-		Responses: agenttest.NewResponseBuilder().
-			Add(&agent.ResponseUpdate{
-				Role: message.RoleAssistant,
-				Contents: []message.Content{
-					&message.ToolApprovalRequestContent{
-						RequestID: "r1",
-						ToolCall: &message.FunctionCallContent{
-							CallID:    "c1",
-							Name:      "deploy",
-							Arguments: `{"env":"prod"}`,
+	tests := []struct {
+		name     string
+		toolCall message.ToolCallContent
+		mutate   func(message.ToolCallContent)
+		assert   func(*testing.T, message.ToolCallContent)
+	}{
+		{
+			name:     "function call",
+			toolCall: &message.FunctionCallContent{CallID: "c1", Name: "deploy", Arguments: `{"env":"prod"}`},
+			mutate: func(content message.ToolCallContent) {
+				call := content.(*message.FunctionCallContent)
+				call.Name = "delete"
+				call.Arguments = `{"env":"dev"}`
+			},
+			assert: func(t *testing.T, content message.ToolCallContent) {
+				call := content.(*message.FunctionCallContent)
+				if call.Name != "deploy" || call.Arguments != `{"env":"prod"}` {
+					t.Fatalf("bound tool call = %q %q, want deploy/prod", call.Name, call.Arguments)
+				}
+			},
+		},
+		{
+			name:     "MCP server call",
+			toolCall: &message.MCPServerToolCallContent{CallID: "c1", Name: "lookup", ServerName: "server-a"},
+			mutate: func(content message.ToolCallContent) {
+				call := content.(*message.MCPServerToolCallContent)
+				call.Name = "delete"
+				call.ServerName = "server-b"
+			},
+			assert: func(t *testing.T, content message.ToolCallContent) {
+				call := content.(*message.MCPServerToolCallContent)
+				if call.Name != "lookup" || call.ServerName != "server-a" {
+					t.Fatalf("bound tool call = %q %q, want lookup/server-a", call.Name, call.ServerName)
+				}
+			},
+		},
+		{
+			name: "code interpreter call",
+			toolCall: &message.CodeInterpreterToolCallContent{
+				CallID: "c1",
+				Inputs: message.Contents{&message.TextContent{Text: "original"}},
+			},
+			mutate: func(content message.ToolCallContent) {
+				content.(*message.CodeInterpreterToolCallContent).Inputs[0] = &message.TextContent{Text: "changed"}
+			},
+			assert: func(t *testing.T, content message.ToolCallContent) {
+				call := content.(*message.CodeInterpreterToolCallContent)
+				if text := call.Inputs[0].(*message.TextContent).Text; text != "original" {
+					t.Fatalf("bound input = %q, want original", text)
+				}
+			},
+		},
+		{
+			name: "image generation call",
+			toolCall: &message.ImageGenerationToolCallContent{
+				ContentHeader: message.ContentHeader{AdditionalProperties: map[string]any{"model": "original"}},
+				CallID:        "c1",
+			},
+			mutate: func(content message.ToolCallContent) {
+				content.(*message.ImageGenerationToolCallContent).AdditionalProperties["model"] = "changed"
+			},
+			assert: func(t *testing.T, content message.ToolCallContent) {
+				call := content.(*message.ImageGenerationToolCallContent)
+				if model := call.AdditionalProperties["model"]; model != "original" {
+					t.Fatalf("bound model = %v, want original", model)
+				}
+			},
+		},
+		{
+			name:     "web search call",
+			toolCall: &message.WebSearchToolCallContent{CallID: "c1", Queries: []string{"original"}},
+			mutate: func(content message.ToolCallContent) {
+				content.(*message.WebSearchToolCallContent).Queries[0] = "changed"
+			},
+			assert: func(t *testing.T, content message.ToolCallContent) {
+				call := content.(*message.WebSearchToolCallContent)
+				if call.Queries[0] != "original" {
+					t.Fatalf("bound query = %q, want original", call.Queries[0])
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var innerCallMessages []*message.Message
+			runner := &agenttest.Runner{
+				Responses: agenttest.NewResponseBuilder().
+					Add(&agent.ResponseUpdate{
+						Role: message.RoleAssistant,
+						Contents: []message.Content{
+							&message.ToolApprovalRequestContent{RequestID: "r1", ToolCall: test.toolCall},
 						},
-					},
-				},
-			}).
-			NewTurn(func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
-				innerCallMessages = messages
-			}).
-			AddText("done").
-			Build(),
-	}
-
-	session := agenttest.CreateSession()
-	mw := toolapproval.New(toolapproval.Config{})
-	turn1 := collectUpdates(t, mw, runner.Run, []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}},
-	}, agent.WithSession(session))
-	req := firstApprovalRequest(t, turn1)
-
-	forged := req.ToolCall.(*message.FunctionCallContent)
-	forged.Name = "delete"
-	forged.Arguments = `{"env":"dev"}`
-
-	turn2 := collectUpdates(t, mw, runner.Run, []*message.Message{
-		{Role: message.RoleUser, Contents: []message.Content{req.CreateResponse(true, "approved")}},
-	}, agent.WithSession(session))
-
-	responses := approvalResponsesFromMessages(innerCallMessages)
-	if len(responses) != 1 {
-		t.Fatalf("expected 1 injected approval response, got %d", len(responses))
-	}
-	fc, ok := responses[0].ToolCall.(*message.FunctionCallContent)
-	if !ok {
-		t.Fatalf("expected function-call tool binding, got %#v", responses[0].ToolCall)
-	}
-	if fc.Name != "deploy" || fc.Arguments != `{"env":"prod"}` {
-		t.Fatalf("expected bound tool call deploy/prod, got %q %q", fc.Name, fc.Arguments)
-	}
-
-	var gotDone bool
-	for _, u := range turn2 {
-		if u == nil {
-			continue
-		}
-		for _, c := range u.Contents {
-			if tc, ok := c.(*message.TextContent); ok && tc.Text == "done" {
-				gotDone = true
+					}).
+					NewTurn(func(_ context.Context, messages []*message.Message, _ ...agent.Option) {
+						innerCallMessages = messages
+					}).
+					AddText("done").
+					Build(),
 			}
-		}
-	}
-	if !gotDone {
-		t.Fatal("expected run to continue after bound approval response")
+
+			session := agenttest.CreateSession()
+			mw := toolapproval.New(toolapproval.Config{})
+			turn1 := collectUpdates(t, mw, runner.Run, []*message.Message{
+				{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "go"}}},
+			}, agent.WithSession(session))
+			req := firstApprovalRequest(t, turn1)
+			test.mutate(req.ToolCall)
+
+			turn2 := collectUpdates(t, mw, runner.Run, []*message.Message{
+				{Role: message.RoleUser, Contents: []message.Content{req.CreateResponse(true, "approved")}},
+			}, agent.WithSession(session))
+
+			responses := approvalResponsesFromMessages(innerCallMessages)
+			if len(responses) != 1 {
+				t.Fatalf("expected 1 injected approval response, got %d", len(responses))
+			}
+			test.assert(t, responses[0].ToolCall)
+
+			var gotDone bool
+			for _, update := range turn2 {
+				if update == nil {
+					continue
+				}
+				for _, content := range update.Contents {
+					if text, ok := content.(*message.TextContent); ok && text.Text == "done" {
+						gotDone = true
+					}
+				}
+			}
+			if !gotDone {
+				t.Fatal("expected run to continue after bound approval response")
+			}
+		})
 	}
 }
 

--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -931,7 +931,14 @@ func snapshotApprovalRequest(request *message.ToolApprovalRequestContent) *messa
 	if request == nil {
 		return nil
 	}
-	clone := &message.ToolApprovalRequestContent{RequestID: request.RequestID}
+	clone := &message.ToolApprovalRequestContent{
+		ContentHeader: message.ContentHeader{
+			AdditionalProperties: maps.Clone(request.AdditionalProperties),
+			Annotations:          slices.Clone(request.Annotations),
+			RawRepresentation:    request.RawRepresentation,
+		},
+		RequestID: request.RequestID,
+	}
 	switch call := request.ToolCall.(type) {
 	case *message.FunctionCallContent:
 		if call != nil {
@@ -945,6 +952,29 @@ func snapshotApprovalRequest(request *message.ToolApprovalRequestContent) *messa
 			callClone := *call
 			callClone.AdditionalProperties = maps.Clone(call.AdditionalProperties)
 			callClone.Annotations = slices.Clone(call.Annotations)
+			clone.ToolCall = &callClone
+		}
+	case *message.CodeInterpreterToolCallContent:
+		if call != nil {
+			callClone := *call
+			callClone.AdditionalProperties = maps.Clone(call.AdditionalProperties)
+			callClone.Annotations = slices.Clone(call.Annotations)
+			callClone.Inputs = slices.Clone(call.Inputs)
+			clone.ToolCall = &callClone
+		}
+	case *message.ImageGenerationToolCallContent:
+		if call != nil {
+			callClone := *call
+			callClone.AdditionalProperties = maps.Clone(call.AdditionalProperties)
+			callClone.Annotations = slices.Clone(call.Annotations)
+			clone.ToolCall = &callClone
+		}
+	case *message.WebSearchToolCallContent:
+		if call != nil {
+			callClone := *call
+			callClone.AdditionalProperties = maps.Clone(call.AdditionalProperties)
+			callClone.Annotations = slices.Clone(call.Annotations)
+			callClone.Queries = slices.Clone(call.Queries)
 			clone.ToolCall = &callClone
 		}
 	default:

--- a/message/annotation.go
+++ b/message/annotation.go
@@ -149,8 +149,8 @@ func (t *RawAnnotatedRegion) kind() annotatedRegionKind { return "" }
 // TextSpanAnnotatedRegion describes a location in the associated [Content]
 // based on starting and ending character indices.
 type TextSpanAnnotatedRegion struct {
-	Start int // Start character index (inclusive) of the annotated span.
-	End   int // End character index (exclusive) of the annotated span.
+	StartIndex *int `json:",omitempty"` // Start character index (inclusive) of the annotated span.
+	EndIndex   *int `json:",omitempty"` // End character index (exclusive) of the annotated span.
 }
 
 func (t *TextSpanAnnotatedRegion) MarshalJSON() ([]byte, error) {
@@ -165,4 +165,4 @@ func (t *TextSpanAnnotatedRegion) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
-func (t *TextSpanAnnotatedRegion) kind() annotatedRegionKind { return "text_span" }
+func (t *TextSpanAnnotatedRegion) kind() annotatedRegionKind { return "textSpan" }

--- a/message/annotation_test.go
+++ b/message/annotation_test.go
@@ -117,17 +117,18 @@ func TestAnnotationEncoding_KnownTypeInvalidPayloadReturnsError(t *testing.T) {
 		t.Fatal("expected error decoding known annotation with invalid payload, got nil")
 	}
 
-	// Likewise for a known annotated region type ("text_span").
-	if err := json.Unmarshal([]byte(`[{"Type":"text_span","Start":"nope"}]`), new(message.AnnotatedRegions)); err == nil {
+	// Likewise for a known annotated region type ("textSpan").
+	if err := json.Unmarshal([]byte(`[{"Type":"textSpan","StartIndex":"nope"}]`), new(message.AnnotatedRegions)); err == nil {
 		t.Fatal("expected error decoding known region with invalid payload, got nil")
 	}
 }
 
 func TestAnnotatedRegionEncoding_Roundtrip(t *testing.T) {
+	start, end := 10, 50
 	regions := message.AnnotatedRegions{
 		&message.TextSpanAnnotatedRegion{
-			Start: 10,
-			End:   50,
+			StartIndex: &start,
+			EndIndex:   &end,
 		},
 	}
 	data, err := json.Marshal(regions)
@@ -145,5 +146,34 @@ func TestAnnotatedRegionEncoding_Roundtrip(t *testing.T) {
 		if !reflect.DeepEqual(v, decoded[i]) {
 			t.Errorf("[%d]: expected region %v, got %v", i, v, decoded[i])
 		}
+	}
+}
+
+func TestTextSpanAnnotatedRegionEncoding_NullableEndpoints(t *testing.T) {
+	zero := 0
+	regions := message.AnnotatedRegions{
+		&message.TextSpanAnnotatedRegion{},
+		&message.TextSpanAnnotatedRegion{StartIndex: &zero},
+	}
+
+	data, err := json.Marshal(regions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(data), `[{"Type":"textSpan"},{"StartIndex":0,"Type":"textSpan"}]`; got != want {
+		t.Fatalf("JSON = %s, want %s", got, want)
+	}
+
+	var decoded message.AnnotatedRegions
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	first := decoded[0].(*message.TextSpanAnnotatedRegion)
+	second := decoded[1].(*message.TextSpanAnnotatedRegion)
+	if first.StartIndex != nil || first.EndIndex != nil {
+		t.Fatalf("first region = %#v, want nil endpoints", first)
+	}
+	if second.StartIndex == nil || *second.StartIndex != 0 || second.EndIndex != nil {
+		t.Fatalf("second region = %#v, want start 0 and nil end", second)
 	}
 }

--- a/message/content.go
+++ b/message/content.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/microsoft/agent-framework-go/internal/jsonx"
 )
@@ -28,6 +29,8 @@ func init() {
 		&FunctionResultContent{},
 		&HostedFileContent{},
 		&HostedVectorStoreContent{},
+		&ImageGenerationToolCallContent{},
+		&ImageGenerationToolResultContent{},
 		&TextReasoningContent{},
 		&URIContent{},
 		&UsageContent{},
@@ -38,6 +41,8 @@ func init() {
 		&CodeInterpreterToolCallContent{},
 		&CodeInterpreterToolResultContent{},
 		&MCPServerToolResultContent{},
+		&WebSearchToolCallContent{},
+		&WebSearchToolResultContent{},
 	} {
 		supportedContents[c.kind()] = reflect.TypeOf(c).Elem()
 	}
@@ -70,6 +75,27 @@ type ToolCallContent interface {
 	Content
 
 	GetCallID() string
+}
+
+// ToolResultContent represents the result of a tool call.
+type ToolResultContent interface {
+	Content
+
+	GetCallID() string
+}
+
+// InputRequestContent represents a request for input from the user or application.
+type InputRequestContent interface {
+	Content
+
+	GetRequestID() string
+}
+
+// InputResponseContent represents the response to an [InputRequestContent].
+type InputResponseContent interface {
+	Content
+
+	GetRequestID() string
 }
 
 // Contents is a slice of Content that supports JSON encoding.
@@ -184,7 +210,7 @@ func (t *DataContent) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
-	d, err := newDataContentFromURI(tmp.URI, "")
+	d, err := NewDataContentFromURI(tmp.URI, "")
 	if err != nil {
 		return err
 	}
@@ -197,6 +223,17 @@ func (t *DataContent) UnmarshalJSON(data []byte) error {
 
 func (t DataContent) kind() contentKind { return "data" }
 
+// NewDataContent creates a [DataContent] from raw bytes and a media type.
+func NewDataContent(data []byte, mediaType string) (*DataContent, error) {
+	if !isValidMediaType(mediaType) {
+		return nil, fmt.Errorf("invalid media type: %s", mediaType)
+	}
+	return &DataContent{
+		Data:      base64.StdEncoding.EncodeToString(data),
+		MediaType: mediaType,
+	}, nil
+}
+
 // URI returns the Data URI representation of the content,
 // as defined in RFC 2397:
 //
@@ -205,10 +242,10 @@ func (t *DataContent) URI() string {
 	return fmt.Sprintf("data:%s;base64,%s", t.MediaType, t.Data)
 }
 
-// newDataContentFromURI creates a new DataContent from a Data URI string.
+// NewDataContentFromURI creates a new [DataContent] from a Data URI string.
 // The mediaType parameter is optional; if not provided, it must be present in the URI.
 // Returns an error if the URI is invalid or doesn't contain a media type when required.
-func newDataContentFromURI(uri string, mediaType string) (*DataContent, error) {
+func NewDataContentFromURI(uri string, mediaType string) (*DataContent, error) {
 	if uri == "" {
 		return nil, fmt.Errorf("uri cannot be empty")
 	}
@@ -248,6 +285,12 @@ func (t *DataContent) Bytes() ([]byte, error) {
 // TopLevelMediaType returns the normalized (lowercased, whitespace-trimmed) top-level part of the content's MediaType - the portion before the / (for example image for image/png). If MediaType contains no /, the whole normalized value is returned; if MediaType is unset, it returns an empty string.
 func (t *DataContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
+}
+
+// HasTopLevelMediaType reports whether MediaType has the specified top-level type.
+func (t *DataContent) HasTopLevelMediaType(topLevelType string) bool {
+	topLevel := t.TopLevelMediaType()
+	return topLevel != "" && strings.EqualFold(topLevel, topLevelType)
 }
 
 // ErrorContent represents an error.
@@ -320,14 +363,18 @@ func (t *MCPServerToolCallContent) MarshalJSON() ([]byte, error) {
 type MCPServerToolResultContent struct {
 	ContentHeader
 
-	CallID     string
-	Name       string
-	ServerName string   `json:",omitempty"`
-	Outputs    Contents `json:",omitempty"`
-	Error      string   `json:",omitempty"`
+	CallID  string
+	Outputs Contents `json:",omitempty"`
 }
 
 func (t MCPServerToolResultContent) kind() contentKind { return "mcpServerToolResult" }
+
+func (t *MCPServerToolResultContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
 
 func (t *MCPServerToolResultContent) MarshalJSON() ([]byte, error) {
 	type alias MCPServerToolResultContent
@@ -440,6 +487,13 @@ func (t *FunctionResultContent) UnmarshalJSON(data []byte) error {
 
 func (t FunctionResultContent) kind() contentKind { return "functionResult" }
 
+func (t *FunctionResultContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
+
 // HostedFileContent represents a file that is hosted by the AI service.
 //
 // Unlike [DataContent] which contains the data for a file or blob, this class represents a file
@@ -448,14 +502,23 @@ func (t FunctionResultContent) kind() contentKind { return "functionResult" }
 type HostedFileContent struct {
 	ContentHeader
 
-	FileID    string
-	Name      string `json:",omitempty"`
-	MediaType string `json:",omitempty"`
+	FileID      string
+	Name        string     `json:",omitempty"`
+	MediaType   string     `json:",omitempty"`
+	Scope       string     `json:",omitempty"`
+	SizeInBytes *int64     `json:",omitempty"`
+	CreatedAt   *time.Time `json:",omitempty"`
 }
 
 // TopLevelMediaType returns the normalized (lowercased, whitespace-trimmed) top-level part of the content's MediaType - the portion before the / (for example image for image/png). If MediaType contains no /, the whole normalized value is returned; if MediaType is unset, it returns an empty string.
 func (t *HostedFileContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
+}
+
+// HasTopLevelMediaType reports whether MediaType has the specified top-level type.
+func (t *HostedFileContent) HasTopLevelMediaType(topLevelType string) bool {
+	topLevel := t.TopLevelMediaType()
+	return topLevel != "" && strings.EqualFold(topLevel, topLevelType)
 }
 
 func (t *HostedFileContent) MarshalJSON() ([]byte, error) {
@@ -590,6 +653,12 @@ func (t *URIContent) TopLevelMediaType() string {
 	return topLevelMediaType(t.MediaType)
 }
 
+// HasTopLevelMediaType reports whether MediaType has the specified top-level type.
+func (t *URIContent) HasTopLevelMediaType(topLevelType string) bool {
+	topLevel := t.TopLevelMediaType()
+	return topLevel != "" && strings.EqualFold(topLevel, topLevelType)
+}
+
 func (t *URIContent) MarshalJSON() ([]byte, error) {
 	type alias URIContent
 	tmp := struct {
@@ -705,52 +774,21 @@ func (t *ToolApprovalRequestContent) UnmarshalJSON(data []byte) error {
 
 func (t ToolApprovalRequestContent) kind() contentKind { return "toolApprovalRequest" }
 
+func (t *ToolApprovalRequestContent) GetRequestID() string {
+	if t == nil {
+		return ""
+	}
+	return t.RequestID
+}
+
 // CreateResponse builds a [ToolApprovalResponseContent] that approves or rejects this
-// request. It carries over the RequestID, records the decision and reason, and clones the
-// pending tool call along with the AdditionalProperties and Annotations of the content
-// header. Note that RawRepresentation is copied by reference.
+// request. It carries over the RequestID and tool call, and records the decision and reason.
 func (t *ToolApprovalRequestContent) CreateResponse(approved bool, reason string) *ToolApprovalResponseContent {
 	return &ToolApprovalResponseContent{
 		RequestID: t.RequestID,
 		Approved:  approved,
 		Reason:    reason,
-		ToolCall:  cloneToolCallContent(t.ToolCall),
-		ContentHeader: ContentHeader{
-			AdditionalProperties: maps.Clone(t.AdditionalProperties),
-			Annotations:          slices.Clone(t.Annotations),
-			RawRepresentation:    t.RawRepresentation,
-		},
-	}
-}
-
-func cloneToolCallContent(toolCall ToolCallContent) ToolCallContent {
-	switch toolCall := toolCall.(type) {
-	case nil:
-		return nil
-	case *FunctionCallContent:
-		if toolCall == nil {
-			return nil
-		}
-		cloned := *toolCall
-		cloned.ContentHeader = cloneContentHeader(toolCall.ContentHeader)
-		return &cloned
-	case *MCPServerToolCallContent:
-		if toolCall == nil {
-			return nil
-		}
-		cloned := *toolCall
-		cloned.ContentHeader = cloneContentHeader(toolCall.ContentHeader)
-		return &cloned
-	default:
-		return toolCall
-	}
-}
-
-func cloneContentHeader(header ContentHeader) ContentHeader {
-	return ContentHeader{
-		AdditionalProperties: maps.Clone(header.AdditionalProperties),
-		Annotations:          slices.Clone(header.Annotations),
-		RawRepresentation:    header.RawRepresentation,
+		ToolCall:  t.ToolCall,
 	}
 }
 
@@ -843,6 +881,13 @@ func (t *ToolApprovalResponseContent) UnmarshalJSON(data []byte) error {
 
 func (t ToolApprovalResponseContent) kind() contentKind { return "toolApprovalResponse" }
 
+func (t *ToolApprovalResponseContent) GetRequestID() string {
+	if t == nil {
+		return ""
+	}
+	return t.RequestID
+}
+
 func unmarshalToolApprovalToolCall(data json.RawMessage) (ToolCallContent, error) {
 	if len(data) == 0 || string(data) == "null" {
 		return nil, nil
@@ -862,6 +907,24 @@ func unmarshalToolApprovalToolCall(data json.RawMessage) (ToolCallContent, error
 		return &toolCall, nil
 	case contentKind("mcpServerToolCall"):
 		var toolCall MCPServerToolCallContent
+		if err := json.Unmarshal(data, &toolCall); err != nil {
+			return nil, err
+		}
+		return &toolCall, nil
+	case contentKind("codeInterpreterToolCall"):
+		var toolCall CodeInterpreterToolCallContent
+		if err := json.Unmarshal(data, &toolCall); err != nil {
+			return nil, err
+		}
+		return &toolCall, nil
+	case contentKind("imageGenerationToolCall"):
+		var toolCall ImageGenerationToolCallContent
+		if err := json.Unmarshal(data, &toolCall); err != nil {
+			return nil, err
+		}
+		return &toolCall, nil
+	case contentKind("webSearchToolCall"):
+		var toolCall WebSearchToolCallContent
 		if err := json.Unmarshal(data, &toolCall); err != nil {
 			return nil, err
 		}
@@ -912,6 +975,13 @@ type CodeInterpreterToolCallContent struct {
 	Inputs Contents
 }
 
+func (t *CodeInterpreterToolCallContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
+
 func (t *CodeInterpreterToolCallContent) MarshalJSON() ([]byte, error) {
 	type alias CodeInterpreterToolCallContent
 	tmp := struct {
@@ -947,6 +1017,130 @@ func (t *CodeInterpreterToolResultContent) MarshalJSON() ([]byte, error) {
 }
 
 func (t CodeInterpreterToolResultContent) kind() contentKind { return "codeInterpreterToolResult" }
+
+func (t *CodeInterpreterToolResultContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
+
+// ImageGenerationToolCallContent represents the invocation of an image generation tool by a hosted service.
+type ImageGenerationToolCallContent struct {
+	ContentHeader
+
+	CallID string
+}
+
+func (t *ImageGenerationToolCallContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
+
+func (t *ImageGenerationToolCallContent) MarshalJSON() ([]byte, error) {
+	type alias ImageGenerationToolCallContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t ImageGenerationToolCallContent) kind() contentKind { return "imageGenerationToolCall" }
+
+// ImageGenerationToolResultContent represents the result of an image generation tool invocation by a hosted service.
+type ImageGenerationToolResultContent struct {
+	ContentHeader
+
+	CallID  string
+	Outputs Contents
+}
+
+func (t *ImageGenerationToolResultContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
+
+func (t *ImageGenerationToolResultContent) MarshalJSON() ([]byte, error) {
+	type alias ImageGenerationToolResultContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t ImageGenerationToolResultContent) kind() contentKind {
+	return "imageGenerationToolResult"
+}
+
+// WebSearchToolCallContent represents a web search tool invocation by a hosted service.
+type WebSearchToolCallContent struct {
+	ContentHeader
+
+	CallID  string
+	Queries []string
+}
+
+func (t *WebSearchToolCallContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
+
+func (t *WebSearchToolCallContent) MarshalJSON() ([]byte, error) {
+	type alias WebSearchToolCallContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t WebSearchToolCallContent) kind() contentKind { return "webSearchToolCall" }
+
+// WebSearchToolResultContent represents the results of a web search tool invocation by a hosted service.
+type WebSearchToolResultContent struct {
+	ContentHeader
+
+	CallID  string
+	Outputs Contents
+}
+
+func (t *WebSearchToolResultContent) GetCallID() string {
+	if t == nil {
+		return ""
+	}
+	return t.CallID
+}
+
+func (t *WebSearchToolResultContent) MarshalJSON() ([]byte, error) {
+	type alias WebSearchToolResultContent
+	tmp := struct {
+		*alias
+		Type contentKind
+	}{
+		alias: (*alias)(t),
+		Type:  t.kind(),
+	}
+	return json.Marshal(tmp)
+}
+
+func (t WebSearchToolResultContent) kind() contentKind { return "webSearchToolResult" }
 
 // CoalesceContents combines sequential contents elements.
 func CoalesceContents(contents []Content) []Content {
@@ -1002,9 +1196,12 @@ func CoalesceContents(contents []Content) []Content {
 			return content
 		})
 
+	contents = coalesceImageGenerationToolResults(contents)
+	contents = coalesceWebSearchToolCalls(contents)
+
 	contents = coalesce(contents, false,
 		func(a, b *DataContent) bool {
-			if !strings.EqualFold(a.MediaType, b.MediaType) || a.TopLevelMediaType() != "text" || a.Name != b.Name {
+			if a.MediaType != b.MediaType || !a.HasTopLevelMediaType("text") || a.Name != b.Name {
 				return false
 			}
 			if _, err := a.Bytes(); err != nil {
@@ -1017,9 +1214,6 @@ func CoalesceContents(contents []Content) []Content {
 			first := contents[start].(*DataContent)
 
 			return &DataContent{
-				ContentHeader: ContentHeader{
-					AdditionalProperties: maps.Clone(first.AdditionalProperties),
-				},
 				Name:      first.Name,
 				MediaType: first.MediaType,
 				Data:      mergeBase64(contents, start, end),
@@ -1030,14 +1224,16 @@ func CoalesceContents(contents []Content) []Content {
 		func(a, b *CodeInterpreterToolCallContent) bool { return a.CallID == b.CallID },
 		func(contents []Content, start, end int) *CodeInterpreterToolCallContent {
 			first := contents[start].(*CodeInterpreterToolCallContent)
+			if end-start == 1 {
+				first.Inputs = CoalesceContents(first.Inputs)
+				return first
+			}
 			var inputs Contents
 			for _, c := range contents[start:end] {
 				inputs = append(inputs, c.(*CodeInterpreterToolCallContent).Inputs...)
 			}
-			header := first.ContentHeader
-			header.AdditionalProperties = maps.Clone(first.AdditionalProperties)
 			return &CodeInterpreterToolCallContent{
-				ContentHeader: header,
+				ContentHeader: ContentHeader{AdditionalProperties: maps.Clone(first.AdditionalProperties)},
 				CallID:        first.CallID,
 				Inputs:        CoalesceContents(inputs),
 			}
@@ -1047,20 +1243,86 @@ func CoalesceContents(contents []Content) []Content {
 		func(a, b *CodeInterpreterToolResultContent) bool { return a.CallID == b.CallID },
 		func(contents []Content, start, end int) *CodeInterpreterToolResultContent {
 			first := contents[start].(*CodeInterpreterToolResultContent)
+			if end-start == 1 {
+				first.Outputs = CoalesceContents(first.Outputs)
+				return first
+			}
 			var outputs Contents
 			for _, c := range contents[start:end] {
 				outputs = append(outputs, c.(*CodeInterpreterToolResultContent).Outputs...)
 			}
-			header := first.ContentHeader
-			header.AdditionalProperties = maps.Clone(first.AdditionalProperties)
 			return &CodeInterpreterToolResultContent{
-				ContentHeader: header,
+				ContentHeader: ContentHeader{AdditionalProperties: maps.Clone(first.AdditionalProperties)},
 				CallID:        first.CallID,
 				Outputs:       CoalesceContents(outputs),
 			}
 		})
 
 	return contents
+}
+
+func coalesceImageGenerationToolResults(contents []Content) []Content {
+	indexByCallID := make(map[string]int)
+	for i, content := range contents {
+		result, ok := content.(*ImageGenerationToolResultContent)
+		if !ok || result == nil {
+			continue
+		}
+		if existingIndex, ok := indexByCallID[result.CallID]; ok {
+			contents[existingIndex] = result
+			contents[i] = nil
+		} else {
+			indexByCallID[result.CallID] = i
+		}
+	}
+	return slices.DeleteFunc(contents, func(c Content) bool { return c == nil })
+}
+
+func coalesceWebSearchToolCalls(contents []Content) []Content {
+	indexByCallID := make(map[string]int)
+	for i, content := range contents {
+		toolCall, ok := content.(*WebSearchToolCallContent)
+		if !ok || toolCall == nil {
+			continue
+		}
+
+		existingIndex, ok := indexByCallID[toolCall.CallID]
+		if !ok {
+			indexByCallID[toolCall.CallID] = i
+			continue
+		}
+
+		existing := contents[existingIndex].(*WebSearchToolCallContent)
+		if existing != toolCall {
+			header := existing.ContentHeader
+			if header.RawRepresentation == nil {
+				header.RawRepresentation = toolCall.RawRepresentation
+			}
+			if header.AdditionalProperties == nil {
+				header.AdditionalProperties = toolCall.AdditionalProperties
+			}
+			if header.Annotations == nil {
+				header.Annotations = toolCall.Annotations
+			}
+
+			queries := existing.Queries
+			switch {
+			case len(toolCall.Queries) == 0:
+			case len(existing.Queries) == 0:
+				queries = toolCall.Queries
+			default:
+				queries = slices.Concat(existing.Queries, toolCall.Queries)
+			}
+
+			contents[existingIndex] = &WebSearchToolCallContent{
+				ContentHeader: header,
+				CallID:        existing.CallID,
+				Queries:       queries,
+			}
+		}
+		contents[i] = nil
+	}
+	return slices.DeleteFunc(contents, func(c Content) bool { return c == nil })
 }
 
 func coalesce[T Content](contents []Content, mergeSingle bool, canMerge func(a, b T) bool, merge func([]Content, int, int) T) []Content {

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -9,8 +9,26 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/microsoft/agent-framework-go/message"
+)
+
+var (
+	_ message.ToolCallContent = (*message.FunctionCallContent)(nil)
+	_ message.ToolCallContent = (*message.MCPServerToolCallContent)(nil)
+	_ message.ToolCallContent = (*message.ImageGenerationToolCallContent)(nil)
+	_ message.ToolCallContent = (*message.CodeInterpreterToolCallContent)(nil)
+	_ message.ToolCallContent = (*message.WebSearchToolCallContent)(nil)
+
+	_ message.ToolResultContent = (*message.FunctionResultContent)(nil)
+	_ message.ToolResultContent = (*message.MCPServerToolResultContent)(nil)
+	_ message.ToolResultContent = (*message.ImageGenerationToolResultContent)(nil)
+	_ message.ToolResultContent = (*message.CodeInterpreterToolResultContent)(nil)
+	_ message.ToolResultContent = (*message.WebSearchToolResultContent)(nil)
+
+	_ message.InputRequestContent  = (*message.ToolApprovalRequestContent)(nil)
+	_ message.InputResponseContent = (*message.ToolApprovalResponseContent)(nil)
 )
 
 // Test TextContent
@@ -109,6 +127,8 @@ func TestUsageDetails_AddWithAdditionalCounts(t *testing.T) {
 }
 
 func TestContentEncoding_Roundtrip(t *testing.T) {
+	createdAt := time.Date(2026, time.September, 9, 12, 30, 0, 0, time.UTC)
+	sizeInBytes := int64(1024)
 	contents := message.Contents{
 		&message.TextContent{Text: "sample text"},
 		&message.TextReasoningContent{Text: "sample reasoning"},
@@ -140,7 +160,11 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 			MediaType: "text/plain",
 		},
 		&message.HostedFileContent{
-			FileID: "file-123",
+			FileID:      "file-123",
+			Name:        "document.txt",
+			MediaType:   "text/plain",
+			SizeInBytes: &sizeInBytes,
+			CreatedAt:   &createdAt,
 		},
 		&message.HostedVectorStoreContent{
 			VectorStoreID: "store-123",
@@ -195,13 +219,35 @@ func TestContentEncoding_Roundtrip(t *testing.T) {
 			ServerName: "mcpServer",
 		},
 		&message.MCPServerToolResultContent{
-			CallID:     "mcp-call-123",
-			Name:       "mcpName",
-			ServerName: "mcpServer",
+			CallID: "mcp-call-123",
 			Outputs: message.Contents{
 				&message.TextContent{Text: "mcp tool output"},
 			},
-			Error: "mcp tool error",
+		},
+		&message.ImageGenerationToolCallContent{
+			CallID: "image-call-123",
+		},
+		&message.ImageGenerationToolResultContent{
+			CallID: "image-call-123",
+			Outputs: message.Contents{
+				&message.DataContent{
+					Data:      base64.StdEncoding.EncodeToString([]byte("image")),
+					MediaType: "image/png",
+				},
+			},
+		},
+		&message.WebSearchToolCallContent{
+			CallID:  "web-call-123",
+			Queries: []string{"first query", "second query"},
+		},
+		&message.WebSearchToolResultContent{
+			CallID: "web-call-123",
+			Outputs: message.Contents{
+				&message.URIContent{
+					URI:       "https://example.com/result",
+					MediaType: "text/html",
+				},
+			},
 		},
 	}
 	data, err := json.Marshal(contents)
@@ -384,6 +430,47 @@ func TestCodeInterpreterContentEncoding_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestCodeInterpreterToolCallContentImplementsToolCallContent(t *testing.T) {
+	var content message.ToolCallContent = &message.CodeInterpreterToolCallContent{CallID: "call-123"}
+	if content.GetCallID() != "call-123" {
+		t.Fatalf("GetCallID() = %q, want call-123", content.GetCallID())
+	}
+}
+
+func TestToolApprovalContentEncoding_RoundtripsStableToolCalls(t *testing.T) {
+	toolCalls := []message.ToolCallContent{
+		&message.FunctionCallContent{CallID: "function-call", Name: "lookup"},
+		&message.MCPServerToolCallContent{CallID: "mcp-call", Name: "lookup"},
+		&message.ImageGenerationToolCallContent{CallID: "image-call"},
+		&message.CodeInterpreterToolCallContent{
+			CallID: "code-call",
+			Inputs: message.Contents{&message.TextContent{Text: "print('hello')"}},
+		},
+		&message.WebSearchToolCallContent{CallID: "web-call", Queries: []string{"query"}},
+	}
+
+	for _, toolCall := range toolCalls {
+		t.Run(toolCall.GetCallID(), func(t *testing.T) {
+			request := &message.ToolApprovalRequestContent{
+				RequestID: "request-" + toolCall.GetCallID(),
+				ToolCall:  toolCall,
+			}
+			contents := message.Contents{request, request.CreateResponse(true, "approved")}
+			data, err := json.Marshal(contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded message.Contents
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(contents, decoded) {
+				t.Fatalf("decoded = %#v, want %#v", decoded, contents)
+			}
+		})
+	}
+}
+
 func TestDataContentUnmarshalDefaultsMissingMediaType(t *testing.T) {
 	var content message.DataContent
 	if err := json.Unmarshal([]byte(`{"Type":"data","URI":"data:,hello%20world+literal"}`), &content); err != nil {
@@ -398,6 +485,43 @@ func TestDataContentUnmarshalDefaultsMissingMediaType(t *testing.T) {
 	}
 	if string(data) != "hello world+literal" {
 		t.Fatalf("data = %q, want hello world+literal", string(data))
+	}
+}
+
+func TestNewDataContent(t *testing.T) {
+	content, err := message.NewDataContent([]byte("hello"), "text/plain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.Data != "aGVsbG8=" || content.MediaType != "text/plain" {
+		t.Fatalf("content = %#v", content)
+	}
+	data, err := content.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("Bytes() = %q, want hello", data)
+	}
+	if _, err := message.NewDataContent(nil, "invalid media type"); err == nil {
+		t.Fatal("NewDataContent() error = nil, want invalid media type error")
+	}
+}
+
+func TestNewDataContentFromURI(t *testing.T) {
+	content, err := message.NewDataContentFromURI("data:,hello%20world", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.MediaType != "text/plain;charset=US-ASCII" {
+		t.Fatalf("MediaType = %q", content.MediaType)
+	}
+	data, err := content.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello world" {
+		t.Fatalf("Bytes() = %q, want hello world", data)
 	}
 }
 
@@ -484,6 +608,31 @@ func TestNewURIContentUsesExplicitMediaType(t *testing.T) {
 	}
 }
 
+func TestContentHasTopLevelMediaType(t *testing.T) {
+	tests := []struct {
+		name    string
+		content interface{ HasTopLevelMediaType(string) bool }
+		want    string
+		missing string
+	}{
+		{name: "data", content: &message.DataContent{MediaType: " Image/PNG "}, want: "image", missing: "text"},
+		{name: "hosted file", content: &message.HostedFileContent{MediaType: "TEXT/PLAIN"}, want: "text", missing: "image"},
+		{name: "URI", content: &message.URIContent{MediaType: "application/json"}, want: "APPLICATION", missing: "text"},
+		{name: "unset", content: &message.DataContent{}, want: "image", missing: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.content.HasTopLevelMediaType(test.want); got != (test.name != "unset") {
+				t.Fatalf("HasTopLevelMediaType(%q) = %v", test.want, got)
+			}
+			if test.content.HasTopLevelMediaType(test.missing) {
+				t.Fatalf("HasTopLevelMediaType(%q) = true, want false", test.missing)
+			}
+		})
+	}
+}
+
 func TestContentEncoding_UnmarshalMissingTypeUsesRawContent(t *testing.T) {
 	const rawContent = `{"Provider":"github","Payload":{"value":42}}`
 	data := []byte(`[` + rawContent + `]`)
@@ -539,45 +688,39 @@ func TestContentEncoding_RawContentMarshalHasNoType(t *testing.T) {
 	}
 }
 
-func TestToolApprovalRequestContent_CreateResponseSnapshotsFunctionCall(t *testing.T) {
-	toolCall := &message.FunctionCallContent{
-		ContentHeader: message.ContentHeader{
-			AdditionalProperties: map[string]any{"key": "value"},
-		},
-		CallID:    "call-1",
-		Name:      "deploy",
-		Arguments: `{"environment":"prod"}`,
-	}
-	request := &message.ToolApprovalRequestContent{
-		ContentHeader: message.ContentHeader{
-			AdditionalProperties: map[string]any{"request": "value"},
-		},
-		RequestID: "approval-1",
-		ToolCall:  toolCall,
+func TestToolApprovalRequestContent_CreateResponseUsesToolCallReference(t *testing.T) {
+	toolCalls := []message.ToolCallContent{
+		&message.FunctionCallContent{CallID: "function-call", Name: "lookup"},
+		&message.MCPServerToolCallContent{CallID: "mcp-call", Name: "lookup"},
+		&message.ImageGenerationToolCallContent{CallID: "image-call"},
+		&message.CodeInterpreterToolCallContent{CallID: "code-call"},
+		&message.WebSearchToolCallContent{CallID: "web-call"},
 	}
 
-	response := request.CreateResponse(true, "approved")
+	for _, toolCall := range toolCalls {
+		t.Run(toolCall.GetCallID(), func(t *testing.T) {
+			request := &message.ToolApprovalRequestContent{
+				ContentHeader: message.ContentHeader{
+					AdditionalProperties: map[string]any{"request": "value"},
+					Annotations:          message.Annotations{&message.CitationAnnotation{Title: "source"}},
+					RawRepresentation:    "raw-request",
+				},
+				RequestID: "approval-1",
+				ToolCall:  toolCall,
+			}
 
-	toolCall.Name = "destroy"
-	toolCall.Arguments = `{"environment":"dev"}`
-	toolCall.AdditionalProperties["key"] = "changed"
-	request.AdditionalProperties["request"] = "changed"
+			response := request.CreateResponse(true, "approved")
 
-	responseToolCall, ok := response.ToolCall.(*message.FunctionCallContent)
-	if !ok {
-		t.Fatalf("expected FunctionCallContent, got %T", response.ToolCall)
-	}
-	if responseToolCall.Name != "deploy" {
-		t.Fatalf("expected response tool name to be snapshotted, got %q", responseToolCall.Name)
-	}
-	if responseToolCall.Arguments != `{"environment":"prod"}` {
-		t.Fatalf("expected response tool arguments to be snapshotted, got %q", responseToolCall.Arguments)
-	}
-	if responseToolCall.AdditionalProperties["key"] != "value" {
-		t.Fatalf("expected response tool additional properties to be snapshotted, got %v", responseToolCall.AdditionalProperties["key"])
-	}
-	if response.AdditionalProperties["request"] != "value" {
-		t.Fatalf("expected response additional properties to be snapshotted, got %v", response.AdditionalProperties["request"])
+			if response.RequestID != request.RequestID || !response.Approved || response.Reason != "approved" {
+				t.Fatalf("response = %#v", response)
+			}
+			if response.ToolCall != toolCall {
+				t.Fatalf("ToolCall = %p, want original %p", response.ToolCall, toolCall)
+			}
+			if response.AdditionalProperties != nil || response.Annotations != nil || response.RawRepresentation != nil {
+				t.Fatalf("ContentHeader = %#v, want zero value", response.ContentHeader)
+			}
+		})
 	}
 }
 
@@ -612,46 +755,6 @@ func TestToolApprovalRequestContent_AlwaysApproveSnapshotsAdditionalProperties(t
 			t.Fatalf("expected response additional properties to be snapshotted, got %v", response.AdditionalProperties["request"])
 		}
 	})
-}
-
-func TestToolApprovalRequestContent_CreateResponseSnapshotsMCPServerToolCall(t *testing.T) {
-	toolCall := &message.MCPServerToolCallContent{
-		ContentHeader: message.ContentHeader{
-			AdditionalProperties: map[string]any{"key": "value"},
-		},
-		CallID:     "call-1",
-		Name:       "lookup",
-		ServerName: "server-a",
-		Arguments:  `{"query":"alpha"}`,
-	}
-	request := &message.ToolApprovalRequestContent{
-		RequestID: "approval-1",
-		ToolCall:  toolCall,
-	}
-
-	response := request.CreateResponse(true, "approved")
-
-	toolCall.Name = "delete"
-	toolCall.ServerName = "server-b"
-	toolCall.Arguments = `{"query":"beta"}`
-	toolCall.AdditionalProperties["key"] = "changed"
-
-	responseToolCall, ok := response.ToolCall.(*message.MCPServerToolCallContent)
-	if !ok {
-		t.Fatalf("expected MCPServerToolCallContent, got %T", response.ToolCall)
-	}
-	if responseToolCall.Name != "lookup" {
-		t.Fatalf("expected response tool name to be snapshotted, got %q", responseToolCall.Name)
-	}
-	if responseToolCall.ServerName != "server-a" {
-		t.Fatalf("expected response server name to be snapshotted, got %q", responseToolCall.ServerName)
-	}
-	if responseToolCall.Arguments != `{"query":"alpha"}` {
-		t.Fatalf("expected response tool arguments to be snapshotted, got %q", responseToolCall.Arguments)
-	}
-	if responseToolCall.AdditionalProperties["key"] != "value" {
-		t.Fatalf("expected response tool additional properties to be snapshotted, got %v", responseToolCall.AdditionalProperties["key"])
-	}
 }
 
 func TestCoalesceContents(t *testing.T) {
@@ -813,6 +916,17 @@ func TestCoalesceContents(t *testing.T) {
 					Data:      base64.StdEncoding.EncodeToString([]byte("world")),
 					MediaType: "text/html",
 				},
+			},
+		},
+		{
+			name: "data contents with differently cased media types not coalesced",
+			input: []message.Content{
+				&message.DataContent{Data: base64.StdEncoding.EncodeToString([]byte("hello")), MediaType: "text/plain"},
+				&message.DataContent{Data: base64.StdEncoding.EncodeToString([]byte(" world")), MediaType: "TEXT/PLAIN"},
+			},
+			expected: []message.Content{
+				&message.DataContent{Data: base64.StdEncoding.EncodeToString([]byte("hello")), MediaType: "text/plain"},
+				&message.DataContent{Data: base64.StdEncoding.EncodeToString([]byte(" world")), MediaType: "TEXT/PLAIN"},
 			},
 		},
 		{
@@ -1128,6 +1242,65 @@ func TestCoalesceContents(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "image generation results with the same call id keep the latest result",
+			input: []message.Content{
+				&message.ImageGenerationToolResultContent{
+					CallID:  "image-1",
+					Outputs: message.Contents{&message.TextContent{Text: "partial"}},
+				},
+				&message.TextContent{Text: "between"},
+				&message.ImageGenerationToolResultContent{
+					CallID:  "image-2",
+					Outputs: message.Contents{&message.TextContent{Text: "other"}},
+				},
+				&message.ImageGenerationToolResultContent{
+					ContentHeader: message.ContentHeader{AdditionalProperties: map[string]any{"final": true}},
+					CallID:        "image-1",
+					Outputs:       message.Contents{&message.TextContent{Text: "complete"}},
+				},
+			},
+			expected: []message.Content{
+				&message.ImageGenerationToolResultContent{
+					ContentHeader: message.ContentHeader{AdditionalProperties: map[string]any{"final": true}},
+					CallID:        "image-1",
+					Outputs:       message.Contents{&message.TextContent{Text: "complete"}},
+				},
+				&message.TextContent{Text: "between"},
+				&message.ImageGenerationToolResultContent{
+					CallID:  "image-2",
+					Outputs: message.Contents{&message.TextContent{Text: "other"}},
+				},
+			},
+		},
+		{
+			name: "web search calls with the same call id merge queries and metadata",
+			input: []message.Content{
+				&message.WebSearchToolCallContent{CallID: "web-1", Queries: []string{"first query"}},
+				&message.TextContent{Text: "between"},
+				&message.WebSearchToolCallContent{CallID: "web-2", Queries: []string{"other query"}},
+				&message.WebSearchToolCallContent{
+					ContentHeader: message.ContentHeader{
+						AdditionalProperties: map[string]any{"provider": "search"},
+						RawRepresentation:    "raw-search-call",
+					},
+					CallID:  "web-1",
+					Queries: []string{"second query"},
+				},
+			},
+			expected: []message.Content{
+				&message.WebSearchToolCallContent{
+					ContentHeader: message.ContentHeader{
+						AdditionalProperties: map[string]any{"provider": "search"},
+						RawRepresentation:    "raw-search-call",
+					},
+					CallID:  "web-1",
+					Queries: []string{"first query", "second query"},
+				},
+				&message.TextContent{Text: "between"},
+				&message.WebSearchToolCallContent{CallID: "web-2", Queries: []string{"other query"}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1152,5 +1325,30 @@ func TestCoalesceContents_PreservesInvalidDataContent(t *testing.T) {
 	got := message.CoalesceContents([]message.Content{invalid, valid})
 	if len(got) != 2 || got[0] != invalid || got[1] != valid {
 		t.Fatalf("CoalesceContents() = %#v, want original contents", got)
+	}
+}
+
+func TestCoalesceContents_PreservesSingleCodeInterpreterContentIdentity(t *testing.T) {
+	call := &message.CodeInterpreterToolCallContent{
+		CallID: "call-1",
+		Inputs: message.Contents{
+			&message.TextContent{Text: "a"},
+			&message.TextContent{Text: "b"},
+		},
+	}
+	result := &message.CodeInterpreterToolResultContent{
+		CallID: "call-1",
+		Outputs: message.Contents{
+			&message.TextContent{Text: "c"},
+			&message.TextContent{Text: "d"},
+		},
+	}
+
+	got := message.CoalesceContents([]message.Content{call, result})
+	if got[0] != call || got[1] != result {
+		t.Fatalf("CoalesceContents() replaced single code-interpreter content")
+	}
+	if call.Inputs.Text() != "ab" || result.Outputs.Text() != "cd" {
+		t.Fatalf("nested contents = %q, %q", call.Inputs.Text(), result.Outputs.Text())
 	}
 }

--- a/message/datacontent.go
+++ b/message/datacontent.go
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package message
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"os"
+	"path/filepath"
+)
+
+// NewDataContentFromFile loads a [DataContent] from path. When mediaType is
+// empty, it is inferred from the file extension or defaults to
+// application/octet-stream.
+func NewDataContentFromFile(path string, mediaType string) (*DataContent, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path cannot be empty")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	content, err := NewDataContentFromReader(file, mediaType)
+	if err != nil {
+		return nil, err
+	}
+	content.Name = filepath.Base(path)
+	return content, nil
+}
+
+// NewDataContentFromReader reads all data from reader. When reader is an
+// [os.File], its name is used for the content name and media-type inference.
+// Other readers default to application/octet-stream when mediaType is empty.
+func NewDataContentFromReader(reader io.Reader, mediaType string) (*DataContent, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("reader cannot be nil")
+	}
+
+	var name string
+	if file, ok := reader.(*os.File); ok {
+		name = filepath.Base(file.Name())
+		if mediaType == "" {
+			mediaType = inferMediaTypeFromFilePath(file.Name())
+		}
+	}
+	if mediaType == "" {
+		mediaType = uriContentDefaultMediaType
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	content, err := NewDataContent(data, mediaType)
+	if err != nil {
+		return nil, err
+	}
+	content.Name = name
+	return content, nil
+}
+
+// SaveToFile writes the decoded content to path without overwriting an
+// existing file. If path is empty or names an existing directory, Name is used
+// as the file name; otherwise a random name and inferred extension are used.
+// The returned path identifies the created file.
+func (t *DataContent) SaveToFile(path string) (string, error) {
+	if t == nil {
+		return "", fmt.Errorf("content cannot be nil")
+	}
+	data, err := t.Bytes()
+	if err != nil {
+		return "", err
+	}
+
+	directory := ""
+	if path == "" {
+		directory = "."
+	} else if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
+		directory = path
+	}
+
+	if directory != "" {
+		if name := filepath.Base(t.Name); t.Name != "" && name != "." {
+			path = filepath.Join(directory, name)
+		} else {
+			file, createErr := os.CreateTemp(directory, "*"+extensionForMediaType(t.MediaType))
+			if createErr != nil {
+				return "", createErr
+			}
+			return writeDataContentFile(file, data)
+		}
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o666)
+	if err != nil {
+		return "", err
+	}
+	return writeDataContentFile(file, data)
+}
+
+func writeDataContentFile(file *os.File, data []byte) (path string, err error) {
+	filePath := file.Name()
+	path = filePath
+	defer func() {
+		if err != nil {
+			_ = file.Close()
+			_ = os.Remove(filePath)
+		}
+	}()
+	if _, err = file.Write(data); err != nil {
+		return "", err
+	}
+	if err = file.Close(); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func inferMediaTypeFromFilePath(path string) string {
+	mediaType := mime.TypeByExtension(filepath.Ext(path))
+	if mediaType == "" {
+		return uriContentDefaultMediaType
+	}
+	if parsed, _, err := mime.ParseMediaType(mediaType); err == nil {
+		return parsed
+	}
+	return mediaType
+}
+
+func extensionForMediaType(mediaType string) string {
+	extensions, err := mime.ExtensionsByType(mediaType)
+	if err == nil && len(extensions) > 0 {
+		return extensions[0]
+	}
+	return ""
+}

--- a/message/datacontent.go
+++ b/message/datacontent.go
@@ -21,7 +21,7 @@ func NewDataContentFromFile(path string, mediaType string) (*DataContent, error)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	content, err := NewDataContentFromReader(file, mediaType)
 	if err != nil {

--- a/message/datacontent_test.go
+++ b/message/datacontent_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package message_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+func TestNewDataContentFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input.json")
+	want := []byte(`{"value":42}`)
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := message.NewDataContentFromFile(path, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.Name != "input.json" || content.MediaType != "application/json" {
+		t.Fatalf("content = %#v", content)
+	}
+	got, err := content.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Bytes() = %q, want %q", got, want)
+	}
+}
+
+func TestNewDataContentFromReader(t *testing.T) {
+	content, err := message.NewDataContentFromReader(bytes.NewBufferString("hello"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content.Name != "" || content.MediaType != "application/octet-stream" {
+		t.Fatalf("content = %#v", content)
+	}
+}
+
+func TestDataContentSaveToFile(t *testing.T) {
+	content, err := message.NewDataContent([]byte("hello"), "text/plain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content.Name = filepath.Join("ignored", "note.txt")
+
+	directory := t.TempDir()
+	path, err := content.SaveToFile(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(directory, "note.txt"); path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("saved data = %q, want hello", data)
+	}
+}
+
+func TestDataContentSaveToFileDoesNotOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing.bin")
+	if err := os.WriteFile(path, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	content, err := message.NewDataContent([]byte("replacement"), "application/octet-stream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := content.SaveToFile(path); err == nil {
+		t.Fatal("SaveToFile() error = nil, want existing-file error")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "original" {
+		t.Fatalf("existing data = %q, want original", data)
+	}
+}

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -5,13 +5,17 @@ package anthropicprovider
 import (
 	"cmp"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"iter"
 	"maps"
 	"mime"
+	"net/url"
+	"path"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -157,6 +161,12 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				usage.OutputTokenCount = delta.OutputTokenCount
 				usage.ReasoningTokenCount = delta.ReasoningTokenCount
 				usage.TotalTokenCount = usage.InputTokenCount + usage.OutputTokenCount
+				if delta.AdditionalCounts != nil {
+					if usage.AdditionalCounts == nil {
+						usage.AdditionalCounts = make(map[string]int64)
+					}
+					maps.Copy(usage.AdditionalCounts, delta.AdditionalCounts)
+				}
 				// Later chunks may carry an empty stop_reason; don't clobber a
 				// value we already captured.
 				if fr := mapStopReason(event.Delta.StopReason); fr != "" {
@@ -164,7 +174,9 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				}
 			case anthropic.ContentBlockStartEvent:
 				block := event.ContentBlock.AsAny()
-				if _, isToolUse := block.(anthropic.ToolUseBlock); !isToolUse {
+				switch block.(type) {
+				case anthropic.ToolUseBlock, anthropic.ServerToolUseBlock:
+				default:
 					contents = a.buildBlock(int(event.Index), block, contents, nil)
 				}
 			case anthropic.ContentBlockDeltaEvent:
@@ -177,6 +189,8 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 						Name:      block.Name,
 						Arguments: string(block.Input),
 					})
+				case anthropic.ServerToolUseBlock:
+					contents = a.buildBlock(int(event.Index), block, contents, nil)
 				case anthropic.TextBlock:
 					// The text itself is streamed incrementally via TextDelta, but
 					// citations are only available on the accumulated block. Emit an
@@ -258,6 +272,18 @@ func toUsageDetails(usage anthropic.Usage) message.UsageDetails {
 		}
 		details.AdditionalCounts["cache_creation_input_tokens"] = usage.CacheCreationInputTokens
 	}
+	if usage.ServerToolUse.WebFetchRequests != 0 {
+		if details.AdditionalCounts == nil {
+			details.AdditionalCounts = make(map[string]int64)
+		}
+		details.AdditionalCounts["web_fetch_requests"] = usage.ServerToolUse.WebFetchRequests
+	}
+	if usage.ServerToolUse.WebSearchRequests != 0 {
+		if details.AdditionalCounts == nil {
+			details.AdditionalCounts = make(map[string]int64)
+		}
+		details.AdditionalCounts["web_search_requests"] = usage.ServerToolUse.WebSearchRequests
+	}
 	return details
 }
 
@@ -268,6 +294,7 @@ func toUsageDetailsDelta(usage anthropic.MessageDeltaUsage) message.UsageDetails
 		CacheCreationInputTokens: usage.CacheCreationInputTokens,
 		CacheReadInputTokens:     usage.CacheReadInputTokens,
 		OutputTokensDetails:      usage.OutputTokensDetails,
+		ServerToolUse:            usage.ServerToolUse,
 	})
 }
 
@@ -302,8 +329,223 @@ func (a *client) buildBlock(index int, v any, contents []message.Content, functi
 			Name:      v.Name,
 			Arguments: string(v.Input),
 		}
+	case anthropic.ServerToolUseBlock:
+		contents = append(contents, serverToolCallContent(v))
+	case anthropic.WebSearchToolResultBlock:
+		result := &message.WebSearchToolResultContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: v},
+			CallID:        v.ToolUseID,
+		}
+		for _, searchResult := range v.Content.AsWebSearchResultBlockArray() {
+			result.Outputs = append(result.Outputs, &message.URIContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: searchResult},
+				URI:           searchResult.URL,
+				MediaType:     inferMediaTypeFromURI(searchResult.URL),
+			})
+		}
+		if v.Content.ErrorCode != "" {
+			result.Outputs = append(result.Outputs, &message.ErrorContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: v.Content.AsResponseWebSearchToolResultError()},
+				ErrorCode:     string(v.Content.ErrorCode),
+			})
+		}
+		contents = append(contents, result)
+	case anthropic.WebFetchToolResultBlock:
+		result := &message.WebSearchToolResultContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: v},
+			CallID:        v.ToolUseID,
+		}
+		if v.Content.URL != "" {
+			fetchResult := v.Content.AsResponseWebFetchResultBlock()
+			result.Outputs = append(result.Outputs, &message.URIContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: fetchResult},
+				URI:           fetchResult.URL,
+				MediaType:     inferMediaTypeFromURI(fetchResult.URL),
+			})
+		} else if v.Content.ErrorCode != "" {
+			result.Outputs = append(result.Outputs, &message.ErrorContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: v.Content.AsResponseWebFetchToolResultError()},
+				ErrorCode:     string(v.Content.ErrorCode),
+			})
+		}
+		contents = append(contents, result)
+	case anthropic.CodeExecutionToolResultBlock:
+		result := &message.CodeInterpreterToolResultContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: v},
+			CallID:        v.ToolUseID,
+		}
+		switch v.Content.Type {
+		case "code_execution_result":
+			output := v.Content.AsResponseCodeExecutionResultBlock()
+			appendCodeExecutionOutputs(result, output.Stdout, output.Stderr, output.ReturnCode, codeExecutionFileIDs(output.Content))
+		case "encrypted_code_execution_result":
+			output := v.Content.AsResponseEncryptedCodeExecutionResultBlock()
+			appendCodeExecutionOutputs(result, "", output.Stderr, output.ReturnCode, codeExecutionFileIDs(output.Content))
+		case "code_execution_tool_result_error":
+			output := v.Content.AsResponseCodeExecutionToolResultError()
+			result.Outputs = append(result.Outputs, &message.ErrorContent{ErrorCode: string(output.ErrorCode)})
+		}
+		contents = append(contents, result)
+	case anthropic.BashCodeExecutionToolResultBlock:
+		result := &message.CodeInterpreterToolResultContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: v},
+			CallID:        v.ToolUseID,
+		}
+		switch v.Content.Type {
+		case "bash_code_execution_result":
+			output := v.Content.AsResponseBashCodeExecutionResultBlock()
+			fileIDs := make([]string, 0, len(output.Content))
+			for _, file := range output.Content {
+				fileIDs = append(fileIDs, file.FileID)
+			}
+			appendCodeExecutionOutputs(result, output.Stdout, output.Stderr, output.ReturnCode, fileIDs)
+		case "bash_code_execution_tool_result_error":
+			output := v.Content.AsResponseBashCodeExecutionToolResultError()
+			result.Outputs = append(result.Outputs, &message.ErrorContent{ErrorCode: string(output.ErrorCode)})
+		}
+		contents = append(contents, result)
+	case anthropic.TextEditorCodeExecutionToolResultBlock:
+		result := &message.CodeInterpreterToolResultContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: v},
+			CallID:        v.ToolUseID,
+		}
+		switch v.Content.Type {
+		case "text_editor_code_execution_tool_result_error":
+			output := v.Content.AsResponseTextEditorCodeExecutionToolResultError()
+			result.Outputs = append(result.Outputs, &message.ErrorContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: output},
+				Message:       output.ErrorMessage,
+				ErrorCode:     string(output.ErrorCode),
+			})
+		case "text_editor_code_execution_view_result":
+			output := v.Content.AsResponseTextEditorCodeExecutionViewResultBlock()
+			result.Outputs = append(result.Outputs, &message.TextContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: output},
+				Text:          output.Content,
+			})
+		case "text_editor_code_execution_create_result":
+			output := v.Content.AsResponseTextEditorCodeExecutionCreateResultBlock()
+			text := "File created"
+			if output.IsFileUpdate {
+				text = "File updated"
+			}
+			result.Outputs = append(result.Outputs, &message.TextContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: output},
+				Text:          text,
+			})
+		case "text_editor_code_execution_str_replace_result":
+			output := v.Content.AsResponseTextEditorCodeExecutionStrReplaceResultBlock()
+			text := "String replacement applied"
+			if len(output.Lines) > 0 {
+				text = strings.Join(output.Lines, "\n")
+			}
+			result.Outputs = append(result.Outputs, &message.TextContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: output},
+				Text:          text,
+			})
+		}
+		contents = append(contents, result)
+	case anthropic.ToolSearchToolResultBlock:
+		contents = append(contents, &message.RawContent{ContentHeader: message.ContentHeader{
+			RawRepresentation: json.RawMessage(v.RawJSON()),
+		}})
+	case anthropic.ContainerUploadBlock:
+		contents = append(contents, &message.HostedFileContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: v},
+			FileID:        v.FileID,
+		})
 	}
 	return contents
+}
+
+func codeExecutionFileIDs(files []anthropic.CodeExecutionOutputBlock) []string {
+	fileIDs := make([]string, 0, len(files))
+	for _, file := range files {
+		fileIDs = append(fileIDs, file.FileID)
+	}
+	return fileIDs
+}
+
+func appendCodeExecutionOutputs(result *message.CodeInterpreterToolResultContent, stdout, stderr string, returnCode int64, fileIDs []string) {
+	if strings.TrimSpace(stdout) != "" {
+		result.Outputs = append(result.Outputs, &message.TextContent{Text: stdout})
+	}
+	if strings.TrimSpace(stderr) != "" || returnCode != 0 {
+		result.Outputs = append(result.Outputs, &message.ErrorContent{
+			Message:   stderr,
+			ErrorCode: strconv.FormatInt(returnCode, 10),
+		})
+	}
+	for _, fileID := range fileIDs {
+		result.Outputs = append(result.Outputs, &message.HostedFileContent{FileID: fileID})
+	}
+}
+
+func serverToolCallContent(toolUse anthropic.ServerToolUseBlock) message.Content {
+	header := message.ContentHeader{RawRepresentation: toolUse}
+	switch string(toolUse.Name) {
+	case "web_search", "web_fetch":
+		call := &message.WebSearchToolCallContent{ContentHeader: header, CallID: toolUse.ID}
+		if query := serverToolInputString(toolUse.Input, "query"); query != "" {
+			call.Queries = []string{query}
+		}
+		return call
+	case "code_execution", "bash_code_execution", "text_editor_code_execution":
+		call := &message.CodeInterpreterToolCallContent{ContentHeader: header, CallID: toolUse.ID}
+		code := serverToolInputString(toolUse.Input, "code")
+		if code == "" {
+			code = serverToolInputString(toolUse.Input, "command")
+		}
+		if code != "" {
+			mediaType := "text/plain"
+			switch string(toolUse.Name) {
+			case "code_execution":
+				mediaType = "text/x-python"
+			case "bash_code_execution":
+				mediaType = "application/x-sh"
+			}
+			call.Inputs = message.Contents{&message.DataContent{
+				Data:      base64.StdEncoding.EncodeToString([]byte(code)),
+				MediaType: mediaType,
+			}}
+		}
+		return call
+	default:
+		return &message.RawContent{ContentHeader: message.ContentHeader{
+			RawRepresentation: json.RawMessage(toolUse.RawJSON()),
+		}}
+	}
+}
+
+func serverToolInputString(input any, key string) string {
+	if values, ok := input.(map[string]any); ok {
+		value, _ := values[key].(string)
+		return value
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return ""
+	}
+	var values map[string]any
+	if json.Unmarshal(data, &values) != nil {
+		return ""
+	}
+	value, _ := values[key].(string)
+	return value
+}
+
+func inferMediaTypeFromURI(rawURI string) string {
+	uriPath := rawURI
+	if parsed, err := url.Parse(rawURI); err == nil {
+		uriPath = parsed.Path
+	}
+	if mediaType := mime.TypeByExtension(path.Ext(uriPath)); mediaType != "" {
+		if baseType, _, err := mime.ParseMediaType(mediaType); err == nil {
+			return baseType
+		}
+		return mediaType
+	}
+	return "application/octet-stream"
 }
 
 // citationAnnotations converts Anthropic text-block citations into
@@ -312,11 +554,19 @@ func (a *client) buildBlock(index int, v any, contents []message.Content, functi
 func citationAnnotations(citations []anthropic.TextCitationUnion) []message.Annotation {
 	var annotations []message.Annotation
 	for _, citation := range citations {
+		var regions message.AnnotatedRegions
+		if citation.Type == "char_location" {
+			startIndex, endIndex := int(citation.StartCharIndex), int(citation.EndCharIndex)
+			regions = message.AnnotatedRegions{
+				&message.TextSpanAnnotatedRegion{StartIndex: &startIndex, EndIndex: &endIndex},
+			}
+		}
 		annotations = append(annotations, &message.CitationAnnotation{
 			FileID:            citation.FileID,
 			Snippet:           citation.CitedText,
 			Title:             cmp.Or(citation.DocumentTitle, citation.Title),
 			URL:               citation.URL,
+			AnnotatedRegions:  regions,
 			RawRepresentation: citation,
 		})
 	}
@@ -372,6 +622,12 @@ func (a *client) buildMessageParams(messages []*message.Message, opts []agent.Op
 		if ws, ok := tl.(*hostedtool.WebSearch); ok {
 			tools = append(tools, anthropic.ToolUnionParam{
 				OfWebSearchTool20250305: buildWebSearchTool(ws),
+			})
+			continue
+		}
+		if _, ok := tl.(*hostedtool.CodeInterpreter); ok {
+			tools = append(tools, anthropic.ToolUnionParam{
+				OfCodeExecutionTool20250825: &anthropic.CodeExecutionTool20250825Param{},
 			})
 			continue
 		}

--- a/provider/anthropicprovider/agent_test.go
+++ b/provider/anthropicprovider/agent_test.go
@@ -484,6 +484,142 @@ func TestTextCitationsBecomeAnnotations(t *testing.T) {
 	}
 }
 
+func TestCharacterLocationCitationsBecomeAnnotatedRegions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_char_citation",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-3-5-sonnet-20241022",
+			"stop_reason":"end_turn",
+			"content":[{
+				"type":"text",
+				"text":"The answer cites a document.",
+				"citations":[{
+					"type":"char_location",
+					"cited_text":"document excerpt",
+					"document_index":0,
+					"document_title":"Document",
+					"start_char_index":4,
+					"end_char_index":12
+				}]
+			}],
+			"usage":{"input_tokens":10,"output_tokens":5}
+		}`)
+	}))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "cite something").Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var citation *message.CitationAnnotation
+	for content := range resp.Contents() {
+		if text, ok := content.(*message.TextContent); ok && len(text.Annotations) > 0 {
+			citation, _ = text.Annotations[0].(*message.CitationAnnotation)
+		}
+	}
+	if citation == nil || len(citation.AnnotatedRegions) != 1 {
+		t.Fatalf("citation = %#v", citation)
+	}
+	span, ok := citation.AnnotatedRegions[0].(*message.TextSpanAnnotatedRegion)
+	if !ok || span.StartIndex == nil || *span.StartIndex != 4 || span.EndIndex == nil || *span.EndIndex != 12 {
+		t.Fatalf("annotated region = %#v, want [4, 12)", citation.AnnotatedRegions[0])
+	}
+}
+
+func TestHostedServerToolContents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_server_tools",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-sonnet-4-5",
+			"stop_reason":"end_turn",
+			"content":[
+				{"type":"server_tool_use","id":"srv_web","name":"web_search","input":{"query":"go sdk"}},
+				{"type":"web_search_tool_result","tool_use_id":"srv_web","content":[{"type":"web_search_result","url":"https://example.com/doc.pdf","title":"Docs","encrypted_content":"encrypted","page_age":"today"}]},
+				{"type":"server_tool_use","id":"srv_code","name":"code_execution","input":{"code":"print(1)"}},
+				{"type":"code_execution_tool_result","tool_use_id":"srv_code","content":{"type":"code_execution_result","stdout":"1\n","stderr":"warning\n","return_code":0,"content":[{"type":"code_execution_output","file_id":"file_1"}]}},
+				{"type":"container_upload","file_id":"file_2"}
+			],
+			"usage":{"input_tokens":10,"output_tokens":5,"server_tool_use":{"web_search_requests":1,"web_fetch_requests":2}}
+		}`)
+	}))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "use hosted tools").Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var webCall *message.WebSearchToolCallContent
+	var webResult *message.WebSearchToolResultContent
+	var codeCall *message.CodeInterpreterToolCallContent
+	var codeResult *message.CodeInterpreterToolResultContent
+	var uploadedFile *message.HostedFileContent
+	var usage *message.UsageContent
+	for content := range resp.Contents() {
+		switch content := content.(type) {
+		case *message.WebSearchToolCallContent:
+			webCall = content
+		case *message.WebSearchToolResultContent:
+			webResult = content
+		case *message.CodeInterpreterToolCallContent:
+			codeCall = content
+		case *message.CodeInterpreterToolResultContent:
+			codeResult = content
+		case *message.HostedFileContent:
+			uploadedFile = content
+		case *message.UsageContent:
+			usage = content
+		}
+	}
+
+	if webCall == nil || webCall.CallID != "srv_web" || len(webCall.Queries) != 1 || webCall.Queries[0] != "go sdk" {
+		t.Fatalf("web call = %#v", webCall)
+	}
+	if webResult == nil || webResult.CallID != webCall.CallID || len(webResult.Outputs) != 1 {
+		t.Fatalf("web result = %#v", webResult)
+	}
+	webURI, ok := webResult.Outputs[0].(*message.URIContent)
+	if !ok || webURI.URI != "https://example.com/doc.pdf" || webURI.MediaType != "application/pdf" {
+		t.Fatalf("web output = %#v", webResult.Outputs[0])
+	}
+	if codeCall == nil || codeCall.CallID != "srv_code" || len(codeCall.Inputs) != 1 {
+		t.Fatalf("code call = %#v", codeCall)
+	}
+	codeInput, ok := codeCall.Inputs[0].(*message.DataContent)
+	if !ok || codeInput.MediaType != "text/x-python" {
+		t.Fatalf("code input = %#v", codeCall.Inputs[0])
+	}
+	code, err := codeInput.Bytes()
+	if err != nil || string(code) != "print(1)" {
+		t.Fatalf("decoded code = %q, error = %v", code, err)
+	}
+	if codeResult == nil || codeResult.CallID != codeCall.CallID || len(codeResult.Outputs) != 3 {
+		t.Fatalf("code result = %#v", codeResult)
+	}
+	if text, ok := codeResult.Outputs[0].(*message.TextContent); !ok || text.Text != "1\n" {
+		t.Fatalf("stdout = %#v", codeResult.Outputs[0])
+	}
+	if codeError, ok := codeResult.Outputs[1].(*message.ErrorContent); !ok || codeError.Message != "warning\n" || codeError.ErrorCode != "0" {
+		t.Fatalf("stderr = %#v", codeResult.Outputs[1])
+	}
+	if file, ok := codeResult.Outputs[2].(*message.HostedFileContent); !ok || file.FileID != "file_1" {
+		t.Fatalf("code file = %#v", codeResult.Outputs[2])
+	}
+	if uploadedFile == nil || uploadedFile.FileID != "file_2" {
+		t.Fatalf("uploaded file = %#v", uploadedFile)
+	}
+	if usage == nil || usage.Details.AdditionalCounts["web_search_requests"] != 1 || usage.Details.AdditionalCounts["web_fetch_requests"] != 2 {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
 // TestStreamingTextCitationsBecomeAnnotations mirrors
 // TestTextCitationsBecomeAnnotations for the streaming path: citations are only
 // present on the accumulated text block, so the content_block_stop handler must
@@ -718,6 +854,42 @@ func TestStreamingToolCallsSupportInterleavedDeltas(t *testing.T) {
 		if call.Arguments != want[call.CallID] {
 			t.Errorf("call %q arguments = %q, want %q", call.CallID, call.Arguments, want[call.CallID])
 		}
+	}
+}
+
+func TestStreamingServerToolCallAccumulatesInput(t *testing.T) {
+	events := "event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_code","name":"code_execution","input":{}}}` + "\n\n" +
+		streamingToolDelta(0, `{"code":`) +
+		streamingToolDelta(0, `"print(2)"}`) +
+		streamingToolStop(0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, streamingToolCallResponse(events))
+	}))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "run code", agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []*message.CodeInterpreterToolCallContent
+	for content := range resp.Contents() {
+		if call, ok := content.(*message.CodeInterpreterToolCallContent); ok {
+			calls = append(calls, call)
+		}
+	}
+	if len(calls) != 1 || calls[0].CallID != "srvtoolu_code" || len(calls[0].Inputs) != 1 {
+		t.Fatalf("code calls = %#v", calls)
+	}
+	input, ok := calls[0].Inputs[0].(*message.DataContent)
+	if !ok || input.MediaType != "text/x-python" {
+		t.Fatalf("code input = %#v", calls[0].Inputs[0])
+	}
+	code, err := input.Bytes()
+	if err != nil || string(code) != "print(2)" {
+		t.Fatalf("decoded code = %q, error = %v", code, err)
 	}
 }
 
@@ -1337,6 +1509,39 @@ func TestWebSearchHostedToolMappingWithoutProperties(t *testing.T) {
 		if _, present := tl[k]; present {
 			t.Errorf("%s should be omitted, got %#v", k, tl[k])
 		}
+	}
+}
+
+func TestCodeInterpreterHostedToolMapping(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		bodyCh <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, minimalMessageResponse("ok"))
+	}))
+	defer server.Close()
+
+	if _, err := newTestClient(t, server).RunText(t.Context(), "run code", agent.WithTool(&hostedtool.CodeInterpreter{})).Collect(); err != nil {
+		t.Fatal(err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(<-bodyCh, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	tools, ok := req["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %#v, want one tool", req["tools"])
+	}
+	codeTool, _ := tools[0].(map[string]any)
+	if codeTool["type"] != "code_execution_20250825" || codeTool["name"] != "code_execution" {
+		t.Fatalf("code tool = %#v", codeTool)
 	}
 }
 

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -9,6 +9,9 @@ import (
 	"fmt"
 	"iter"
 	"math"
+	"mime"
+	"net/url"
+	"path"
 	"reflect"
 	"slices"
 	"strings"
@@ -112,8 +115,9 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 			cand := resp.Candidates[0]
 			finishReason = toFinishReason(cand.FinishReason)
 			if cand.Content != nil {
+				partState := responsePartState{}
 				for _, part := range cand.Content.Parts {
-					responseContents, err = buildResponsePart(part, responseContents)
+					responseContents, err = buildResponsePart(part, responseContents, &partState)
 					if err != nil {
 						return func(yield func(*agent.ResponseUpdate, error) bool) {
 							yield(nil, err)
@@ -121,6 +125,8 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 					}
 				}
 			}
+			addCitationAnnotations(responseContents, cand.CitationMetadata)
+			responseContents = append(responseContents, groundingContents(cand.GroundingMetadata, "web-search-"+uuid.NewString())...)
 		}
 		if blocked := promptBlockedContent(resp); blocked != nil {
 			responseContents = append(responseContents, blocked)
@@ -143,7 +149,8 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 
 	return func(yield func(*agent.ResponseUpdate, error) bool) {
 		var latestUsage *genai.GenerateContentResponseUsageMetadata
-		var latestUsageResp *genai.GenerateContentResponse
+		var latestMetadataResp *genai.GenerateContentResponse
+		partState := responsePartState{}
 		for resp, err := range a.client.Models.GenerateContentStream(ctx, a.config.Model, contents, cfg) {
 			if err != nil {
 				yield(nil, err)
@@ -156,13 +163,15 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				finishReason = toFinishReason(cand.FinishReason)
 				if cand.Content != nil {
 					for _, part := range cand.Content.Parts {
-						streamContents, err = buildResponsePart(part, streamContents)
+						streamContents, err = buildResponsePart(part, streamContents, &partState)
 						if err != nil {
 							yield(nil, err)
 							return
 						}
 					}
 				}
+				addCitationAnnotations(streamContents, cand.CitationMetadata)
+				streamContents = append(streamContents, groundingContents(cand.GroundingMetadata, "web-search-"+uuid.NewString())...)
 			}
 			if blocked := promptBlockedContent(resp); blocked != nil {
 				streamContents = append(streamContents, blocked)
@@ -173,7 +182,7 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 			// remember the latest and emit it once after the stream ends.
 			if resp.UsageMetadata != nil {
 				latestUsage = resp.UsageMetadata
-				latestUsageResp = resp
+				latestMetadataResp = resp
 			}
 			if !yield(&agent.ResponseUpdate{
 				Contents:          streamContents,
@@ -185,12 +194,16 @@ func (a *client) run(ctx context.Context, messages []*message.Message, options .
 				return
 			}
 		}
+		var finalContents []message.Content
 		if latestUsage != nil {
+			finalContents = append(finalContents, &message.UsageContent{Details: toUsageDetails(latestUsage)})
+		}
+		if len(finalContents) > 0 {
 			yield(&agent.ResponseUpdate{
-				Contents:          []message.Content{&message.UsageContent{Details: toUsageDetails(latestUsage)}},
+				Contents:          finalContents,
 				Role:              message.RoleAssistant,
 				CreatedAt:         time.Now(),
-				RawRepresentation: latestUsageResp,
+				RawRepresentation: latestMetadataResp,
 			}, nil)
 		}
 	}
@@ -491,8 +504,12 @@ func buildRequestParts(msg *message.Message, callIDToName map[string]string) ([]
 	return parts, nil
 }
 
+type responsePartState struct {
+	pendingCodeCallID string
+}
+
 // buildResponsePart converts a genai Part from a response into framework message content.
-func buildResponsePart(part *genai.Part, contents []message.Content) ([]message.Content, error) {
+func buildResponsePart(part *genai.Part, contents []message.Content, state *responsePartState) ([]message.Content, error) {
 	if part.Thought {
 		// Thinking model: emit TextReasoningContent. Encode ThoughtSignature as
 		// base64 in ProtectedData so it can be passed back in multi-turn requests.
@@ -579,9 +596,14 @@ func buildResponsePart(part *genai.Part, contents []message.Content) ([]message.
 		})
 	}
 	if part.ExecutableCode != nil {
+		callID := part.ExecutableCode.ID
+		if callID == "" {
+			callID = "code-call-" + uuid.NewString()
+		}
+		state.pendingCodeCallID = callID
 		contents = append(contents, &message.CodeInterpreterToolCallContent{
 			ContentHeader: message.ContentHeader{RawRepresentation: part},
-			CallID:        part.ExecutableCode.ID,
+			CallID:        callID,
 			Inputs: message.Contents{&message.DataContent{
 				Data:      base64.StdEncoding.EncodeToString([]byte(part.ExecutableCode.Code)),
 				MediaType: geminiCodeMediaType(part.ExecutableCode.Language),
@@ -589,7 +611,15 @@ func buildResponsePart(part *genai.Part, contents []message.Content) ([]message.
 		})
 	}
 	if part.CodeExecutionResult != nil {
-		contents = append(contents, codeExecutionResultContent(part))
+		callID := part.CodeExecutionResult.ID
+		if callID == "" {
+			callID = state.pendingCodeCallID
+			if callID == "" {
+				callID = "code-call-" + uuid.NewString()
+			}
+		}
+		state.pendingCodeCallID = ""
+		contents = append(contents, codeExecutionResultContent(part, callID))
 	}
 	return contents, nil
 }
@@ -598,10 +628,10 @@ func geminiCodeMediaType(language genai.Language) string {
 	if language == genai.LanguagePython {
 		return "text/x-python"
 	}
-	return "text/plain"
+	return "text/x-source-code"
 }
 
-func codeExecutionResultContent(part *genai.Part) *message.CodeInterpreterToolResultContent {
+func codeExecutionResultContent(part *genai.Part, callID string) *message.CodeInterpreterToolResultContent {
 	result := part.CodeExecutionResult
 	output := message.Content(&message.TextContent{
 		Text:          result.Output,
@@ -616,9 +646,86 @@ func codeExecutionResultContent(part *genai.Part) *message.CodeInterpreterToolRe
 	}
 	return &message.CodeInterpreterToolResultContent{
 		ContentHeader: message.ContentHeader{RawRepresentation: part},
-		CallID:        result.ID,
+		CallID:        callID,
 		Outputs:       message.Contents{output},
 	}
+}
+
+func groundingContents(metadata *genai.GroundingMetadata, callID string) message.Contents {
+	if metadata == nil || (len(metadata.WebSearchQueries) == 0 && len(metadata.GroundingChunks) == 0) {
+		return nil
+	}
+
+	var outputs message.Contents
+	for _, chunk := range metadata.GroundingChunks {
+		if chunk == nil || chunk.Web == nil || chunk.Web.URI == "" {
+			continue
+		}
+		header := message.ContentHeader{RawRepresentation: chunk.Web}
+		if chunk.Web.Title != "" {
+			header.AdditionalProperties = map[string]any{"title": chunk.Web.Title}
+		}
+		outputs = append(outputs, &message.URIContent{
+			ContentHeader: header,
+			URI:           chunk.Web.URI,
+			MediaType:     inferMediaTypeFromURI(chunk.Web.URI),
+		})
+	}
+
+	return message.Contents{
+		&message.WebSearchToolCallContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: metadata},
+			CallID:        callID,
+			Queries:       slices.Clone(metadata.WebSearchQueries),
+		},
+		&message.WebSearchToolResultContent{
+			CallID:  callID,
+			Outputs: outputs,
+		},
+	}
+}
+
+func addCitationAnnotations(contents message.Contents, metadata *genai.CitationMetadata) {
+	if metadata == nil || len(metadata.Citations) == 0 {
+		return
+	}
+	var textContent *message.TextContent
+	for _, content := range contents {
+		if text, ok := content.(*message.TextContent); ok {
+			textContent = text
+			break
+		}
+	}
+	if textContent == nil {
+		return
+	}
+	for _, citation := range metadata.Citations {
+		if citation == nil {
+			continue
+		}
+		startIndex, endIndex := int(citation.StartIndex), int(citation.EndIndex)
+		textContent.Annotations = append(textContent.Annotations, &message.CitationAnnotation{
+			Title: citation.Title,
+			URL:   citation.URI,
+			AnnotatedRegions: message.AnnotatedRegions{
+				&message.TextSpanAnnotatedRegion{StartIndex: &startIndex, EndIndex: &endIndex},
+			},
+		})
+	}
+}
+
+func inferMediaTypeFromURI(rawURI string) string {
+	uriPath := rawURI
+	if parsed, err := url.Parse(rawURI); err == nil {
+		uriPath = parsed.Path
+	}
+	if mediaType := mime.TypeByExtension(path.Ext(uriPath)); mediaType != "" {
+		if baseType, _, err := mime.ParseMediaType(mediaType); err == nil {
+			return baseType
+		}
+		return mediaType
+	}
+	return "application/octet-stream"
 }
 
 // toFunctionResponseMap converts a FunctionResultContent's result to the map[string]any
@@ -679,11 +786,17 @@ func toFinishReason(reason genai.FinishReason) string {
 }
 
 func toUsageDetails(u *genai.GenerateContentResponseUsageMetadata) message.UsageDetails {
-	return message.UsageDetails{
+	details := message.UsageDetails{
 		InputTokenCount:       int64(u.PromptTokenCount),
 		OutputTokenCount:      int64(u.CandidatesTokenCount),
 		TotalTokenCount:       int64(u.TotalTokenCount),
 		CachedInputTokenCount: int64(u.CachedContentTokenCount),
 		ReasoningTokenCount:   int64(u.ThoughtsTokenCount),
 	}
+	if u.ToolUsePromptTokenCount != 0 {
+		details.AdditionalCounts = map[string]int64{
+			"ToolUsePromptTokenCount": int64(u.ToolUsePromptTokenCount),
+		}
+	}
+	return details
 }

--- a/provider/geminiprovider/agent_test.go
+++ b/provider/geminiprovider/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -207,6 +208,146 @@ func TestBasicText_Streaming(t *testing.T) {
 	if got := resp.String(); got != wantText {
 		t.Errorf("response text = %q, want %q", got, wantText)
 	}
+}
+
+func TestGoogleSearchGrounding_NonStreaming(t *testing.T) {
+	response := map[string]any{
+		"candidates": []any{map[string]any{
+			"content":      map[string]any{"role": "model", "parts": []any{map[string]any{"text": "grounded"}}},
+			"finishReason": "STOP",
+			"groundingMetadata": map[string]any{
+				"webSearchQueries": []string{"first query", "second query"},
+				"groundingChunks": []any{
+					map[string]any{"web": map[string]any{"uri": "https://example.com/source", "title": "Example"}},
+				},
+			},
+		}},
+	}
+	body, _ := json.Marshal(response)
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "application/json", string(body)))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "search", agent.WithTool(&hostedtool.WebSearch{})).Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	call, result := webSearchContents(resp)
+	if call == nil || call.CallID == "" || !slices.Equal(call.Queries, []string{"first query", "second query"}) || call.RawRepresentation == nil {
+		t.Fatalf("call = %#v", call)
+	}
+	if result == nil || result.CallID != call.CallID || len(result.Outputs) != 1 || result.RawRepresentation != nil {
+		t.Fatalf("result = %#v", result)
+	}
+	source, ok := result.Outputs[0].(*message.URIContent)
+	if !ok || source.URI != "https://example.com/source" || source.MediaType != "application/octet-stream" || source.AdditionalProperties["title"] != "Example" {
+		t.Fatalf("source = %#v", result.Outputs[0])
+	}
+}
+
+func TestCitationMetadataAnnotatesFirstTextContent(t *testing.T) {
+	response := map[string]any{
+		"candidates": []any{map[string]any{
+			"content": map[string]any{"role": "model", "parts": []any{map[string]any{"text": "A cited response"}}},
+			"citationMetadata": map[string]any{
+				"citationSources": []any{map[string]any{
+					"startIndex": 2,
+					"endIndex":   7,
+					"title":      "Example",
+					"uri":        "https://example.com/article",
+				}},
+			},
+		}},
+	}
+	body, _ := json.Marshal(response)
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "application/json", string(body)))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "cite").Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var text *message.TextContent
+	for content := range resp.Contents() {
+		if candidate, ok := content.(*message.TextContent); ok {
+			text = candidate
+			break
+		}
+	}
+	if text == nil || len(text.Annotations) != 1 {
+		t.Fatalf("text content = %#v", text)
+	}
+	citation, ok := text.Annotations[0].(*message.CitationAnnotation)
+	if !ok || citation.Title != "Example" || citation.URL != "https://example.com/article" || len(citation.AnnotatedRegions) != 1 {
+		t.Fatalf("citation = %#v", text.Annotations[0])
+	}
+	span, ok := citation.AnnotatedRegions[0].(*message.TextSpanAnnotatedRegion)
+	if !ok || span.StartIndex == nil || *span.StartIndex != 2 || span.EndIndex == nil || *span.EndIndex != 7 {
+		t.Fatalf("annotated region = %#v", citation.AnnotatedRegions[0])
+	}
+}
+
+func TestGoogleSearchGrounding_StreamingProcessesEachMetadataChunk(t *testing.T) {
+	chunk := func(queries []string, sources ...string) string {
+		chunks := make([]any, len(sources))
+		for i, source := range sources {
+			chunks[i] = map[string]any{"web": map[string]any{"uri": source}}
+		}
+		body, _ := json.Marshal(map[string]any{
+			"candidates": []any{map[string]any{
+				"content": map[string]any{"role": "model", "parts": []any{map[string]any{"text": "grounded"}}},
+				"groundingMetadata": map[string]any{
+					"webSearchQueries": queries,
+					"groundingChunks":  chunks,
+				},
+			}},
+		})
+		return "data:" + string(body) + "\n\n"
+	}
+	stream := chunk([]string{"first"}, "https://example.com/first") +
+		chunk([]string{"first", "second"}, "https://example.com/first", "https://example.com/second")
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "text/event-stream", stream))
+	defer server.Close()
+
+	resp, err := newTestClient(t, server).RunText(t.Context(), "search", agent.Stream(true), agent.WithTool(&hostedtool.WebSearch{})).Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	call, result := webSearchContents(resp)
+	if call == nil || !slices.Equal(call.Queries, []string{"first", "second"}) {
+		t.Fatalf("call = %#v", call)
+	}
+	if result == nil || result.CallID != call.CallID || len(result.Outputs) != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+	var callCount, resultCount int
+	for content := range resp.Contents() {
+		switch content.(type) {
+		case *message.WebSearchToolCallContent:
+			callCount++
+		case *message.WebSearchToolResultContent:
+			resultCount++
+		}
+	}
+	if callCount != 2 || resultCount != 2 {
+		t.Fatalf("web search content counts = call:%d result:%d", callCount, resultCount)
+	}
+}
+
+func webSearchContents(resp *agent.Response) (*message.WebSearchToolCallContent, *message.WebSearchToolResultContent) {
+	var call *message.WebSearchToolCallContent
+	var result *message.WebSearchToolResultContent
+	for content := range resp.Contents() {
+		switch content := content.(type) {
+		case *message.WebSearchToolCallContent:
+			call = content
+		case *message.WebSearchToolResultContent:
+			result = content
+		}
+	}
+	return call, result
 }
 
 // TestStructuredOutput_NonStreaming verifies that passing agent.WithStructuredOutput
@@ -540,10 +681,11 @@ func TestUsageContent_ReasoningTokens(t *testing.T) {
 			},
 		},
 		"usageMetadata": map[string]any{
-			"promptTokenCount":     10,
-			"candidatesTokenCount": 5,
-			"thoughtsTokenCount":   8,
-			"totalTokenCount":      23,
+			"promptTokenCount":        10,
+			"candidatesTokenCount":    5,
+			"thoughtsTokenCount":      8,
+			"toolUsePromptTokenCount": 3,
+			"totalTokenCount":         26,
 		},
 	}
 	body, _ := json.Marshal(resp)
@@ -575,8 +717,11 @@ func TestUsageContent_ReasoningTokens(t *testing.T) {
 	if usage.Details.OutputTokenCount != 5 {
 		t.Errorf("OutputTokenCount = %d, want 5", usage.Details.OutputTokenCount)
 	}
-	if usage.Details.TotalTokenCount != 23 {
-		t.Errorf("TotalTokenCount = %d, want 23", usage.Details.TotalTokenCount)
+	if usage.Details.TotalTokenCount != 26 {
+		t.Errorf("TotalTokenCount = %d, want 26", usage.Details.TotalTokenCount)
+	}
+	if got := usage.Details.AdditionalCounts["ToolUsePromptTokenCount"]; got != 3 {
+		t.Errorf("ToolUsePromptTokenCount = %d, want 3", got)
 	}
 }
 
@@ -1410,6 +1555,45 @@ func TestResponseWithCodeExecutionParts(t *testing.T) {
 	output, ok := codeResult.Outputs[0].(*message.TextContent)
 	if !ok || output.Text != "1\n" {
 		t.Fatalf("code output = %#v", codeResult.Outputs[0])
+	}
+}
+
+func TestResponseWithCodeExecutionPartsWithoutIDs(t *testing.T) {
+	resp := map[string]any{
+		"candidates": []any{map[string]any{
+			"content": map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{"executableCode": map[string]any{"language": "PYTHON", "code": "print(1)"}},
+					map[string]any{"codeExecutionResult": map[string]any{"outcome": "OUTCOME_OK", "output": "1\n"}},
+				},
+			},
+		}},
+	}
+	body, _ := json.Marshal(resp)
+	server := httptest.NewServer(captureAndRespond(t, make(chan []byte, 1), "application/json", string(body)))
+	defer server.Close()
+
+	result, err := newTestClient(t, server).RunText(t.Context(), "run code").Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var call *message.CodeInterpreterToolCallContent
+	var codeResult *message.CodeInterpreterToolResultContent
+	for content := range result.Contents() {
+		switch content := content.(type) {
+		case *message.CodeInterpreterToolCallContent:
+			call = content
+		case *message.CodeInterpreterToolResultContent:
+			codeResult = content
+		}
+	}
+	if call == nil || call.CallID == "" {
+		t.Fatalf("code call = %#v", call)
+	}
+	if codeResult == nil || codeResult.CallID != call.CallID {
+		t.Fatalf("code result = %#v, want CallID %q", codeResult, call.CallID)
 	}
 }
 

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/format/jsonformat"
@@ -142,7 +141,7 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 					Arguments: tc.Function.Arguments,
 				})
 			}
-			if choice.Message.Content != "" {
+			if choice.Message.Content != "" || len(choice.Message.Annotations) > 0 {
 				textContent := &message.TextContent{Text: choice.Message.Content}
 				populateChatAnnotations(choice.Message.Annotations, textContent)
 				contents = append(contents, textContent)
@@ -195,7 +194,7 @@ func (a *chatClient) run(ctx context.Context, messages []*message.Message, optio
 				})
 			}
 			if refusal, ok := acc.JustFinishedRefusal(); ok {
-				contents = append(contents, &message.ErrorContent{Message: refusal})
+				contents = append(contents, &message.ErrorContent{Message: refusal, ErrorCode: "Refusal"})
 			}
 			role := message.RoleAssistant
 			if len(chunk.Choices) > 0 {
@@ -450,7 +449,7 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 				default:
 					contents = append(contents, openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
 						FileData: openai.String(c.URI()),
-						Filename: openai.String(c.Name),
+						Filename: openai.String(requiredOpenAIFileName(c.Name, c.MediaType)),
 					}))
 				}
 			case *message.HostedFileContent:
@@ -476,6 +475,7 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 	case message.RoleAssistant:
 		var contents []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
 		var toolCalls []openai.ChatCompletionMessageToolCallUnionParam
+		var refusal string
 		for _, c := range msg.Contents {
 			switch c := c.(type) {
 			case *message.TextContent:
@@ -495,14 +495,18 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 					},
 				})
 			case *message.ErrorContent:
-				contents = append(contents, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
-					OfText: &openai.ChatCompletionContentPartTextParam{
-						Text: c.Message,
-					},
-				})
+				if c.ErrorCode == "Refusal" {
+					refusal = c.Message
+				} else {
+					contents = append(contents, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+						OfText: &openai.ChatCompletionContentPartTextParam{
+							Text: c.Message,
+						},
+					})
+				}
 			}
 		}
-		if len(contents) == 0 && len(toolCalls) == 0 {
+		if len(contents) == 0 && len(toolCalls) == 0 && refusal == "" {
 			return nil, nil
 		}
 		var content openai.ChatCompletionAssistantMessageParamContentUnion
@@ -514,6 +518,9 @@ func buildMessageParam(msg *message.Message) ([]openai.ChatCompletionMessagePara
 		asst := openai.ChatCompletionAssistantMessageParam{
 			Content:   content,
 			ToolCalls: toolCalls,
+		}
+		if refusal != "" {
+			asst.Refusal = openai.String(refusal)
 		}
 		if name := sanitizeAuthorName(msg.AuthorName); name != "" {
 			asst.Name = openai.String(name)
@@ -553,7 +560,7 @@ func sanitizeAuthorName(name string) string {
 	var b strings.Builder
 	n := 0
 	for _, r := range name {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		if r == '_' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
 			b.WriteRune(r)
 			n++
 			if n >= maxLen {
@@ -600,6 +607,7 @@ func populateChatAnnotations(anns []openai.ChatCompletionMessageAnnotation, cont
 		content.Annotations = append(content.Annotations, &message.CitationAnnotation{
 			URL:               ann.URLCitation.URL,
 			Title:             ann.URLCitation.Title,
+			AnnotatedRegions:  message.AnnotatedRegions{textSpanAnnotatedRegion(ann.URLCitation.StartIndex, ann.URLCitation.EndIndex)},
 			RawRepresentation: ann,
 		})
 	}
@@ -683,7 +691,7 @@ func dataContentPart(c *message.DataContent) openai.ChatCompletionContentPartUni
 	default:
 		return openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
 			FileData: openai.String(c.URI()),
-			Filename: openai.String(c.Name),
+			Filename: openai.String(requiredOpenAIFileName(c.Name, c.MediaType)),
 		})
 	}
 }

--- a/provider/openaiprovider/chat_test.go
+++ b/provider/openaiprovider/chat_test.go
@@ -446,7 +446,7 @@ func TestChatURLCitationAnnotations_NonStreaming(t *testing.T) {
                   "index": 0,
                   "message": {
                     "role": "assistant",
-                    "content": "See Example.",
+										"content": "",
                     "annotations": [
                       {
                         "type": "url_citation",
@@ -499,6 +499,13 @@ func TestChatURLCitationAnnotations_NonStreaming(t *testing.T) {
 	}
 	if citation.Title != "Example" {
 		t.Errorf("expected Title Example, got %q", citation.Title)
+	}
+	if len(citation.AnnotatedRegions) != 1 {
+		t.Fatalf("expected 1 annotated region, got %d", len(citation.AnnotatedRegions))
+	}
+	span, ok := citation.AnnotatedRegions[0].(*message.TextSpanAnnotatedRegion)
+	if !ok || span.StartIndex == nil || *span.StartIndex != 4 || span.EndIndex == nil || *span.EndIndex != 11 {
+		t.Fatalf("annotated region = %#v, want [4, 11)", citation.AnnotatedRegions[0])
 	}
 }
 
@@ -714,6 +721,9 @@ data: [DONE]
 	}
 	if refusal.Message != "I'm sorry, I can't help with that." {
 		t.Errorf("refusal message = %q, want full accumulated refusal", refusal.Message)
+	}
+	if refusal.ErrorCode != "Refusal" {
+		t.Errorf("refusal error code = %q, want Refusal", refusal.ErrorCode)
 	}
 }
 
@@ -1768,36 +1778,7 @@ func TestChatURIContentMessage_DataURI_NonStreaming(t *testing.T) {
 	// to input_audio/file exactly like the equivalent DataContent (Python keys
 	// audio/application on both data and uri). Plain http(s) audio/file URLs have
 	// no chat-completions mapping and are still dropped.
-	const input = `
-            {
-              "messages": [
-                {
-                  "role": "user",
-                  "content": [
-                    {
-                      "type": "text",
-                      "text": "Transcribe and summarize the attachments."
-                    },
-                    {
-                      "type": "input_audio",
-                      "input_audio": {
-                        "data": "QUJDRA==",
-                        "format": "wav"
-                      }
-                    },
-                    {
-                      "type": "file",
-                      "file": {
-                        "file_data": "data:application/pdf;base64,JVBERg==",
-                        "filename": ""
-                      }
-                    }
-                  ]
-                }
-              ],
-              "model": "gpt-4o-mini"
-            }
-            `
+	bodyCh := make(chan []byte, 1)
 	const output = `
             {
               "choices": [
@@ -1830,7 +1811,15 @@ func TestChatURIContentMessage_DataURI_NonStreaming(t *testing.T) {
 		},
 	}
 
-	server := newTestServer(t, input, output)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bodyCh <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, output)
+	}))
 	defer server.Close()
 
 	a := newTestClient(server)
@@ -1856,6 +1845,27 @@ func TestChatURIContentMessage_DataURI_NonStreaming(t *testing.T) {
 	}
 	if err := messagetest.MessagesEqual(resp.Messages, want); err != nil {
 		t.Error(err)
+	}
+
+	var request map[string]any
+	if err := json.Unmarshal(<-bodyCh, &request); err != nil {
+		t.Fatal(err)
+	}
+	wireMessages, _ := request["messages"].([]any)
+	wireMessage, _ := wireMessages[0].(map[string]any)
+	parts, _ := wireMessage["content"].([]any)
+	if len(parts) != 3 {
+		t.Fatalf("content parts = %#v", wireMessage["content"])
+	}
+	audioPart, _ := parts[1].(map[string]any)
+	if audioPart["type"] != "input_audio" {
+		t.Fatalf("audio part = %#v", audioPart)
+	}
+	filePart, _ := parts[2].(map[string]any)
+	file, _ := filePart["file"].(map[string]any)
+	filename, _ := file["filename"].(string)
+	if !strings.HasPrefix(filename, "file_") || !strings.HasSuffix(filename, ".pdf") {
+		t.Fatalf("generated filename = %q", filename)
 	}
 }
 
@@ -2170,9 +2180,9 @@ func TestChatAuthorNamePropagation_NonStreaming(t *testing.T) {
 	const input = `
             {
                 "messages": [
-                    {"role": "system", "content": "You are helpful.", "name": "AgentOne"},
-                    {"role": "user", "content": "hi", "name": "AgentOne"},
-                    {"role": "assistant", "content": "hello", "name": "AgentOne"}
+					{"role": "system", "content": "You are helpful.", "name": "Agent_One"},
+					{"role": "user", "content": "hi", "name": "Agent_One"},
+					{"role": "assistant", "content": "hello", "name": "Agent_One"}
                 ],
                 "model": "gpt-4o-mini"
             }
@@ -2194,9 +2204,9 @@ func TestChatAuthorNamePropagation_NonStreaming(t *testing.T) {
 	a := newTestClient(server)
 
 	messages := []*message.Message{
-		{Role: message.RoleSystem, AuthorName: "Agent One", Contents: []message.Content{&message.TextContent{Text: "You are helpful."}}},
-		{Role: message.RoleUser, AuthorName: "Agent One", Contents: []message.Content{&message.TextContent{Text: "hi"}}},
-		{Role: message.RoleAssistant, AuthorName: "Agent One", Contents: []message.Content{&message.TextContent{Text: "hello"}}},
+		{Role: message.RoleSystem, AuthorName: "Agent_ Oneé", Contents: []message.Content{&message.TextContent{Text: "You are helpful."}}},
+		{Role: message.RoleUser, AuthorName: "Agent_ Oneé", Contents: []message.Content{&message.TextContent{Text: "hi"}}},
+		{Role: message.RoleAssistant, AuthorName: "Agent_ Oneé", Contents: []message.Content{&message.TextContent{Text: "hello"}}},
 	}
 	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
 		t.Fatalf("error = %v", err)
@@ -2368,5 +2378,40 @@ func TestChatResponseWithRefusalContent_ParsesCorrectly(t *testing.T) {
 	}
 	if errorContent.ErrorCode != "Refusal" {
 		t.Errorf("expected error code 'Refusal', got %q", errorContent.ErrorCode)
+	}
+}
+
+func TestChatAssistantRefusal_ReplaysAsRefusal(t *testing.T) {
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl-refusal-replay","object":"chat.completion","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+	}))
+	defer server.Close()
+
+	messages := []*message.Message{{
+		Role: message.RoleAssistant,
+		Contents: message.Contents{&message.ErrorContent{
+			Message:   "I cannot help with that",
+			ErrorCode: "Refusal",
+		}},
+	}}
+	if _, err := newTestClient(server).Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatal(err)
+	}
+
+	wireMessages, ok := captured["messages"].([]any)
+	if !ok || len(wireMessages) != 1 {
+		t.Fatalf("messages = %#v", captured["messages"])
+	}
+	assistant, _ := wireMessages[0].(map[string]any)
+	if assistant["refusal"] != "I cannot help with that" {
+		t.Fatalf("assistant message = %#v", assistant)
+	}
+	if assistant["content"] == "I cannot help with that" {
+		t.Fatal("refusal was replayed as ordinary assistant text")
 	}
 }

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -1828,8 +1828,9 @@ func webSearchQueries(item responses.ResponseFunctionWebSearch) []string {
 	if len(action.Queries) > 0 {
 		return slices.Clone(action.Queries)
 	}
-	if action.Query != "" {
-		return []string{action.Query}
+	query := action.Query //nolint:staticcheck // Query is deprecated but remains the fallback for older Responses API payloads.
+	if query != "" {
+		return []string{query}
 	}
 	return nil
 }

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/microsoft/agent-framework-go/agent"
 	"github.com/microsoft/agent-framework-go/agent/format/jsonformat"
 	"github.com/microsoft/agent-framework-go/agent/harness/toolautocall"
@@ -28,6 +29,8 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
 )
+
+const reasoningItemIDKey = "reasoningItemId"
 
 // NewAgent creates an agent backed by the OpenAI API that best fits the Agent
 // Framework. The underlying OpenAI API is an implementation detail and can
@@ -144,10 +147,11 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 					StartingAfter: openai.Int(ct.SequenceNumber),
 				}, telemetryRequestOption)
 				defer func() { _ = streamResp.Close() }()
+				streamState := &responsesStreamState{}
 				// Update conversation ID when resuming
 				updateConversationID(ct.ResponseID)
 				for streamResp.Next() {
-					update, err := responsesProcessStreamingUpdate(streamResp.Current(), ct.ResponseID, true)
+					update, err := responsesProcessStreamingUpdate(streamResp.Current(), ct.ResponseID, true, streamState)
 					if err != nil {
 						yield(nil, err)
 						return
@@ -189,8 +193,9 @@ func (a *responsesClient) run(ctx context.Context, messages []*message.Message, 
 			responseID := ""
 			createdAt := time.Time{}
 			isBackground, _ := agent.GetOption(options, agent.AllowBackgroundResponses)
+			streamState := &responsesStreamState{}
 			for streamResp.Next() {
-				update, err := responsesProcessStreamingUpdate(streamResp.Current(), responseID, isBackground)
+				update, err := responsesProcessStreamingUpdate(streamResp.Current(), responseID, isBackground, streamState)
 				if err != nil {
 					yield(nil, err)
 					return
@@ -477,6 +482,17 @@ func responseInputItemParamOfFunctionCallOutput[T string | responses.ResponseFun
 	return item
 }
 
+func requiredOpenAIFileName(name, mediaType string) string {
+	if name != "" {
+		return name
+	}
+	extension := ""
+	if baseType := strings.TrimSpace(strings.SplitN(mediaType, ";", 2)[0]); strings.EqualFold(baseType, "application/pdf") {
+		extension = ".pdf"
+	}
+	return "file_" + strings.ReplaceAll(uuid.NewString(), "-", "") + extension
+}
+
 // responsesBuildMessageParam converts an agent.Message to one or more OpenAI message parameters.
 // Returns a slice because some agent messages (like RoleTool) need to be split into multiple OpenAI messages.
 func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInputParam) (responses.ResponseInputParam, error) {
@@ -493,6 +509,17 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 			}
 		}
 	case message.RoleUser:
+		flushInputContents := func() {
+			if len(contents) == 0 {
+				return
+			}
+			var msgParam responses.ResponseInputItemMessageParam
+			msgParam.Content = contents
+			msgParam.Role = string(responses.EasyInputMessageRole(msg.Role))
+			msgParam.Type = "message"
+			resp = append(resp, responses.ResponseInputItemUnionParam{OfInputMessage: &msgParam})
+			contents = nil
+		}
 		for _, c := range msg.Contents {
 			switch c := c.(type) {
 			case *message.TextContent:
@@ -533,9 +560,7 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 				default:
 					file := responses.ResponseInputFileParam{
 						FileData: openai.String(c.URI()),
-					}
-					if c.Name != "" {
-						file.Filename = openai.String(c.Name)
+						Filename: openai.String(requiredOpenAIFileName(c.Name, c.MediaType)),
 					}
 					contents = append(contents, responses.ResponseInputContentUnionParam{OfInputFile: &file})
 				}
@@ -547,11 +572,23 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 				contents = append(contents, responses.ResponseInputContentUnionParam{
 					OfInputFile: &file,
 				})
+			case *message.ToolApprovalResponseContent:
+				if _, ok := c.ToolCall.(*message.MCPServerToolCallContent); !ok {
+					continue
+				}
+				flushInputContents()
+				item := responses.ResponseInputItemParamOfMcpApprovalResponse(c.RequestID, c.Approved)
+				if c.Reason != "" {
+					item.OfMcpApprovalResponse.Reason = param.NewOpt(c.Reason)
+				}
+				resp = append(resp, item)
 			}
 		}
 
 	case message.RoleAssistant:
 		var outputContents []responses.ResponseOutputMessageContentUnionParam
+		mcpCalls := make(map[string]*message.MCPServerToolCallContent)
+		seenFileSearchItems := make(map[string]struct{})
 		outputGroup := 0
 		flushOutputContents := func() {
 			if len(outputContents) == 0 {
@@ -566,6 +603,17 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 			outputGroup++
 		}
 		for _, c := range msg.Contents {
+			if item, ok := c.Header().RawRepresentation.(responses.ResponseFileSearchToolCall); ok {
+				if _, seen := seenFileSearchItems[item.ID]; seen {
+					continue
+				}
+				seenFileSearchItems[item.ID] = struct{}{}
+			}
+			if rawItem, ok := responsesRawInputItem(c.Header().RawRepresentation); ok {
+				flushOutputContents()
+				resp = append(resp, rawItem)
+				continue
+			}
 			switch c := c.(type) {
 			case *message.TextContent:
 				outputContents = append(outputContents, responses.ResponseOutputMessageContentUnionParam{
@@ -589,6 +637,8 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 				// id is required and must match the original reasoning item; recover it.
 				if item, ok := c.RawRepresentation.(responses.ResponseReasoningItem); ok {
 					reasoning.ID = item.ID
+				} else if itemID, ok := c.AdditionalProperties[reasoningItemIDKey].(string); ok {
+					reasoning.ID = itemID
 				}
 				// content must stay empty on input; reasoning is replayed via encrypted_content.
 				reasoning.EncryptedContent = openai.String(c.ProtectedData)
@@ -598,6 +648,41 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 			case *message.FunctionCallContent:
 				flushOutputContents()
 				resp = append(resp, responses.ResponseInputItemParamOfFunctionCall(c.Arguments, c.CallID, c.Name))
+			case *message.ToolApprovalRequestContent:
+				mcpCall, ok := c.ToolCall.(*message.MCPServerToolCallContent)
+				if !ok {
+					continue
+				}
+				flushOutputContents()
+				resp = append(resp, responses.ResponseInputItemUnionParam{
+					OfMcpApprovalRequest: &responses.ResponseInputItemMcpApprovalRequestParam{
+						ID:          c.RequestID,
+						Arguments:   mcpCall.Arguments,
+						Name:        mcpCall.Name,
+						ServerLabel: mcpCall.ServerName,
+					},
+				})
+			case *message.MCPServerToolCallContent:
+				mcpCalls[c.CallID] = c
+			case *message.MCPServerToolResultContent:
+				mcpCall, ok := mcpCalls[c.CallID]
+				if !ok {
+					continue
+				}
+				delete(mcpCalls, c.CallID)
+				flushOutputContents()
+				mcpItem := &responses.ResponseInputItemMcpCallParam{
+					ID:          mcpCall.CallID,
+					Arguments:   mcpCall.Arguments,
+					Name:        mcpCall.Name,
+					ServerLabel: mcpCall.ServerName,
+				}
+				if errorContent := firstErrorContent(c.Outputs); errorContent != nil {
+					mcpItem.Error = responses.McpToolCallErrorParamOfMcpToolExecutionError(errorContent.Message)
+				} else {
+					mcpItem.Output = openai.String(c.Outputs.Text())
+				}
+				resp = append(resp, responses.ResponseInputItemUnionParam{OfMcpCall: mcpItem})
 			}
 		}
 		flushOutputContents()
@@ -606,6 +691,9 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 		for _, c := range msg.Contents {
 			if funcResult, ok := c.(*message.FunctionResultContent); ok {
 				ret := funcResult.Result
+				if contentSlice, ok := ret.(message.Contents); ok {
+					ret = []message.Content(contentSlice)
+				}
 				var outputContent responses.ResponseFunctionCallOutputItemListParam
 
 				if funcResult.Error != nil {
@@ -652,7 +740,7 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 								{
 									OfInputFile: &responses.ResponseInputFileContentParam{
 										FileData: param.NewOpt(dataURI),
-										Filename: param.NewOpt(c.Name),
+										Filename: param.NewOpt(requiredOpenAIFileName(c.Name, c.MediaType)),
 									},
 								},
 							}
@@ -730,7 +818,7 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 								outputContent = append(outputContent, responses.ResponseFunctionCallOutputItemUnionParam{
 									OfInputFile: &responses.ResponseInputFileContentParam{
 										FileData: param.NewOpt(dataURI),
-										Filename: param.NewOpt(c.Name),
+										Filename: param.NewOpt(requiredOpenAIFileName(c.Name, c.MediaType)),
 									},
 								})
 							}
@@ -804,6 +892,141 @@ func responsesBuildMessageParam(msg *message.Message, resp responses.ResponseInp
 	return resp, nil
 }
 
+func responsesRawInputItem(rawRepresentation any) (responses.ResponseInputItemUnionParam, bool) {
+	switch item := rawRepresentation.(type) {
+	case responses.ResponseFileSearchToolCall:
+		param := item.ToParam()
+		return responses.ResponseInputItemUnionParam{OfFileSearchCall: &param}, true
+	case responses.ResponseCodeInterpreterToolCall:
+		param := item.ToParam()
+		return responses.ResponseInputItemUnionParam{OfCodeInterpreterCall: &param}, true
+	case responses.ResponseFunctionWebSearch:
+		param := item.ToParam()
+		return responses.ResponseInputItemUnionParam{OfWebSearchCall: &param}, true
+	case responses.ResponseOutputItemImageGenerationCall:
+		return responses.ResponseInputItemParamOfImageGenerationCall(item.ID, item.Result, item.Status), true
+	case responses.ResponseOutputItemMcpCall:
+		data, err := json.Marshal(item)
+		if err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		var param responses.ResponseInputItemMcpCallParam
+		if err := json.Unmarshal(data, &param); err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		return responses.ResponseInputItemUnionParam{OfMcpCall: &param}, true
+	case responses.ResponseOutputItemMcpApprovalRequest:
+		data, err := json.Marshal(item)
+		if err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		var param responses.ResponseInputItemMcpApprovalRequestParam
+		if err := json.Unmarshal(data, &param); err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		return responses.ResponseInputItemUnionParam{OfMcpApprovalRequest: &param}, true
+	case responses.ResponseOutputItemMcpApprovalResponse:
+		data, err := json.Marshal(item)
+		if err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		var param responses.ResponseInputItemMcpApprovalResponseParam
+		if err := json.Unmarshal(data, &param); err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		return responses.ResponseInputItemUnionParam{OfMcpApprovalResponse: &param}, true
+	case responses.ResponseFunctionToolCallOutputItem:
+		data, err := json.Marshal(item)
+		if err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		var param responses.ResponseInputItemFunctionCallOutputParam
+		if err := json.Unmarshal(data, &param); err != nil {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		return responses.ResponseInputItemUnionParam{OfFunctionCallOutput: &param}, true
+	default:
+		return responses.ResponseInputItemUnionParam{}, false
+	}
+}
+
+func firstErrorContent(contents message.Contents) *message.ErrorContent {
+	for _, content := range contents {
+		if errorContent, ok := content.(*message.ErrorContent); ok {
+			return errorContent
+		}
+	}
+	return nil
+}
+
+func functionResultContent(item responses.ResponseFunctionToolCallOutputItem) *message.FunctionResultContent {
+	var result any
+	if item.Output.JSON.OfString.Valid() {
+		result = item.Output.AsString()
+	} else {
+		contents := make(message.Contents, 0, len(item.Output.OfOutputContentList))
+		for _, output := range item.Output.AsOutputContentList() {
+			var content message.Content
+			switch output := output.AsAny().(type) {
+			case responses.ResponseInputText:
+				content = &message.TextContent{
+					ContentHeader: message.ContentHeader{RawRepresentation: output},
+					Text:          output.Text,
+				}
+			case responses.ResponseInputImage:
+				switch {
+				case output.FileID != "":
+					content = &message.HostedFileContent{
+						ContentHeader: message.ContentHeader{RawRepresentation: output},
+						FileID:        output.FileID,
+						MediaType:     "image/*",
+					}
+				case strings.HasPrefix(strings.ToLower(output.ImageURL), "data:"):
+					if dataContent, err := message.NewDataContentFromURI(output.ImageURL, ""); err == nil {
+						dataContent.RawRepresentation = output
+						content = dataContent
+					}
+				case output.ImageURL != "":
+					content = &message.URIContent{
+						ContentHeader: message.ContentHeader{RawRepresentation: output},
+						URI:           output.ImageURL,
+						MediaType:     imageURIToMediaType(output.ImageURL),
+					}
+				}
+			case responses.ResponseInputFile:
+				switch {
+				case output.FileID != "":
+					content = &message.HostedFileContent{
+						ContentHeader: message.ContentHeader{RawRepresentation: output},
+						FileID:        output.FileID,
+						Name:          output.Filename,
+					}
+				case output.FileData != "":
+					if dataContent, err := message.NewDataContentFromURI(output.FileData, ""); err == nil {
+						dataContent.Name = output.Filename
+						dataContent.RawRepresentation = output
+						content = dataContent
+					}
+				case output.FileURL != "":
+					if uriContent, err := message.NewURIContent(output.FileURL, ""); err == nil {
+						uriContent.RawRepresentation = output
+						content = uriContent
+					}
+				}
+			}
+			if content != nil {
+				contents = append(contents, content)
+			}
+		}
+		result = contents
+	}
+	return &message.FunctionResultContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: item},
+		CallID:        item.CallID,
+		Result:        result,
+	}
+}
+
 func schemaToMap(schema any) (map[string]any, error) {
 	if schema == nil {
 		return nil, nil
@@ -853,6 +1076,7 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 		currentUpdate.ContinuationToken = contToken
 	}
 
+	mcpApprovalRequests := make(map[string]*message.ToolApprovalRequestContent)
 	for _, out := range resp.Output {
 		switch out := out.AsAny().(type) {
 		case responses.ResponseOutputMessage:
@@ -905,6 +1129,9 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 				if firstReasoning {
 					rc.ProtectedData = out.EncryptedContent
 					rc.RawRepresentation = out
+					if out.ID != "" {
+						rc.AdditionalProperties = map[string]any{reasoningItemIDKey: out.ID}
+					}
 					firstReasoning = false
 				}
 				currentUpdate.Contents = append(currentUpdate.Contents, rc)
@@ -930,6 +1157,9 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 				},
 			})
 
+		case responses.ResponseFunctionToolCallOutputItem:
+			currentUpdate.Contents = append(currentUpdate.Contents, functionResultContent(out))
+
 		case responses.ResponseCodeInterpreterToolCall:
 			var input message.CodeInterpreterToolCallContent
 			input.CallID = out.ID
@@ -942,42 +1172,38 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 				}
 			}
 			currentUpdate.Contents = append(currentUpdate.Contents, &input)
-
-			var output message.CodeInterpreterToolResultContent
-			output.CallID = out.ID
-			output.RawRepresentation = out
-			for _, res := range out.Outputs {
-				switch res := res.AsAny().(type) {
-				case responses.ResponseCodeInterpreterToolCallOutputLogs:
-					output.Outputs = append(output.Outputs, &message.TextContent{
-						Text:          res.Logs,
-						ContentHeader: message.ContentHeader{RawRepresentation: res},
-					})
-				case responses.ResponseCodeInterpreterToolCallOutputImage:
-					output.Outputs = append(output.Outputs, &message.URIContent{
-						URI:       res.URL,
-						MediaType: imageURIToMediaType(res.URL),
-						ContentHeader: message.ContentHeader{
-							RawRepresentation: res,
-						},
-					})
-				}
-			}
-			currentUpdate.Contents = append(currentUpdate.Contents, &output)
+			currentUpdate.Contents = append(currentUpdate.Contents, codeInterpreterResultContent(out))
 
 		case responses.ResponseFileSearchToolCall:
 			currentUpdate.Contents = append(currentUpdate.Contents, fileSearchToolCallContents(out)...)
 
 		case responses.ResponseOutputItemMcpApprovalRequest:
-			currentUpdate.Contents = append(currentUpdate.Contents, mcpApprovalRequestContent(out))
+			request := mcpApprovalRequestContent(out)
+			mcpApprovalRequests[request.RequestID] = request
+			currentUpdate.Contents = append(currentUpdate.Contents, request)
+
+		case responses.ResponseOutputItemMcpApprovalResponse:
+			if response := mcpApprovalResponseContent(out, mcpApprovalRequests); response != nil {
+				currentUpdate.Contents = append(currentUpdate.Contents, response)
+			} else {
+				currentUpdate.Contents = append(currentUpdate.Contents, &message.RawContent{
+					ContentHeader: message.ContentHeader{RawRepresentation: out},
+				})
+			}
 
 		case responses.ResponseOutputItemMcpCall:
 			currentUpdate.Contents = append(currentUpdate.Contents, mcpCallContents(out)...)
 
+		case responses.ResponseFunctionWebSearch:
+			currentUpdate.Contents = append(currentUpdate.Contents, webSearchContents(out)...)
+
 		case responses.ResponseOutputItemImageGenerationCall:
-			if content := imageGenerationContent(out); content != nil {
-				currentUpdate.Contents = append(currentUpdate.Contents, content)
-			}
+			currentUpdate.Contents = append(currentUpdate.Contents, imageGenerationContents(out)...)
+
+		default:
+			currentUpdate.Contents = append(currentUpdate.Contents, &message.RawContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: out},
+			})
 		}
 	}
 
@@ -992,8 +1218,62 @@ func responsesProcessResponse(resp *responses.Response, seqNum int64, yield func
 	yield(currentUpdate, nil)
 }
 
+func codeInterpreterResultContent(item responses.ResponseCodeInterpreterToolCall) *message.CodeInterpreterToolResultContent {
+	result := &message.CodeInterpreterToolResultContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: item},
+		CallID:        item.ID,
+	}
+	for _, output := range item.Outputs {
+		switch typedOutput := output.AsAny().(type) {
+		case responses.ResponseCodeInterpreterToolCallOutputLogs:
+			result.Outputs = append(result.Outputs, &message.TextContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: typedOutput},
+				Text:          typedOutput.Logs,
+			})
+		case responses.ResponseCodeInterpreterToolCallOutputImage:
+			result.Outputs = append(result.Outputs, &message.URIContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: typedOutput},
+				URI:           typedOutput.URL,
+				MediaType:     imageURIToMediaType(typedOutput.URL),
+			})
+		default:
+			addCodeInterpreterHostedFiles(&result.Outputs, output.RawJSON(), output, item.ContainerID)
+		}
+	}
+	return result
+}
+
+func addCodeInterpreterHostedFiles(contents *message.Contents, rawJSON string, rawRepresentation any, containerID string) {
+	var payload struct {
+		Files []struct {
+			FileID    string `json:"file_id"`
+			ID        string `json:"id"`
+			MediaType string `json:"mime_type"`
+		} `json:"files"`
+	}
+	if json.Unmarshal([]byte(rawJSON), &payload) != nil {
+		return
+	}
+	for _, file := range payload.Files {
+		fileID := cmp.Or(file.FileID, file.ID)
+		if fileID == "" {
+			continue
+		}
+		*contents = append(*contents, &message.HostedFileContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: rawRepresentation},
+			FileID:        fileID,
+			MediaType:     file.MediaType,
+			Scope:         containerID,
+		})
+	}
+}
+
 func imageURIToMediaType(uri string) string {
-	switch strings.ToLower(path.Ext(uri)) {
+	uriPath := uri
+	if parsed, err := url.Parse(uri); err == nil {
+		uriPath = parsed.Path
+	}
+	switch strings.ToLower(path.Ext(uriPath)) {
 	case ".png":
 		return "image/png"
 	case ".jpg", ".jpeg":
@@ -1014,7 +1294,14 @@ func responsesFinishReason(resp *responses.Response) string {
 	case responses.ResponseStatusCompleted:
 		return "stop"
 	case responses.ResponseStatusIncomplete:
-		return resp.IncompleteDetails.Reason
+		switch resp.IncompleteDetails.Reason {
+		case "max_output_tokens":
+			return "length"
+		case "content_filter":
+			return "content_filter"
+		default:
+			return resp.IncompleteDetails.Reason
+		}
 	default:
 		return ""
 	}
@@ -1065,12 +1352,23 @@ func responsesErrorContent(msg string, code string, details string) *message.Err
 	}
 }
 
-// responsesProcessStreamingUpdate processes a streaming update from the Responses API
-func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, responseID string, isBackground bool) (*agent.ResponseUpdate, error) {
+type responsesStreamState struct {
+	mcpApprovalRequests map[string]*message.ToolApprovalRequestContent
+	messageID           string
+	role                message.Role
+	anyFunctions        bool
+}
+
+// responsesProcessStreamingUpdate processes a streaming update from the Responses API.
+func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, responseID string, isBackground bool, state *responsesStreamState) (*agent.ResponseUpdate, error) {
 	createUpdate := func(role message.Role, contents []message.Content) *agent.ResponseUpdate {
+		if state.role != "" {
+			role = state.role
+		}
 		u := &agent.ResponseUpdate{
 			Role:              role,
 			Contents:          contents,
+			MessageID:         state.messageID,
 			ResponseID:        responseID,
 			RawRepresentation: update,
 		}
@@ -1107,11 +1405,31 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 			u.ContinuationToken = contToken
 		}
 
+	case responses.ResponseOutputItemAddedEvent:
+		switch item := event.Item.AsAny().(type) {
+		case responses.ResponseOutputMessage:
+			state.messageID = item.ID
+			state.role = message.Role(item.Role)
+			if state.role == "" {
+				state.role = message.RoleAssistant
+			}
+		case responses.ResponseFunctionToolCall:
+			state.anyFunctions = true
+			state.role = message.RoleAssistant
+		}
+		u = createUpdate(message.RoleAssistant, nil)
+		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusInProgress, isBackground); contToken != "" {
+			u.ContinuationToken = contToken
+		}
+
 	case responses.ResponseCompletedEvent:
 		u = createUpdate(message.RoleAssistant, nil)
 		u.CreatedAt = time.Unix(int64(event.Response.CreatedAt), 0)
 		u.ResponseID = event.Response.ID
 		u.FinishReason = responsesFinishReason(&event.Response)
+		if state.anyFunctions && u.FinishReason == "stop" {
+			u.FinishReason = "tool_calls"
+		}
 		u.AdditionalProperties = responsesPopulateAdditionalProperties(&event.Response)
 		// Add usage if present
 		if usage := responsesUsageToContent(event.Response.Usage); usage != nil {
@@ -1138,6 +1456,9 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 		}
 
 	case responses.ResponseTextDeltaEvent:
+		if event.ItemID != "" {
+			state.messageID = event.ItemID
+		}
 		u = createUpdate(message.RoleAssistant, []message.Content{
 			&message.TextContent{Text: event.Delta},
 		})
@@ -1147,7 +1468,12 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 
 	case responses.ResponseReasoningTextDeltaEvent:
 		u = createUpdate(message.RoleAssistant, []message.Content{
-			&message.TextReasoningContent{Text: event.Delta},
+			&message.TextReasoningContent{
+				ContentHeader: message.ContentHeader{AdditionalProperties: map[string]any{
+					reasoningItemIDKey: event.ItemID,
+				}},
+				Text: event.Delta,
+			},
 		})
 		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusInProgress, isBackground); contToken != "" {
 			u.ContinuationToken = contToken
@@ -1155,7 +1481,29 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 
 	case responses.ResponseReasoningSummaryTextDeltaEvent:
 		u = createUpdate(message.RoleAssistant, []message.Content{
-			&message.TextReasoningContent{Text: event.Delta},
+			&message.TextReasoningContent{
+				ContentHeader: message.ContentHeader{AdditionalProperties: map[string]any{
+					reasoningItemIDKey: event.ItemID,
+				}},
+				Text: event.Delta,
+			},
+		})
+		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusInProgress, isBackground); contToken != "" {
+			u.ContinuationToken = contToken
+		}
+
+	case responses.ResponseCodeInterpreterCallCodeDeltaEvent:
+		u = createUpdate(message.RoleAssistant, []message.Content{
+			&message.CodeInterpreterToolCallContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: event},
+				CallID:        event.ItemID,
+				Inputs: message.Contents{
+					&message.DataContent{
+						Data:      base64.StdEncoding.EncodeToString([]byte(event.Delta)),
+						MediaType: "text/x-python",
+					},
+				},
+			},
 		})
 		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusInProgress, isBackground); contToken != "" {
 			u.ContinuationToken = contToken
@@ -1172,6 +1520,40 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 			u.ContinuationToken = contToken
 		}
 
+	case responses.ResponseImageGenCallInProgressEvent:
+		u = createUpdate(message.RoleAssistant, []message.Content{
+			&message.ImageGenerationToolCallContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: event},
+				CallID:        event.ItemID,
+			},
+		})
+		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusInProgress, isBackground); contToken != "" {
+			u.ContinuationToken = contToken
+		}
+
+	case responses.ResponseImageGenCallPartialImageEvent:
+		result := imageGenerationResult(event.ItemID, event.PartialImageB64, cmp.Or(event.OutputFormat, "png"), event)
+		result.Outputs[0].Header().AdditionalProperties = map[string]any{
+			"ItemId":            event.ItemID,
+			"OutputIndex":       event.OutputIndex,
+			"PartialImageIndex": event.PartialImageIndex,
+		}
+		u = createUpdate(message.RoleAssistant, []message.Content{result})
+		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusInProgress, isBackground); contToken != "" {
+			u.ContinuationToken = contToken
+		}
+
+	case responses.ResponseWebSearchCallInProgressEvent:
+		u = createUpdate(message.RoleAssistant, []message.Content{
+			&message.WebSearchToolCallContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: event},
+				CallID:        event.ItemID,
+			},
+		})
+		if contToken := createContinuationToken(responseID, event.SequenceNumber, responses.ResponseStatusInProgress, isBackground); contToken != "" {
+			u.ContinuationToken = contToken
+		}
+
 	case responses.ResponseOutputItemDoneEvent:
 		// Create update for all output item done events
 		u = createUpdate(message.RoleAssistant, nil)
@@ -1180,6 +1562,10 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 		}
 		switch item := event.Item.AsAny().(type) {
 		case responses.ResponseOutputMessage:
+			state.messageID = item.ID
+			state.role = message.Role(item.Role)
+			u.MessageID = state.messageID
+			u.Role = state.role
 			// For messages, only emit content if there are annotations that weren't in delta events
 			// Delta events handle the text itself, but annotations only appear in done events
 			hasAnnotations := false
@@ -1191,24 +1577,18 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 			}
 
 			if hasAnnotations {
-				// Parse message content with annotations
+				annotatedContent := &message.TextContent{}
 				for _, c := range item.Content {
-					switch c := c.AsAny().(type) {
-					case responses.ResponseOutputText:
-						textContent := &message.TextContent{Text: c.Text}
-						populateAnnotations(c.Annotations, textContent)
-						u.Contents = append(u.Contents, textContent)
-					case responses.ResponseOutputRefusal:
-						u.Contents = append(u.Contents, &message.ErrorContent{
-							Message:   c.Refusal,
-							ErrorCode: "Refusal",
-						})
+					if outputText, ok := c.AsAny().(responses.ResponseOutputText); ok {
+						populateAnnotations(outputText.Annotations, annotatedContent)
 					}
 				}
+				u.Contents = []message.Content{annotatedContent}
 			}
 			// If no annotations, don't emit content (delta events already did)
 
 		case responses.ResponseFunctionToolCall:
+			state.anyFunctions = true
 			// Add function call content
 			callID := cmp.Or(item.CallID, item.ID)
 			u.Contents = []message.Content{
@@ -1219,71 +1599,53 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 				},
 			}
 
-		case responses.ResponseCodeInterpreterToolCall:
-			// Emit structured content matching the non-streaming path so
-			// streaming consumers receive the same code-interpreter call and
-			// result contents rather than a free-form text blob.
-			var input message.CodeInterpreterToolCallContent
-			input.CallID = item.ID
-			if item.Code != "" {
-				input.Inputs = []message.Content{
-					&message.DataContent{
-						Data:      base64.StdEncoding.EncodeToString([]byte(item.Code)),
-						MediaType: "text/x-python",
-					},
-				}
-			}
+		case responses.ResponseFunctionToolCallOutputItem:
+			u.Contents = []message.Content{functionResultContent(item)}
 
-			var output message.CodeInterpreterToolResultContent
-			output.CallID = item.ID
-			output.RawRepresentation = item
-			for _, res := range item.Outputs {
-				switch res := res.AsAny().(type) {
-				case responses.ResponseCodeInterpreterToolCallOutputLogs:
-					output.Outputs = append(output.Outputs, &message.TextContent{
-						Text:          res.Logs,
-						ContentHeader: message.ContentHeader{RawRepresentation: res},
-					})
-				case responses.ResponseCodeInterpreterToolCallOutputImage:
-					output.Outputs = append(output.Outputs, &message.URIContent{
-						URI:       res.URL,
-						MediaType: imageURIToMediaType(res.URL),
-						ContentHeader: message.ContentHeader{
-							RawRepresentation: res,
-						},
-					})
-				}
-			}
-			u.Contents = []message.Content{&input, &output}
+		case responses.ResponseCodeInterpreterToolCall:
+			u.Contents = []message.Content{codeInterpreterResultContent(item)}
 		case responses.ResponseFileSearchToolCall:
 			u.Contents = fileSearchToolCallContents(item)
 		case responses.ResponseOutputItemMcpApprovalRequest:
-			u.Contents = []message.Content{mcpApprovalRequestContent(item)}
+			request := mcpApprovalRequestContent(item)
+			if state.mcpApprovalRequests == nil {
+				state.mcpApprovalRequests = make(map[string]*message.ToolApprovalRequestContent)
+			}
+			state.mcpApprovalRequests[request.RequestID] = request
+			u.Contents = []message.Content{request}
+		case responses.ResponseOutputItemMcpApprovalResponse:
+			if response := mcpApprovalResponseContent(item, state.mcpApprovalRequests); response != nil {
+				u.Contents = []message.Content{response}
+			} else {
+				u.Contents = []message.Content{&message.RawContent{
+					ContentHeader: message.ContentHeader{RawRepresentation: item},
+				}}
+			}
 		case responses.ResponseOutputItemMcpCall:
 			u.Contents = mcpCallContents(item)
+		case responses.ResponseFunctionWebSearch:
+			u.Contents = webSearchContents(item)
 		case responses.ResponseOutputItemImageGenerationCall:
-			if content := imageGenerationContent(item); content != nil {
-				u.Contents = []message.Content{content}
-			}
+			// Dedicated image-generation events emit the call and partial results.
 		case responses.ResponseReasoningItem:
 			// Carry the completed reasoning item's encrypted content so it can be
 			// replayed on the next turn when store=false (reasoning delta events only
-			// carry text and drop EncryptedContent). Mirrors the non-streaming handler.
-			var sb strings.Builder
-			for _, c := range item.Content {
-				sb.WriteString(c.Text)
-			}
-			u.Contents = []message.Content{
-				&message.TextReasoningContent{
-					Text:          sb.String(),
-					ProtectedData: item.EncryptedContent,
-					ContentHeader: message.ContentHeader{
-						RawRepresentation: item,
+			// carry text and drop EncryptedContent). Avoid the completed item's text
+			// and raw representation because both would duplicate streamed deltas.
+			if item.EncryptedContent != "" {
+				u.Contents = []message.Content{
+					&message.TextReasoningContent{
+						ProtectedData: item.EncryptedContent,
+						ContentHeader: message.ContentHeader{AdditionalProperties: map[string]any{
+							reasoningItemIDKey: item.ID,
+						}},
 					},
-				},
+				}
 			}
 		default:
-			u = createUpdate(message.RoleAssistant, nil)
+			u.Contents = []message.Content{&message.RawContent{
+				ContentHeader: message.ContentHeader{RawRepresentation: item},
+			}}
 		}
 	case responses.ResponseErrorEvent:
 		u = createUpdate(message.RoleAssistant, []message.Content{
@@ -1353,17 +1715,31 @@ func mcpApprovalRequestContent(item responses.ResponseOutputItemMcpApprovalReque
 	}
 }
 
+func mcpApprovalResponseContent(item responses.ResponseOutputItemMcpApprovalResponse, requests map[string]*message.ToolApprovalRequestContent) *message.ToolApprovalResponseContent {
+	request := requests[item.ApprovalRequestID]
+	if request == nil {
+		return nil
+	}
+	delete(requests, item.ApprovalRequestID)
+	return &message.ToolApprovalResponseContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: item},
+		RequestID:     item.ApprovalRequestID,
+		Approved:      item.Approve,
+		Reason:        item.Reason,
+		ToolCall:      request.ToolCall,
+	}
+}
+
 // mcpCallContents surfaces a completed hosted MCP tool call, emitting both the
 // call (from its arguments) and its result so the output is not silently
 // dropped. Any tool-call error is surfaced as an ErrorContent.
 func mcpCallContents(item responses.ResponseOutputItemMcpCall) []message.Content {
 	contents := []message.Content{
 		&message.MCPServerToolCallContent{
-			ContentHeader: message.ContentHeader{RawRepresentation: item},
-			Arguments:     item.Arguments,
-			CallID:        item.ID,
-			Name:          item.Name,
-			ServerName:    item.ServerLabel,
+			Arguments:  item.Arguments,
+			CallID:     item.ID,
+			Name:       item.Name,
+			ServerName: item.ServerLabel,
 		},
 	}
 
@@ -1371,22 +1747,17 @@ func mcpCallContents(item responses.ResponseOutputItemMcpCall) []message.Content
 	result := &message.MCPServerToolResultContent{
 		ContentHeader: message.ContentHeader{RawRepresentation: item},
 		CallID:        item.ID,
-		Name:          item.Name,
-		ServerName:    item.ServerLabel,
-		Error:         errorMessage,
 	}
-	if item.Output != "" {
+	if errorMessage != "" {
+		result.Outputs = message.Contents{
+			&message.ErrorContent{Message: errorMessage},
+		}
+	} else {
 		result.Outputs = message.Contents{
 			&message.TextContent{Text: item.Output},
 		}
 	}
 	contents = append(contents, result)
-
-	if errorMessage != "" {
-		contents = append(contents, &message.ErrorContent{
-			Message: errorMessage,
-		})
-	}
 	return contents
 }
 
@@ -1415,20 +1786,71 @@ func mcpToolCallErrorMessage(err responses.McpToolCallErrorUnion) string {
 	return raw
 }
 
-func imageGenerationContent(item responses.ResponseOutputItemImageGenerationCall) *message.DataContent {
-	if item.Result == "" {
+func imageGenerationContents(item responses.ResponseOutputItemImageGenerationCall) message.Contents {
+	return message.Contents{
+		&message.ImageGenerationToolCallContent{CallID: item.ID},
+		imageGenerationResult(item.ID, item.Result, "png", item),
+	}
+}
+
+func imageGenerationResult(callID, data, outputFormat string, rawRepresentation any) *message.ImageGenerationToolResultContent {
+	return &message.ImageGenerationToolResultContent{
+		ContentHeader: message.ContentHeader{RawRepresentation: rawRepresentation},
+		CallID:        callID,
+		Outputs: message.Contents{
+			&message.DataContent{
+				Data:      data,
+				MediaType: "image/" + outputFormat,
+			},
+		},
+	}
+}
+
+func webSearchContents(item responses.ResponseFunctionWebSearch) message.Contents {
+	return message.Contents{
+		&message.WebSearchToolCallContent{
+			CallID:  item.ID,
+			Queries: webSearchQueries(item),
+		},
+		&message.WebSearchToolResultContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: item},
+			CallID:        item.ID,
+			Outputs:       webSearchOutputs(item),
+		},
+	}
+}
+
+func webSearchQueries(item responses.ResponseFunctionWebSearch) []string {
+	action, ok := item.Action.AsAny().(responses.ResponseFunctionWebSearchActionSearch)
+	if !ok {
 		return nil
 	}
-	name := ""
-	if item.ID != "" {
-		name = item.ID + ".png"
+	if len(action.Queries) > 0 {
+		return slices.Clone(action.Queries)
 	}
-	return &message.DataContent{
-		ContentHeader: message.ContentHeader{RawRepresentation: item},
-		Data:          item.Result,
-		MediaType:     "image/png",
-		Name:          name,
+	if action.Query != "" {
+		return []string{action.Query}
 	}
+	return nil
+}
+
+func webSearchOutputs(item responses.ResponseFunctionWebSearch) message.Contents {
+	action, ok := item.Action.AsAny().(responses.ResponseFunctionWebSearchActionSearch)
+	if !ok {
+		return nil
+	}
+	var outputs message.Contents
+	for _, source := range action.Sources {
+		if source.URL == "" {
+			continue
+		}
+		outputs = append(outputs, &message.URIContent{
+			ContentHeader: message.ContentHeader{RawRepresentation: source},
+			URI:           source.URL,
+			MediaType:     "text/html",
+		})
+	}
+	return outputs
 }
 
 func populateAnnotations(anns []responses.ResponseOutputTextAnnotationUnion, content *message.TextContent) {
@@ -1444,14 +1866,14 @@ func populateAnnotations(anns []responses.ResponseOutputTextAnnotationUnion, con
 			content.Annotations = append(content.Annotations, &message.CitationAnnotation{
 				Title:             a.Title,
 				URL:               a.URL,
-				AnnotatedRegions:  message.AnnotatedRegions{&message.TextSpanAnnotatedRegion{Start: int(a.StartIndex), End: int(a.EndIndex)}},
+				AnnotatedRegions:  message.AnnotatedRegions{textSpanAnnotatedRegion(a.StartIndex, a.EndIndex)},
 				RawRepresentation: a,
 			})
 		case responses.ResponseOutputTextAnnotationContainerFileCitation:
 			content.Annotations = append(content.Annotations, &message.CitationAnnotation{
 				FileID:               a.FileID,
 				Title:                a.Filename,
-				AnnotatedRegions:     message.AnnotatedRegions{&message.TextSpanAnnotatedRegion{Start: int(a.StartIndex), End: int(a.EndIndex)}},
+				AnnotatedRegions:     message.AnnotatedRegions{textSpanAnnotatedRegion(a.StartIndex, a.EndIndex)},
 				AdditionalProperties: map[string]any{"ContainerId": a.ContainerID},
 				RawRepresentation:    a,
 			})
@@ -1464,13 +1886,21 @@ func populateAnnotations(anns []responses.ResponseOutputTextAnnotationUnion, con
 	}
 }
 
+func textSpanAnnotatedRegion(start, end int64) *message.TextSpanAnnotatedRegion {
+	startIndex, endIndex := int(start), int(end)
+	return &message.TextSpanAnnotatedRegion{StartIndex: &startIndex, EndIndex: &endIndex}
+}
+
 func responsesPopulateAdditionalProperties(resp *responses.Response) map[string]any {
 	props := make(map[string]any)
 	if resp.User != "" { //nolint:staticcheck // SA1019: no replacement available
 		props["EndUserId"] = resp.User //nolint:staticcheck // SA1019: no replacement available
 	}
-	if resp.Error.Message != "" {
-		props["Error"] = resp.Error.Message
+	if resp.SafetyIdentifier != "" {
+		props["SafetyIdentifier"] = resp.SafetyIdentifier
+	}
+	if resp.Error.Message != "" || resp.Error.Code != "" {
+		props["Error"] = resp.Error
 	}
 	return props
 }

--- a/provider/openaiprovider/responses_test.go
+++ b/provider/openaiprovider/responses_test.go
@@ -963,6 +963,221 @@ func TestResponsesAssistantReplayPreservesContentOrder(t *testing.T) {
 	}
 }
 
+func TestResponsesAssistantReplayPreservesHostedToolItems(t *testing.T) {
+	rawItems := []struct {
+		content message.Content
+		rawJSON string
+	}{
+		{
+			content: &message.CodeInterpreterToolResultContent{CallID: "ci_1"},
+			rawJSON: `{"type":"code_interpreter_call","id":"ci_1","container_id":"container","status":"completed","code":"print(1)","outputs":[]}`,
+		},
+		{
+			content: &message.ImageGenerationToolResultContent{CallID: "ig_1"},
+			rawJSON: `{"type":"image_generation_call","id":"ig_1","status":"completed","result":"aW1hZ2U="}`,
+		},
+		{
+			content: &message.WebSearchToolResultContent{CallID: "ws_1"},
+			rawJSON: `{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","queries":["query"]}}`,
+		},
+		{
+			content: &message.MCPServerToolResultContent{CallID: "mcp_1"},
+			rawJSON: `{"type":"mcp_call","id":"mcp_1","server_label":"server","name":"tool","arguments":"{}","output":"ok","error":null}`,
+		},
+	}
+
+	for i := range rawItems {
+		var raw any
+		switch i {
+		case 0:
+			raw = new(responses.ResponseCodeInterpreterToolCall)
+		case 1:
+			raw = new(responses.ResponseOutputItemImageGenerationCall)
+		case 2:
+			raw = new(responses.ResponseFunctionWebSearch)
+		case 3:
+			raw = new(responses.ResponseOutputItemMcpCall)
+		}
+		if err := json.Unmarshal([]byte(rawItems[i].rawJSON), raw); err != nil {
+			t.Fatal(err)
+		}
+		rawItems[i].content.Header().RawRepresentation = reflect.ValueOf(raw).Elem().Interface()
+	}
+
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp","object":"response","created_at":1,"status":"completed","model":"gpt-4o-mini","output":[]}`)
+	}))
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	contents := make(message.Contents, len(rawItems))
+	for i := range rawItems {
+		contents[i] = rawItems[i].content
+	}
+	if _, err := a.Run(t.Context(), []*message.Message{{Role: message.RoleAssistant, Contents: contents}}).Collect(); err != nil {
+		t.Fatal(err)
+	}
+
+	input, ok := captured["input"].([]any)
+	if !ok || len(input) != len(rawItems) {
+		t.Fatalf("input = %#v", captured["input"])
+	}
+	wantTypes := []string{"code_interpreter_call", "image_generation_call", "web_search_call", "mcp_call"}
+	for i, wantType := range wantTypes {
+		item, ok := input[i].(map[string]any)
+		if !ok || item["type"] != wantType {
+			t.Fatalf("input[%d] = %#v, want type %q", i, input[i], wantType)
+		}
+	}
+}
+
+func TestResponsesAssistantReplayReconstructsPersistedMCPContents(t *testing.T) {
+	original := message.Contents{
+		&message.ToolApprovalRequestContent{
+			RequestID: "approval_1",
+			ToolCall: &message.MCPServerToolCallContent{
+				CallID:     "approval_1",
+				Name:       "review_issue",
+				ServerName: "github",
+				Arguments:  `{"number":42}`,
+			},
+		},
+		&message.MCPServerToolCallContent{
+			CallID:     "mcp_1",
+			Name:       "get_issue",
+			ServerName: "github",
+			Arguments:  `{"number":42}`,
+		},
+		&message.MCPServerToolResultContent{
+			CallID:  "mcp_1",
+			Outputs: message.Contents{&message.TextContent{Text: "issue 42"}},
+		},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted message.Contents
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp","object":"response","created_at":1,"status":"completed","model":"gpt-4o-mini","output":[]}`)
+	}))
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	if _, err := a.Run(t.Context(), []*message.Message{{Role: message.RoleAssistant, Contents: persisted}}).Collect(); err != nil {
+		t.Fatal(err)
+	}
+
+	input, ok := captured["input"].([]any)
+	if !ok || len(input) != 2 {
+		t.Fatalf("input = %#v", captured["input"])
+	}
+	approval, _ := input[0].(map[string]any)
+	if approval["type"] != "mcp_approval_request" || approval["id"] != "approval_1" || approval["server_label"] != "github" {
+		t.Fatalf("approval item = %#v", approval)
+	}
+	mcpCall, _ := input[1].(map[string]any)
+	if mcpCall["type"] != "mcp_call" || mcpCall["id"] != "mcp_1" || mcpCall["output"] != "issue 42" {
+		t.Fatalf("MCP item = %#v", mcpCall)
+	}
+}
+
+func TestResponsesAssistantReplayDeduplicatesFileSearchItem(t *testing.T) {
+	var item responses.ResponseFileSearchToolCall
+	if err := json.Unmarshal([]byte(`{"type":"file_search_call","id":"fs_1","status":"completed","queries":["query"],"results":[]}`), &item); err != nil {
+		t.Fatal(err)
+	}
+	contents := message.Contents{
+		&message.TextContent{ContentHeader: message.ContentHeader{RawRepresentation: item}, Text: "first"},
+		&message.TextContent{ContentHeader: message.ContentHeader{RawRepresentation: item}, Text: "second"},
+	}
+
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp","object":"response","created_at":1,"status":"completed","model":"gpt-4o-mini","output":[]}`)
+	}))
+	defer server.Close()
+
+	if _, err := newTestResponsesClient(server, "gpt-4o-mini").Run(t.Context(), []*message.Message{{Role: message.RoleAssistant, Contents: contents}}).Collect(); err != nil {
+		t.Fatal(err)
+	}
+	input, ok := captured["input"].([]any)
+	if !ok || len(input) != 1 {
+		t.Fatalf("input = %#v", captured["input"])
+	}
+	fileSearch, _ := input[0].(map[string]any)
+	if fileSearch["type"] != "file_search_call" || fileSearch["id"] != "fs_1" {
+		t.Fatalf("file search item = %#v", fileSearch)
+	}
+}
+
+func TestResponsesMCPApprovalResponsePreservesUserContentOrder(t *testing.T) {
+	const input = `
+            {
+              "input":[
+                {"type":"message","role":"user","content":[{"type":"input_text","text":"before"}]},
+                {"type":"mcp_approval_response","approval_request_id":"approval_1","approve":true,"reason":"trusted"},
+                {"type":"message","role":"user","content":[{"type":"input_text","text":"after"}]}
+              ],
+              "model":"gpt-4o-mini"
+            }
+            `
+	const output = `
+            {
+              "id":"resp_test",
+              "object":"response",
+              "created_at":1727894187,
+              "status":"completed",
+              "model":"gpt-4o-mini",
+              "output":[]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	approval := &message.ToolApprovalResponseContent{
+		RequestID: "approval_1",
+		Approved:  true,
+		Reason:    "trusted",
+		ToolCall: &message.MCPServerToolCallContent{
+			CallID:     "call_1",
+			Name:       "lookup",
+			ServerName: "server",
+		},
+	}
+	messages := []*message.Message{{
+		Role: message.RoleUser,
+		Contents: message.Contents{
+			&message.TextContent{Text: "before"},
+			approval,
+			&message.TextContent{Text: "after"},
+		},
+	}}
+	if _, err := a.Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestResponsesDataContentMessage_Image_NonStreaming(t *testing.T) {
 	// A minimal 1x1 PNG image as a data URI (red pixel)
 	_ = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
@@ -1500,15 +1715,43 @@ data: {"type":"response.completed","sequence_number":10,"response":{"id":"resp_e
 	// The completed reasoning item must surface as a TextReasoningContent that
 	// carries the encrypted content forward.
 	var protectedData string
+	var reasoningProperties map[string]any
+	var reasoningText strings.Builder
 	for _, update := range updates {
 		for _, content := range update.Contents {
-			if rc, ok := content.(*message.TextReasoningContent); ok && rc.ProtectedData != "" {
-				protectedData = rc.ProtectedData
+			if rc, ok := content.(*message.TextReasoningContent); ok {
+				reasoningText.WriteString(rc.Text)
+				if rc.ProtectedData != "" {
+					protectedData = rc.ProtectedData
+					reasoningProperties = rc.AdditionalProperties
+				}
 			}
 		}
 	}
 	if protectedData != encrypted {
 		t.Fatalf("expected reasoning ProtectedData %q, got %q", encrypted, protectedData)
+	}
+	if reasoningText.String() != "Analyzing." {
+		t.Fatalf("expected streamed reasoning once, got %q", reasoningText.String())
+	}
+	if reasoningProperties["reasoningItemId"] != "rs_enc123" {
+		t.Fatalf("reasoning item metadata = %#v", reasoningProperties)
+	}
+
+	var collected agent.Response
+	for _, update := range updates {
+		collected.Update(update)
+	}
+	collected.Coalesce()
+	var collectedReasoning *message.TextReasoningContent
+	for content := range collected.Contents() {
+		if reasoning, ok := content.(*message.TextReasoningContent); ok {
+			collectedReasoning = reasoning
+			break
+		}
+	}
+	if collectedReasoning == nil || collectedReasoning.AdditionalProperties["reasoningItemId"] != "rs_enc123" {
+		t.Fatalf("collected reasoning = %#v", collectedReasoning)
 	}
 
 	// Round-trip: replaying the collected reasoning content on the next turn must
@@ -1529,7 +1772,11 @@ data: {"type":"response.completed","sequence_number":10,"response":{"id":"resp_e
 	messages := []*message.Message{
 		{Role: message.RoleUser, Contents: []message.Content{&message.TextContent{Text: "Solve this problem step by step."}}},
 		{Role: message.RoleAssistant, Contents: []message.Content{
-			&message.TextReasoningContent{Text: "Analyzing.", ProtectedData: protectedData},
+			&message.TextReasoningContent{
+				ContentHeader: message.ContentHeader{AdditionalProperties: reasoningProperties},
+				Text:          "Analyzing.",
+				ProtectedData: protectedData,
+			},
 			&message.TextContent{Text: "The solution is 42."},
 		}},
 	}
@@ -1538,6 +1785,9 @@ data: {"type":"response.completed","sequence_number":10,"response":{"id":"resp_e
 	}
 	if !strings.Contains(capturedBody, `"encrypted_content":"`+encrypted+`"`) {
 		t.Fatalf("expected replay request to carry encrypted_content %q, body = %s", encrypted, capturedBody)
+	}
+	if !strings.Contains(capturedBody, `"id":"rs_enc123"`) {
+		t.Fatalf("expected replay request to carry reasoning item id, body = %s", capturedBody)
 	}
 	// summary is required by the Responses API even when empty.
 	if !strings.Contains(capturedBody, `"summary":[]`) {
@@ -1828,6 +2078,83 @@ func TestResponsesMultipleOutputItems_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestResponsesStreamingPreservesMultipleMessageItems(t *testing.T) {
+	const input = `{
+		"model":"gpt-4o-mini",
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}],
+		"stream":true
+	}`
+	const output = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_multi","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"type":"message","id":"msg_1","status":"in_progress","role":"assistant","content":[]}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"first"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"type":"message","id":"msg_1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"first","annotations":[]}]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"type":"message","id":"msg_2","status":"in_progress","role":"assistant","content":[]}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_2","output_index":1,"content_index":0,"delta":"second"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":6,"output_index":1,"item":{"type":"message","id":"msg_2","status":"completed","role":"assistant","content":[{"type":"output_text","text":"second","annotations":[]}]}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":7,"response":{"id":"resp_multi","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+
+`
+
+	server := newTestResponsesServerStreaming(t, input, output)
+	defer server.Close()
+	resp, err := newTestResponsesClient(server, "gpt-4o-mini").RunText(t.Context(), "test", agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Messages) != 2 {
+		t.Fatalf("messages = %#v", resp.Messages)
+	}
+	if resp.Messages[0].ID != "msg_1" || resp.Messages[0].String() != "first" || resp.Messages[1].ID != "msg_2" || resp.Messages[1].String() != "second" {
+		t.Fatalf("messages = %#v", resp.Messages)
+	}
+}
+
+func TestResponsesStreamingFunctionCallUsesToolCallsFinishReason(t *testing.T) {
+	const input = `{
+		"model":"gpt-4o-mini",
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}],
+		"stream":true
+	}`
+	const output = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_tool","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{}"}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":2,"output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{}"}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_tool","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+
+`
+
+	server := newTestResponsesServerStreaming(t, input, output)
+	defer server.Close()
+	resp, err := newTestResponsesClient(server, "gpt-4o-mini").RunText(t.Context(), "test", agent.Stream(true)).Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want tool_calls", resp.FinishReason)
+	}
+}
+
 func TestResponsesFunctionCallWithResult_NonStreaming(t *testing.T) {
 	// First request - function call
 	const input1 = `
@@ -2034,6 +2361,62 @@ func TestResponsesFunctionCallWithResult_NonStreaming(t *testing.T) {
 	}
 	if responseText != "The weather in Seattle is sunny with a temperature of 72°F." {
 		t.Errorf("expected weather response, got %q", responseText)
+	}
+}
+
+func TestResponsesFunctionCallOutputItem_MapsToFunctionResultContent(t *testing.T) {
+	const input = `{
+		"model":"gpt-4o-mini",
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"test"}]}]
+	}`
+	const output = `{
+		"id":"resp_output",
+		"object":"response",
+		"created_at":1741892091,
+		"status":"completed",
+		"model":"gpt-4o-mini",
+		"output":[{
+			"type":"function_call_output",
+			"id":"out_1",
+			"call_id":"call_1",
+			"status":"completed",
+			"output":[
+				{"type":"input_text","text":"result text"},
+				{"type":"input_image","image_url":"https://example.com/chart.png","detail":"auto"},
+				{"type":"input_file","file_id":"file_1","filename":"report.pdf"}
+			]
+		}]
+	}`
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+	resp, err := newTestResponsesClient(server, "gpt-4o-mini").RunText(t.Context(), "test").Collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var functionResult *message.FunctionResultContent
+	for content := range resp.Contents() {
+		if result, ok := content.(*message.FunctionResultContent); ok {
+			functionResult = result
+			break
+		}
+	}
+	if functionResult == nil || functionResult.CallID != "call_1" || functionResult.RawRepresentation == nil {
+		t.Fatalf("function result = %#v", functionResult)
+	}
+	contents, ok := functionResult.Result.(message.Contents)
+	if !ok || len(contents) != 3 {
+		t.Fatalf("result contents = %#v", functionResult.Result)
+	}
+	if text, ok := contents[0].(*message.TextContent); !ok || text.Text != "result text" {
+		t.Fatalf("text output = %#v", contents[0])
+	}
+	if image, ok := contents[1].(*message.URIContent); !ok || image.URI != "https://example.com/chart.png" || image.MediaType != "image/png" {
+		t.Fatalf("image output = %#v", contents[1])
+	}
+	if file, ok := contents[2].(*message.HostedFileContent); !ok || file.FileID != "file_1" || file.Name != "report.pdf" {
+		t.Fatalf("file output = %#v", contents[2])
 	}
 }
 
@@ -2411,8 +2794,8 @@ func TestResponsesNonStreamingResponseWithIncompleteReason_MapsFinishReason(t *t
 	if responseText != "Partial" {
 		t.Errorf("expected response text 'Partial', got %q", responseText)
 	}
-	if resp.FinishReason != "max_output_tokens" {
-		t.Errorf("expected FinishReason max_output_tokens, got %q", resp.FinishReason)
+	if resp.FinishReason != "length" {
+		t.Errorf("expected FinishReason length, got %q", resp.FinishReason)
 	}
 }
 
@@ -2431,13 +2814,22 @@ func TestResponsesNonStreamingMCPApprovalRequest_MapsApprovalContent(t *testing.
               "created_at":1741892091,
               "status":"completed",
               "model":"gpt-4o-mini",
-              "output":[{
-                "type":"mcp_approval_request",
-                "id":"approval_123",
-                "server_label":"github",
-                "name":"create_issue",
-                "arguments":"{\"title\":\"Bug\"}"
-              }]
+							"output":[
+								{
+									"type":"mcp_approval_request",
+									"id":"approval_123",
+									"server_label":"github",
+									"name":"create_issue",
+									"arguments":"{\"title\":\"Bug\"}"
+								},
+								{
+									"type":"mcp_approval_response",
+									"id":"approval_response_123",
+									"approval_request_id":"approval_123",
+									"approve":true,
+									"reason":"approved"
+								}
+							]
             }
             `
 
@@ -2470,6 +2862,18 @@ func TestResponsesNonStreamingMCPApprovalRequest_MapsApprovalContent(t *testing.
 	if approval.RawRepresentation == nil || mcpCall.RawRepresentation == nil {
 		t.Error("RawRepresentation is nil")
 	}
+	var approvalResponse *message.ToolApprovalResponseContent
+	for content := range resp.Contents() {
+		if response, ok := content.(*message.ToolApprovalResponseContent); ok {
+			approvalResponse = response
+		}
+	}
+	if approvalResponse == nil || approvalResponse.RequestID != approval.RequestID || !approvalResponse.Approved || approvalResponse.Reason != "approved" {
+		t.Fatalf("approval response = %#v", approvalResponse)
+	}
+	if approvalResponse.ToolCall != approval.ToolCall {
+		t.Fatal("approval response did not reuse request ToolCall")
+	}
 }
 
 func TestResponsesStreamingMCPApprovalRequest_MapsApprovalContent(t *testing.T) {
@@ -2487,8 +2891,11 @@ data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001"
 event: response.output_item.done
 data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,"item":{"type":"mcp_approval_request","id":"approval_123","server_label":"github","name":"create_issue","arguments":"{\"title\":\"Bug\"}"}}
 
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":2,"output_index":1,"item":{"type":"mcp_approval_response","id":"approval_response_123","approval_request_id":"approval_123","approve":false,"reason":"denied"}}
+
 event: response.completed
-data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
 
 `
 
@@ -2497,13 +2904,17 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
 	var approval *message.ToolApprovalRequestContent
+	var approvalResponse *message.ToolApprovalResponseContent
 	for update, err := range a.RunText(t.Context(), "test", agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("error = %v", err)
 		}
 		for _, content := range update.Contents {
-			if req, ok := content.(*message.ToolApprovalRequestContent); ok {
-				approval = req
+			switch content := content.(type) {
+			case *message.ToolApprovalRequestContent:
+				approval = content
+			case *message.ToolApprovalResponseContent:
+				approvalResponse = content
 			}
 		}
 	}
@@ -2517,6 +2928,12 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 	}
 	if approval.RequestID != "approval_123" || mcpCall.ServerName != "github" || mcpCall.Name != "create_issue" {
 		t.Fatalf("approval = %#v, tool call = %#v", approval, mcpCall)
+	}
+	if approvalResponse == nil || approvalResponse.RequestID != approval.RequestID || approvalResponse.Approved || approvalResponse.Reason != "denied" {
+		t.Fatalf("approval response = %#v", approvalResponse)
+	}
+	if approvalResponse.ToolCall != approval.ToolCall {
+		t.Fatal("approval response did not reuse request ToolCall")
 	}
 }
 
@@ -2569,15 +2986,12 @@ func TestResponsesNonStreamingMCPCall_MapsResultContent(t *testing.T) {
 
 	var call *message.MCPServerToolCallContent
 	var result *message.MCPServerToolResultContent
-	var errContent *message.ErrorContent
 	for content := range resp.Contents() {
 		switch c := content.(type) {
 		case *message.MCPServerToolCallContent:
 			call = c
 		case *message.MCPServerToolResultContent:
 			result = c
-		case *message.ErrorContent:
-			errContent = c
 		}
 	}
 
@@ -2587,24 +3001,24 @@ func TestResponsesNonStreamingMCPCall_MapsResultContent(t *testing.T) {
 	if call.CallID != "mcp_123" || call.Name != "create_issue" || call.ServerName != "github" || call.Arguments != `{"title":"Bug"}` {
 		t.Fatalf("call = %#v", call)
 	}
+	if call.RawRepresentation != nil {
+		t.Error("call RawRepresentation is non-nil")
+	}
 	if result == nil {
 		t.Fatal("expected MCPServerToolResultContent")
 	}
-	if result.CallID != "mcp_123" || result.Name != "create_issue" || result.ServerName != "github" {
+	if result.CallID != "mcp_123" {
 		t.Fatalf("result = %#v", result)
-	}
-	if result.Error != "rate limited" {
-		t.Errorf("result.Error = %q, want %q", result.Error, "rate limited")
 	}
 	if len(result.Outputs) != 1 {
 		t.Fatalf("Outputs len = %d, want 1", len(result.Outputs))
 	}
-	text, ok := result.Outputs[0].(*message.TextContent)
-	if !ok || text.Text != "issue #7 created" {
+	errContent, ok := result.Outputs[0].(*message.ErrorContent)
+	if !ok || errContent.Message != "rate limited" {
 		t.Fatalf("Outputs[0] = %#v", result.Outputs[0])
 	}
-	if errContent == nil || errContent.Message != "rate limited" {
-		t.Fatalf("expected ErrorContent with tool error, got %#v", errContent)
+	if result.RawRepresentation == nil {
+		t.Error("result RawRepresentation is nil")
 	}
 }
 
@@ -2634,7 +3048,6 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 	a := newTestResponsesClient(server, "gpt-4o-mini")
 	var call *message.MCPServerToolCallContent
 	var result *message.MCPServerToolResultContent
-	var errContent *message.ErrorContent
 	for update, err := range a.RunText(t.Context(), "test", agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("error = %v", err)
@@ -2645,8 +3058,6 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 				call = c
 			case *message.MCPServerToolResultContent:
 				result = c
-			case *message.ErrorContent:
-				errContent = c
 			}
 		}
 	}
@@ -2657,21 +3068,24 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 	if call.CallID != "mcp_123" || call.ServerName != "github" || call.Name != "create_issue" || call.Arguments != `{"title":"Bug"}` {
 		t.Fatalf("call = %#v", call)
 	}
+	if call.RawRepresentation != nil {
+		t.Error("call RawRepresentation is non-nil")
+	}
 	if result == nil {
 		t.Fatal("expected MCPServerToolResultContent")
 	}
-	if result.CallID != "mcp_123" || result.ServerName != "github" || result.Name != "create_issue" {
+	if result.CallID != "mcp_123" {
 		t.Fatalf("result = %#v", result)
 	}
 	if len(result.Outputs) != 1 {
 		t.Fatalf("Outputs len = %d, want 1", len(result.Outputs))
 	}
-	text, ok := result.Outputs[0].(*message.TextContent)
-	if !ok || text.Text != "issue #7 created" {
+	errContent, ok := result.Outputs[0].(*message.ErrorContent)
+	if !ok || errContent.Message != "rate limited" {
 		t.Fatalf("Outputs[0] = %#v", result.Outputs[0])
 	}
-	if errContent == nil || errContent.Message != "rate limited" {
-		t.Fatalf("expected ErrorContent with tool error, got %#v", errContent)
+	if result.RawRepresentation == nil {
+		t.Error("result RawRepresentation is nil")
 	}
 }
 
@@ -3044,7 +3458,8 @@ func TestResponsesCodeInterpreterTool_NonStreaming(t *testing.T) {
                   "container_id":"cntr_68fb7476c384819186524b78cdc3180000a9a0fdd06b3cd4",
                   "outputs":[
                     {"type":"logs","logs":"15\n"},
-                    {"type":"image","url":"https://example.com/plot.png"}
+										{"type":"image","url":"https://example.com/plot.png?download=1"},
+										{"type":"files","files":[{"file_id":"file_123","mime_type":"text/csv"}]}
                   ]
                 },
                 {
@@ -3119,9 +3534,9 @@ func TestResponsesCodeInterpreterTool_NonStreaming(t *testing.T) {
 		t.Errorf("expected result CallID to match call CallID, got %s vs %s", codeResult.CallID, codeCall.CallID)
 	}
 	// The include=code_interpreter_call.outputs must surface the tool outputs
-	// (logs + image) into CodeInterpreterToolResultContent.Outputs.
-	if len(codeResult.Outputs) != 2 {
-		t.Fatalf("expected 2 code interpreter outputs (logs, image), got %d", len(codeResult.Outputs))
+	// (logs + image + hosted file) into CodeInterpreterToolResultContent.Outputs.
+	if len(codeResult.Outputs) != 3 {
+		t.Fatalf("expected 3 code interpreter outputs (logs, image, file), got %d", len(codeResult.Outputs))
 	}
 	logsOutput, ok := codeResult.Outputs[0].(*message.TextContent)
 	if !ok {
@@ -3134,11 +3549,18 @@ func TestResponsesCodeInterpreterTool_NonStreaming(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected second output to be URIContent (image), got %T", codeResult.Outputs[1])
 	}
-	if imageOutput.URI != "https://example.com/plot.png" {
-		t.Errorf("expected image URI 'https://example.com/plot.png', got %q", imageOutput.URI)
+	if imageOutput.URI != "https://example.com/plot.png?download=1" {
+		t.Errorf("expected image URI with query, got %q", imageOutput.URI)
 	}
 	if imageOutput.MediaType != "image/png" {
 		t.Errorf("expected image media type 'image/png', got %q", imageOutput.MediaType)
+	}
+	hostedFile, ok := codeResult.Outputs[2].(*message.HostedFileContent)
+	if !ok {
+		t.Fatalf("expected third output to be HostedFileContent, got %T", codeResult.Outputs[2])
+	}
+	if hostedFile.FileID != "file_123" || hostedFile.MediaType != "text/csv" || hostedFile.Scope != "cntr_68fb7476c384819186524b78cdc3180000a9a0fdd06b3cd4" {
+		t.Fatalf("hosted file = %#v", hostedFile)
 	}
 
 	// Check for TextContent
@@ -3179,6 +3601,9 @@ data: {"type":"response.created","response":{"id":"resp_002","object":"response"
 
 event: response.output_item.added
 data: {"type":"response.output_item.added","item":{"type":"code_interpreter_call","id":"call_code_002","code":"","container_id":"container_002","status":"in_progress","outputs":[]}}
+
+event: response.code_interpreter_call_code.delta
+data: {"type":"response.code_interpreter_call_code.delta","sequence_number":1,"output_index":0,"item_id":"call_code_002","delta":"print(3+3)"}
 
 event: response.output_item.done
 data: {"type":"response.output_item.done","item":{"type":"code_interpreter_call","id":"call_code_002","code":"print(3+3)","container_id":"container_002","status":"completed","outputs":[{"type":"logs","logs":"6\n"},{"type":"image","url":"https://example.com/plot.png"}]}}
@@ -3674,6 +4099,9 @@ data: {"type":"response.incomplete","response":{"id":"resp_001","object":"respon
 			t.Errorf("update %d: expected ResponseID resp_001, got %s", i, update.ResponseID)
 		}
 	}
+	if got := updates[len(updates)-1].FinishReason; got != "length" {
+		t.Errorf("expected final FinishReason length, got %q", got)
+	}
 }
 
 func TestResponsesResponseWithUsageDetails_ParsesTokenCounts(t *testing.T) {
@@ -3953,6 +4381,9 @@ func TestResponsesStreamingResponseWithAnnotations_HandlesCorrectly(t *testing.T
 	const output = `event: response.created
 data: {"type":"response.created","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
 
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","response_id":"resp_001","item_id":"msg_001","output_index":0,"content_index":0,"delta":"Annotated text"}
+
 event: response.output_item.done
 data: {"type":"response.output_item.done","response_id":"resp_001","output_index":0,"item":{"type":"message","id":"msg_001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Annotated text","annotations":[{"type":"file_citation","file_id":"file_123","start_index":0,"end_index":14}]}]}}
 
@@ -4006,6 +4437,18 @@ data: {"type":"response.completed","response":{"id":"resp_001","object":"respons
 
 	if len(firstAnnotations) == 0 {
 		t.Error("expected first content to have annotations")
+	}
+
+	var streamedText strings.Builder
+	for _, update := range updates {
+		for _, content := range update.Contents {
+			if tc, ok := content.(*message.TextContent); ok {
+				streamedText.WriteString(tc.Text)
+			}
+		}
+	}
+	if streamedText.String() != "Annotated text" {
+		t.Fatalf("expected annotated output text once, got %q", streamedText.String())
 	}
 }
 
@@ -4075,8 +4518,8 @@ func TestResponsesAnnotations_NonStreaming_PreservesFidelity(t *testing.T) {
 	}
 	if span, ok := url.AnnotatedRegions[0].(*message.TextSpanAnnotatedRegion); !ok {
 		t.Errorf("url region type = %T, want *TextSpanAnnotatedRegion", url.AnnotatedRegions[0])
-	} else if span.Start != 0 || span.End != 9 {
-		t.Errorf("url span = {%d,%d}, want {0,9}", span.Start, span.End)
+	} else if span.StartIndex == nil || *span.StartIndex != 0 || span.EndIndex == nil || *span.EndIndex != 9 {
+		t.Errorf("url span = {%v,%v}, want {0,9}", span.StartIndex, span.EndIndex)
 	}
 
 	file, ok := annotations[1].(*message.CitationAnnotation)
@@ -4102,8 +4545,8 @@ func TestResponsesAnnotations_NonStreaming_PreservesFidelity(t *testing.T) {
 	}
 	if span, ok := container.AnnotatedRegions[0].(*message.TextSpanAnnotatedRegion); !ok {
 		t.Errorf("container region type = %T, want *TextSpanAnnotatedRegion", container.AnnotatedRegions[0])
-	} else if span.Start != 2 || span.End != 8 {
-		t.Errorf("container span = {%d,%d}, want {2,8}", span.Start, span.End)
+	} else if span.StartIndex == nil || *span.StartIndex != 2 || span.EndIndex == nil || *span.EndIndex != 8 {
+		t.Errorf("container span = {%v,%v}, want {2,8}", span.StartIndex, span.EndIndex)
 	}
 }
 
@@ -4313,7 +4756,8 @@ func TestResponsesResponseWithEndUserId_IncludesInAdditionalProperties(t *testin
               "status":"completed",
               "model":"gpt-4o-mini",
               "output":[{"type":"message","id":"msg_001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Done","annotations":[]}]}],
-              "user":"user_123"
+			  "user":"user_123",
+			  "safety_identifier":"safety_123"
             }
             `
 
@@ -4335,6 +4779,9 @@ func TestResponsesResponseWithEndUserId_IncludesInAdditionalProperties(t *testin
 		t.Error("expected EndUserId in AdditionalProperties")
 	} else if endUserID != "user_123" {
 		t.Errorf("expected EndUserId 'user_123', got %v", endUserID)
+	}
+	if safetyIdentifier := resp.AdditionalProperties["SafetyIdentifier"]; safetyIdentifier != "safety_123" {
+		t.Errorf("expected SafetyIdentifier 'safety_123', got %v", safetyIdentifier)
 	}
 }
 
@@ -4372,8 +4819,10 @@ func TestResponsesResponseWithError_IncludesInAdditionalPropertiesAndMessage(t *
 	if resp.AdditionalProperties == nil {
 		t.Fatal("expected AdditionalProperties to be set")
 	}
-	if _, ok := resp.AdditionalProperties["Error"]; !ok {
-		t.Error("expected Error in AdditionalProperties")
+	if responseError, ok := resp.AdditionalProperties["Error"].(responses.ResponseError); !ok {
+		t.Fatalf("Error metadata = %T, want responses.ResponseError", resp.AdditionalProperties["Error"])
+	} else if responseError.Message != "Rate limit exceeded" {
+		t.Errorf("Error metadata message = %q", responseError.Message)
 	}
 
 	// Verify last message contains error content
@@ -4670,7 +5119,7 @@ func TestResponsesUserMessageWithVariousContentTypes_ConvertsCorrectly(t *testin
 	}
 }
 
-func TestResponsesNonStreamingImageGenerationCall_MapsToDataContent(t *testing.T) {
+func TestResponsesNonStreamingImageGenerationCall_MapsToToolContents(t *testing.T) {
 	const imageBase64 = "iVBORw0KGgo="
 	const input = `
             {
@@ -4704,22 +5153,38 @@ func TestResponsesNonStreamingImageGenerationCall_MapsToDataContent(t *testing.T
 		t.Fatalf("error = %v", err)
 	}
 
-	image := firstDataContent(t, resp)
+	var call *message.ImageGenerationToolCallContent
+	var result *message.ImageGenerationToolResultContent
+	for content := range resp.Contents() {
+		switch content := content.(type) {
+		case *message.ImageGenerationToolCallContent:
+			call = content
+		case *message.ImageGenerationToolResultContent:
+			result = content
+		}
+	}
+	if call == nil || call.CallID != "ig_123" {
+		t.Fatalf("call = %#v, want CallID ig_123", call)
+	}
+	if result == nil || result.CallID != "ig_123" || len(result.Outputs) != 1 {
+		t.Fatalf("result = %#v, want one output for CallID ig_123", result)
+	}
+	image, ok := result.Outputs[0].(*message.DataContent)
+	if !ok {
+		t.Fatalf("output = %T, want *message.DataContent", result.Outputs[0])
+	}
 	if image.Data != imageBase64 {
 		t.Errorf("Data = %q, want %q", image.Data, imageBase64)
 	}
 	if image.MediaType != "image/png" {
 		t.Errorf("MediaType = %q, want %q", image.MediaType, "image/png")
 	}
-	if image.Name != "ig_123.png" {
-		t.Errorf("Name = %q, want %q", image.Name, "ig_123.png")
-	}
-	if image.RawRepresentation == nil {
+	if result.RawRepresentation == nil {
 		t.Error("RawRepresentation is nil")
 	}
 }
 
-func TestResponsesStreamingImageGenerationCall_MapsToDataContent(t *testing.T) {
+func TestResponsesStreamingImageGenerationCall_MapsToToolContents(t *testing.T) {
 	const imageBase64 = "iVBORw0KGgo="
 	const input = `
             {
@@ -4732,11 +5197,17 @@ func TestResponsesStreamingImageGenerationCall_MapsToDataContent(t *testing.T) {
 	const output = `event: response.created
 data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
 
+event: response.image_generation_call.in_progress
+data: {"type":"response.image_generation_call.in_progress","sequence_number":1,"output_index":0,"item_id":"ig_123"}
+
+event: response.image_generation_call.partial_image
+data: {"type":"response.image_generation_call.partial_image","sequence_number":2,"output_index":0,"item_id":"ig_123","partial_image_index":0,"partial_image_b64":"` + imageBase64 + `","output_format":"webp"}
+
 event: response.output_item.done
-data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,"item":{"type":"image_generation_call","id":"ig_123","status":"completed","result":"` + imageBase64 + `"}}
+data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"type":"image_generation_call","id":"ig_123","status":"completed","result":"` + imageBase64 + `"}}
 
 event: response.completed
-data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+data: {"type":"response.completed","sequence_number":4,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
 
 `
 
@@ -4744,35 +5215,161 @@ data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_00
 	defer server.Close()
 
 	a := newTestResponsesClient(server, "gpt-4o-mini")
-	var image *message.DataContent
+	var call *message.ImageGenerationToolCallContent
+	var result *message.ImageGenerationToolResultContent
 	for update, err := range a.RunText(t.Context(), "draw", agent.Stream(true)) {
 		if err != nil {
 			t.Fatalf("error = %v", err)
 		}
 		for _, content := range update.Contents {
-			if data, ok := content.(*message.DataContent); ok {
-				image = data
+			switch content := content.(type) {
+			case *message.ImageGenerationToolCallContent:
+				call = content
+			case *message.ImageGenerationToolResultContent:
+				result = content
 			}
 		}
 	}
 
-	if image == nil {
-		t.Fatal("expected DataContent")
+	if call == nil || call.CallID != "ig_123" {
+		t.Fatalf("call = %#v, want CallID ig_123", call)
 	}
-	if image.Data != imageBase64 || image.MediaType != "image/png" || image.Name != "ig_123.png" {
+	if result == nil || result.CallID != "ig_123" || len(result.Outputs) != 1 {
+		t.Fatalf("result = %#v, want one output for CallID ig_123", result)
+	}
+	image, ok := result.Outputs[0].(*message.DataContent)
+	if !ok {
+		t.Fatalf("output = %T, want *message.DataContent", result.Outputs[0])
+	}
+	if image.Data != imageBase64 || image.MediaType != "image/webp" {
 		t.Fatalf("image content = %#v", image)
+	}
+	if image.AdditionalProperties["ItemId"] != "ig_123" || image.AdditionalProperties["OutputIndex"] != int64(0) || image.AdditionalProperties["PartialImageIndex"] != int64(0) {
+		t.Fatalf("image metadata = %#v", image.AdditionalProperties)
+	}
+	if result.RawRepresentation == nil {
+		t.Error("RawRepresentation is nil")
 	}
 }
 
-func firstDataContent(t *testing.T, resp *agent.Response) *message.DataContent {
-	t.Helper()
+func TestResponsesNonStreamingWebSearchCall_MapsToToolContents(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"search"}]}]
+            }
+            `
+
+	const output = `
+            {
+              "id":"resp_001",
+              "object":"response",
+              "created_at":1741892091,
+              "status":"completed",
+              "model":"gpt-4o-mini",
+              "output":[{
+                "type":"web_search_call",
+                "id":"ws_123",
+                "status":"completed",
+                "action":{
+                  "type":"search",
+                  "queries":["first query","second query"],
+                  "query":"legacy query",
+                  "sources":[{"type":"url","url":"https://example.com/source"}]
+                }
+              }]
+            }
+            `
+
+	server := newTestResponsesServer(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	resp, err := a.RunText(t.Context(), "search").Collect()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	var call *message.WebSearchToolCallContent
+	var result *message.WebSearchToolResultContent
 	for content := range resp.Contents() {
-		if data, ok := content.(*message.DataContent); ok {
-			return data
+		switch content := content.(type) {
+		case *message.WebSearchToolCallContent:
+			call = content
+		case *message.WebSearchToolResultContent:
+			result = content
 		}
 	}
-	t.Fatal("expected DataContent")
-	return nil
+	if call == nil || call.CallID != "ws_123" || !reflect.DeepEqual(call.Queries, []string{"first query", "second query"}) {
+		t.Fatalf("call = %#v", call)
+	}
+	if call.RawRepresentation != nil {
+		t.Error("call RawRepresentation is non-nil")
+	}
+	if result == nil || result.CallID != "ws_123" || len(result.Outputs) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	source, ok := result.Outputs[0].(*message.URIContent)
+	if !ok || source.URI != "https://example.com/source" || source.MediaType != "text/html" || source.RawRepresentation == nil {
+		t.Fatalf("source = %#v", result.Outputs[0])
+	}
+	if result.RawRepresentation == nil {
+		t.Error("result RawRepresentation is nil")
+	}
+}
+
+func TestResponsesStreamingWebSearchCall_MapsToToolContents(t *testing.T) {
+	const input = `
+            {
+                "model":"gpt-4o-mini",
+                "input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"search"}]}],
+                "stream":true
+            }
+            `
+
+	const output = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.web_search_call.in_progress
+data: {"type":"response.web_search_call.in_progress","sequence_number":1,"output_index":0,"item_id":"ws_123"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":2,"output_index":0,"item":{"type":"web_search_call","id":"ws_123","status":"completed","action":{"type":"search","query":"fallback query","sources":[{"type":"url","url":"https://example.com/source"}]}}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
+
+`
+
+	server := newTestResponsesServerStreaming(t, input, output)
+	defer server.Close()
+
+	a := newTestResponsesClient(server, "gpt-4o-mini")
+	var calls []*message.WebSearchToolCallContent
+	var result *message.WebSearchToolResultContent
+	for update, err := range a.RunText(t.Context(), "search", agent.Stream(true)) {
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		for _, content := range update.Contents {
+			switch content := content.(type) {
+			case *message.WebSearchToolCallContent:
+				calls = append(calls, content)
+			case *message.WebSearchToolResultContent:
+				result = content
+			}
+		}
+	}
+
+	if len(calls) != 2 || calls[0].CallID != "ws_123" || calls[0].RawRepresentation == nil {
+		t.Fatalf("calls = %#v", calls)
+	}
+	if !reflect.DeepEqual(calls[1].Queries, []string{"fallback query"}) || calls[1].RawRepresentation != nil {
+		t.Fatalf("completed call = %#v", calls[1])
+	}
+	if result == nil || result.CallID != "ws_123" || len(result.Outputs) != 1 || result.RawRepresentation == nil {
+		t.Fatalf("result = %#v", result)
+	}
 }
 
 func TestResponsesToolCallResult_DataContent_SerializesAsInputImage(t *testing.T) {
@@ -5179,6 +5776,46 @@ func TestResponsesToolCallResult_DataContentPDF_SerializesAsInputFile(t *testing
 	}
 	if responseText != "PDF processed" {
 		t.Errorf("expected response text 'PDF processed', got %q", responseText)
+	}
+}
+
+func TestResponsesUnnamedDataContent_GeneratesRequiredFilenames(t *testing.T) {
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp","object":"response","created_at":1,"status":"completed","model":"gpt-4o-mini","output":[]}`)
+	}))
+	defer server.Close()
+
+	messages := []*message.Message{
+		{Role: message.RoleUser, Contents: message.Contents{&message.DataContent{Data: "cGRm", MediaType: "application/pdf"}}},
+		{Role: message.RoleTool, Contents: message.Contents{&message.FunctionResultContent{
+			CallID: "call_file",
+			Result: &message.DataContent{Data: "ZmlsZQ==", MediaType: "application/octet-stream"},
+		}}},
+	}
+	if _, err := newTestResponsesClient(server, "gpt-4o-mini").Run(t.Context(), messages).Collect(); err != nil {
+		t.Fatal(err)
+	}
+
+	input, ok := captured["input"].([]any)
+	if !ok || len(input) != 2 {
+		t.Fatalf("input = %#v", captured["input"])
+	}
+	userMessage, _ := input[0].(map[string]any)
+	userContents, _ := userMessage["content"].([]any)
+	userFile, _ := userContents[0].(map[string]any)
+	if filename, _ := userFile["filename"].(string); filename == "" {
+		t.Fatalf("user file = %#v", userFile)
+	}
+	toolOutput, _ := input[1].(map[string]any)
+	toolContents, _ := toolOutput["output"].([]any)
+	toolFile, _ := toolContents[0].(map[string]any)
+	if filename, _ := toolFile["filename"].(string); filename == "" {
+		t.Fatalf("tool file = %#v", toolFile)
 	}
 }
 
@@ -5617,7 +6254,7 @@ func TestResponsesToolCallResult_MultipleContentObjects_SerializesCorrectly(t *t
 		{Role: message.RoleTool, Contents: []message.Content{
 			&message.FunctionResultContent{
 				CallID: "call_multi",
-				Result: []message.Content{
+				Result: message.Contents{
 					&message.TextContent{Text: "First part"},
 					&message.TextContent{Text: "Second part"},
 				},


### PR DESCRIPTION
## Summary
- align stable message content, annotations, hosted-file metadata, and data-content helpers with Microsoft.Extensions.AI
- preserve tool approval identity and account for known stable nested content during compaction
- map stable web search, code interpreter, image generation, MCP, citation, usage, and replay behavior across OpenAI, Anthropic, and Gemini providers

## Testing
- `go test ./message ./agent/compaction ./agent/harness/toolapproval ./agent/harness/toolautocall ./provider/openaiprovider ./provider/anthropicprovider ./provider/geminiprovider`
- `git diff HEAD^ HEAD --check`