### PR TITLE
Use message.Contents for content collections

### DIFF
--- a/agent/harness/toolautocall/autocall.go
+++ b/agent/harness/toolautocall/autocall.go
@@ -394,11 +394,11 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 			for _, fcc := range processedFunctionCalls {
 				processedFCCSet[fcc] = struct{}{}
 			}
-			var iterationContents []message.Content
+			var iterationContents message.Contents
 			for _, u := range updates {
 				iterationContents = append(iterationContents, u.Contents...)
 			}
-			iterationContents = message.CoalesceContents(iterationContents)
+			iterationContents = iterationContents.Coalesce()
 			assistantContents := make([]message.Content, 0, len(iterationContents))
 			for _, c := range iterationContents {
 				switch v := c.(type) {
@@ -431,8 +431,8 @@ func (f *autocall) Run(next agent.RunFunc, ctx context.Context, messages []*mess
 	}
 }
 
-func (f *autocall) prepareApprovalContents(ctx context.Context, contents []message.Content, tools map[string]tool.SchemaTool, session *agent.Session) ([]message.Content, error) {
-	var updated []message.Content
+func (f *autocall) prepareApprovalContents(ctx context.Context, contents message.Contents, tools map[string]tool.SchemaTool, session *agent.Session) (message.Contents, error) {
+	var updated message.Contents
 	var autoApproved []*message.FunctionCallContent
 	for i, c := range contents {
 		if fcc, ok := c.(*message.FunctionCallContent); ok && !fcc.InformationalOnly {
@@ -1516,11 +1516,11 @@ func convertToToolCallContentMessage(msg toolApprovalResultWithRequestMessage, f
 	return newMsg
 }
 
-func (f *autocall) generateRejectedFunctionResults(ctx context.Context, rejections []toolApprovalResultWithRequestMessage) []message.Content {
+func (f *autocall) generateRejectedFunctionResults(ctx context.Context, rejections []toolApprovalResultWithRequestMessage) message.Contents {
 	if len(rejections) == 0 {
 		return nil
 	}
-	contents := make([]message.Content, 0, len(rejections))
+	contents := make(message.Contents, 0, len(rejections))
 	for _, rej := range rejections {
 		fcc, ok := approvalToolCallAsFunctionCall(rej.Response.ToolCall)
 		if !ok {

--- a/agent/response.go
+++ b/agent/response.go
@@ -124,7 +124,7 @@ func (resp *Response) Coalesce() {
 		return
 	}
 	for _, msg := range resp.Messages {
-		msg.Contents = message.CoalesceContents(msg.Contents)
+		msg.Contents = msg.Contents.Coalesce()
 	}
 }
 

--- a/message/content.go
+++ b/message/content.go
@@ -1142,8 +1142,9 @@ func (t *WebSearchToolResultContent) MarshalJSON() ([]byte, error) {
 
 func (t WebSearchToolResultContent) kind() contentKind { return "webSearchToolResult" }
 
-// CoalesceContents combines sequential contents elements.
-func CoalesceContents(contents []Content) []Content {
+// Coalesce combines adjacent compatible content elements and returns the
+// resulting slice. It may reuse and modify the receiver's backing array.
+func (contents Contents) Coalesce() Contents {
 	var sb strings.Builder
 	mergeText := func(contents []Content, start, end int) string {
 		sb.Reset()
@@ -1225,7 +1226,7 @@ func CoalesceContents(contents []Content) []Content {
 		func(contents []Content, start, end int) *CodeInterpreterToolCallContent {
 			first := contents[start].(*CodeInterpreterToolCallContent)
 			if end-start == 1 {
-				first.Inputs = CoalesceContents(first.Inputs)
+				first.Inputs = first.Inputs.Coalesce()
 				return first
 			}
 			var inputs Contents
@@ -1235,7 +1236,7 @@ func CoalesceContents(contents []Content) []Content {
 			return &CodeInterpreterToolCallContent{
 				ContentHeader: ContentHeader{AdditionalProperties: maps.Clone(first.AdditionalProperties)},
 				CallID:        first.CallID,
-				Inputs:        CoalesceContents(inputs),
+				Inputs:        inputs.Coalesce(),
 			}
 		})
 
@@ -1244,7 +1245,7 @@ func CoalesceContents(contents []Content) []Content {
 		func(contents []Content, start, end int) *CodeInterpreterToolResultContent {
 			first := contents[start].(*CodeInterpreterToolResultContent)
 			if end-start == 1 {
-				first.Outputs = CoalesceContents(first.Outputs)
+				first.Outputs = first.Outputs.Coalesce()
 				return first
 			}
 			var outputs Contents
@@ -1254,14 +1255,14 @@ func CoalesceContents(contents []Content) []Content {
 			return &CodeInterpreterToolResultContent{
 				ContentHeader: ContentHeader{AdditionalProperties: maps.Clone(first.AdditionalProperties)},
 				CallID:        first.CallID,
-				Outputs:       CoalesceContents(outputs),
+				Outputs:       outputs.Coalesce(),
 			}
 		})
 
 	return contents
 }
 
-func coalesceImageGenerationToolResults(contents []Content) []Content {
+func coalesceImageGenerationToolResults(contents Contents) Contents {
 	indexByCallID := make(map[string]int)
 	for i, content := range contents {
 		result, ok := content.(*ImageGenerationToolResultContent)
@@ -1278,7 +1279,7 @@ func coalesceImageGenerationToolResults(contents []Content) []Content {
 	return slices.DeleteFunc(contents, func(c Content) bool { return c == nil })
 }
 
-func coalesceWebSearchToolCalls(contents []Content) []Content {
+func coalesceWebSearchToolCalls(contents Contents) Contents {
 	indexByCallID := make(map[string]int)
 	for i, content := range contents {
 		toolCall, ok := content.(*WebSearchToolCallContent)
@@ -1325,7 +1326,7 @@ func coalesceWebSearchToolCalls(contents []Content) []Content {
 	return slices.DeleteFunc(contents, func(c Content) bool { return c == nil })
 }
 
-func coalesce[T Content](contents []Content, mergeSingle bool, canMerge func(a, b T) bool, merge func([]Content, int, int) T) []Content {
+func coalesce[T Content](contents Contents, mergeSingle bool, canMerge func(a, b T) bool, merge func([]Content, int, int) T) Contents {
 	// Iterate through all of the items in the list looking for contiguous items that can be coalesced.
 	start := 0
 	tryAsCoalescable := func(c Content) (T, bool) {

--- a/message/content_test.go
+++ b/message/content_test.go
@@ -757,11 +757,11 @@ func TestToolApprovalRequestContent_AlwaysApproveSnapshotsAdditionalProperties(t
 	})
 }
 
-func TestCoalesceContents(t *testing.T) {
+func TestContentsCoalesce(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []message.Content
-		expected []message.Content
+		input    message.Contents
+		expected message.Contents
 	}{
 		{
 			name:     "empty list",
@@ -1305,7 +1305,7 @@ func TestCoalesceContents(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := message.CoalesceContents(tt.input)
+			result := tt.input.Coalesce()
 			if len(result) != len(tt.expected) {
 				t.Fatalf("expected %d contents, got %d", len(tt.expected), len(result))
 			}
@@ -1318,17 +1318,17 @@ func TestCoalesceContents(t *testing.T) {
 	}
 }
 
-func TestCoalesceContents_PreservesInvalidDataContent(t *testing.T) {
+func TestContentsCoalesce_PreservesInvalidDataContent(t *testing.T) {
 	invalid := &message.DataContent{Data: "%%%", MediaType: "text/plain"}
 	valid := &message.DataContent{Data: base64.StdEncoding.EncodeToString([]byte("valid")), MediaType: "text/plain"}
 
-	got := message.CoalesceContents([]message.Content{invalid, valid})
+	got := (message.Contents{invalid, valid}).Coalesce()
 	if len(got) != 2 || got[0] != invalid || got[1] != valid {
-		t.Fatalf("CoalesceContents() = %#v, want original contents", got)
+		t.Fatalf("Contents.Coalesce() = %#v, want original contents", got)
 	}
 }
 
-func TestCoalesceContents_PreservesSingleCodeInterpreterContentIdentity(t *testing.T) {
+func TestContentsCoalesce_PreservesSingleCodeInterpreterContentIdentity(t *testing.T) {
 	call := &message.CodeInterpreterToolCallContent{
 		CallID: "call-1",
 		Inputs: message.Contents{
@@ -1344,9 +1344,9 @@ func TestCoalesceContents_PreservesSingleCodeInterpreterContentIdentity(t *testi
 		},
 	}
 
-	got := message.CoalesceContents([]message.Content{call, result})
+	got := (message.Contents{call, result}).Coalesce()
 	if got[0] != call || got[1] != result {
-		t.Fatalf("CoalesceContents() replaced single code-interpreter content")
+		t.Fatalf("Contents.Coalesce() replaced single code-interpreter content")
 	}
 	if call.Inputs.Text() != "ab" || result.Outputs.Text() != "cd" {
 		t.Fatalf("nested contents = %q, %q", call.Inputs.Text(), result.Outputs.Text())

--- a/provider/a2aprovider/a2a.go
+++ b/provider/a2aprovider/a2a.go
@@ -446,7 +446,7 @@ func updateSessionContextID(session *agent.Session, contextID, taskID string, ta
 	return nil
 }
 
-func partsToContents(parts a2a.ContentParts, contents []message.Content) ([]message.Content, error) {
+func partsToContents(parts a2a.ContentParts, contents message.Contents) (message.Contents, error) {
 	contents = slices.Grow(contents, len(parts))
 	for _, part := range parts {
 		if part == nil {

--- a/provider/anthropicprovider/agent.go
+++ b/provider/anthropicprovider/agent.go
@@ -298,7 +298,7 @@ func toUsageDetailsDelta(usage anthropic.MessageDeltaUsage) message.UsageDetails
 	})
 }
 
-func (a *client) buildBlock(index int, v any, contents []message.Content, functions map[int]*message.FunctionCallContent) []message.Content {
+func (a *client) buildBlock(index int, v any, contents message.Contents, functions map[int]*message.FunctionCallContent) message.Contents {
 	switch v := v.(type) {
 	case anthropic.TextBlock:
 		contents = append(contents, &message.TextContent{
@@ -573,7 +573,7 @@ func citationAnnotations(citations []anthropic.TextCitationUnion) []message.Anno
 	return annotations
 }
 
-func (a *client) buildDelta(v any, contents []message.Content) []message.Content {
+func (a *client) buildDelta(v any, contents message.Contents) message.Contents {
 	switch d := v.(type) {
 	case anthropic.TextDelta:
 		contents = append(contents, &message.TextContent{

--- a/provider/geminiprovider/agent.go
+++ b/provider/geminiprovider/agent.go
@@ -509,7 +509,7 @@ type responsePartState struct {
 }
 
 // buildResponsePart converts a genai Part from a response into framework message content.
-func buildResponsePart(part *genai.Part, contents []message.Content, state *responsePartState) ([]message.Content, error) {
+func buildResponsePart(part *genai.Part, contents message.Contents, state *responsePartState) (message.Contents, error) {
 	if part.Thought {
 		// Thinking model: emit TextReasoningContent. Encode ThoughtSignature as
 		// base64 in ProtectedData so it can be passed back in multi-turn requests.

--- a/provider/openaiprovider/chat.go
+++ b/provider/openaiprovider/chat.go
@@ -613,7 +613,7 @@ func populateChatAnnotations(anns []openai.ChatCompletionMessageAnnotation, cont
 	}
 }
 
-func addUsage(contents []message.Content, usage openai.CompletionUsage) []message.Content {
+func addUsage(contents message.Contents, usage openai.CompletionUsage) message.Contents {
 	details := message.UsageDetails{
 		InputTokenCount:       usage.PromptTokens,
 		OutputTokenCount:      usage.CompletionTokens,

--- a/provider/openaiprovider/responses.go
+++ b/provider/openaiprovider/responses.go
@@ -1672,7 +1672,7 @@ func responsesProcessStreamingUpdate(update responses.ResponseStreamEventUnion, 
 // surfacing of FileSearch results. When the call returns no results, a single empty
 // annotated TextContent is emitted so the call is still surfaced and, being annotated,
 // is not coalesced away (which would strip its RawRepresentation).
-func fileSearchToolCallContents(item responses.ResponseFileSearchToolCall) []message.Content {
+func fileSearchToolCallContents(item responses.ResponseFileSearchToolCall) message.Contents {
 	if len(item.Results) == 0 {
 		textContent := &message.TextContent{
 			ContentHeader: message.ContentHeader{RawRepresentation: item},
@@ -1681,9 +1681,9 @@ func fileSearchToolCallContents(item responses.ResponseFileSearchToolCall) []mes
 			ToolName:          "file_search",
 			RawRepresentation: item,
 		})
-		return []message.Content{textContent}
+		return message.Contents{textContent}
 	}
-	contents := make([]message.Content, 0, len(item.Results))
+	contents := make(message.Contents, 0, len(item.Results))
 	for _, res := range item.Results {
 		textContent := &message.TextContent{
 			ContentHeader: message.ContentHeader{RawRepresentation: item},
@@ -1733,8 +1733,8 @@ func mcpApprovalResponseContent(item responses.ResponseOutputItemMcpApprovalResp
 // mcpCallContents surfaces a completed hosted MCP tool call, emitting both the
 // call (from its arguments) and its result so the output is not silently
 // dropped. Any tool-call error is surfaced as an ErrorContent.
-func mcpCallContents(item responses.ResponseOutputItemMcpCall) []message.Content {
-	contents := []message.Content{
+func mcpCallContents(item responses.ResponseOutputItemMcpCall) message.Contents {
+	contents := message.Contents{
 		&message.MCPServerToolCallContent{
 			Arguments:  item.Arguments,
 			CallID:     item.ID,

--- a/tool/mcptool/mcp.go
+++ b/tool/mcptool/mcp.go
@@ -76,13 +76,13 @@ func ListTools(ctx context.Context, session *mcp.ClientSession) ([]tool.Tool, er
 	return result, nil
 }
 
-func mcpCallToolResultToAgentContent(result *mcp.CallToolResult) []message.Content {
+func mcpCallToolResultToAgentContent(result *mcp.CallToolResult) message.Contents {
 	if result == nil {
 		return nil
 	}
 
 	if mcpCallToolResultNeedsEnvelope(result) {
-		return []message.Content{
+		return message.Contents{
 			&message.TextContent{
 				ContentHeader: mcpContentHeader(result),
 				Text:          jsonText(result),
@@ -116,16 +116,16 @@ func hasUserDefinedMeta(meta mcp.Meta) bool {
 	return false
 }
 
-func mcpContentToAgentContent(mcpContents []mcp.Content) []message.Content {
+func mcpContentToAgentContent(mcpContents []mcp.Content) message.Contents {
 	return mcpContentToAgentContentWithRaw(mcpContents, nil)
 }
 
-func mcpContentToAgentContentWithRaw(mcpContents []mcp.Content, rawOverride any) []message.Content {
+func mcpContentToAgentContentWithRaw(mcpContents []mcp.Content, rawOverride any) message.Contents {
 	if len(mcpContents) == 0 {
 		return nil
 	}
 
-	result := make([]message.Content, 0, len(mcpContents))
+	result := make(message.Contents, 0, len(mcpContents))
 
 	for _, contentValue := range mcpContents {
 		var raw any = contentValue

--- a/tool/mcptool/mcp_test.go
+++ b/tool/mcptool/mcp_test.go
@@ -76,9 +76,9 @@ func TestCallPreservesMCPErrorResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call() error = %v", err)
 	}
-	contents, ok := result.([]message.Content)
+	contents, ok := result.(message.Contents)
 	if !ok {
-		t.Fatalf("Call() result is %T, want []message.Content", result)
+		t.Fatalf("Call() result is %T, want message.Contents", result)
 	}
 	if len(contents) != 1 {
 		t.Fatalf("expected one content item, got %d", len(contents))
@@ -141,7 +141,7 @@ func TestCallConvertsMCPContentTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call() error = %v", err)
 	}
-	contents := result.([]message.Content)
+	contents := result.(message.Contents)
 	if len(contents) != 6 {
 		t.Fatalf("expected six content items, got %d", len(contents))
 	}
@@ -912,9 +912,9 @@ func TestCallReturnsEmptyAndStructuredOnlyMCPResults(t *testing.T) {
 
 	t.Run("structured only", func(t *testing.T) {
 		result := callMCPResult(t, &mcp.CallToolResult{StructuredContent: map[string]any{"key": "value", "number": 42}})
-		contents, ok := result.([]message.Content)
+		contents, ok := result.(message.Contents)
 		if !ok {
-			t.Fatalf("result is %T, want []message.Content", result)
+			t.Fatalf("result is %T, want message.Contents", result)
 		}
 		if len(contents) != 1 {
 			t.Fatalf("expected one content item, got %d", len(contents))
@@ -954,9 +954,9 @@ func TestCallConvertsMCPToolUseAndToolResultContent(t *testing.T) {
 		},
 	}})
 
-	contents, ok := result.([]message.Content)
+	contents, ok := result.(message.Contents)
 	if !ok {
-		t.Fatalf("result is %T, want []message.Content", result)
+		t.Fatalf("result is %T, want message.Contents", result)
 	}
 	if len(contents) != 2 {
 		t.Fatalf("expected two content items, got %d", len(contents))
@@ -1003,9 +1003,9 @@ func TestCallConvertsMCPToolUseAndToolResultContent(t *testing.T) {
 func callSingleMCPContent(t *testing.T, content mcp.Content) message.Content {
 	t.Helper()
 	result := callMCPResult(t, &mcp.CallToolResult{Content: []mcp.Content{content}})
-	contents, ok := result.([]message.Content)
+	contents, ok := result.(message.Contents)
 	if !ok {
-		t.Fatalf("Call() result is %T, want []message.Content", result)
+		t.Fatalf("Call() result is %T, want message.Contents", result)
 	}
 	if len(contents) != 1 {
 		t.Fatalf("expected one content item, got %d", len(contents))
@@ -1129,7 +1129,7 @@ func TestAddToolTypedNilContentDoesNotPanic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call() error = %v", err)
 	}
-	contents, ok := result.([]message.Content)
+	contents, ok := result.(message.Contents)
 	if !ok || len(contents) != 1 {
 		t.Fatalf("Call() result = %#v, want one content item", result)
 	}


### PR DESCRIPTION
## Summary
- standardize content-producing helpers on `message.Contents` instead of `[]message.Content`
- replace `message.CoalesceContents` with `message.Contents.Coalesce`
- return `message.Contents` from MCP result conversion and update concrete-type assertions

## Compatibility
- removes the exported `message.CoalesceContents`; callers should use `contents.Coalesce()`
- retains support for raw `[]message.Content` values returned by user-defined tools

## Testing
- focused message content unit tests
- agent response and tool autocall unit tests
- focused A2A, Anthropic, Gemini, OpenAI, and MCP unit tests