### PR TITLE
chore: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto eol=lf
+
 .github/workflows/*.lock.yml linguist-generated=true


### PR DESCRIPTION
## Summary
- define repository-wide Git text normalization
- force LF working-tree line endings across platforms
- preserve the generated workflow lock-file classification

## Testing
- `git check-attr text eol -- .gitattributes agent/agent.go .github/workflows/agentic-auto-upgrade.yml`
- `git diff --check`