### PR TITLE
[dotnet-code] Clarify edge runner kind internals

### DIFF
--- a/workflow/internal/execution/edgerunner.go
+++ b/workflow/internal/execution/edgerunner.go
@@ -33,6 +33,14 @@ type statefulEdgeState struct {
 	unseen          map[string]struct{}
 }
 
+type edgeKind int
+
+const (
+	directEdge edgeKind = iota
+	fanOutEdge
+	fanInEdge
+)
+
 func newStatefulEdgeState(sourceIDs []string) *statefulEdgeState {
 	state := &statefulEdgeState{
 		sourceIDs: sourceIDs,
@@ -134,7 +142,7 @@ func NewEdgeRunner(wf *workflow.Workflow, tracer StepTracer, ensureExecutor func
 	var statefulEdges map[int]*statefulEdgeState
 	for _, edges := range wf.Edges() {
 		for _, edge := range edges {
-			if len(edge.Connection.SourceIDs) <= 1 {
+			if kindOfEdge(edge) != fanInEdge {
 				continue
 			}
 			if statefulEdges == nil {
@@ -458,11 +466,22 @@ func edgeGroupMetadata(edge workflow.Edge) observability.EdgeGroupMetadata {
 }
 
 func edgeGroupType(edge workflow.Edge) string {
-	if len(edge.Connection.SourceIDs) > 1 {
+	switch kindOfEdge(edge) {
+	case fanInEdge:
 		return "FanInEdgeRunner"
+	case fanOutEdge:
+		return "FanOutEdgeRunner"
+	default:
+		return "DirectEdgeRunner"
+	}
+}
+
+func kindOfEdge(edge workflow.Edge) edgeKind {
+	if len(edge.Connection.SourceIDs) > 1 {
+		return fanInEdge
 	}
 	if len(edge.Connection.SinkIDs) > 1 || edge.Assigner != nil {
-		return "FanOutEdgeRunner"
+		return fanOutEdge
 	}
-	return "DirectEdgeRunner"
+	return directEdge
 }


### PR DESCRIPTION
> [!TIP]
> **Your pull request is ready to create! 🎉 ✅**
>
> Everything is OK—the changes have been pushed to branch `dotnet-code-edge-kind-internals-20260909222836-5dd8b328a27fec17`. Please review the changes, including any protected files, before creating the pull request.
>
> **[Create the pull request](https://github.com/microsoft/agent-framework-go/compare/main...dotnet-code-edge-kind-internals-20260909222836-5dd8b328a27fec17?expand=1&title=%5Bdotnet-code%5D%20Clarify%20edge%20runner%20kind%20internals)**
>
> The original pull request description is below.

---

## Summary

Introduces a small unexported edge-kind helper in the workflow edge runner and routes telemetry/stateful-edge setup through it. This keeps the Go internals closer to the .NET workflow model's explicit EdgeKind classification while preserving the existing public API and runtime behavior.

## .NET Reference

- dotnet/src/Microsoft.Agents.AI.Workflows/Edge.cs - defines explicit EdgeKind values for direct, fan-out, and fan-in workflow edges.
- dotnet/src/Microsoft.Agents.AI.Workflows/EdgeData.cs - keeps edge data tied to a connection representation used by the edge kind.

## Public API and Behavior

No public Go API changed. No intentional behavior change was made.

## Tests

- go test ./workflow/internal/execution ./workflow

## Notes

Random .NET sample inspection covered workflow edge/run internals and shared agent JSON utilities. I rejected Run.cs because the corresponding Go run handle code already has distinct lifecycle responsibilities and any cleanup risked behavior churn. I rejected AgentJsonUtilities.cs because the Go JSON helper is already a narrow generic utility and changing serializer defaults would not be portability-only. Visible open PR checks did not show an open [dotnet-code] PR covering the workflow edge candidate; two lower-integrity PR records were unavailable to inspect. The required direct git fetch of microsoft/agent-framework was blocked by the environment, so the .NET files were inspected through the configured GitHub read bridge instead.


<!-- gh-aw-tracker-id: dotnet-code-portability-nightly -->

Closes #1050